### PR TITLE
Examples ReactRouter.replaceWith() causing error.

### DIFF
--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -66,7 +66,7 @@ var AuthenticatedRoute = {
     if (!auth.loggedIn()) {
       this.render = function() { return <span/>};
       AuthenticatedRoute.lastInfo = ReactRouter.getCurrentInfo();
-      ReactRouter.replaceWith('login');
+      ReactRouter.replaceWith('login', {});
     }
   }
 };
@@ -106,7 +106,7 @@ var Login = React.createClass({
       if (lastInfo) {
         return ReactRouter.replaceWith(lastInfo.route.props.name, lastInfo.params);
       }
-      ReactRouter.replaceWith('about');
+      ReactRouter.replaceWith('about', {});
     }.bind(this));
   },
 

--- a/examples/master-detail/app.js
+++ b/examples/master-detail/app.js
@@ -161,7 +161,7 @@ var store = {
       var url = api+'/'+id;
       getJSON(url, function(err, res) {
         if (err) {
-          return ReactRouter.replaceWith('not-found');
+          return ReactRouter.replaceWith('not-found', {});
         }
         var contact = res.contact;
         store.contacts.map[contact.id] = contact;


### PR DESCRIPTION
Fix `ReactRouter.replaceWith()` in examples to include an empty params object.

Without the fix the following error will occur.
`Uncaught TypeError: Cannot read property 'query' of undefined`

I think this could also be fixed by making the params object optional.
