### PR TITLE
Include query string when retrieving window path

### DIFF
--- a/lib/stores/url-store.js
+++ b/lib/stores/url-store.js
@@ -11,7 +11,7 @@ var CHANGE_EVENTS = {
 var _location;
 
 function getWindowPathname() {
-  return _location === 'history' ? window.location.pathname : window.location.hash.substr(1);
+  return _location === 'history' ? window.location.pathname + window.location.search : window.location.hash.substr(1);
 }
 
 function pushHistory(path) {


### PR DESCRIPTION
Seems query string routing was only working in hash mode, this tiny fix makes sure `getWindowPathname` uses both `pathname` and `search` properties of the location object.
