### PR TITLE
Fix reference to uppercase files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,3 +1,3 @@
-exports.Router = require('./router');
-exports.Route = require('./components/route');
-exports.Link = require('./components/link');
+exports.Router = require('./Router');
+exports.Route = require('./components/Route');
+exports.Link = require('./components/Link');


### PR DESCRIPTION
Fixes these webpack warnings:

``` Shell
WARNING in ./~/react-router/lib/components/route.js
There is another module with a equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected
```
