### PR TITLE
renderComponentToString()

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -208,6 +208,25 @@ mergeProperties(Router.prototype, {
     return component;
   },
 
+  /**
+   * Renders this Router's component as a string. Since this may be an asynchronous
+   * process, this returns a Promise.
+   */
+  renderComponentToString: function(path) {
+    invariant(
+      !this.state.props,
+      'You may only call renderComponentToString() on a new Router'
+    );
+
+    return this.dispatch(path).then(function() {
+      var route = this.route;
+      var state = this.state;
+      var descriptor = route.handler(state.props);
+      var markup = React.renderComponentToString(descriptor);
+      return markup;
+    }.bind(this));
+  },
+
   handleRouteChange: function () {
     this.dispatch(URLStore.getCurrentPath());
   }


### PR DESCRIPTION
This adds a `renderComponentToString()` method for server-side rendering. Server side rendering doesn't work yet since we need to call `dispatch()` before `renderComponent()`, but it looks like you already have a plan in place for this seeing as it appears that `state.props` is expected to be shared.
