### PR TITLE
moved react to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "react-nested-router",
-  "version": "0.2.1",
->>>>>>> up/master
+  "version": "0.2.0",
   "description": "A complete routing library for React",
   "tags": [
     "react",


### PR DESCRIPTION
This makes it less likely to clash with a user's react version.  If they upgrade to 0.11 when it comes out, your package will automatically use their version.  If you discover it's not compatible with 0.11, you can restrict the peerDependencies to disallow it, and then they'll get a warning/error instead of it silently including both react versions.
