### PR TITLE
Reserve className param

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -6,6 +6,7 @@ var makeHref = require('../helpers/makeHref');
 
 var RESERVED_PROPS = {
   to: true,
+  className: true,
   activeClassName: true,
   query: true,
   children: true // ReactChildren


### PR DESCRIPTION
When you set className on a Link instance, isActive is never true since it is included in the route comparison.
