### PR TITLE
Update active state when changing props

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -98,6 +98,14 @@ var Link = React.createClass({
     ActiveStore.removeChangeListener(this.handleActiveChange);
   },
 
+  componentWillReceiveProps: function(props) {
+    var params = Link.getUnreservedProps(props);
+
+    this.setState({
+      isActive: ActiveStore.isActive(props.to, params, props.query)
+    });
+  },
+
   handleActiveChange: function () {
     if (this.isMounted())
       this.updateActive();


### PR DESCRIPTION
Assigning new props to a Link instance should force a re-check of it's active state.
