### PR TITLE
[fixed] injectParams invariant should not throw on values that coerce to false.

### DIFF
--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -85,7 +85,7 @@ var Path = {
       var paramName = getParamName(pathSegment);
 
       invariant(
-        params[paramName],
+        params[paramName] != null,
         'Missing "' + paramName + '" parameter for path "' + pattern + '"'
       );
 

--- a/specs/Path.spec.js
+++ b/specs/Path.spec.js
@@ -127,6 +127,10 @@ describe('Path.injectParams', function () {
       it('returns the correct path', function () {
         expect(Path.injectParams(pattern, { id: 'abc' })).toEqual('comments/abc/edit');
       });
+
+      it('returns the correct path when the value is 0', function () {
+        expect(Path.injectParams(pattern, { id: 0 })).toEqual('comments/0/edit');
+      });
     });
 
     describe('and some params have special URL encoding', function () {


### PR DESCRIPTION
I noticed when I had an numeric 0 as a parameter value that an invariant messages was thrown. This is because the param value was coercing to false. This PR changes that invariant to handle those situations.
