### PR TITLE
Support for IE8. Alternative to window.addEventListener and reload page after transitionTo

### DIFF
--- a/modules/stores/URLStore.js
+++ b/modules/stores/URLStore.js
@@ -58,6 +58,8 @@ var URLStore = {
       notifyChange();
     } else if (_location === 'hash') {
       window.location.hash = path;
+      if (!window.addEventListener)
+        window.location.reload();
     } else {
       _lastPath = _currentPath;
       _currentPath = path;
@@ -139,7 +141,10 @@ var URLStore = {
     if (location === 'hash' && window.location.hash === '')
       URLStore.replace('/');
 
-    window.addEventListener(changeEvent, notifyChange, false);
+    if (window.addEventListener)
+      window.addEventListener(changeEvent, notifyChange, false);
+    else
+      window.attachEvent(changeEvent,notifyChange);
 
     notifyChange();
   },


### PR DESCRIPTION
IE 8 Does not support the method `window.addEventListener`.

Also IE 8 needs an explicit page refresh after a `Rotuer.transitionTo` call.
