### PR TITLE
[fixed] checks for class instead of components

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -105,7 +105,7 @@ var Route = React.createClass({
 
   propTypes: {
     location: React.PropTypes.oneOf([ 'hash', 'history' ]).isRequired,
-    handler: React.PropTypes.component.isRequired,
+    handler: React.PropTypes.any.isRequired,
     path: React.PropTypes.string,
     name: React.PropTypes.string,
   },

--- a/modules/stores/RouteStore.js
+++ b/modules/stores/RouteStore.js
@@ -28,7 +28,7 @@ var RouteStore = {
 
     // Make sure the <Route> has a valid React component for a handler.
     invariant(
-      React.isValidComponent(route.props.handler),
+      React.isValidClass(route.props.handler),
       'The handler for Route "' + (route.props.name || route.props.path) + '" ' +
       'must be a valid React component'
     );


### PR DESCRIPTION
Previously the checks for components were the same as react classes. This caused reacted-nested-router to break in react@react-0.11.0-rc1. See this issue: https://github.com/facebook/react/issues/1164. 
