### PR TITLE
turn activeRoute into a function that returns null when no child routes are active

### DIFF
--- a/examples/master-detail/app.js
+++ b/examples/master-detail/app.js
@@ -111,7 +111,6 @@ var App = React.createClass({
     var contacts = this.state.contacts.map(function(contact) {
       return <li key={contact.id}><Link to="contact" id={contact.id}>{contact.first}</Link></li>
     });
-    var content = (this.props.activeRoute) ? this.props.activeRoute() : this.indexTemplate();
     return (
       <div className="App">
         <div className="ContactList">
@@ -121,7 +120,7 @@ var App = React.createClass({
           </ul>
         </div>
         <div className="Content">
-          {content}
+          {this.props.activeRoute() || this.indexTemplate()}
         </div>
       </div>
     );

--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var warning = require('react/lib/warning');
 var invariant = require('react/lib/invariant');
+var emptyFunction = require('react/lib/emptyFunction');
 var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
 var mergeProperties = require('../helpers/mergeProperties');
 var goBack = require('../helpers/goBack');
@@ -426,7 +427,7 @@ function computeHandlerProps(matches, query) {
     key: null,
     params: null,
     query: null,
-    activeRoute: null
+    activeRoute: emptyFunction.thatReturnsNull
   };
 
   var childHandler;
@@ -443,7 +444,7 @@ function computeHandlerProps(matches, query) {
     if (childHandler) {
       props.activeRoute = childHandler;
     } else {
-      props.activeRoute = null;
+      props.activeRoute = emptyFunction.thatReturnsNull;
     }
 
     childHandler = function (props, addedProps, children) {


### PR DESCRIPTION
Examples are broken for not checking that activeRoute is null before calling it.
Thoughts on activeRoute being a function that returns null by default?

``` js
this.props.activeRoute() || this.IndexTemplate()
```

vs

``` js
this.props.activeRoute ? this.props.activeRoute() : this.IndexTemplate();
```
