### PR TITLE
activeRoute needs to support multiple children and needs to always return a function.

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -447,7 +447,7 @@ function computeHandlerProps(matches, query) {
     }
 
     childHandler = function (props, addedProps, children) {
-      return route.props.handler(mergeProperties(props, addedProps), children);
+      return route.props.handler.apply(null, [mergeProperties(props, addedProps)].concat(children));
     }.bind(this, props);
 
     match.refName = props.ref;


### PR DESCRIPTION
- activeRoute should be a function returning null when no route.
- activeRoute actually needs to support multiple children.

![Sigh](http://i.imgur.com/xBZrGHE.gif)
