### PR TITLE
Improving tests for URLStore

### DIFF
--- a/specs/URLStore.spec.js
+++ b/specs/URLStore.spec.js
@@ -6,6 +6,10 @@ describe('when a new path is pushed to the URL', function () {
     URLStore.push('/a/b/c');
   });
 
+  afterEach(function () {
+    URLStore.teardown();
+  });
+
   it('has the correct path', function () {
     expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
   });
@@ -13,10 +17,42 @@ describe('when a new path is pushed to the URL', function () {
 
 describe('when a new path is used to replace the URL', function () {
   beforeEach(function () {
-    URLStore.push('/a/b/c');
+    URLStore.replace('/a/b/c');
+  });
+
+  afterEach(function () {
+    URLStore.teardown();
   });
 
   it('has the correct path', function () {
     expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+  });
+});
+
+describe('when going back in history', function () {
+  afterEach(function () {
+    URLStore.teardown();
+  });
+
+  it('has the correct path', function () {
+    URLStore.push('/a/b/c');
+    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+
+    URLStore.push('/d/e/f');
+    expect(URLStore.getCurrentPath()).toEqual('/d/e/f');
+
+    URLStore.back();
+    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+  });
+
+  it('should not go back before recorded history', function () {
+    var error = false;
+    try {
+      URLStore.back();
+    } catch (e) {
+      error = true;
+    }
+
+    expect(error).toEqual(true);
   });
 });


### PR DESCRIPTION
Made a few improvements:
- The test for `URLStore.replace` was calling `URLStore.push`
- Added coverage for `URLStore.back`
