### PR TITLE
Add params prop to link component

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,11 @@ change the path of your route, you don't have to change your links.
 **query** - Object, Query parameters to add to the link. Access query
 parameters in your route handler with `this.props.query`.
 
-**[param]** - Any parameters the route defines are passed by name
-through the link's properties.
+**params** - Object, Route parameters to add to the link.  Access route
+parameters in your route handler with `this.props.params`.
+
+**[param]** - As an alternative to the params prop, route params can be
+passed as separate props where the prop name matches the route param name.
 
 #### Example
 

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -14,6 +14,7 @@ var RESERVED_PROPS = {
   className: true,
   activeClassName: true,
   query: true,
+  params: true,
   children: true // ReactChildren
 };
 
@@ -27,7 +28,7 @@ var RESERVED_PROPS = {
  *   <Route name="showPost" path="/posts/:postId" handler={Post}/>
  *
  * You could use the following component to link to that route:
- * 
+ *
  *   <Link to="showPost" postId="123"/>
  *
  * In addition to params, links may pass along query string parameters
@@ -71,7 +72,7 @@ var Link = React.createClass({
    * Returns a hash of URL parameters to use in this <Link>'s path.
    */
   getParams: function () {
-    return Link.getUnreservedProps(this.props);
+    return this.props.params || Link.getUnreservedProps(this.props);
   },
 
   /**


### PR DESCRIPTION
This change allows a params prop to be passed to the Link component as an alternative to passing a separate prop for each route param.  Although you could achieve the same result using transferPropsTo, doing so will also transfer extraneous props that aren't route params, causing isActive to return false when it should return true.
