### PR TITLE
Fix middle click on Links

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -109,7 +109,7 @@ var Link = React.createClass({
   },
 
   handleClick: function (event) {
-    if (isModifiedEvent(event))
+    if (isModifiedEvent(event) || isMiddleClick(event))
       return;
 
     event.preventDefault();
@@ -128,6 +128,10 @@ var Link = React.createClass({
   }
 
 });
+
+function isMiddleClick(event) {
+  return event.button === 1;
+}
 
 function isModifiedEvent(event) {
   return !!(event.metaKey || event.ctrlKey || event.shiftKey);


### PR DESCRIPTION
Restore the de facto browser behavior for middle click on links: Open to
background tab.
