### PR TITLE
eslint cleanup; trailing comma fix for IE

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -12,6 +12,7 @@
     "no-use-before-define": 0,
     "no-cond-assign": 0,
     "consistent-return": 0,
-    "new-cap": 0
+    "new-cap": 0,
+    "no-unused-vars": 0
   }
 }

--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -422,7 +422,7 @@ function checkTransitionFromHooks(matches, transition) {
 function checkTransitionToHooks(matches, transition) {
   var promise = Promise.resolve();
 
-  matches.forEach(function (match) {
+  matches.forEach(function (match, index) {
     promise = promise.then(function () {
       var handler = match.route.props.handler;
 

--- a/modules/stores/RouteStore.js
+++ b/modules/stores/RouteStore.js
@@ -71,7 +71,7 @@ var RouteStore = {
     if (route.props.name)
       delete _namedRoutes[route.props.name];
 
-    React.Children.forEach(route.props.children, function () {
+    React.Children.forEach(route.props.children, function (child) {
       RouteStore.unregisterRoute(route);
     });
   },


### PR DESCRIPTION
- Removed unused variables
- Removed double declarations
- Most importantly, removed trailing comma which was breaking IE
- Added eslint.json for future eslint usage
