### PR TITLE
Fixing error in updated example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Usage
 -----
 
 ```
+var Routes = require('react-router').Routes;
 var Route = require('react-router').Route;
 
 React.renderComponent((


### PR DESCRIPTION
The new example would throw an error because `Routes` is undefined.

It might be neater to use the new style with React 0.11.x in the examples, not sure how you feel about that. e.g.

```
var Router = require('react-router');
React.renderComponent((
  <Router.Routes>
```

...etc.
