### PR TITLE
[added] preserveScrollPosition Route/Routes props

### DIFF
--- a/docs/api/components/Route.md
+++ b/docs/api/components/Route.md
@@ -23,6 +23,12 @@ inherit the path of their parent.
 
 The component to be rendered when the route is active.
 
+### `preserveScrollPosition`
+
+If `true`, the router will not scroll the window up when the route is
+transitioned to. Defaults to `false`. Ignored if the parent `<Routes/>`
+has been set to `true`.
+
 ### `children`
 
 Routes can be nested. When a child route matches, the parent route's

--- a/docs/api/components/Routes.md
+++ b/docs/api/components/Routes.md
@@ -17,8 +17,15 @@ works without a server, if you use `history` your server will need to
 support it.
 
 For browsers that don't support the HTML5 history API the router will
-fall back to `window.location` if you choose `history`. This way all
-users get the same urls and can share them.
+fall back to `window.location` if you choose `history`, in other words,
+the router will simply cause a full page reload. This way all users get
+the same urls and can share them.
+
+### `preserveScrollPosition`
+
+If `true`, the router will not scroll the window up globally when any
+route is transitioned to. Defaults to `false`. When `false`, the
+`<Route/>` gets to decide whether or not to scroll on transition.
 
 Example
 -------

--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -72,10 +72,17 @@ var Route = React.createClass({
 
   },
 
+  getDefaultProps: function() {
+    return {
+      preserveScrollPosition: false
+    };
+  },
+
   propTypes: {
     handler: React.PropTypes.any.isRequired,
     path: React.PropTypes.string,
-    name: React.PropTypes.string
+    name: React.PropTypes.string,
+    preserveScrollPosition: React.PropTypes.bool
   },
 
   render: function () {

--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -54,11 +54,13 @@ var Routes = React.createClass({
 
   propTypes: {
     location: React.PropTypes.oneOf([ 'hash', 'history' ]).isRequired,
+    preserveScrollPosition: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
     return {
-      location: 'hash'
+      location: 'hash',
+      preserveScrollPosition: false
     };
   },
 
@@ -339,6 +341,8 @@ function syncWithTransition(routes, transition) {
         })
       };
 
+      // TODO: add functional test
+      maybeScrollWindow(routes, toMatches[toMatches.length - 1]);
       routes.setState(state);
 
       return state;
@@ -434,6 +438,16 @@ function returnNull() {
 
 function reversedArray(array) {
   return array.slice(0).reverse();
+}
+
+function maybeScrollWindow(routes, match) {
+  if (routes.props.preserveScrollPosition)
+    return;
+
+  if (!match || match.route.props.preserveScrollPosition)
+    return;
+
+  window.scrollTo(0, 0);
 }
 
 module.exports = Routes;


### PR DESCRIPTION
When a page’s content is long and you transition
to a new route, the scroll position persists
and its super dumb.

This mixin goes on a route handler that you know
has long content and scrolls the window up when
you leave the page.

Not a bad idea to put this on every route handler

closes #121
