### PR TITLE
[docs] `routeName` or `routeNameOrPath` in Router interface?

### DIFF
--- a/docs/api/Router.md
+++ b/docs/api/Router.md
@@ -27,7 +27,7 @@ Router.transitionTo('about');
 Router.transitionTo('/users/10?showAge=true');
 ```
 
-### `replaceWith(routeName, [params[, query]])`
+### `replaceWith(routeNameOrPath, [params[, query]])`
 
 Programatically replace current route with a new route. Does not add an
 entry into the browser history.


### PR DESCRIPTION
Router should be injectable to be usably on client or server differently.
This var name difference in docs can be interpreted as more separate methods in behavior.
