### PR TITLE
[added] onActiveStateChange, onCancelledTransition, onTransitionError Routes props

### DIFF
--- a/specs/Route.spec.js
+++ b/specs/Route.spec.js
@@ -1,6 +1,7 @@
 require('./helper');
 var Route = require('../modules/components/Route');
 var Routes = require('../modules/components/Routes');
+var URLStore = require('../modules/stores/URLStore');
 
 var App = React.createClass({
   displayName: 'App',
@@ -9,113 +10,122 @@ var App = React.createClass({
   }
 });
 
-describe('a Route that matches a URL', function () {
-  it('returns an array', function () {
-    var routes = renderComponent(
-      Routes(null,
-        Route({ handler: App },
-          Route({ path: '/a/b/c', handler: App })
-        )
-      )
-    );
+describe('Route', function() {
 
-    var matches = routes.match('/a/b/c');
-    assert(matches);
-    expect(matches.length).toEqual(2);
-
-    var rootMatch = getRootMatch(matches);
-    expect(rootMatch.params).toEqual({});
-
-    removeComponent(routes);
+  afterEach(function() {
+    URLStore.teardown();
+    window.location.hash = '';
   });
 
-  describe('that contains dynamic segments', function () {
-    it('returns an array with the correct params', function () {
+  describe('a Route that matches a URL', function () {
+    it('returns an array', function () {
       var routes = renderComponent(
         Routes(null,
           Route({ handler: App },
-            Route({ path: '/posts/:id/edit', handler: App })
+            Route({ path: '/a/b/c', handler: App })
           )
         )
       );
 
-      var matches = routes.match('/posts/abc/edit');
+      var matches = routes.match('/a/b/c');
       assert(matches);
       expect(matches.length).toEqual(2);
 
       var rootMatch = getRootMatch(matches);
-      expect(rootMatch.params).toEqual({ id: 'abc' });
+      expect(rootMatch.params).toEqual({});
 
-      removeComponent(routes);
+      // this causes tests to fail, no clue why ...
+      //removeComponent(routes);
+    });
+
+    describe('that contains dynamic segments', function () {
+      it('returns an array with the correct params', function () {
+        var routes = renderComponent(
+          Routes(null,
+            Route({ handler: App },
+              Route({ path: '/posts/:id/edit', handler: App })
+            )
+          )
+        );
+
+        var matches = routes.match('/posts/abc/edit');
+        assert(matches);
+        expect(matches.length).toEqual(2);
+
+        var rootMatch = getRootMatch(matches);
+        expect(rootMatch.params).toEqual({ id: 'abc' });
+
+        //removeComponent(routes);
+      });
     });
   });
-});
 
-describe('a Route that does not match the URL', function () {
-  it('returns null', function () {
-    var routes = renderComponent(
-      Routes(null,
-        Route({ handler: App },
-          Route({ path: '/a/b/c', handler: App })
-        )
-      )
-    );
-
-    expect(routes.match('/not-found')).toBe(null);
-
-    removeComponent(routes);
-  });
-});
-
-describe('a nested Route that matches the URL', function () {
-  it('returns the appropriate params for each match', function () {
-    var routes = renderComponent(
-      Routes(null,
-        Route({ handler: App },
-          Route({ name: 'posts', path: '/posts/:id', handler: App },
-            Route({ name: 'comment', path: '/posts/:id/comments/:commentId', handler: App })
+  describe('a Route that does not match the URL', function () {
+    it('returns null', function () {
+      var routes = renderComponent(
+        Routes(null,
+          Route({ handler: App },
+            Route({ path: '/a/b/c', handler: App })
           )
         )
-      )
-    );
+      );
 
-    var matches = routes.match('/posts/abc/comments/123');
-    assert(matches);
-    expect(matches.length).toEqual(3);
+      expect(routes.match('/not-found')).toBe(null);
 
-    var rootMatch = getRootMatch(matches);
-    expect(rootMatch.route.props.name).toEqual('comment');
-    expect(rootMatch.params).toEqual({ id: 'abc', commentId: '123' });
-
-    var postsMatch = matches[1];
-    expect(postsMatch.route.props.name).toEqual('posts');
-    expect(postsMatch.params).toEqual({ id: 'abc' });
-
-    removeComponent(routes);
+      //removeComponent(routes);
+    });
   });
-});
 
-describe('multiple nested Router that match the URL', function () {
-  it('returns the first one in the subtree, depth-first', function () {
-    var routes = renderComponent(
-      Routes(null,
-        Route({ handler: App },
-          Route({ path: '/a', handler: App },
-            Route({ path: '/a/b', name: 'expected', handler: App })
-          ),
-          Route({ path: '/a/b', handler: App })
+  describe('a nested Route that matches the URL', function () {
+    it('returns the appropriate params for each match', function () {
+      var routes = renderComponent(
+        Routes(null,
+          Route({ handler: App },
+            Route({ name: 'posts', path: '/posts/:id', handler: App },
+              Route({ name: 'comment', path: '/posts/:id/comments/:commentId', handler: App })
+            )
+          )
         )
-      )
-    );
+      );
 
-    var matches = routes.match('/a/b');
-    assert(matches);
-    expect(matches.length).toEqual(3);
+      var matches = routes.match('/posts/abc/comments/123');
+      assert(matches);
+      expect(matches.length).toEqual(3);
 
-    var rootMatch = getRootMatch(matches);
-    expect(rootMatch.route.props.name).toEqual('expected');
+      var rootMatch = getRootMatch(matches);
+      expect(rootMatch.route.props.name).toEqual('comment');
+      expect(rootMatch.params).toEqual({ id: 'abc', commentId: '123' });
 
-    removeComponent(routes);
+      var postsMatch = matches[1];
+      expect(postsMatch.route.props.name).toEqual('posts');
+      expect(postsMatch.params).toEqual({ id: 'abc' });
+
+      //removeComponent(routes);
+    });
+  });
+
+  describe('multiple nested Router that match the URL', function () {
+    it('returns the first one in the subtree, depth-first', function () {
+      var routes = renderComponent(
+        Routes(null,
+          Route({ handler: App },
+            Route({ path: '/a', handler: App },
+              Route({ path: '/a/b', name: 'expected', handler: App })
+            ),
+            Route({ path: '/a/b', handler: App })
+          )
+        )
+      );
+
+      var matches = routes.match('/a/b');
+      assert(matches);
+      expect(matches.length).toEqual(3);
+
+      var rootMatch = getRootMatch(matches);
+      expect(rootMatch.route.props.name).toEqual('expected');
+
+      //removeComponent(routes);
+    });
   });
 });
 

--- a/specs/Routes.spec.js
+++ b/specs/Routes.spec.js
@@ -1,0 +1,90 @@
+require('./helper');
+var URLStore = require('../modules/stores/URLStore');
+var Route = require('../modules/components/Route');
+var Routes = require('../modules/components/Routes');
+
+describe('Routes', function() {
+
+  afterEach(function() {
+    URLStore.teardown();
+    window.location.hash = '';
+  });
+
+  describe('a change in active state', function () {
+    it('triggers onActiveStateChange', function (done) {
+      var App = React.createClass({
+        render: function () {
+          return React.DOM.div();
+        }
+      });
+
+      function handleActiveStateChange(state) {
+        assert(state);
+        removeComponent(routes);
+        done();
+      }
+
+      var routes = renderComponent(
+        Routes({ onActiveStateChange: handleActiveStateChange },
+          Route({ handler: App })
+        )
+      );
+    });
+  });
+
+  describe('a cancelled transition', function () {
+    it('triggers onCancelledTransition', function (done) {
+      var App = React.createClass({
+        statics: {
+          willTransitionTo: function (transition) {
+            transition.abort();
+          }
+        },
+        render: function () {
+          return React.DOM.div();
+        }
+      });
+
+      function handleCancelledTransition(transition) {
+        assert(transition);
+        removeComponent(routes);
+        done();
+      }
+
+      var routes = renderComponent(
+        Routes({ onCancelledTransition: handleCancelledTransition },
+          Route({ handler: App })
+        )
+      );
+    });
+  });
+
+  describe('an error in a transition hook', function () {
+    it('triggers onTransitionError', function (done) {
+      var App = React.createClass({
+        statics: {
+          willTransitionTo: function (transition) {
+            throw new Error('boom!');
+          }
+        },
+        render: function () {
+          return React.DOM.div();
+        }
+      });
+
+      function handleTransitionError(error) {
+        assert(error);
+        expect(error.message).toEqual('boom!');
+        removeComponent(routes);
+        done();
+      }
+
+      var routes = renderComponent(
+        Routes({ onTransitionError: handleTransitionError },
+          Route({ handler: App })
+        )
+      );
+    });
+  });
+
+});

--- a/specs/main.js
+++ b/specs/main.js
@@ -5,4 +5,5 @@ require('./AsyncState.spec.js');
 require('./Path.spec.js');
 require('./PathStore.spec.js');
 require('./Route.spec.js');
+require('./Routes.spec.js');
 require('./RouteStore.spec.js');


### PR DESCRIPTION
Also, removed Routes.handleAsyncError and Routes.handleCancelledTransition.

This PR exposes these handlers as props so they can be overridden by users. The `onTransitionError` prop is especially useful since it permits users to attach their own error handlers instead of using the default error handler that just `throw`s (see #151).

I've written tests for these new features that all pass when I run them alone. However, when I run `npm test` locally there are 3 failing tests, but I'm not convinced that any of them have to do with my changes. I've digged around quite a bit but can't figure out what's going on in the DOM while the tests are running.

@rpflorence Since you're more experienced with karma than I am (and writing DOM tests in general) I thought you might be able to take a look?
