### PR TITLE
[changed] handlers receive route name

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -8,7 +8,6 @@ var withoutProperties = require('../helpers/withoutProperties');
  */
 var RESERVED_PROPS = {
   handler: true,
-  name: true,
   path: true,
   children: true // ReactChildren
 };


### PR DESCRIPTION
There are a lot of requests to introspect in handlers on the route name. We transfer other "static" props to the handler, why not `name`?

Some requests:  #150, #119.

Use cases:
- single handler for multiple routes can branch on name
- introspection in general allows for building convention in an app
- bread crumbs
- managing document title

But really, best argument for passing it down to the handler is that we pass other props down and there is no harm in the handler knowing the name of the route its handling.

If we don't pass it in, then people can/will just do this instead:

``` xml
<Route name="someName" gimmeabreak="someName"/>
```
