### PR TITLE
[fixed] Navigation to root URL can fail

### DIFF
--- a/modules/stores/URLStore.js
+++ b/modules/stores/URLStore.js
@@ -58,10 +58,10 @@ var URLStore = {
   getCurrentPath: function () {
     if (_location === 'history')
       return getWindowPath();
-    
+
     if (_location === 'hash')
       return window.location.hash.substr(1);
-    
+
     return _currentPath;
   },
 
@@ -69,7 +69,7 @@ var URLStore = {
    * Pushes the given path onto the browser navigation stack.
    */
   push: function (path) {
-    if (path === _currentPath)
+    if (path === this.getCurrentPath())
       return;
 
     if (_location === 'disabledHistory')
@@ -193,6 +193,7 @@ var URLStore = {
     }
 
     _location = null;
+    _currentPath = '/';
   }
 
 };

--- a/specs/URLStore.spec.js
+++ b/specs/URLStore.spec.js
@@ -56,3 +56,26 @@ describe('when going back in history', function () {
     expect(error).toEqual(true);
   });
 });
+
+describe('when navigating back to the root', function() {
+  beforeEach(function () {
+    // not all tests are constructing and tearing down the URLStore.
+    // Let's set it up correctly once and then tear it down to ensure that all
+    // variables in the URLStore module are reset.
+    URLStore.setup('hash');
+    URLStore.teardown();
+
+    // simulating that the browser opens a page with #/dashboard
+    window.location.hash = '/dashboard';
+    URLStore.setup('hash');
+  });
+
+  afterEach(function () {
+    URLStore.teardown();
+  });
+
+  it('should have the correct path', function () {
+    URLStore.push('/');
+    expect(window.location.hash).toEqual('#/');
+  });
+});


### PR DESCRIPTION
Navigation to root URL can fail when the URLStore is setup with
location strategy 'hash'. This happens because URLStore.push
verifies the current path. Unfortunately the used currentPath is
not valid for the location strategies _hash_ and _history_.

This change changes URLStore.push so that it uses the location
strategy specific current path. This value is already provided
by URLStore.getCurrentPath.
