### PR TITLE
Changing function param doesn't do nothin

### DIFF
--- a/modules/stores/URLStore.js
+++ b/modules/stores/URLStore.js
@@ -56,7 +56,7 @@ var URLStore = {
    * Returns the value of the current URL path.
    */
   getCurrentPath: function () {
-    if (_location === 'history')
+    if (_location === 'history' || _location === 'disabledHistory')
       return getWindowPath();
 
     if (_location === 'hash')


### PR DESCRIPTION
Looks to be a simple typo in assigning the "disabledHistory" value... it was never being assigned correctly before, and non-history browsers weren't actually showing anything.
