### PR TITLE
[added] pluggable history implementations

### DIFF
--- a/Location.js
+++ b/Location.js
@@ -1,0 +1,1 @@
+module.exports = require('./modules/helpers/Location');

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ exports.AsyncState = require('./AsyncState');
 exports.Link = require('./Link');
 exports.Route = require('./Route');
 exports.Routes = require('./Routes');
+exports.Location = require('./Location');
 exports.goBack = require('./goBack');
 exports.replaceWith = require('./replaceWith');
 exports.transitionTo = require('./transitionTo');

--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -5,6 +5,7 @@ var mergeProperties = require('../helpers/mergeProperties');
 var goBack = require('../helpers/goBack');
 var replaceWith = require('../helpers/replaceWith');
 var transitionTo = require('../helpers/transitionTo');
+var Location = require('../helpers/Location');
 var Route = require('../components/Route');
 var Path = require('../helpers/Path');
 var ActiveStore = require('../stores/ActiveStore');
@@ -53,7 +54,14 @@ var Routes = React.createClass({
   },
 
   propTypes: {
-    location: React.PropTypes.oneOf([ 'hash', 'history' ]).isRequired,
+    location: function(props, propName, componentName) {
+      var location = props[propName];
+      if (!Location[location]) {
+        return new Error('No matching location: "' + location +
+          '".  Must be one of: ' + Object.keys(Location) +
+          '. See: ' + componentName);
+      }
+    }
   },
 
   getDefaultProps: function () {

--- a/modules/helpers/DisabledLocation.js
+++ b/modules/helpers/DisabledLocation.js
@@ -1,0 +1,34 @@
+var getWindowPath = require('./getWindowPath');
+
+/**
+ * Location handler that doesn't actually do any location handling.  Instead, requests
+ * are sent to the server as normal.
+ */
+var DisabledLocation = {
+
+  type: 'disabled',
+
+  init: function() { },
+
+  destroy: function() { },
+
+  getCurrentPath: function() {
+    return getWindowPath();
+  },
+
+  push: function(path) {
+    window.location = path;
+  },
+
+  replace: function(path) {
+    window.location.replace(path);
+  },
+
+  back: function() {
+    window.history.back();
+  }
+
+};
+
+module.exports = DisabledLocation;
+

--- a/modules/helpers/HashLocation.js
+++ b/modules/helpers/HashLocation.js
@@ -1,0 +1,60 @@
+var getWindowPath = require('./getWindowPath');
+
+function getWindowChangeEvent() {
+  return window.addEventListener ? 'hashchange' : 'onhashchange';
+}
+
+/**
+ * Location handler which uses the `window.location.hash` to push and replace URLs
+ */
+var HashLocation = {
+
+  type: 'hash',
+  onChange: null,
+
+  init: function(onChange) {
+    var changeEvent = getWindowChangeEvent();
+
+    if (window.location.hash === '') {
+      this.replace('/');
+    }
+
+    if (window.addEventListener) {
+      window.addEventListener(changeEvent, onChange, false);
+    } else {
+      window.attachEvent(changeEvent, onChange);
+    }
+
+    this.onChange = onChange;
+    onChange();
+  },
+
+  destroy: function() {
+    var changeEvent = getWindowChangeEvent();
+    if (window.removeEventListener) {
+      window.removeEventListener(changeEvent, this.onChange, false);
+    } else {
+      window.detachEvent(changeEvent, this.onChange);
+    }
+  },
+
+  getCurrentPath: function() {
+    return window.location.hash.substr(1);
+  },
+
+  push: function(path) {
+    window.location.hash = path;
+  },
+
+  replace: function(path) {
+    window.location.replace(getWindowPath() + '#' + path);
+  },
+
+  back: function() {
+    window.history.back();
+  }
+
+};
+
+module.exports = HashLocation;
+

--- a/modules/helpers/HistoryLocation.js
+++ b/modules/helpers/HistoryLocation.js
@@ -1,0 +1,50 @@
+var getWindowPath = require('./getWindowPath');
+
+/**
+ * Location handler which uses the HTML5 History API to push and replace URLs
+ */
+var HistoryLocation = {
+
+  type: 'history',
+  onChange: null,
+
+  init: function(onChange) {
+    if (window.addEventListener) {
+      window.addEventListener('popstate', onChange, false);
+    } else {
+      window.attachEvent('popstate', onChange);
+    }
+    this.onChange = onChange;
+    onChange();
+  },
+
+  destroy: function() {
+    if (window.removeEventListener) {
+      window.removeEventListener('popstate', this.onChange, false);
+    } else {
+      window.detachEvent('popstate', this.onChange);
+    }
+  },
+
+  getCurrentPath: function() {
+    return getWindowPath();
+  },
+
+  push: function(path) {
+    window.history.pushState({ path: path }, '', path);
+    this.onChange();
+  },
+
+  replace: function(path) {
+    window.history.replaceState({ path: path }, '', path);
+    this.onChange();
+  },
+
+  back: function() {
+    window.history.back();
+  }
+
+};
+
+module.exports = HistoryLocation;
+

--- a/modules/helpers/Location.js
+++ b/modules/helpers/Location.js
@@ -1,0 +1,10 @@
+/**
+ * Map of location type to handler.
+ * @see Routes#location
+ */
+module.exports = {
+  hash: require('./HashLocation'),
+  history: require('./HistoryLocation'),
+  disabled: require('./DisabledLocation'),
+  memory: require('./MemoryLocation')
+};

--- a/modules/helpers/MemoryLocation.js
+++ b/modules/helpers/MemoryLocation.js
@@ -1,0 +1,53 @@
+var invariant = require('react/lib/invariant');
+
+var _lastPath;
+var _currentPath = '/';
+
+/**
+ * Fake location handler that can be used outside the scope of the browser.  It
+ * tracks the current and previous path, as given to #push() and #replace().
+ */
+var MemoryLocation = {
+
+  type: 'memory',
+  onChange: null,
+
+  init: function(onChange) {
+    this.onChange = onChange;
+  },
+
+  destroy: function() {
+    this.onChange = null;
+    _lastPath = null;
+    _currentPath = '/';
+  },
+
+  getCurrentPath: function() {
+    return _currentPath;
+  },
+
+  push: function(path) {
+    _lastPath = _currentPath;
+    _currentPath = path;
+    this.onChange();
+  },
+
+  replace: function(path) {
+    _currentPath = path;
+    this.onChange();
+  },
+
+  back: function() {
+    invariant(
+      _lastPath,
+      'You cannot make the URL store go back more than once when it does not use the DOM'
+    );
+
+    _currentPath = _lastPath;
+    _lastPath = null;
+    this.onChange();
+  }
+};
+
+module.exports = MemoryLocation;
+

--- a/modules/helpers/getWindowPath.js
+++ b/modules/helpers/getWindowPath.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the current URL path from `window.location`, including query string
+ */
+function getWindowPath() {
+  return window.location.pathname + window.location.search;
+}
+
+module.exports = getWindowPath;
+

--- a/specs/URLStore.spec.js
+++ b/specs/URLStore.spec.js
@@ -1,81 +1,101 @@
 require('./helper');
 var URLStore = require('../modules/stores/URLStore');
 
-describe('when a new path is pushed to the URL', function () {
-  beforeEach(function () {
-    URLStore.push('/a/b/c');
+describe('URLStore', function() {
+
+  beforeEach(function() {
+    URLStore.setup("hash");
   });
 
-  afterEach(function () {
+  afterEach(function() {
     URLStore.teardown();
   });
 
-  it('has the correct path', function () {
-    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
-  });
-});
+  describe('when a new path is pushed to the URL', function() {
+    beforeEach(function() {
+      URLStore.push('/a/b/c');
+    });
 
-describe('when a new path is used to replace the URL', function () {
-  beforeEach(function () {
-    URLStore.replace('/a/b/c');
-  });
-
-  afterEach(function () {
-    URLStore.teardown();
+    it('has the correct path', function() {
+      expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+    });
   });
 
-  it('has the correct path', function () {
-    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
-  });
-});
+  describe('when a new path is used to replace the URL', function() {
+    beforeEach(function() {
+      URLStore.replace('/a/b/c');
+    });
 
-describe('when going back in history', function () {
-  afterEach(function () {
-    URLStore.teardown();
-  });
-
-  it('has the correct path', function () {
-    URLStore.push('/a/b/c');
-    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
-
-    URLStore.push('/d/e/f');
-    expect(URLStore.getCurrentPath()).toEqual('/d/e/f');
-
-    URLStore.back();
-    expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+    it('has the correct path', function() {
+      expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+    });
   });
 
-  it('should not go back before recorded history', function () {
-    var error = false;
-    try {
+  describe('when going back in history', function() {
+    it('has the correct path', function() {
+      URLStore.push('/a/b/c');
+      expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+
+      URLStore.push('/d/e/f');
+      expect(URLStore.getCurrentPath()).toEqual('/d/e/f');
+
       URLStore.back();
-    } catch (e) {
-      error = true;
-    }
-
-    expect(error).toEqual(true);
+      expect(URLStore.getCurrentPath()).toEqual('/a/b/c');
+    });
   });
+
+  describe('when navigating back to the root', function() {
+    beforeEach(function() {
+      URLStore.teardown();
+
+      // simulating that the browser opens a page with #/dashboard
+      window.location.hash = '/dashboard';
+      URLStore.setup('hash');
+    });
+
+    it('should have the correct path', function() {
+      URLStore.push('/');
+      expect(window.location.hash).toEqual('#/');
+    });
+  });
+
+  describe('when using history location handler', function() {
+    itShouldManagePathsForLocation('history');
+  });
+
+  describe('when using memory location handler', function() {
+    itShouldManagePathsForLocation('memory');
+  });
+
+  function itShouldManagePathsForLocation(location) {
+    var origPath;
+
+    beforeEach(function() {
+      URLStore.teardown();
+      URLStore.setup(location);
+      origPath = URLStore.getCurrentPath();
+    });
+
+    afterEach(function() {
+      URLStore.push(origPath);
+      expect(URLStore.getCurrentPath()).toEqual(origPath);
+    });
+
+    it('should manage the path correctly', function() {
+      URLStore.push('/test');
+      expect(URLStore.getCurrentPath()).toEqual('/test');
+
+      URLStore.push('/test/123');
+      expect(URLStore.getCurrentPath()).toEqual('/test/123');
+
+      URLStore.replace('/test/replaced');
+      expect(URLStore.getCurrentPath()).toEqual('/test/replaced');
+
+      URLStore.back();
+      expect(URLStore.getCurrentPath()).toEqual('/test');
+
+    });
+  }
+
 });
 
-describe('when navigating back to the root', function() {
-  beforeEach(function () {
-    // not all tests are constructing and tearing down the URLStore.
-    // Let's set it up correctly once and then tear it down to ensure that all
-    // variables in the URLStore module are reset.
-    URLStore.setup('hash');
-    URLStore.teardown();
-
-    // simulating that the browser opens a page with #/dashboard
-    window.location.hash = '/dashboard';
-    URLStore.setup('hash');
-  });
-
-  afterEach(function () {
-    URLStore.teardown();
-  });
-
-  it('should have the correct path', function () {
-    URLStore.push('/');
-    expect(window.location.hash).toEqual('#/');
-  });
-});


### PR DESCRIPTION
Mostly just cut/paste code into various locations handlers.  A nice side-effect is that we could use the `memoryHandler` for rendering on the server-side I would imagine.  Just need to support passing in the `currentPath` somehow.

All tests should be passing.  As @mjackson warned me, I did have some trouble with the tests, but they should all be passing now, and I think the coverage isn't too bad.

This location handler API will make it easy to plug in HistoryJS support now.

closes #166
