### PR TITLE
[added] stopPropagation prop to <Link />

### DIFF
--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -27,6 +27,13 @@ name through the link's properties to the resulting url.
 The className a `Link` receives when it's route is active. Defaults to
 `active`.
 
+### `stopPropagation`
+
+If set, the click handler for the link will call
+[`event.stopPropagation`][stopPropagation] on the click event.
+
+[stopPropagation]:https://developer.mozilla.org/en-US/docs/Web/API/event.stopPropagation
+
 Example
 -------
 

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -52,7 +52,8 @@ var Link = React.createClass({
   propTypes: {
     to: React.PropTypes.string.isRequired,
     activeClassName: React.PropTypes.string.isRequired,
-    query: React.PropTypes.object
+    query: React.PropTypes.object,
+    stopPropagation: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -111,6 +112,10 @@ var Link = React.createClass({
   handleClick: function (event) {
     if (isModifiedEvent(event) || !isLeftClick(event))
       return;
+
+    if (this.props.stopPropagation) {
+      event.stopPropagation();
+    }
 
     event.preventDefault();
 


### PR DESCRIPTION
When `stopPropagation` is set, `event.stopPropagation()` will be called in the `<Link />`'s click handler.

I didn't add tests for this because I didn't see any for `<Link/>` yet; LMK if they're needed.
