### PR TITLE
[added] Router.renderRoutesToString

### DIFF
--- a/docs/api/Router.md
+++ b/docs/api/Router.md
@@ -63,3 +63,64 @@ need to build components similar to `Link`.
 <Route name="user" path="users/:userId"/>
 Router.makeHref('user', {userId: 123}); // "users/123"
 ```
+
+### `renderRoutesToString(routes, path)`
+
+* `routes` is the `<Routes/>` component
+* `path` is the full path with query string
+
+Returns a Promise resolving with a `data` object:
+
+```js
+{
+	html: string
+}
+```
+
+* `html` is the string returned from React.renderComponentToString
+
+The Promise may reject with an error. If this error has a `httpStatus`
+302 and `location` it should be sent to the client for redirect.
+
+#### Example
+
+```js
+Router.renderRoutesToString(routes, path).then(function (data) {
+  //merge a template with `data.html`
+
+  res.send(html);
+
+}).catch(function (error){
+  //if error is from a `<Redirect />` route.
+  if (error.httpStatus == 302) {
+    return res.redirect(error.location);
+  }
+
+  //else pass error to server error handler.
+  res.send(error);
+});
+```
+
+### `renderRoutesToStaticMarkup(routes, path)`
+
+Same as `renderRoutesToString` except it uses 
+`React.renderComponentToStaticMarkup`.
+However, the resulting `data.html` will not contain the `initalData` 
+to be sent to the client.
+
+```js
+Router.renderRoutesToStaticMarkup(routes, path).then(function (data) {
+  //merge a template with `data.html`
+
+  res.send(html);
+
+}).catch(function (error){
+  //if error is from a `<Redirect />` route.
+  if (error.httpStatus == 302) {
+    return res.redirect(error.location);
+  }
+
+  //else pass error to server error handler.
+  res.send(error);
+});
+```

--- a/index.js
+++ b/index.js
@@ -9,3 +9,5 @@ exports.goBack = require('./goBack');
 exports.replaceWith = require('./replaceWith');
 exports.transitionTo = require('./transitionTo');
 exports.makeHref = require('./makeHref');
+exports.renderRoutesToString = require('./renderRoutesToString');
+exports.renderRoutesToStaticMarkup = require('./renderRoutesToStaticMarkup');

--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -14,6 +14,7 @@ var RefreshLocation = require('../locations/RefreshLocation');
 var ActiveStore = require('../stores/ActiveStore');
 var PathStore = require('../stores/PathStore');
 var RouteStore = require('../stores/RouteStore');
+var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
 
 /**
  * The ref name that can be used to reference the active route component.
@@ -70,6 +71,11 @@ var Routes = React.createClass({
 
   displayName: 'Routes',
 
+  statics: {
+    findMatches: findMatches,
+    defaultAbortedTransitionHandler: defaultAbortedTransitionHandler
+  },
+
   propTypes: {
     onAbortedTransition: React.PropTypes.func.isRequired,
     onActiveStateChange: React.PropTypes.func.isRequired,
@@ -80,7 +86,9 @@ var Routes = React.createClass({
 
       if (typeof location === 'string' && !(location in NAMED_LOCATIONS))
         return new Error('Unknown location "' + location + '", see ' + componentName);
-    }
+    },
+    initialPath: React.PropTypes.string,
+    initialData: React.PropTypes.object
   },
 
   getDefaultProps: function () {
@@ -98,8 +106,6 @@ var Routes = React.createClass({
       routes: RouteStore.registerChildren(this.props.children, this)
     };
   },
-
-
   getLocation: function () {
     var location = this.props.location;
 
@@ -111,7 +117,34 @@ var Routes = React.createClass({
 
   componentWillMount: function () {
     PathStore.setup(this.getLocation());
-    PathStore.addChangeListener(this.handlePathChange);
+        
+    if (ExecutionEnvironment.canUseDOM) {
+      //if initial data from server - setState, else allow state to be set by this.dispatch
+      if (window.__ReactRouter_initialData)
+        this.setStateFromPath(PathStore.getCurrentPath(), window.__ReactRouter_initialData);
+      
+      PathStore.addChangeListener(this.handlePathChange);
+    } else {
+      this.setStateFromPath(this.props.initialPath, this.props.initialData || null);
+    }    
+  },
+
+  setStateFromPath: function (path, initialData) {
+    var matches = this.match(path);
+    var rootMatch = (matches && getRootMatch(matches)) || false;
+    var params = (rootMatch && rootMatch.params) || {};
+    var newState = {
+      initialData: initialData,
+      matches: matches,
+      path: path,
+      activeQuery: Path.extractQuery(path) || {},
+      activeParams: params,
+      activeRoutes: matches && matches.map(function (match) {
+        return match.route;
+      })
+    };
+    this.setState(newState);
+    this.props.onActiveStateChange(newState);
   },
 
   componentDidMount: function () {
@@ -179,6 +212,8 @@ var Routes = React.createClass({
       if (transition.isAborted) {
         routes.props.onAbortedTransition(transition);
       } else if (nextState) {
+        //remove initial data from state
+        nextState.initialData = undefined;
         routes.setState(nextState);
         routes.props.onActiveStateChange(nextState);
 
@@ -209,7 +244,21 @@ var Routes = React.createClass({
       return null;
 
     var matches = this.state.matches;
-    if (matches.length) {
+    if (matches && matches.length) {
+
+      for (var i=0; i<matches.length; i++) {
+        //clear all initial state data
+        matches[i].route.props.initialAsyncState = null;
+      }
+      //set initial data on matched routes.
+      if (this.state.initialData) {
+        for (var i=0; i<matches.length; i++) {
+          if (this.state.initialData[i]) {
+            matches[i].route.props.initialAsyncState = this.state.initialData[i];
+          }
+        }
+      }
+
       // matches[0] corresponds to the top-most match
       return matches[0].route.props.handler(computeHandlerProps(matches, this.state.activeQuery));
     } else {
@@ -221,6 +270,7 @@ var Routes = React.createClass({
 
 function findMatches(path, routes, defaultRoute) {
   var matches = null, route, params;
+  var query = Path.extractQuery(path) || {};
 
   for (var i = 0, len = routes.length; i < len; ++i) {
     route = routes[i];
@@ -257,7 +307,7 @@ function findMatches(path, routes, defaultRoute) {
   return matches;
 }
 
-function makeMatch(route, params) {
+function makeMatch(route, params, query) {
   return { route: route, params: params };
 }
 
@@ -276,7 +326,10 @@ function hasMatch(matches, match) {
 }
 
 function getRootMatch(matches) {
-  return matches[matches.length - 1];
+  if (matches)
+    return matches[matches.length - 1];
+
+  return false;
 }
 
 function updateMatchComponents(matches, refs) {

--- a/modules/helpers/renderRoutes.js
+++ b/modules/helpers/renderRoutes.js
@@ -1,0 +1,85 @@
+var React = require('react/addons');
+var ActiveStore = require('../stores/ActiveStore');
+var Path = require('../helpers/Path');
+var makePath = require('../helpers/makePath');
+var Transition = require('../helpers/Transition');
+var copyProperties = require('react/lib/copyProperties');
+var RouteStore = require('../stores/RouteStore');
+var PathStore = require('../stores/PathStore');
+var ServerLocation = require('../locations/ServerLocation');
+var Promise = require('es6-promise').Promise;
+var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
+
+var renderRoutes = function (routes, fullPath, staticMarkup) {
+
+  return new Promise(function (resolve, reject) {
+    var query = Path.extractQuery(fullPath) || {};
+    var initialData = {};
+    var promises = [];
+    var httpStatus = 200;
+
+    RouteStore.unregisterAllRoutes();
+    var registeredRoutes = RouteStore.registerChildren(routes.props.children, routes);
+    var matches = routes.constructor.findMatches(Path.withoutQuery(fullPath), registeredRoutes, routes.props.defaultRoute);
+
+    if (!matches) {
+      var error = new Error("Not route matched path.");
+      error.status = error.httpStatus = 404;
+      throw error;
+    }
+
+    if (matches.length) {
+      //Loop over all matches getInitalAsyncState and apply
+      promises = matches.map(function (match, i){
+        var handler = match.route.props.handler;
+
+        //check matches for redirect and httpStatus
+        if (handler.willTransitionTo) {
+          var transition = new Transition(fullPath);
+          handler.willTransitionTo(transition, match.params, query);
+          if (transition.isAborted) {            
+            //should throw and be caught by Promise
+            routes.constructor.defaultAbortedTransitionHandler(transition);
+          }
+        }
+        //getInitialAsyncState from AsyncState mixin
+        if (handler.getInitialAsyncState) {
+          return handler.getInitialAsyncState(match.params, query, function (state) {
+            initialData[i] = state;
+          });
+        }
+        return Promise.resolve(true);
+      });
+    }
+
+    Promise.all(promises).then(function () {
+
+      RouteStore.unregisterAllRoutes();
+
+      var newRoutes = React.addons.cloneWithProps(routes, {
+        location: ServerLocation,
+        initialPath: fullPath, 
+        initialData: initialData
+      });
+
+      var html;
+      if (!staticMarkup) {
+        var initialDataScript = '<script type="text/javascript">window.__ReactRouter_initialData=' + JSON.stringify(initialData) + ';<\/script>';
+        html = React.renderComponentToString(newRoutes) + initialDataScript;
+      } else {
+        html = React.renderComponentToStaticMarkup(newRoutes)
+      }
+
+      RouteStore.unregisterAllRoutes();
+
+      resolve({
+        html: html,
+        httpStatus: httpStatus,
+        status: httpStatus
+      });
+    }).catch(reject);
+
+  });
+};
+
+module.exports = renderRoutes;

--- a/modules/helpers/renderRoutesToStaticMarkup.js
+++ b/modules/helpers/renderRoutesToStaticMarkup.js
@@ -1,0 +1,7 @@
+var renderRoutes = require('./renderRoutes');
+
+var renderRoutesToStaticMarkup = function (routes, fullPath) {
+  return renderRoutes(routes, fullPath, true);
+};
+
+module.exports = renderRoutesToStaticMarkup;

--- a/modules/helpers/renderRoutesToString.js
+++ b/modules/helpers/renderRoutesToString.js
@@ -1,0 +1,7 @@
+var renderRoutes = require('./renderRoutes');
+
+var renderRoutesToString = function (routes, fullPath) {
+  return renderRoutes(routes, fullPath, false);
+};
+
+module.exports = renderRoutesToString;

--- a/modules/locations/ServerLocation.js
+++ b/modules/locations/ServerLocation.js
@@ -1,0 +1,39 @@
+var invariant = require('react/lib/invariant');
+var RouteStore = require('../stores/RouteStore');
+
+var _currentPath = '/';
+
+/**
+ * Location handler that does not require a DOM.
+ */
+var ServerLocation = {
+
+  push: function (path) {
+    RouteStore.unregisterAllRoutes();
+
+    var error = new Error("Redirect");
+    error.httpStatus = error.status = 302;
+    error.location = path;
+
+    throw error;
+  },
+
+  replace: function (path) {
+    ServerLocation.push(path);
+  },
+
+  pop: function () {
+    throw new Error('Cannot goBack on server');
+  },
+
+  getCurrentPath: function () {
+    return _currentPath;
+  },
+
+  toString: function () {
+    return '<ServerLocation>';
+  }
+
+};
+
+module.exports = ServerLocation;

--- a/modules/mixins/ActiveState.js
+++ b/modules/mixins/ActiveState.js
@@ -44,9 +44,7 @@ var ActiveState = {
 
   componentWillMount: function () {
     ActiveStore.addChangeListener(this.handleActiveStateChange);
-  },
-
-  componentDidMount: function () {
+    
     if (this.updateActiveState)
       this.updateActiveState();
   },

--- a/modules/mixins/AsyncState.js
+++ b/modules/mixins/AsyncState.js
@@ -85,7 +85,7 @@ var AsyncState = {
   },
 
   getInitialState: function () {
-    return this.props.initialAsyncState || null;
+    return this.props.initialAsyncState || {};
   },
 
   updateAsyncState: function (state) {

--- a/modules/stores/ActiveStore.js
+++ b/modules/stores/ActiveStore.js
@@ -1,3 +1,4 @@
+var ExecutionEnvironment = require('react/lib/ExecutionEnvironment');
 var EventEmitter = require('events').EventEmitter;
 
 var CHANGE_EVENT = 'change';
@@ -43,6 +44,9 @@ function queryIsActive(query) {
 var ActiveStore = {
 
   addChangeListener: function (listener) {
+    if (!ExecutionEnvironment.canUseDOM) 
+      return;
+    
     _events.on(CHANGE_EVENT, listener);
   },
 

--- a/modules/stores/RouteStore.js
+++ b/modules/stores/RouteStore.js
@@ -100,7 +100,7 @@ var RouteStore = {
     props.children = RouteStore.registerChildren(props.children, route);
 
     return route;
-  }
+  },
 
   /**
    * Registers many children routes at once, always returning an array.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "browserify": "4.2.3",
     "browserify-shim": "3.6.0",
     "bundle-loader": "0.5.0",
+    "cheerio": "^0.17.0",
     "envify": "1.2.0",
     "expect": "0.1.1",
+    "express": "^4.8.5",
     "jsx-loader": "0.10.2",
     "karma": "0.12.16",
     "karma-chrome-launcher": "0.1.4",
@@ -39,6 +41,7 @@
     "mocha": "1.20.1",
     "react": ">=0.11.0",
     "rf-release": "0.3.1",
+    "supertest": "^0.13.0",
     "uglify-js": "2.4.15",
     "webpack": "1.2.0-beta5",
     "webpack-dev-server": "1.4.2"

--- a/renderRoutesToStaticMarkup.js
+++ b/renderRoutesToStaticMarkup.js
@@ -1,0 +1,1 @@
+module.exports = require('./modules/helpers/renderRoutesToStaticMarkup');

--- a/renderRoutesToString.js
+++ b/renderRoutesToString.js
@@ -1,0 +1,1 @@
+module.exports = require('./modules/helpers/renderRoutesToString');

--- a/script/test
+++ b/script/test
@@ -1,3 +1,4 @@
 #!/bin/sh
 node_modules/.bin/karma start "$@"
+node_modules/.bin/mocha -R spec
 

--- a/test/renderToString.js
+++ b/test/renderToString.js
@@ -1,0 +1,155 @@
+var express = require('express');
+var request = require('supertest');
+var expect = require('expect');
+var cheerio = require('cheerio');
+
+var React = require('react');
+var Router = require('../index');
+var Routes = Router.Routes;
+var Route = Router.Route;
+var Redirect = Router.Redirect;
+var AsyncState = Router.AsyncState;
+var Promise = require('es6-promise').Promise;
+
+var App = React.createClass({
+	displayName: "App",
+	render: function () {
+		return this.props.activeRouteHandler();
+	}
+});
+
+var HelloWorld = React.createClass({
+	displayName: 'HelloWorld',
+	render: function () {
+		return React.DOM.div(null, "Hello World!");
+	}
+});
+
+var AsyncWorld = React.createClass({
+	displayName: 'AsyncWorld',
+	mixins:[AsyncState],
+	statics: {
+		getInitialAsyncState: function (params, query, setState){
+			return new Promise(function (resolve, reject) {
+				if (query.errorPlease) {
+					throw new Error("ok");
+				}
+				setTimeout(function(){
+					setState({
+						params:params,
+						query:query
+					});
+					resolve();
+				}, 10);
+			});
+		}
+	},
+	render: function () {
+		return React.DOM.div(null, this.state.params.name, this.state.query.page);
+	}
+});
+
+var CatchAll = React.createClass({
+	displayName: 'CatchAll',
+	render: function () {
+		return React.DOM.div(null, "CatchAll!");
+	}
+});
+
+var ErrorRoute = React.createClass({
+	displayName: 'ErrorRoute',
+	render: function () {
+		throw new Error("ErrorRoute");
+	}
+});
+
+describe("serverside rendering", function(){
+
+	var routes = Routes(null, 
+		Route({handler:App}, 
+			Route({name:'hello', handler: HelloWorld}),
+			Route({name:'async', path:"/async/:name", handler: AsyncWorld}),
+			Route({name:'error', handler: ErrorRoute}),
+			Redirect({from:"redirect", to:"hello"})
+		)
+	);
+
+	it("should render the HelloWorld component for the /hello path", function(done){
+		requestWithRoutes(routes).get('/hello')
+		.expect(200)
+		.end(function (err, res) {
+			var doc = cheerio.load(res.text);
+			expect(doc("div").html()).toBe("Hello World!");
+			done();
+		});
+	});
+
+	it("should redirect for <Redirect/> Route", function(done){
+		requestWithRoutes(routes).get('/redirect')
+		.expect(302)
+		.end(function (err, res) {
+			expect(res.header.location).toBe("/hello");
+			done();
+		});
+	});
+
+	it("should expect 404 for no matching Route", function(done){
+		requestWithRoutes(routes).get('/not-found')
+		.expect(404)
+		.end(done);
+	});
+
+	it("should expect 500 for error Route", function(done){
+		requestWithRoutes(routes).get('/error')
+		.expect(500)
+		.end(done);
+	});
+
+	it("should render the AsyncWorld component with initialData", function(done){
+		requestWithRoutes(routes).get('/async/hello?page=world')
+		.expect(200)
+		.end(function (err, res) {
+			var doc = cheerio.load(res.text);
+			expect(doc("script").html()).toBe('window.__ReactRouter_initialData={"1":{"params":{"name":"hello"},"query":{"page":"world"}}};');
+			done();
+		});
+	});
+
+	it("should expect 500 for error in AsyncWorld", function(done){
+		requestWithRoutes(routes).get('/async/hello?errorPlease=please')
+		.expect(500)
+		.end(function (err, res) {
+			done();
+		});
+	});
+
+});
+
+
+function requestWithRoutes (routes){
+	var app = express();
+
+	app.use(function (req, res, next) {
+		if (req.originalUrl == "/favicon.ico")
+			return next();
+
+		Router.renderRoutesToString(routes, req.originalUrl).then(function (data) {
+			var body = '<!DOCTYPE html><html><head><title>' + data.title + '</title></head><body>' + data.html + '</body></html>';
+			res.status(data && data.httpStatus || 200).send(body);
+
+		}).catch(function (err) {
+
+		    if (err.httpStatus == 302 && err.location) {
+		      return res.redirect(err.location);
+		    }
+
+		    if(err.httpStatus == 404){
+		    	return next();
+		    }
+
+			next(err);
+		});
+	});
+
+	return request(app);
+}


### PR DESCRIPTION
This PR allows the path to be given to <Routes> as a prop.

``` javascript
<Routes initialPath="/some/path"> ... </Routes>
```

This only works server side. This patch also stops the URLStore and RoutesStore being started as componentWillMount is called but componentWillUnmount isn't call on server side. This would lead to a memory leak and potential async issue when multiple pages are being rendered at once.

When rendering on server side you should always make a new instance of `<Routes>` so if multiple pages are being rendered they don't change the routes in another page.

``` javascript
var App = React.createClass({
  render: function(){
    return <Routes initialPath={this.props.initialPath} location="history"> ... </Routes>
  }
});

//server side
React.renderComponentToString(<App initialPath="/some/path" />);

//client side
React.renderCompoent(<App />, domelement);
```
