### PR TITLE
Add name to redirect route

### DIFF
--- a/modules/components/Redirect.js
+++ b/modules/components/Redirect.js
@@ -3,6 +3,7 @@ var Route = require('./Route');
 
 function Redirect(props) {
   return Route({
+    name: props.name,
     path: props.from,
     handler: createRedirectClass(props.to)
   });


### PR DESCRIPTION
This allows `<Redirect />` routes to be more transparently used as a `<Route />`.  This is especially helpful in a refactor situation where you change a route into a redirect, but you don't want to find and change all the `<Link />` in your app.
