### PR TITLE
Fixed #193 by allowing nested arrays of routes

### DIFF
--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -242,7 +242,20 @@ function Redirect(to, params, query) {
   this.query = query;
 }
 
-function findMatches(path, route) {
+function findMatches(path,route){
+  var matches = null;
+  if(Array.isArray(route)){
+    for (var i = 0, len = route.length; matches == null && i < len; ++i) {
+      matches = findMatches(path, route[i]);
+    }
+  }else {
+    matches = findMatchesForRoute(path,route);  
+  }
+  
+  return matches;
+}
+
+function findMatchesForRoute(path, route) {
   var children = route.props.children, matches;
   var params;
 


### PR DESCRIPTION
Unwinds incoming arrays to findMatches to allow a usage like this:

```
<Routes>
    {someRoutes}
    {someOtherRoutes}
    <Route name="start ... />
</Routes
```
