### PR TITLE
[added] manually choose the key of a Handler

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -9,7 +9,8 @@ var withoutProperties = require('../helpers/withoutProperties');
 var RESERVED_PROPS = {
   handler: true,
   path: true,
-  children: true // ReactChildren
+  children: true, // ReactChildren
+  routeString: true
 };
 
 /**

--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -438,6 +438,7 @@ function computeHandlerProps(matches, query) {
   var props = {
     ref: null,
     key: null,
+    routeString: null,
     params: null,
     query: null,
     activeRouteHandler: returnNull
@@ -450,7 +451,10 @@ function computeHandlerProps(matches, query) {
     props = Route.getUnreservedProps(route.props);
 
     props.ref = REF_NAME;
-    props.key = Path.injectParams(route.props.path, match.params);
+    props.routeString = Path.injectParams(route.props.path, match.params);
+    if (!props.key) {
+      props.key = props.routeString;
+    }
     props.params = match.params;
     props.query = query;
 


### PR DESCRIPTION
I've run into a small issue: A Route pushes the route string as a key prop to the Handler. This means that every time the URL changes, the Handler is newly mounted. In desktop browsers, this will not be noticed, however on the Ipad this re-mount will create a distinct flicker that can be undesirable.

As far as I can see, it's often not necessary to remount the same Component in the same place more than one time.

Would you guys be open to a change where you are able to choose the key of your Handler manually if you'd like to, and maybe put the route string on a different prop?

If yes, I would edit the help and implement potential changes you guys suggest.
