### PR TITLE
Trivial missing comma in RouteStore

### DIFF
--- a/modules/stores/RouteStore.js
+++ b/modules/stores/RouteStore.js
@@ -100,7 +100,7 @@ var RouteStore = {
     props.children = RouteStore.registerChildren(props.children, route);
 
     return route;
-  }
+  },
 
   /**
    * Registers many children routes at once, always returning an array.


### PR DESCRIPTION
as reported by the jsx compiler when attempting to pack things up:

```
ERROR in ./~/react-router/modules/stores/RouteStore.js
Module build failed: Error: Parse Error: Line 108: Unexpected identifier
    at throwError (.../node_modules/jsx-loader/node_modules/react-tools/node_modules/esprima-fb/esprima.js:2278:21)
    at throwUnexpected (.../node_modules/jsx-loader/node_modules/react-tools/node_modules/esprima-fb/esprima.js:2322:13)
```

Oh boy: a trivial PR of one character. I wont take it personally if you guys make the edit and correction yourself rather than merge this.

Many thanks for an awesome component and excellent explanations around it!

I hope this helps.
