### PR TITLE
Allow infinite ActiveState change listeners.

### DIFF
--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -230,7 +230,7 @@ function findMatches(path, routes, defaultRoute) {
 
     if (matches != null) {
       var rootParams = getRootMatch(matches).params;
-
+      
       params = route.props.paramNames.reduce(function (params, paramName) {
         params[paramName] = rootParams[paramName];
         return params;
@@ -281,7 +281,7 @@ function getRootMatch(matches) {
 
 function updateMatchComponents(matches, refs) {
   var i = 0, component;
-  while ((component = refs[REF_NAME]) && (matches[i+1] !== undefined)) {
+  while (component = refs[REF_NAME]) {
     matches[i++].component = component;
     refs = component.refs;
   }


### PR DESCRIPTION
Fixes a warning from event-emitter when using more than ten Links (or
other components using the ActiveState mixin) by allowing an unlimited number of listeners (as suggested here: http://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n). 

This is to try to fix issue #220.

Or would it be better to somehow group event listeners? Or is there some other way of solving this problem?

(Sorry if I'm doing this wrong, haven't done a pull request before.)
