### PR TITLE
[changed] paths to inherit parents

### DIFF
--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -36,7 +36,7 @@ var Image = React.createClass({
 var routes = (
   <Routes>
     <Route handler={App}>
-      <Route name="image" path="/:service" handler={Image} addHandlerKey={true} />
+      <Route name="image" path=":service" handler={Image} addHandlerKey={true} />
     </Route>
   </Routes>
 );

--- a/examples/dynamic-segments/app.js
+++ b/examples/dynamic-segments/app.js
@@ -49,8 +49,8 @@ var Task = React.createClass({
 var routes = (
   <Route handler={App}>
     <Route name="user" path="/user/:userId" handler={User}>
-      <Route name="task" path="/user/:userId/tasks/:taskId" handler={Task}/>
-      <Redirect from="/user/:userId/todos/:taskId" to="task"/>
+      <Route name="task" path="tasks/:taskId" handler={Task}/>
+      <Redirect from="todos/:taskId" to="task"/>
     </Route>
   </Route>
 );

--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -143,7 +143,10 @@ var Path = {
   /**
    * Returns a normalized version of the given path.
    */
-  normalize: function (path) {
+  normalize: function (path, parentRoute) {
+    if (parentRoute && path.charAt(0) !== '/')
+      path = parentRoute.props.path + '/' + path;
+
     return path.replace(/^\/*/, '/');
   }
 

--- a/modules/stores/RouteStore.js
+++ b/modules/stores/RouteStore.js
@@ -49,7 +49,7 @@ var RouteStore = {
     );
 
     if ((props.path || props.name) && !props.catchAll) {
-      props.path = Path.normalize(props.path || props.name);
+      props.path = Path.normalize(props.path || props.name, parentRoute);
     } else if (parentRoute) {
       // <Routes> have no path prop.
       props.path = parentRoute.props.path || '/';

--- a/specs/RouteStore.spec.js
+++ b/specs/RouteStore.spec.js
@@ -28,6 +28,31 @@ describe('when a route is looked up by name', function () {
 });
 
 describe('when registering a route', function () {
+
+  describe('that starts with /', function() {
+    it('does not inherit the parent path', function() {
+      var child;
+      var route = Route({ name: 'home', handler: App },
+        child = Route({ path: '/foo', handler: App })
+      );
+      RouteStore.registerRoute(route);
+      expect(child.props.path).toEqual('/foo');
+      RouteStore.unregisterRoute(route);
+    });
+  });
+
+  describe('that does not start with /', function() {
+    it('inherits the parent path', function() {
+      var child;
+      var route = Route({ name: 'home', handler: App },
+        child = Route({ path: 'foo', handler: App })
+      );
+      RouteStore.registerRoute(route);
+      expect(child.props.path).toEqual('/home/foo');
+      RouteStore.unregisterRoute(route);
+    });
+  });
+
   describe('with no handler', function () {
     it('throws an Error', function () {
       expect(function () {


### PR DESCRIPTION
- paths that start with `/` are absolute like they
  used to be
- paths that don't start with `/` are now relative
  (meaning they inherit their parent path)
- assumed `path`s from `name`s are relative

closes #244
