### PR TITLE
[changed] Transition retry uses replaceWith instead of transitionTo

### DIFF
--- a/modules/utils/Transition.js
+++ b/modules/utils/Transition.js
@@ -1,6 +1,6 @@
 var mixInto = require('react/lib/mixInto');
-var transitionTo = require('../actions/LocationActions').transitionTo;
 var Redirect = require('./Redirect');
+var replaceWith = require('../actions/LocationActions').replaceWith;
 
 /**
  * Encapsulates a transition to a given path.
@@ -26,7 +26,7 @@ mixInto(Transition, {
   },
 
   retry: function () {
-    transitionTo(this.path);
+    replaceWith(this.path);
   }
 
 });


### PR DESCRIPTION
I added a `retryAndReplace` method to `Transition` that acts the same as `retry` except it uses `replaceWith` instead of `transitionTo`.

My use case for this was that I was saving a transition during authentication. After authentication, I would prefer the back button to go to the screen that requested the original transition instead of back to the auth screen.
