### PR TITLE
[fixed] Properly cast active params and query before comparing.

### DIFF
--- a/modules/mixins/ActiveDelegate.js
+++ b/modules/mixins/ActiveDelegate.js
@@ -9,7 +9,7 @@ function routeIsActive(activeRoutes, routeName) {
 
 function paramsAreActive(activeParams, params) {
   for (var property in params) {
-    if (activeParams[property] !== String(params[property]))
+    if (activeParams[property] != params[property])
       return false;
   }
 
@@ -18,7 +18,7 @@ function paramsAreActive(activeParams, params) {
 
 function queryIsActive(activeQuery, query) {
   for (var property in query) {
-    if (activeQuery[property] !== String(query[property]))
+    if (activeQuery[property] != query[property])
       return false;
   }
 

--- a/specs/ActiveDelegate.spec.js
+++ b/specs/ActiveDelegate.spec.js
@@ -43,8 +43,8 @@ describe('when a Route is active', function () {
         App({
           initialState: {
             activeRoutes: [ route ],
-            activeParams: { id: '123', show: 'true' },
-            activeQuery: { search: 'abc' }
+            activeParams: { id: '123', show: 'true', variant: 456 },
+            activeQuery: { search: 'abc', limit: 789 }
           }
         })
       );
@@ -52,19 +52,19 @@ describe('when a Route is active', function () {
 
     describe('and no query is used', function () {
       it('is active', function () {
-        assert(app.isActive('products', { id: 123 }));
+        assert(app.isActive('products', { id: 123, variant: '456' }));
       });
     });
 
     describe('and a matching query is used', function () {
       it('is active', function () {
-        assert(app.isActive('products', { id: 123 }, { search: 'abc' }));
+        assert(app.isActive('products', { id: 123 }, { search: 'abc', limit: '789' }));
       });
     });
 
     describe('but the query does not match', function () {
       it('is not active', function () {
-        refute(app.isActive('products', { id: 123 }, { search: 'def' }));
+        refute(app.isActive('products', { id: 123 }, { search: 'def', limit: '123' }));
       });
     });
   });


### PR DESCRIPTION
This patch resolves a small issue where `ActiveDelegate.paramsAreActive` and `ActiveDelegate.queryIsActive` only cast the incoming parameters to strings.

This prevents the following link from having the `active` class set:

``` javascript
<Link params={{numeric: 123}} />
```
