### PR TITLE
[added] failing unit test when using transitionTo with a dot in the path

### DIFF
--- a/specs/PathStore.spec.js
+++ b/specs/PathStore.spec.js
@@ -20,6 +20,13 @@ describe('PathStore', function () {
     });
   });
 
+  describe('when a new path with a dot is pushed to the URL', function() {
+    it('has the correct path', function() {
+      transitionTo('/two.json');
+      expect(getCurrentPath()).toEqual('/two.json');
+    });
+  });
+
   describe('when a new path is used to replace the URL', function () {
     beforeEach(function () {
       transitionTo('/two');


### PR DESCRIPTION
Using Router.transitionTo with a dot in the path throws : 

`Uncaught Error: Invariant Violation: Missing "splat" parameter for path : [the path]`

Related to #297
