### PR TITLE
Allow any React component to act as a Link, not just <a>

### DIFF
--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -29,6 +29,10 @@ Object, the parameters to fill in the dynamic segments of your route.
 <Link to="user" params={user}/>
 ```
 
+### `tag`
+
+The component to act as a link. `React.DOM.a` by default.
+
 ### `query`
 
 Object, Query parameters to add to the link. Access query parameters in

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -22,6 +22,7 @@ function isModifiedEvent(event) {
 var RESERVED_PROPS = {
   to: true,
   key: true,
+  tag: true,
   className: true,
   activeClassName: true,
   query: true,
@@ -77,6 +78,7 @@ var Link = React.createClass({
 
   propTypes: {
     to: React.PropTypes.string.isRequired,
+    tag: React.PropTypes.component,
     activeClassName: React.PropTypes.string.isRequired,
     params: React.PropTypes.object,
     query: React.PropTypes.object,
@@ -161,7 +163,9 @@ var Link = React.createClass({
         props[propName] = this.props[propName];
     }
 
-    return React.DOM.a(props, this.props.children);
+    var tag = this.props.tag || React.DOM.a;
+
+    return tag(props, this.props.children);
   }
 
 });


### PR DESCRIPTION
Makes `Link` more like Ember's `link-to`, allowing any React component to act as a link (i.e. to get the `active` class and nice `to`/`params`/`query` handling).
