### PR TITLE
Passes actual props to rendered Route.

### DIFF
--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -169,6 +169,16 @@ var Routes = React.createClass({
     var matches = this.state.matches;
     if (matches.length) {
       // matches[0] corresponds to the top-most match
+      React.Children.forEach(this.props.children, function(child) {
+        var childProps = child.props, matchProps = matches[0].route.props;
+        if (childProps.path && childProps.path === matchProps.path) {
+          for (var key in childProps) {
+            if (childProps.hasOwnProperty(key)) {
+              matchProps[key] = childProps[key];
+            }
+          }
+        }
+      });
       return matches[0].route.props.handler(computeHandlerProps(matches, this.state.activeQuery));
     } else {
       return null;
@@ -188,7 +198,7 @@ function findMatches(path, routes, defaultRoute, notFoundRoute) {
 
     if (matches != null) {
       var rootParams = getRootMatch(matches).params;
-      
+
       params = route.props.paramNames.reduce(function (params, paramName) {
         params[paramName] = rootParams[paramName];
         return params;


### PR DESCRIPTION
Currently changed props are not passed down to children as reported by issue https://github.com/rackt/react-router/issues/268.

But this is necessary if the router should work with a functional cursor library, like:
https://github.com/mquan/cortex
https://github.com/dustingetz/react-cursor
https://github.com/caseywebdev/cursors

This pull request contains the changes necessary to support changing props. This was a quick way to get it working and might not be the prettiest, but I felt like I should atleast share this effort... Might help to integrate it into `computeHandlerProps` or so...
