### PR TITLE
[fixed] Document the name prop passed to RouteHandlers

### DIFF
--- a/docs/api/components/RouteHandler.md
+++ b/docs/api/components/RouteHandler.md
@@ -45,6 +45,10 @@ var routes = (
 React.renderComponent(routes, document.body);
 ```
 
+### `name`
+
+The current route name.
+
 ### `params`
 
 When a route has dynamic segments like `<Route path="users/:userId"/>`,


### PR DESCRIPTION
I found that there is an undocumented prop, `name`, which is passed to a `RouteHandler` in addition to `params`, `query`, and `activeRouteHandler`. It is really useful so I added it to the docs (hopefully it's not meant to be internal use only).
