### PR TITLE
fix path for scripts directory in README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,5 @@ In order to try out the examples, you need to follow these steps:
 1. Clone this repo
 1. Run `npm -g install webpack`, if you don't have it installed already
 1. Run `npm install` from the repo's root directory
-1. Run `./script/build-examples` from the repo's root directory
+1. Run `./scripts/build-examples` from the repo's root directory
 1. Point your browser to the `index.html` location in this directory


### PR DESCRIPTION
Just a simple path fix. Perhaps it might also be more advantageous to explain that these commands should be run from the root of the project? I always try to assume a user has no knowledge of NPM/package.json/etc.
