### PR TITLE
added <ReplaceWith /> and <TransitionTo /> components

### DIFF
--- a/modules/components/ReplaceWith.js
+++ b/modules/components/ReplaceWith.js
@@ -1,0 +1,40 @@
+var React = require('react');
+var LocationActions = require('../actions/LocationActions');
+
+/**
+ * A <ReplaceWith> component will replace the current route with the route specified
+ * in the `to` or `name` prop with specified `params` and `query`
+ */
+var ReplaceWith = React.createClass({
+  getInitialState: function() {
+    return {
+      redirected: false
+    };
+  },
+
+  componentDidMount: function() {
+    this.redirect();
+  },
+
+  componentDidUpdate: function() {
+    this.redirect();
+  },
+
+  redirect: function() {
+    if (this.state.redirected) {
+      return;
+    }
+
+    this.setState({
+      redirected: true
+    });
+
+    LocationActions.replaceWith(this.props.to || this.props.name, this.props.params, this.props.query);
+  },
+
+  render: function() {
+    return null;
+  }
+});
+
+module.exports = ReplaceWith;

--- a/modules/components/TransitionTo.js
+++ b/modules/components/TransitionTo.js
@@ -1,0 +1,40 @@
+var React = require('react');
+var LocationActions = require('../actions/LocationActions');
+
+/**
+ * A <TransitionTo> component will transition to the route specified
+ * in the `to` or `name` prop with specified `params` and `query`
+ */
+var TransitionTo = React.createClass({
+  getInitialState: function() {
+    return {
+      redirected: false
+    };
+  },
+
+  componentDidMount: function() {
+    this.redirect();
+  },
+
+  componentDidUpdate: function() {
+    this.redirect();
+  },
+
+  redirect: function() {
+    if (this.state.redirected) {
+      return;
+    }
+
+    this.setState({
+      redirected: true
+    });
+
+    LocationActions.transitionTo(this.props.to || this.props.name, this.props.params, this.props.query);
+  },
+
+  render: function() {
+    return null;
+  }
+});
+
+module.exports = TransitionTo;

--- a/modules/index.js
+++ b/modules/index.js
@@ -6,8 +6,10 @@ exports.DefaultRoute = require('./components/DefaultRoute');
 exports.Link = require('./components/Link');
 exports.NotFoundRoute = require('./components/NotFoundRoute');
 exports.Redirect = require('./components/Redirect');
+exports.ReplaceWith = require('./components/ReplaceWith');
 exports.Route = require('./components/Route');
 exports.Routes = require('./components/Routes');
+exports.TransitionTo = require('./components/TransitionTo');
 
 exports.ActiveState = require('./mixins/ActiveState');
 exports.AsyncState = require('./mixins/AsyncState');


### PR DESCRIPTION
#### Description

This pr adds a couple of helper components that make dealing with transitioning in complex components a little easier.  The two components, `<TransitionTo />` and `<ReplaceWith />` expect to be rendered and will trigger their respective `Router` actions.

In a component that manages a fair amount of async state, I often find myself rendering different pieces of content in response to the different states of my data (e.g. spinner when data is loading, alerts when in error state, normal otherwise).  Sometimes, I need to move to a completely different page in response to what the data tells me (think redirecting to login when checking the server for auth state).  Instead of having that state inspection logic in `componentDidUpdate` and another set of data state inspection logic in `render`, these components let me unify that logic in the `render` method.
#### Usage

```
if (this.state.auth == 'loading') {
  return <LoadingThingy>;
}

if (this.state.auth == 'loggedout') {
  return <TransitionTo name="login" query={{next: window.location.pathname + window.location.search}} />;
}

return <SoManyAwesomeThings />;
```
