### PR TITLE
Fixed jsx syntax in documentation

### DIFF
--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -139,7 +139,7 @@ var App = React.createClass({
         </header>
 
         {/* this is the important part */}
-        <this.props.activeRouteHandler/>
+        {this.props.activeRouteHandler/}
       </div>
     );
   }
@@ -220,7 +220,7 @@ var Inbox = React.createClass({
       <div>
         <Toolbar/>
         <Messages/>
-        <this.props.activeRouteHandler/>
+        {this.props.activeRouteHandler}
       </div>
     );
   }


### PR DESCRIPTION
The examples provided didn't use correct jsx syntax and were throwing an error:
`Error: Parse Error: Line 8: Unexpected token .`
