### PR TITLE
[fixed] Corrected CONTRIBUTING.md by replacing 'script' path with 'scripts'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,14 @@ always be in sync.
 
 ### Development
 
-- `script/test` will fire up a karma runner and watch for changes in the
+- `scripts/test` will fire up a karma runner and watch for changes in the
   specs directory.
 - `npm test` will do the same but doesn't watch, just runs the tests.
-- `script/build-examples` does exactly that.
+- `scripts/build-examples` does exactly that.
 
 ### Build
 
-Please do not include the output of `script/build` in your commits, we
+Please do not include the output of `scripts/build` in your commits, we
 only do this when we release. (Also, you probably don't need to build
 anyway unless you are fixing something around our global build.)
 


### PR DESCRIPTION
Seems the /script path was renamed to /scripts with commit bb7b666 but the references weren't updated in CONTRIBUTING.md.
