### PR TITLE
[fixed] Workaround render errors being swallowed by AsyncState

### DIFF
--- a/modules/utils/resolveAsyncState.js
+++ b/modules/utils/resolveAsyncState.js
@@ -14,9 +14,12 @@ function resolveAsyncState(asyncState, setState) {
   return Promise.all(
     keys.map(function (key) {
       return Promise.resolve(asyncState[key]).then(function (value) {
-        var newState = {};
-        newState[key] = value;
-        setState(newState);
+        // use a timeout to set state, so errors aren't swallowed by the Promise
+        setTimeout(function () {
+          var newState = {};
+          newState[key] = value;
+          setState(newState);
+        }, 0);
       });
     })
   );


### PR DESCRIPTION
Fixes #291

By using a timeout, we break outside of the catching effect of Promise.then, so any errors that occur within setState will bubble up and be able to be caught and logged by the console.
