### PR TITLE
[added] RouteLookup::getActiveRoutes

### DIFF
--- a/docs/api/mixins/RouteLookup.md
+++ b/docs/api/mixins/RouteLookup.md
@@ -7,6 +7,17 @@ and links.
 Instance Methods
 ----------------
 
+### `getActiveRoutes()`
+
+Returns an array of the active routes in order of hierarchy, closest to
+root first.
+
+```js
+[route, route, ...]
+```
+
+
+
 ### `getRoutes()`
 
 Returns an array of all routes.

--- a/modules/mixins/RouteContainer.js
+++ b/modules/mixins/RouteContainer.js
@@ -145,6 +145,10 @@ var RouteContainer = {
     return this.state.routes;
   },
 
+  getActiveRoutes: function () {
+    return this.state.activeRoutes;
+  },
+
   /**
    * Returns a hash { name: route } of all named <Route>s in this container.
    */

--- a/modules/mixins/RouteLookup.js
+++ b/modules/mixins/RouteLookup.js
@@ -18,6 +18,13 @@ var RouteLookup = {
   },
 
   /**
+   * See RouteContainer#getActiveRoutes.
+   */
+  getActiveRoutes: function() {
+    return this.context.routeContainer.getActiveRoutes();
+  },
+
+  /**
    * See RouteContainer#getNamedRoutes.
    */
   getNamedRoutes: function () {


### PR DESCRIPTION
Seems to me most everybody's use-case for wanting to know anything about routes is to know the active routes.

This simply exposes the route container's active routes publicly.
