### PR TITLE
[added] RouteHandler `activeRoute`

### DIFF
--- a/docs/api/components/RouteHandler.md
+++ b/docs/api/components/RouteHandler.md
@@ -45,6 +45,10 @@ var routes = (
 React.renderComponent(routes, document.body);
 ```
 
+### `activeRoute`
+
+The active child route, useful for inspection.
+
 ### `name`
 
 The current route name.

--- a/modules/mixins/TransitionHandler.js
+++ b/modules/mixins/TransitionHandler.js
@@ -232,6 +232,7 @@ function computeHandlerProps(matches, query) {
     params: null,
     query: null,
     activeRouteHandler: handler,
+    activeRoute: null,
     key: null
   };
 
@@ -243,6 +244,7 @@ function computeHandlerProps(matches, query) {
     props.ref = '__activeRoute__';
     props.params = match.params;
     props.query = query;
+    props.activeRoute = route;
     props.activeRouteHandler = handler;
 
     // TODO: Can we remove addHandlerKey?


### PR DESCRIPTION
Most the time people ask about getting at route info, they just want to know the name of the active child route.

Today you can do that like this:

``` js
render: function() {
  var child = this.props.activeRouteHandler();
  var name = child.name;
  return  <div>{child}</div>;
}
```

This is useful for sidebar implementations, scoped page search (we do this), and I'm sure many other things.

Might as well just give devs the active route so the code becomes:

``` js
render: function() {
  var name = this.props.activeRoute.name;
  return  <div><this.props.activeRouteHandler/></div>;
}
```
