### PR TITLE
Fix <Link> params in simple-master-detail example

### DIFF
--- a/examples/simple-master-detail/app.js
+++ b/examples/simple-master-detail/app.js
@@ -16,7 +16,7 @@ var App = React.createClass({
 
   render: function() {
     var links = this.state.states.map(function(state) {
-      return <li><Link to="state" abbr={state.abbr}>{state.name}</Link></li>
+      return <li><Link to="state" params={{ abbr: state.abbr }}>{state.name}</Link></li>
     });
     return (
       <div className="App">


### PR DESCRIPTION
This example currently emits the following error:

```
Uncaught Error: Invariant Violation: Missing "abbr" parameter for path "/state/:abbr"
```

It looks like inlining params was an old api for <Link> which is no longer supported.
