### PR TITLE
Removed trailing comma

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -72,7 +72,7 @@ var Route = React.createClass({
 
     getUnreservedProps: function (props) {
       return withoutProperties(props, RESERVED_PROPS);
-    },
+    }
 
   },
 


### PR DESCRIPTION
Trailing commas don't work in old versions of IE, and are not present
in the rest of the codebase. Removed the one that remained, which
allows Google Closure compiler to compiles this code.
