### PR TITLE
[fixed] encoded ampersands in query params

### DIFF
--- a/modules/utils/Path.js
+++ b/modules/utils/Path.js
@@ -112,7 +112,7 @@ var Path = {
    * in the given path, null if the path contains no query string.
    */
   extractQuery: function (path) {
-    var match = decodeURL(path).match(queryMatcher);
+    var match = path.match(queryMatcher);
     return match && qs.parse(match[1]);
   },
 

--- a/modules/utils/__tests__/Path-test.js
+++ b/modules/utils/__tests__/Path-test.js
@@ -229,6 +229,10 @@ describe('Path.extractQuery', function () {
     it('properly handles arrays', function () {
       expect(Path.extractQuery('/?id%5B%5D=a&id%5B%5D=b')).toEqual({ id: [ 'a', 'b' ] });
     });
+
+    it('properly handles encoded ampersands', function () {
+      expect(Path.extractQuery('/?id=a%26b')).toEqual({ id: 'a&b' });
+    });
   });
 
   describe('when the path does not contain a query string', function () {


### PR DESCRIPTION
fixes #343 

@mjackson @spicyj 

I'm worried I'm not thinking about this clearly, but I don't think we need to decode the query params before sending them on to the `qs` module. Can you think of anything I'm missing?
