### PR TITLE
Add package.json configuration for JSPM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,11 @@
   ],
   "browserify-shim": {
     "react": "global:React"
+  },
+  "jspm": {
+    "directories": {
+      "lib": "dist"
+    },
+    "main": "react-router"
   }
 }


### PR DESCRIPTION
Add package support for the [JSPM Module Loader](http://jspm.io)
## Problem

The package's main property points to source files instead of the distributable. When consuming this library with something like jspm we want to be using `dist/react-router.js`
## Solution

Fortunately jspm can utilize jspm-specific configuration so that a library doesn't have to alter their main property if they don't want to. See [Configuring Packages for jspm](https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm) for more information on the specifics.
