### PR TITLE
[fixed] React dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.3",
     "mocha": "1.20.1",
-    "react": ">=0.11.0",
     "reactify": "^0.14.0",
     "rf-release": "0.3.2",
     "uglify-js": "2.4.15"


### PR DESCRIPTION
It should be in peerDependencies, not devDependencies.  Otherwise,
you'll get needless failures on `npm list`.

Note: if you are developing ReactRouter itself, your repo should be
inside your calling app's node_modules until this is fixed:

https://github.com/npm/npm/issues/5875

If you try to instead resolve this by installing a copy of React inside
ReactRouter's node_modules, you're liable to end up with a broken
build, because webpack will include both copies in parallel.
