### PR TITLE
[added] ServerRendering.matchRoutes

### DIFF
--- a/modules/utils/ServerRendering.js
+++ b/modules/utils/ServerRendering.js
@@ -102,7 +102,28 @@ function renderRoutesToStaticMarkup(routes, path, callback) {
   });
 }
 
+function matchRoutes(routes, path, callback) {
+  invariant(
+    ReactDescriptor.isValidDescriptor(routes),
+    'You must pass a valid ReactComponent to matchRoutes'
+  );
+
+  var component = instantiateReactComponent(
+    cloneRoutesForServerRendering(routes)
+  );
+
+  component.dispatch(path, function (error, abortReason, nextState) {
+    if (error || abortReason)
+      return callback(error, abortReason);
+
+    mergeStateIntoInitialProps(nextState, component.props);
+
+    callback(null, null, nextState);
+  });
+}
+
 module.exports = {
   renderRoutesToString: renderRoutesToString,
-  renderRoutesToStaticMarkup: renderRoutesToStaticMarkup
+  renderRoutesToStaticMarkup: renderRoutesToStaticMarkup,
+  matchRoutes: matchRoutes
 };

--- a/modules/utils/__tests__/ServerRendering-test.js
+++ b/modules/utils/__tests__/ServerRendering-test.js
@@ -149,4 +149,32 @@ describe('ServerRendering', function () {
     });
   });
 
+  describe('matchRoutes', function () {
+    var Home = React.createClass({
+      render: function () {
+        return React.DOM.b(null, 'Hello ' + this.props.params.username + '!');
+      }
+    });
+
+    var state = null;
+
+    beforeEach(function (done) {
+      var routes = Routes(null,
+        Route({ path: '/home/:username', handler: Home })
+      );
+
+      ServerRendering.matchRoutes(routes, '/home/rpflo', function (error, abortReason, _state) {
+        assert(error == null);
+        assert(abortReason == null);
+        state = _state;
+        done();
+      });
+    });
+
+    it('has the correct output', function () {
+      expect(state.matches.length).toEqual(1);
+    });
+  });
+
+
 });


### PR DESCRIPTION
**WIP: DON'T MERGE THIS**

This method allows people on the server to use the router as simply a router that matches their route descriptors, and not something that emits a react view.

Its common for a server to emit both HTML and JSON at the same url, depending the `Accept` header. We have an opportunity here to encourage the use of the router for these kinds of servers, instead of making the decision to use react router more difficult by requiring a separate routing mechanism for emitting json (or other types of data).

Imagine something like this on the server:

``` js
handleReqeuest(function(req, res) {
  var requestType = getRequestType(req);

  if (requestType === 'json') {
    Router.matchRoutes(routes, req.path, function(err, abortReason, state) {

      // devs could add a static `getJSON` to handlers to represent their url as json
      var deepestHandler = state.matches.reverse()[0].route.props.handler

      deepestHandler.getJSON(function(json) {
        res.json(json);
      });
    });
  }
  else if (requestType === 'html') {
    Router.renderRoutesToString(routes, req.path, function(err, abortReason, html) {
      res.send(html);
    });
  }
});
```

Right now this just sends along the `nextState`, we'd definitely need to prune down the `state` object a bit, I don't want to have to support our internal data structure as public API.
