### PR TITLE
[added] <Route ignoreScrollBehavior /> to opt out of scroll behavior for itself and descendants

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -53,7 +53,8 @@ var Route = React.createClass({
     handler: React.PropTypes.any.isRequired,
     getAsyncProps: React.PropTypes.func,
     path: React.PropTypes.string,
-    name: React.PropTypes.string
+    name: React.PropTypes.string,
+    ignoreScrollBehavior: React.PropTypes.bool
   },
 
   render: function () {

--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -163,6 +163,16 @@ function updateMatchComponents(matches, refs) {
   }
 }
 
+function shouldUpdateScroll(currentMatches, previousMatches) {
+  var commonMatches = currentMatches.filter(function (match) {
+    return previousMatches.indexOf(match) !== -1;
+  });
+
+  return !commonMatches.some(function (match) {
+    return match.route.props.ignoreScrollBehavior;
+  });
+}
+
 function returnNull() {
   return null;
 }
@@ -285,16 +295,19 @@ var Routes = React.createClass({
       } else if (abortReason) {
         this.goBack();
       } else {
-        this._handleStateChange = this.handleStateChange.bind(this, path, actionType);
+        this._handleStateChange = this.handleStateChange.bind(this, path, actionType, this.state.matches);
         this.setState(nextState);
       }
     });
   },
 
-  handleStateChange: function (path, actionType) {
-    updateMatchComponents(this.state.matches, this.refs);
+  handleStateChange: function (path, actionType, previousMatches) {
+    var currentMatches = this.state.matches;
+    updateMatchComponents(currentMatches, this.refs);
 
-    this.updateScroll(path, actionType);
+    if (shouldUpdateScroll(currentMatches, previousMatches)) {
+      this.updateScroll(path, actionType);
+    }
 
     if (this.props.onChange)
       this.props.onChange.call(this);

--- a/modules/components/__tests__/Routes-test.js
+++ b/modules/components/__tests__/Routes-test.js
@@ -69,4 +69,93 @@ describe('A Routes', function () {
     });
   });
 
+  describe('that considers ignoreScrollBehavior when calling updateScroll', function () {
+    var component;
+    beforeEach(function () {
+      component = ReactTestUtils.renderIntoDocument(
+        Routes({ location: 'none' },
+          Route({ handler: NullHandler, ignoreScrollBehavior: true },
+            Route({ path: '/feed', handler: NullHandler }),
+            Route({ path: '/discover', handler: NullHandler })
+          ),
+          Route({ path: '/search', handler: NullHandler, ignoreScrollBehavior: true }),
+          Route({ path: '/about', handler: NullHandler })
+        )
+      );
+    });
+
+    function spyOnUpdateScroll(action) {
+      var didCall = false;
+
+      var realUpdateScroll = component.updateScroll;
+      component.updateScroll = function mockUpdateScroll() {
+        didCall = true;
+        realUpdateScroll.apply(component, arguments);
+      };
+
+      try {
+        action();
+      } finally {
+        component.updateScroll = realUpdateScroll;
+      }
+
+      return didCall;
+    }
+
+    afterEach(function () {
+      React.unmountComponentAtNode(component.getDOMNode());
+    });
+
+    it('calls updateScroll when no ancestors ignore scroll', function () {
+      component.updateLocation('/feed');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/about');
+      });
+
+      expect(calledUpdateScroll).toEqual(true);
+    });
+
+    it('calls updateScroll when no ancestors ignore scroll even though source and target do', function () {
+      component.updateLocation('/feed');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/search');
+      });
+
+      expect(calledUpdateScroll).toEqual(true);
+    });
+
+    it('calls updateScroll when source is same as target and does not ignore scroll', function () {
+      component.updateLocation('/about');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/about?page=2');
+      });
+
+      expect(calledUpdateScroll).toEqual(true);
+    });
+
+    it('does not call updateScroll when common ancestor ignores scroll', function () {
+      component.updateLocation('/feed');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/discover');
+      });
+
+      expect(calledUpdateScroll).toEqual(false);
+    });
+
+    it('does not call updateScroll when source is same as target and ignores scroll', function () {
+      component.updateLocation('/search');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/search?q=test');
+      });
+
+      expect(calledUpdateScroll).toEqual(false);
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR adds `ignoreScrollBehavior` on `Route` component as [discussed](https://github.com/rackt/react-router/pull/326#issuecomment-58593491) in #326.

It seems to work on my project but I'd like to hear your opinions on **how I should approach testing**.
Should I unit-test `Routes`, `ScrollContext`, or what?

---

If you specify `ignoreScrollBehavior` on a route, scroll behavior will not be triggered when transitioning _within_ that route. It _will_, however, be triggered when transitioning _outside_ this route. This allows us to support a variety of scenarios where you might want scroll behavior to be ignored:
- Searching, where path is updated every time you change a query
- Tabs, where you'd rather not scroll to top when switching between them

In the first case, by specifying `ignoreScrollBehavior` on `search` route we ensure that transitions from `search` to `search` (which is what happens when you type a search query) will _not_ trigger scroll behavior, but transitions from `search` to `home` and back will.

In the second case, by specifying `ignoreScrollBehavior` on `home` parent route, we say transitions _within_ `home` (e.g. from `feed` to `discover` and back) don't trigger scroll behavior. However if you go from `feed` to `about`, scroll behavior will be respected.

``` javascript
<Routes location="history">
  <Route handler={App}>
    <Route name="home" path="/" handler={HomePage}
           ignoreScrollBehavior>
      <Route name="feed" path="/" handler={FeedPage} />
      <Route name="discover" path="/discover" handler={DiscoverPage} />
    </Route>
    <Route name="search" path="/search" handler={SearchResultsPage}
           ignoreScrollBehavior />
    <Route name="about" path="/about" handler={AboutPage} />
  </Route>
</Routes>
```

(I'll draw a better picture later :-)

![](https://cloud.githubusercontent.com/assets/810438/4585743/db9431f0-500a-11e4-9a47-b56116e28cf6.jpg)

By default, scroll behavior is performed on all transitions (red arrows). Routes can create “scrolling realms” for themselves and their descendants by specifying `ignoreScrollBehavior` (purple areas). Transitions that are fully confined to a single scrolling realm, don't have any scroll behavior performed (blue arrows). If transition is not fully confined to a scrolling realm, `scrollBehavior` of `Routes` is respected.
