### PR TITLE
always recompute _currentPath when PathStore.setup is called

### DIFF
--- a/modules/stores/PathStore.js
+++ b/modules/stores/PathStore.js
@@ -47,12 +47,11 @@ var PathStore = {
       _currentLocation, location
     );
 
-    if (_currentLocation !== location) {
-      if (location.setup)
-        location.setup(handleLocationChangeAction);
-
-      _currentPath = location.getCurrentPath();
+    if (_currentLocation !== location && location.setup) {
+      location.setup(handleLocationChangeAction);
     }
+    
+    _currentPath = location.getCurrentPath();
 
     _currentLocation = location;
   },

--- a/modules/stores/__tests__/PathStore-test.js
+++ b/modules/stores/__tests__/PathStore-test.js
@@ -6,12 +6,13 @@ var PathStore = require('../PathStore');
 describe('PathStore', function () {
 
   var _onChange;
+  var _currentPath = '/';
   var MockLocation = {
     setup: function (onChange) {
       _onChange = onChange;
     },
     getCurrentPath: function () {
-      return '/';
+      return _currentPath;
     },
     toString: function () {
       return '<MockLocation>';
@@ -108,6 +109,20 @@ describe('PathStore', function () {
     it('emits a change event', function () {
       assert(changeWasFired);
     });
+  });
+  
+  describe('when a URL path is externally mutated', function() {
+    
+    afterEach(function() {
+      _currentPath = '/';
+    });
+    
+    it('updates the path when .setup is called', function() {
+      _currentPath = '/new-path';
+      PathStore.setup(MockLocation);
+      expect(PathStore.getCurrentPath()).toEqual('/new-path');
+    });
+    
   });
 
 });


### PR DESCRIPTION
We have a use case where we render multiple `<Routes />` components at different points in our app (we are embedding react into an existing Ember app). An issue arises when a different location is pushed _outside_ of react-router and then a new `<Routes>` component is mounted. In previous versions of react-router this worked fine. This fixes a recently introduced regression.
