### PR TITLE
Fixes #436

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-firefox-launcher": "0.1.3",
     "karma-mocha": "0.1.3",
     "mocha": "1.20.1",
-    "react": ">=0.11.0",
+    "react": "0.11.x",
     "reactify": "^0.14.0",
     "rf-release": "0.3.2",
     "uglify-js": "2.4.15",
@@ -42,7 +42,7 @@
     "webpack-dev-server": "1.6.5"
   },
   "peerDependencies": {
-    "react": ">=0.11.0"
+    "react": "0.11.x"
   },
   "dependencies": {
     "events": "1.0.1",


### PR DESCRIPTION
Upgrading reacjs to 0.12.0 breaks react v0.11.2. To fix, use 0.11.x instead of >=0.11.0 until react-router supports react v0.12.

cc: @rpflorence 
