### PR TITLE
[changed] Skip scroll update if only query has changed

### DIFF
--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -163,7 +163,10 @@ function updateMatchComponents(matches, refs) {
   }
 }
 
-function shouldUpdateScroll(currentMatches, previousMatches) {
+function shouldUpdateScroll(path, currentMatches, previousPath, previousMatches) {
+  if (previousPath != null && Path.withoutQuery(path) === Path.withoutQuery(previousPath))
+    return false;
+
   var commonMatches = currentMatches.filter(function (match) {
     return previousMatches.indexOf(match) !== -1;
   });
@@ -289,7 +292,7 @@ var Routes = React.createClass({
       } else if (abortReason) {
         this.goBack();
       } else {
-        this._nextStateChangeHandler = this._finishTransitionTo.bind(this, path, actionType, this.state.matches);
+        this._nextStateChangeHandler = this._finishTransitionTo.bind(this, path, actionType, this.state.path, this.state.matches);
         this.setState(nextState);
       }
     });
@@ -302,11 +305,11 @@ var Routes = React.createClass({
     }
   },
 
-  _finishTransitionTo: function (path, actionType, previousMatches) {
+  _finishTransitionTo: function (path, actionType, previousPath, previousMatches) {
     var currentMatches = this.state.matches;
     updateMatchComponents(currentMatches, this.refs);
 
-    if (shouldUpdateScroll(currentMatches, previousMatches))
+    if (shouldUpdateScroll(path, currentMatches, previousPath, previousMatches))
       this.updateScroll(path, actionType);
 
     if (this.props.onChange)

--- a/modules/components/__tests__/Routes-test.js
+++ b/modules/components/__tests__/Routes-test.js
@@ -79,6 +79,7 @@ describe('A Routes', function () {
             Route({ path: '/discover', handler: NullHandler })
           ),
           Route({ path: '/search', handler: NullHandler, ignoreScrollBehavior: true }),
+          Route({ path: '/users/:userId/posts', handler: NullHandler }),
           Route({ path: '/about', handler: NullHandler })
         )
       );
@@ -126,11 +127,31 @@ describe('A Routes', function () {
       expect(calledUpdateScroll).toEqual(true);
     });
 
-    it('calls updateScroll when source is same as target and does not ignore scroll', function () {
-      component.updateLocation('/about');
+    it('does not call updateScroll when only query changes though route does not ignore scroll', function () {
+      component.updateLocation('/users/3/posts?after=60');
 
       var calledUpdateScroll = spyOnUpdateScroll(function () {
-        component.updateLocation('/about?page=2');
+        component.updateLocation('/users/3/posts?after=120');
+      });
+
+      expect(calledUpdateScroll).toEqual(false);
+    });
+
+    it('calls updateScroll when only parameters change and route does not ignore scroll', function () {
+      component.updateLocation('/users/3/posts?after=120');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/users/5/posts?after=120');
+      });
+
+      expect(calledUpdateScroll).toEqual(true);
+    });
+
+    it('calls updateScroll when both query and parameters change and route does not ignore scroll', function () {
+      component.updateLocation('/users/3/posts?after=60');
+
+      var calledUpdateScroll = spyOnUpdateScroll(function () {
+        component.updateLocation('/users/5/posts?after=120');
       });
 
       expect(calledUpdateScroll).toEqual(true);


### PR DESCRIPTION
This is supposed to fix #432, #439.

@mjackson @rpflorence what do you think?

---

Previously, the only way to opt out of scroll updates for a route would be by using `ignoreScrollBehavior`.
This, however, made it hard to implement arguably the most common use case: resetting scroll when `params` change and preserving it when only `query` changes.

This commit completely disables scroll updates when only `query` has changed.
This provides a reasonable default behavior and leaves `ignoreScrollBehavior` for more complicated cases.

If you'd rather keep the old behavior and reset scroll on query changes, you can either promote `query` variables to be route `params` or reset scroll position yourself in response to `query` changes in route handler's `componentDidUpdate`.
