### PR TITLE
[fixed] Don't record scroll position when replacing route

### DIFF
--- a/modules/components/Routes.js
+++ b/modules/components/Routes.js
@@ -279,7 +279,7 @@ var Routes = React.createClass({
       return; // Nothing to do!
 
     if (this.state.path)
-      this.recordScroll(this.state.path);
+      this.recordScroll(this.state.path, actionType);
 
     this.dispatch(path, function (error, abortReason, nextState) {
       if (error) {

--- a/modules/mixins/ScrollContext.js
+++ b/modules/mixins/ScrollContext.js
@@ -3,6 +3,7 @@ var invariant = require('react/lib/invariant');
 var canUseDOM = require('react/lib/ExecutionEnvironment').canUseDOM;
 var ImitateBrowserBehavior = require('../behaviors/ImitateBrowserBehavior');
 var ScrollToTopBehavior = require('../behaviors/ScrollToTopBehavior');
+var LocationActions = require('../actions/LocationActions');
 
 function getWindowScrollPosition() {
   invariant(
@@ -53,9 +54,11 @@ var ScrollContext = {
     );
   },
 
-  recordScroll: function (path) {
-    var positions = this.getScrollPositions();
-    positions[path] = getWindowScrollPosition();
+  recordScroll: function (path, actionType) {
+    if (actionType !== LocationActions.REPLACE) {
+      var positions = this.getScrollPositions();
+      positions[path] = getWindowScrollPosition();
+    }
   },
 
   updateScroll: function (path, actionType) {


### PR DESCRIPTION
Scroll position should only be recorded for PUSH and POP actions.
There is no point in saving it if the item is replaced in browser history.

(This is mostly a correctness fix)
