### PR TITLE
[fixed] Now execute willTransition* hooks even if only query part was changed

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -53,6 +53,46 @@ describe('Router', function () {
         done();
       });
     });
+
+    it('execute willTransition* callbacks when query changes', function (done) {
+      var fromCallbackExecuted = false;
+      var Spoon = React.createClass({
+        statics: {
+          willTransitionTo: function (transition, params, query) {
+            if (query['filter'] === 'first') {
+              return; // skip first transition
+            }
+
+            expect(query['filter']).toEqual('second');
+            expect(fromCallbackExecuted).toBe(true);
+            done();
+          },
+
+          willTransitionFrom: function (transition, element) {
+            fromCallbackExecuted = true;
+          }
+        },
+
+        render: function () {
+          return <h1>Spoon</h1>;
+        }
+      });
+
+      var routes = (
+        <Route handler={Nested} path='/'>
+          <Route name="spoon" handler={Spoon}/>
+        </Route>
+      );
+
+      TestLocation.history = [ '/spoon?filter=first' ];
+
+      var div = document.createElement('div');
+      Router.run(routes, TestLocation, function (Handler, state) {
+        React.render(<Handler/>, div);
+      });
+
+      TestLocation.push('/spoon?filter=second');
+    });
   });
 
   describe('willTransitionFrom', function () {
@@ -87,7 +127,6 @@ describe('Router', function () {
         });
       });
     });
-
   });
 
 });

--- a/modules/utils/createRouter.js
+++ b/modules/utils/createRouter.js
@@ -298,6 +298,16 @@ function createRouter(options) {
           toRoutes = nextRoutes;
         }
 
+        // If routes' hooks arrays are empty, then we transition to current route.
+        // But path is somehow still get changed.
+        // That could be only because of route query changes.
+        // Need to push current route to routes' hooks arrays.
+        if (!toRoutes.length && !fromRoutes.length) {
+          var currentRoute = state.routes[state.routes.length-1];
+          fromRoutes = [currentRoute];
+          toRoutes = [currentRoute];
+        }
+
         var transition = new Transition(path, this.replaceWith.bind(this, path));
 
         transition.from(fromRoutes, components, function (error) {


### PR DESCRIPTION
Upgraded to 0.11 and discovered that params now passed a bit differently. I had rewritten my app code to use `willTransitionTo` instead of old `componentWillReceiveProps`.

I'm using query params for filtering results. Surprisingly discovered that now query changes doesn't fire hooks, while still producing transition.

This pull request fixes that.
