### PR TITLE
Fix history location double encode

### DIFF
--- a/modules/locations/HistoryLocation.js
+++ b/modules/locations/HistoryLocation.js
@@ -57,12 +57,12 @@ var HistoryLocation = {
   },
 
   push: function (path) {
-    window.history.pushState({ path: path }, '', Path.encode(path));
+    window.history.pushState({ path: path }, '', path);
     notifyChange(LocationActions.PUSH);
   },
 
   replace: function (path) {
-    window.history.replaceState({ path: path }, '', Path.encode(path));
+    window.history.replaceState({ path: path }, '', path);
     notifyChange(LocationActions.REPLACE);
   },
 


### PR DESCRIPTION
While redirecting using `transition.redirect(to, params, query)` with a query param, it will double encode the query params. E.g.

```
transition.redirect("foo", null, {next: "/bar"})
// ..leads to
// /foo%3Fnext%3D%252Fbar
// ..but should redirect to instead
// /foo?next=%2Fbar
```

With this fix it should work, although I'm not really sure what implications this change has. 
