### PR TITLE
Make router work in strict mode.

### DIFF
--- a/modules/utils/createRouter.js
+++ b/modules/utils/createRouter.js
@@ -351,7 +351,7 @@ function createRouter(options) {
        * Router.*Location objects (e.g. Router.HashLocation or Router.HistoryLocation).
        */
       run: function (callback) {
-        function dispatchHandler(error, transition) {
+        var dispatchHandler = function(error, transition) {
           pendingTransition = null;
 
           if (error) {
@@ -380,7 +380,7 @@ function createRouter(options) {
           );
 
           // Listen for changes to the location.
-          function changeListener(change) {
+          var changeListener = function(change) {
             router.dispatch(change.path, change.type, dispatchHandler);
           }
 


### PR DESCRIPTION
I turned functions of the form 'function foo(){}' into 'var foo = function...(){}' in Router.run, so it works in strict mode. Fixes issue #532 

Does this fix need a unit test? If so, I'm not sure how to test it.
