### PR TITLE
Update homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/rackt/react-router.git"
   },
-  "homepage": "https://github.com/rackt/react-router/blob/latest/README.md",
+  "homepage": "https://github.com/rackt/react-router",
   "bugs": "https://github.com/rackt/react-router/issues",
   "directories": {
     "example": "examples"


### PR DESCRIPTION
It was pointing to the branch `latest`, which were in fact not the latest (it was stuck at v. 0.9). Since `npm docs react-router` uses this, it pointed to stale information.

It now points to the main branch according to github, which would presumably be the most up-to-date info.
