### PR TITLE
Get scroll pos in a more portable way.

### DIFF
--- a/modules/utils/getWindowScrollPosition.js
+++ b/modules/utils/getWindowScrollPosition.js
@@ -11,8 +11,8 @@ function getWindowScrollPosition() {
   );
 
   return {
-    x: window.scrollX,
-    y: window.scrollY
+    x: window.pageXOffset || document.documentElement.scrollLeft,
+    y: window.pageYOffset || document.documentElement.scrollTop
   };
 }
 


### PR DESCRIPTION
For #605. React gets scroll this way-- https://github.com/facebook/react/blob/5d3b12bb3bd6a092cf00ede07b8255a8399c2e58/src/vendor/core/dom/getUnboundedScrollPosition.js

I have confirmed this going Back restores scroll pos in safari firefox chrome... also in IE11, though you see the page scrolling back to its old position.
