### PR TITLE
Examples: Minor code changes to address warnings.

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -62,9 +62,9 @@ var App = React.createClass({
   },
 
   renderContacts () {
-    return this.props.data.contacts.map((contact) => {
+    return this.props.data.contacts.map((contact, i) => {
       return (
-        <li>
+        <li key={i}>
           <Link to="contact" params={contact}>{contact.first} {contact.last}</Link>
         </li>
       );

--- a/examples/data-flow/app.js
+++ b/examples/data-flow/app.js
@@ -32,8 +32,12 @@ var App = React.createClass({
   },
 
   render: function () {
-    var links = this.state.tacos.map(function (taco) {
-      return <li><Link to="taco" params={taco}>{taco.name}</Link></li>;
+    var links = this.state.tacos.map(function (taco, i) {
+      return (
+        <li key={i}>
+          <Link to="taco" params={taco}>{taco.name}</Link>
+        </li>
+      );
     });
     return (
       <div className="App">

--- a/examples/partial-app-loading/app.js
+++ b/examples/partial-app-loading/app.js
@@ -20,12 +20,12 @@ var AsyncElement = {
   },
 
   render: function () {
-    var component = this.constructor.loadedComponent;
-    if (component) {
+    var Component = this.constructor.loadedComponent;
+    if (Component) {
       // can't find RouteHandler in the loaded component, so we just grab
       // it here first.
       this.props.activeRoute = <RouteHandler/>;
-      return component(this.props);
+      return <Component {...this.props}/>;
     }
     return this.preRender();
   }


### PR DESCRIPTION
2 examples were triggering: `Each child in an array should have a unique "key" prop. Check the render method of App. See http://fb.me/react-warning-keys for more information.`

1 example was triggering: `Warning: PreDashboard is calling a React component directly. Use a factory or JSX instead. See: http://fb.me/react-legacyfactory`
