### PR TITLE
Promote envify to dependencies and add browserify transform config for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "browserify": "4.2.3",
     "browserify-shim": "3.6.0",
     "bundle-loader": "0.5.1",
-    "envify": "1.2.0",
     "events": "1.0.2",
     "expect": "0.1.1",
     "glob": "4.2.1",
@@ -50,6 +49,7 @@
     "react": "0.12.x"
   },
   "dependencies": {
+    "envify": "1.2.0",
     "qs": "2.2.2",
     "when": "3.4.6"
   },
@@ -65,6 +65,11 @@
     "routes",
     "router"
   ],
+  "browserify": {
+    "transform": [
+      "envify"
+    ]
+  },
   "browserify-shim": {
     "react": "global:React"
   }


### PR DESCRIPTION
`modules/utils/createRouter.js` now contains a `process.env.NODE_ENV` check, which isn't getting envified when react-router gets bundled as a dependency of an app. This change will make that happen.

(You can try `--global-transform` to force envification, but it can get a bit... explodey... if not all your dependencies have envify somewhere in their dependencies)
