### PR TITLE
Added a note about the library being available on the CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ installed from npm.
 There is also a global build available on bower, find the library on
 `window.ReactRouter`.
 
-### CDN
-
 The library is also available on the popular CDN [cdnjs](https://cdnjs.com/libraries/react-router).
 
 Features


### PR DESCRIPTION
I have submitted a pull request https://github.com/cdnjs/cdnjs/pull/4137 to add React Router to the CDN.

I have prepared this `README.md` with a note about the library being available on the CDN.

I will let you guys know in here when the library is live on the CDN and then we can merge this pull request.
