### PR TITLE
Remove transition.wait, use callbacks instead

### DIFF
--- a/docs/api/components/RouteHandler.md
+++ b/docs/api/components/RouteHandler.md
@@ -11,15 +11,16 @@ Static Lifecycle Methods
 You can define static methods on your route handlers that will be called
 during route transitions.
 
-### `willTransitionTo(transition, params, query)`
+### `willTransitionTo(transition, params, query, callback)`
 
 Called when a handler is about to render, giving you the opportunity to
 abort or redirect the transition. You can pause the transition while you
-do some asynchonous work with `transition.wait(promise)`.
+do some asynchonous work and call `callback(error)` when you're done, or
+omit the callback in your argument list and it will be called for you.
 
 See also: [transition](/docs/api/misc/transition.md)
 
-### `willTransitionFrom(transition, component)`
+### `willTransitionFrom(transition, component, callback)`
 
 Called when an active route is being transitioned out giving you an
 opportunity to abort the transition. The `component` is the current
@@ -34,13 +35,11 @@ See also: [transition](/docs/api/misc/transition.md)
 var Settings = React.createClass({
   statics: {
     willTransitionTo: function (transition, params) {
-      return auth.isLoggedIn().then(function (loggedIn) {
-        if (!loggedIn)
-          return;
+      if (!auth.isLoggedIn()) {
         transition.abort();
         auth.logIn({transition: transition});
         // in auth module call `transition.retry()` after being logged in
-      });
+      }
     },
 
     willTransitionFrom: function (transition, component) {

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -35,8 +35,8 @@ describe('Router', function () {
       <Route path="/async" handler={Async}/>
     ];
 
-    describe('transition.wait', function () {
-      it('waits asynchronously in willTransitionTo', function (done) {
+    describe('asynchronous willTransitionTo', function () {
+      it('waits', function (done) {
         TestLocation.history = [ '/bar' ];
 
         var div = document.createElement('div');
@@ -70,7 +70,7 @@ describe('Router', function () {
         });
       });
 
-      it('stops waiting asynchronously in willTransitionTo on location.pop', function (done) {
+      it('stops waiting on location.pop', function (done) {
         TestLocation.history = [ '/bar' ];
 
         var div = document.createElement('div');
@@ -106,7 +106,7 @@ describe('Router', function () {
         });
       });
 
-      it('stops waiting asynchronously in willTransitionTo on router.transitionTo', function (done) {
+      it('stops waiting on router.transitionTo', function (done) {
         TestLocation.history = [ '/bar' ];
 
         var div = document.createElement('div');
@@ -149,7 +149,7 @@ describe('Router', function () {
         });
       });
 
-      it('stops waiting asynchronously in willTransitionTo on router.replaceWith', function (done) {
+      it('stops waiting on router.replaceWith', function (done) {
         TestLocation.history = [ '/bar' ];
 
         var div = document.createElement('div');
@@ -597,7 +597,7 @@ describe('Router', function () {
       var Bar = React.createClass({
         statics: {
           willTransitionFrom: function (transition, component) {
-            expect(div.querySelector('#bar')).toEqual(component.getDOMNode());
+            expect(div.querySelector('#bar')).toBe(component.getDOMNode());
             done();
           }
         },

--- a/modules/__tests__/TestHandlers.js
+++ b/modules/__tests__/TestHandlers.js
@@ -1,7 +1,6 @@
 var React = require('react');
 var RouteHandler = require('../components/RouteHandler');
 var State = require('../mixins/State');
-var delay = require('when/delay');
 
 exports.Nested = React.createClass({
   render: function () {
@@ -36,8 +35,8 @@ exports.Async = React.createClass({
   statics: {
     delay: 10,
 
-    willTransitionTo: function (transition) {
-      transition.wait(delay(this.delay));
+    willTransitionTo: function (transition, params, query, callback) {
+      setTimeout(callback, this.delay);
     }
   },
 
@@ -62,10 +61,11 @@ exports.RedirectToFooAsync = React.createClass({
   statics: {
     delay: 10,
 
-    willTransitionTo: function (transition) {
-      transition.wait(delay(this.delay).then(function () {
+    willTransitionTo: function (transition, params, query, callback) {
+      setTimeout(function () {
         transition.redirect('/foo');
-      }));
+        callback();
+      }, this.delay);
     }
   },
 
@@ -91,10 +91,11 @@ exports.AbortAsync = React.createClass({
   statics: {
     delay: 10,
 
-    willTransitionTo: function (transition) {
-      transition.wait(delay(this.delay).then(function () {
+    willTransitionTo: function (transition, params, query, callback) {
+      setTimeout(function () {
         transition.abort();
-      }));
+        callback();
+      }, this.delay);
     }
   },
 

--- a/modules/utils/Promise.js
+++ b/modules/utils/Promise.js
@@ -1,6 +1,0 @@
-var Promise = require('when/lib/Promise');
-
-// TODO: Use process.env.NODE_ENV check + envify to enable
-// when's promise monitor here when in dev.
-
-module.exports = Promise;

--- a/modules/utils/createRouter.js
+++ b/modules/utils/createRouter.js
@@ -322,7 +322,7 @@ function createRouter(options) {
        * all route handlers we're transitioning to.
        *
        * Both willTransitionFrom and willTransitionTo hooks may either abort or redirect the
-       * transition. To resolve asynchronously, they may use transition.wait(promise). If no
+       * transition. To resolve asynchronously, they may use the callback argument. If no
        * hooks wait, the transition is fully synchronous.
        */
       dispatch: function (path, action, callback) {
@@ -374,7 +374,9 @@ function createRouter(options) {
         var transition = new Transition(path, this.replaceWith.bind(this, path));
         pendingTransition = transition;
 
-        transition.from(fromRoutes, components, function (error) {
+        var fromComponents = components.slice(prevRoutes.length - fromRoutes.length);
+
+        transition.from(fromRoutes, fromComponents, function (error) {
           if (error || transition.isAborted)
             return callback.call(router, error, transition);
 

--- a/modules/utils/reversedArray.js
+++ b/modules/utils/reversedArray.js
@@ -1,5 +1,0 @@
-function reversedArray(array) {
-  return array.slice(0).reverse();
-}
-
-module.exports = reversedArray;

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "react": "0.12.x"
   },
   "dependencies": {
-    "qs": "2.3.3",
-    "when": "3.4.6"
+    "qs": "2.3.3"
   },
   "tags": [
     "react",


### PR DESCRIPTION
This commit also removes our dependency on when.js and introduces
a callback argument in transition hooks. Users are expected to call
callback(error) when they're finished doing async stuff. If they
don't have a callback in their argument list, we automatically call
the callback for them for backwards compat.

Fixes #273
Fixes #631 

I have mixed feelings about this PR. Part of me wishes that everyone would get on the same page, realize how cool promises are, use webpack, and be happy. But hey, at least we get:
1. smaller file size
2. 1 less dependency
3. easier compat with browserify
