### PR TITLE
#4605 match.params aren't URI decoded - further test

### DIFF
--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -84,7 +84,7 @@ describe("A <Route>", () => {
   describe("with dynamic segments in the path", () => {
     it("decodes them", () => {
       renderStrict(
-        <MemoryRouter initialEntries={["/a%20dynamic%20segment"]}>
+        <MemoryRouter initialEntries={["/a%20dynamic%20segment%20%3A%2F%3F%C8%A9%20with%20encoding"]}>
           <Route
             path="/:id"
             render={({ match }) => <h1>{match.params.id}</h1>}
@@ -93,7 +93,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("a dynamic segment");
+      expect(node.innerHTML).toContain("a dynamic segment :/?ȩ with encoding");
     });
   });
 

--- a/packages/react-router/modules/__tests__/Route-test.js
+++ b/packages/react-router/modules/__tests__/Route-test.js
@@ -32,7 +32,7 @@ describe("A <Route>", () => {
       node
     );
 
-    expect(node.innerHTML).toContain(text);
+    expect(node.textContent).toEqual(text);
   });
 
   it("renders when it matches at the root URL", () => {
@@ -45,7 +45,7 @@ describe("A <Route>", () => {
       node
     );
 
-    expect(node.innerHTML).toContain(text);
+    expect(node.textContent).toEqual(text);
   });
 
   it("does not render when it does not match", () => {
@@ -58,7 +58,7 @@ describe("A <Route>", () => {
       node
     );
 
-    expect(node.innerHTML).not.toContain(text);
+    expect(node.textContent).not.toContain(text);
   });
 
   it("matches using nextContext when updating", () => {
@@ -78,7 +78,7 @@ describe("A <Route>", () => {
 
     history.push("/sushi/spicy-tuna");
 
-    expect(node.innerHTML).toContain("/sushi/spicy-tuna");
+    expect(node.textContent).toEqual("/sushi/spicy-tuna");
   });
 
   describe("with dynamic segments in the path", () => {
@@ -93,7 +93,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("a dynamic segment :/?ȩ with encoding");
+      expect(node.textContent).toEqual("a dynamic segment :/?ȩ with encoding");
     });
   });
 
@@ -110,7 +110,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("Hello World");
+      expect(node.textContent).toEqual("Hello World");
     });
 
     it("matches other provided paths", () => {
@@ -125,7 +125,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("Hello World");
+      expect(node.textContent).toEqual("Hello World");
     });
 
     it("provides the matched path as a string", () => {
@@ -140,7 +140,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("/world");
+      expect(node.textContent).toEqual("/world");
     });
 
     it("doesn't remount when moving from one matching path to another", () => {
@@ -165,12 +165,12 @@ describe("A <Route>", () => {
       );
 
       expect(mount).toHaveBeenCalledTimes(1);
-      expect(node.innerHTML).toContain("Hello World");
+      expect(node.textContent).toEqual("Hello World");
 
       history.push("/world/somewhere/else");
 
       expect(mount).toHaveBeenCalledTimes(1);
-      expect(node.innerHTML).toContain("Hello World");
+      expect(node.textContent).toEqual("Hello World");
     });
   });
 
@@ -183,7 +183,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("/パス名");
+      expect(node.textContent).toEqual("/パス名");
     });
   });
 
@@ -199,7 +199,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain("/pizza (1)");
+      expect(node.textContent).toEqual("/pizza (1)");
     });
   });
 
@@ -214,7 +214,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain(text);
+      expect(node.textContent).toEqual(text);
     });
 
     it("renders when the URL has trailing slash", () => {
@@ -227,7 +227,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain(text);
+      expect(node.textContent).toEqual(text);
     });
 
     describe("and `strict=true`", () => {
@@ -246,7 +246,7 @@ describe("A <Route>", () => {
           node
         );
 
-        expect(node.innerHTML).not.toContain(text);
+        expect(node.textContent).not.toContain(text);
       });
 
       it("does not render when the URL does not have a trailing slash", () => {
@@ -264,7 +264,7 @@ describe("A <Route>", () => {
           node
         );
 
-        expect(node.innerHTML).not.toContain(text);
+        expect(node.textContent).not.toContain(text);
       });
     });
   });
@@ -284,7 +284,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain(text);
+      expect(node.textContent).toEqual(text);
     });
   });
 
@@ -302,7 +302,7 @@ describe("A <Route>", () => {
           node
         );
 
-        expect(node.innerHTML).toContain(text);
+        expect(node.textContent).toEqual(text);
       });
     });
 
@@ -340,7 +340,7 @@ describe("A <Route>", () => {
           node
         );
 
-        expect(node.innerHTML).toContain(text);
+        expect(node.textContent).toEqual(text);
       });
 
       describe("that returns `undefined`", () => {
@@ -376,7 +376,7 @@ describe("A <Route>", () => {
           node
         );
 
-        expect(node.innerHTML).toContain(text);
+        expect(node.textContent).toEqual(text);
       });
     });
   });
@@ -394,7 +394,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain(text);
+      expect(node.textContent).toEqual(text);
     });
 
     it("receives { history, location, match } props", () => {
@@ -459,7 +459,7 @@ describe("A <Route>", () => {
         node
       );
 
-      expect(node.innerHTML).toContain(text);
+      expect(node.textContent).toEqual(text);
     });
 
     it("receives { history, location, match } props", () => {

--- a/packages/react-router/modules/matchPath.js
+++ b/packages/react-router/modules/matchPath.js
@@ -53,7 +53,11 @@ function matchPath(pathname, options = {}) {
       url: path === "/" && url === "" ? "/" : url, // the matched portion of the URL
       isExact, // whether or not we matched exactly
       params: keys.reduce((memo, key, index) => {
-        memo[key.name] = values[index];
+        // `values` here contains substrings of a URI, extracted by a regex
+        // These URI substrings will be URI encoded if they contain any URI metachars
+        // Any matched params therefore need URI decoding before they can be
+        // presented to the caller as string typed params
+        memo[key.name] = decodeURIComponent(values[index]);
         return memo;
       }, {})
     };


### PR DESCRIPTION
Hi,

I think that #4605 is still not fixed, as this test demonstrates.

I will attempt to fix, but I can't guarantee I will succeed. I think the fix needs to be in `history`, and that the path component decoding function needs to be [`decodeURIComponent`](https://www.ecma-international.org/ecma-262/6.0/#sec-decodeuricomponent-encodeduricomponent), rather than `decodeURI`. For that to work, we need to rearrange the parsing so that decoding happens after parsing (I think [this commit does it before parsing](https://github.com/ReactTraining/history/pull/442/files#diff-090dc87e7364e24d9acb38fed9878f54R18)), otherwise the parse will be ambiguous.

I think that the current code shows confusion around types, e.g. the line I linked to above `pathname = decodeURI(pathname)` shows that the distinction between encoded URIs and values used as path parameters is not being properly maintained, which has led to this bug IMO. Decoded path parameters are of a different _type_ to encoded URIs, so the two should not be stored in the same variable without inviting confusion and bugs.

Thanks,


Rich
