### PR TITLE
Link - add element shape for innerRef

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import createReactClass from 'create-react-class'
-import { bool, object, string, func, oneOfType } from 'prop-types'
+import { bool, object, string, func, oneOfType, shape, elementType } from 'prop-types'
 import invariant from 'invariant'
 import { routerShape } from './PropTypes'
 import { ContextSubscriber } from './ContextUtils'
@@ -55,7 +55,11 @@ const Link = createReactClass({
     onlyActiveOnIndex: bool.isRequired,
     onClick: func,
     target: string,
-    innerRef: oneOfType([ string, func ])
+    innerRef: oneOfType([
+      string,
+      func,
+      shape({ current: elementType })
+    ])
   },
 
   getDefaultProps() {


### PR DESCRIPTION
The [`innerRef` property](https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#innerref) from the `Link` component is throwing a warning when using the [`React.createRef`](https://reactjs.org/docs/react-api.html#reactcreateref) API introduced in React 16.3.

The warning is the following one: 

```Warning: Failed prop type: Invalid prop `innerRef` supplied to `Link`.
    in Link (created by MyComponent)```

I am taking the approach suggested [here](https://stackoverflow.com/a/56950157/1353771). Basically adding the new shape to the valid types for this property.

Here you have a live example of the warning being thrown when using the `innerRef` prop with the `createRef` function:

https://codesandbox.io/s/react-router-v3-link-ref-ojj07