### PR TITLE
[dev] add useRouteMatch to react-router

### DIFF
--- a/packages/react-router-dom/index.js
+++ b/packages/react-router-dom/index.js
@@ -20,6 +20,7 @@ import {
   useParams,
   useResolvedLocation,
   useRoutes,
+  useRouteMatch,
   // utils
   createRoutesFromChildren,
   matchRoutes,
@@ -51,6 +52,7 @@ export {
   useParams,
   useResolvedLocation,
   useRoutes,
+  useRouteMatch,
   // utils
   createRoutesFromChildren,
   matchRoutes,

--- a/packages/react-router-native/index.js
+++ b/packages/react-router-native/index.js
@@ -20,6 +20,7 @@ import {
   useParams,
   useResolvedLocation,
   useRoutes,
+  useRouteMatch,
   // utils
   createRoutesFromChildren,
   matchRoutes,
@@ -51,6 +52,7 @@ export {
   useParams,
   useResolvedLocation,
   useRoutes,
+  useRouteMatch,
   // utils
   createRoutesFromChildren,
   matchRoutes,

--- a/packages/react-router/__tests__/useRouteMatch-test.js
+++ b/packages/react-router/__tests__/useRouteMatch-test.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import { create as createTestRenderer } from 'react-test-renderer';
+import { MemoryRouter as Router, Routes, Route, useMatch, useRouteMatch } from 'react-router';
+
+describe('useRouteMatch', () => {
+  describe('when the to value matches the current URL', () => {
+    it('returns params and pathname', () => {
+      let routeMatch;
+
+      function User() {
+        routeMatch = useRouteMatch(':tab');
+        return null;
+      }
+
+      function Home() {
+        return <h1>Home</h1>;
+      }
+
+      function Profile() {
+        return <h1>Home</h1>;
+      }
+
+      function Projects() {
+        return <h1>Projects</h1>;
+      }
+
+      createTestRenderer(
+        <Router initialEntries={['/user/10/profile']}>
+          <Routes>
+            <Route path="home" element={<Home/>}/>
+            <Route path="/user/:id/*" element={<User/>}>
+              <Route path="profile" element={<Profile/>}/>
+              <Route path="projects" element={<Projects/>}/>
+            </Route>
+          </Routes>
+        </Router>
+      );
+
+      expect(routeMatch.params.id).toBe('10');
+      expect(routeMatch.params.tab).toBe('profile');
+      expect(routeMatch.params['*']).toBe('profile');
+      expect(routeMatch.pathname).toBe('/user/10/profile');
+    });
+  });
+
+  describe('when the to value matches the current URL', () => {
+    it('returns params and pathname', () => {
+      let routeMatch;
+
+      function User() {
+        routeMatch = useRouteMatch(':tab/*');
+        return null;
+      }
+
+      function Home() {
+        return <h1>Home</h1>;
+      }
+
+      function Profile() {
+        return <h1>Home</h1>;
+      }
+
+      function Projects() {
+        return <h1>Projects</h1>;
+      }
+
+      createTestRenderer(
+        <Router initialEntries={['/user/10/profile/details']}>
+          <Routes>
+            <Route path="home" element={<Home/>}/>
+            <Route path="/user/:id/*" element={<User/>}>
+              <Route path="profile" element={<Profile/>}/>
+              <Route path="projects" element={<Projects/>}/>
+            </Route>
+          </Routes>
+        </Router>
+      );
+
+      expect(routeMatch.params.id).toBe('10');
+      expect(routeMatch.params.tab).toBe('profile');
+      expect(routeMatch.params['*']).toBe('details');
+      expect(routeMatch.pathname).toBe('/user/10/profile');
+    });
+  });
+
+  describe('when the to value does not match the current URL', () => {
+    it('returns null', () => {
+      let routeMatch;
+
+      function User() {
+        routeMatch = useRouteMatch(':tab');
+        return null;
+      }
+
+      function Home() {
+        return <h1>Home</h1>;
+      }
+
+      function Profile() {
+        return <h1>Home</h1>;
+      }
+
+      function Projects() {
+        return <h1>Projects</h1>;
+      }
+
+      createTestRenderer(
+        <Router initialEntries={['/user/10']}>
+          <Routes>
+            <Route path="home" element={<Home/>}/>
+            <Route path="/user/:id/*" element={<User/>}>
+              <Route path="profile" element={<Profile/>}/>
+              <Route path="projects" element={<Projects/>}/>
+            </Route>
+          </Routes>
+        </Router>
+      );
+
+
+      expect(routeMatch).toBe(null);
+    });
+  });
+});

--- a/packages/react-router/index.js
+++ b/packages/react-router/index.js
@@ -378,6 +378,37 @@ export function useMatch(to) {
 }
 
 /**
+ *
+ */
+export function useRouteMatch(to, basename = '', caseSensitive = false) {
+  let {
+    params: parentParams,
+    pathname: parentPathname
+  } = React.useContext(RouteContext);
+  basename = basename ? joinPaths([parentPathname, basename]) : parentPathname;
+  let location = useLocation();
+  const matches = React.useMemo(() => matchRoutes([{
+    path: to,
+    element: null,
+    children: null
+  }], location, basename, caseSensitive), [to, location, basename, caseSensitive]);
+  return React.useMemo(
+    () => {
+      if (!matches || !matches[0]) {
+        return null;
+      }
+      const { pathname, params } = matches[0];
+
+      return {
+        params: readOnly({ ...parentParams, ...params }),
+        pathname: joinPaths([basename, pathname])
+      };
+    },
+    [basename, matches, parentParams]
+  );
+}
+
+/**
  * Returns an imperative method for changing the location. Used by <Link>s, but
  * may also be used by other elements to change the location.
  */


### PR DESCRIPTION
- [x] test
- [ ] doc + example

# About API:
## Old API:
In the old API `<Route />` became `useRouteMatch`

hoc API:
```js
<Route
      path="/blog/:slug"
      render={({ match }) => {
        // Do whatever you want with the match...
        return <div />;
      }}
    />
```
old hook api:
```js
  let match = useRouteMatch("/blog/:slug");
```
old api match shape:
```
{
  path: string,
  url: string,
  isExact: boolean,
  params: object
}
```
## New API:

`useRouteMatch(path)` will returns an object like provided value by `RouteContext` in this code:
```js
<Routes>
  <Route path={path} element={null}/>
</Routes>
```
- the `outlet` key removed because always is behave like a `null` value (context provider with null child)
- the `route` key removed because always is equal to `{ path: path, element: null, children: null }`

The final shape of the returned object:
```
{
  params: object { string: string }
  pathname: string
}
```

**Notes:**
- maybe the hook name should be changed.
- I need help for documentation part

fixes #7133