### PR TITLE
Expose current routes context pathname as useRoutePathname()

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -28,6 +28,7 @@ import {
   createRoutesFromArray,
   createRoutesFromChildren,
   generatePath,
+  useRoutePathname,
   matchRoutes,
   matchPath,
   resolvePath

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -74,6 +74,7 @@ export {
   useLocation,
   useMatch,
   useNavigate,
+  useRoutePathname,
   useOutlet,
   useParams,
   useResolvedPath,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -27,7 +27,6 @@ import {
   useLocation,
   useMatch,
   useRoutePathname,
-  useRoutePathname,
   useNavigate,
   useOutlet,
   useParams,
@@ -64,6 +63,7 @@ export {
   useOutlet,
   useParams,
   useResolvedPath,
+  useRoutePathname,
   useRoutes
 };
 

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -26,6 +26,7 @@ import {
   useInRouterContext,
   useLocation,
   useMatch,
+  useRoutePathname,
   useNavigate,
   useOutlet,
   useParams,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -27,6 +27,7 @@ import {
   useLocation,
   useMatch,
   useRoutePathname,
+  useRoutePathname,
   useNavigate,
   useOutlet,
   useParams,

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -463,6 +463,15 @@ export function useParams(): Params {
   return React.useContext(RouteContext).params;
 }
 
+ /**
+ * Returns the pathname element under current router context.
+ *
+ * @see https://reactrouter.com/api/useRouterPath
+ */
+export function useRoutesPath(): React.ReactElement | null {
+  return React.useContext(RouteContext).pathname;
+}
+
 /**
  * Resolves the pathname of the given `to` value against the current location.
  *

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -468,7 +468,7 @@ export function useParams(): Params {
  *
  * @see https://reactrouter.com/api/useRouterPath
  */
-export function useRoutesPath(): String {
+export function useRoutesPath(): string {
   return React.useContext(RouteContext).pathname;
 }
 

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -466,9 +466,9 @@ export function useParams(): Params {
  /**
  * Returns the pathname element under current router context.
  *
- * @see https://reactrouter.com/api/useRouterPath
+ * @see https://reactrouter.com/api/useRoutePathname
  */
-export function useRoutesPath(): string {
+export function useRoutePathname(): string {
   return React.useContext(RouteContext).pathname;
 }
 

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -468,7 +468,7 @@ export function useParams(): Params {
  *
  * @see https://reactrouter.com/api/useRouterPath
  */
-export function useRoutesPath(): React.ReactElement | null {
+export function useRoutesPath(): String {
   return React.useContext(RouteContext).pathname;
 }
 


### PR DESCRIPTION
There should be a way to get current routes context pathname.

Equal is done as useOutlet() for outlet and  useParams() for params

This change adds useRoutesPath() and Returns the pathname element under current router context...

**Edited:** by @timdorr recomendation will name useRoutePathname()