### PR TITLE
make `RouteObject`, `PartialRouteObject` and `matchRoutes` accept generic props

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -734,14 +734,14 @@ The term "location" in React Router refers to [the `Location` interface](https:/
   <summary>Type declaration</summary>
 
 ```tsx
-declare function matchRoutes(
-  routes: RouteObject[],
+declare function matchRoutes<P = {}>(
+  routes: RouteObject<P>[],
   location: string | PartialLocation,
   basename: string = ""
-): RouteMatch[] | null;
+): RouteMatch<P>[] | null;
 
-interface RouteMatch {
-  route: RouteObject;
+interface RouteMatch<P = {}> {
+  route: RouteObject<P>;
   pathname: string;
   params: Params;
 }
@@ -752,6 +752,8 @@ interface RouteMatch {
 `matchRoutes` runs the route matching algorithm for a set of routes against a given [`location`](#location) to see which routes (if any) match. If it finds a match, an array of `RouteMatch` objects is returned, one for each route that matched.
 
 This is the heart of React Router's matching algorithm. It is used internally by [`useRoutes`](#useroutes) and the [`<Routes>` component](#routes) to determine which routes match the current location. It can also be useful in some situations where you want to manually match a set of routes.
+
+The `P` generic allows you to type additional properties to the route, i.e. `name` or `icon`. This is especially helpful when building navigation from a routes object that is compatible with the [`useRoutes`](#useroutes) hook.
 
 <a name="matchpath"></a>
 


### PR DESCRIPTION
Routes in object syntax is awesome 👍🏻  especially when creating navigation. We can create nav UI items from the routes since it's just an array, and we can figure out what's active using `matchRoutes`:

```js
const routes = [{path: "/", children: [
  { name: "Page 1", path: "page1", element: <Page1 /> },
  { name: "Page 2", path: "page2", element: <Page2 /> },
}}]
const matches = matchRoutes(routes, useLocation());
const matchedPathName = matches?.[0].route.name;
```

(I know it's smarter to use the path as it should be unique, this is for the sake of demonstrating types)

This works great in JS, however we get a few TypeScript errors:

1. matchRoutes expects `caseSensitive` and `element` for all routes, which are optional. I'm ok with being explicit about `element: <Outlet />` though I'd rather not if avoidable. `caseSensitive` defaults to false anyway, so can't this be optional?
2. `matchRoutes` returns `RouteObject[]` which isn't aware of any custom properties the route might have (i.e. `name`, `icon`).

This PR makes `RouteObject` generic so we can pass custom properties like so;

```ts
const routes = [{path: "/", children: [
  { name: "Page 1", path: "page1", element: <Page1 /> },
  { name: "Page 2", path: "page2", element: <Page2 /> },
}}]
const matches = matchRoutes<{name?: string}>(routes, useLocation())
const matchedPathName = matches?.[0].route.name
```

It also makes `caseSensitive` optional, undefined by default which evaluates to false.