### PR TITLE
Pass custom `location` to `Routes` + `useRoutes`

### DIFF
--- a/packages/react-router/__tests__/Routes-test.tsx
+++ b/packages/react-router/__tests__/Routes-test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { create as createTestRenderer } from "react-test-renderer";
 import { MemoryRouter as Router, Routes, Route } from "react-router";
+import { act } from "react-dom/test-utils";
 
 describe("A <Routes>", () => {
   it("renders the first route that matches the URL", () => {
@@ -79,5 +81,27 @@ describe("A <Routes>", () => {
     );
 
     expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  it("Uses the `location` prop instead of context location`", () => {
+    let node = document.createElement("div");
+    document.body.appendChild(node);
+
+    act(() => {
+      ReactDOM.render(
+        <Router initialEntries={["/one"]}>
+          <Routes location={{ pathname: "/two" }}>
+            <Route path="/one" element={<h1>one</h1>} />
+            <Route path="/two" element={<h1>two</h1>} />
+          </Routes>
+        </Router>,
+        node
+      );
+    });
+
+    expect(node.innerHTML).toMatch(/two/);
+
+    // cleanup
+    document.body.removeChild(node);
   });
 });

--- a/packages/react-router/__tests__/useRoutes-test.tsx
+++ b/packages/react-router/__tests__/useRoutes-test.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { create as createTestRenderer } from "react-test-renderer";
 import { MemoryRouter as Router, useRoutes } from "react-router";
+import { act } from "react-dom/test-utils";
+import type { PartialRouteObject } from "react-router";
 
 describe("useRoutes", () => {
   it("returns the matching element from a route config", () => {
-    function RoutesRenderer({ routes }) {
-      return useRoutes(routes);
-    }
-
     function Home() {
       return <h1>Home</h1>;
     }
@@ -29,4 +28,40 @@ describe("useRoutes", () => {
 
     expect(renderer.toJSON()).toMatchSnapshot();
   });
+
+  it("Uses the `location` prop instead of context location`", () => {
+    let node = document.createElement("div");
+    document.body.appendChild(node);
+
+    let routes = [
+      { path: "one", element: <h1>one</h1> },
+      { path: "two", element: <h1>two</h1> }
+    ];
+
+    act(() => {
+      ReactDOM.render(
+        <Router initialEntries={["/one"]}>
+          <RoutesRenderer routes={routes} location={{ pathname: "/two" }} />
+        </Router>,
+        node
+      );
+    });
+
+    expect(node.innerHTML).toMatch(/two/);
+
+    // cleanup
+    document.body.removeChild(node);
+  });
 });
+
+function RoutesRenderer({
+  routes,
+  basename,
+  location
+}: {
+  routes: PartialRouteObject[];
+  basename?: string;
+  location?: Partial<Location>;
+}) {
+  return useRoutes(routes, basename, location);
+}


### PR DESCRIPTION
This resolves #7117.

We will consider updating our animation examples with a more declarative API for dealing with transition states, but this provides a smoother upgrade path for v5 users.