### PR TITLE
Replace NPM with Yarn in quick start guide

### DIFF
--- a/packages/react-router-dom/docs/guides/quick-start.md
+++ b/packages/react-router-dom/docs/guides/quick-start.md
@@ -14,7 +14,7 @@ cd demo-app
 You can install React Router from [the public npm registry](https://npm.im/react-router-dom) with either `npm` or [`yarn`](https://yarnpkg.com). Since we're building a web app, we'll use `react-router-dom` in this guide.
 
 ```sh
-npm install react-router-dom
+yarn add react-router-dom
 ```
 
 Next, copy/paste either of the following examples into `src/App.js`.


### PR DESCRIPTION
# Description

The latest version of `create-react-app` uses Yarn as the package manager, not NPM (even though it's invoked with `npx`). Because of this, specifying `npm install` as [step 2 of the quick start](https://reactrouter.com/web/guides/quick-start/installation) will likely cause confusion for new learners.

# Fix

This changes `npm install` to `yarn add` in the quick start guide. I don't know if there are any other installation guides in the docs; I took a look and didn't see any but it's possible I missed something. 