### PR TITLE
Add `displayName` to `forwardRef` components

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -235,6 +235,10 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   }
 );
 
+if (__DEV__) {
+  Link.displayName = "Link";
+}
+
 export interface NavLinkProps extends LinkProps {
   activeClassName?: string;
   activeStyle?: object;
@@ -292,6 +296,10 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     );
   }
 );
+
+if (__DEV__) {
+  NavLink.displayName = "NavLink";
+}
 
 export interface PromptProps {
   message: string;


### PR DESCRIPTION
Before the `beta.1` release we removed `propTypes` and `displayName` from the dev build. This PR adds `displayName` back for `forwardRef` components to help with debugging and make some Jest tests a bit more predictable (re: #7958)