### PR TITLE
Added location param override to Routes

### DIFF
--- a/packages/react-router/__tests__/Routes-location-test.tsx
+++ b/packages/react-router/__tests__/Routes-location-test.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { create as createTestRenderer } from "react-test-renderer";
+import {
+  MemoryRouter as Router,
+  Route,
+  Routes,
+  useParams
+} from "react-router";
+
+describe("<Routes> with a location", () => {
+
+  function Home() {
+    return <h1>Home</h1>;
+  }
+
+  function User() {
+    let { userId } = useParams();
+    return (
+      <div>
+        <h1>User: {userId}</h1>
+      </div>
+    );
+  }
+
+  it("matches when the location is overridden", () => {
+
+    const location = {
+      pathname: '/home',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'r9qntrej'
+    };
+    const renderer = createTestRenderer(
+      <Router initialEntries={["/users/michael"]}>
+        <Routes location={location}>
+          <Route path="home" element={<Home />} />
+          <Route path="users/:userId" element={<User />} />
+        </Routes>
+      </Router>
+    );
+
+    expect(renderer.toJSON()).not.toBeNull();
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+     <h1>
+       Home
+     </h1>
+    `);
+  });
+
+
+  it("matches when the location is not overridden", () => {
+    const renderer = createTestRenderer(
+      <Router initialEntries={["/users/michael"]}>
+        <Routes>
+          <Route path="home" element={<Home />} />
+          <Route path="users/:userId" element={<User />} />
+        </Routes>
+      </Router>
+    );
+
+    expect(renderer.toJSON()).not.toBeNull();
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      <div>
+        <h1>
+          User: 
+          michael
+        </h1>
+      </div>
+    `);
+  });
+});

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -255,6 +255,7 @@ export function Router({
 export interface RoutesProps {
   basename?: string;
   children?: React.ReactNode;
+  location?: Location;
 }
 
 /**
@@ -265,11 +266,12 @@ export interface RoutesProps {
  */
 export function Routes({
   basename = "",
-  children
+  children,
+  location
 }: RoutesProps): React.ReactElement | null {
   let routes = createRoutesFromChildren(children);
-  let location = useLocation();
-  return useRoutes_(routes, location, basename);
+  let location_ = useLocation();
+  return useRoutes_(routes, location ?? location_, basename);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added the posibility to override the location in the Routes component, like it was possible in Switch in V5.
Useful for implementing logic like in the example: 
https://reactrouter.com/web/example/modal-gallery
Specific test added