### PR TITLE
`NavLink`: add `inactiveClassName` and `inactiveStyle` props

### DIFF
--- a/packages/react-router-dom/docs/api/NavLink.md
+++ b/packages/react-router-dom/docs/api/NavLink.md
@@ -52,6 +52,32 @@ When `true`, the trailing slash on a location's `pathname` will be taken into co
 </NavLink>
 ```
 
+## inactiveClassName: string
+
+The class to give the element only when it is not active. By default, no `inactiveClassName` is assigned.
+
+```jsx
+<NavLink to="/faq" inactiveClassName="unselected">
+  FAQs
+</NavLink>
+```
+
+## inactiveStyle: object
+
+The styles to apply to the element only when it is not active.
+
+```jsx
+<NavLink
+  to="/faq"
+  inactiveStyle={{
+    fontWeight: "bold",
+    color: "blue"
+  }}
+>
+  FAQs
+</NavLink>
+```
+
 ## isActive: func
 
 A function to add extra logic for determining whether the link is active. This should be used if you want to do more than verify that the link's pathname matches the current URL's `pathname`.

--- a/packages/react-router-dom/modules/NavLink.js
+++ b/packages/react-router-dom/modules/NavLink.js
@@ -30,6 +30,8 @@ const NavLink = forwardRef(
       activeStyle,
       className: classNameProp,
       exact,
+      inactiveClassName,
+      inactiveStyle,
       isActive: isActiveProp,
       location: locationProp,
       sensitive,
@@ -68,10 +70,14 @@ const NavLink = forwardRef(
             ? isActiveProp(match, currentLocation)
             : match);
 
-          const className = isActive
-            ? joinClassnames(classNameProp, activeClassName)
-            : classNameProp;
-          const style = isActive ? { ...styleProp, ...activeStyle } : styleProp;
+          const className = joinClassnames(
+            classNameProp,
+            isActive ? activeClassName : inactiveClassName
+          );
+          const style = {
+            ...styleProp,
+            ...(isActive ? activeStyle : inactiveStyle)
+          };
 
           const props = {
             "aria-current": (isActive && ariaCurrent) || null,
@@ -115,6 +121,8 @@ if (__DEV__) {
     activeStyle: PropTypes.object,
     className: PropTypes.string,
     exact: PropTypes.bool,
+    inactiveClassName: PropTypes.string,
+    inactiveStyle: PropTypes.object,
     isActive: PropTypes.func,
     location: PropTypes.object,
     sensitive: PropTypes.bool,

--- a/packages/react-router-dom/modules/__tests__/NavLink-test.js
+++ b/packages/react-router-dom/modules/__tests__/NavLink-test.js
@@ -93,6 +93,37 @@ describe("A <NavLink>", () => {
       expect(a.style.color).toBe(activeStyle.color);
     });
 
+    it("does not apply its inactiveClassName", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink to="/pizza" inactiveClassName="unselected">
+            Pizza!
+          </NavLink>
+        </MemoryRouter>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.className).not.toContain("unselected");
+    });
+
+    it("does not apply its inactiveStyle", () => {
+      const defaultStyle = { color: "black" };
+      const inactiveStyle = { color: "blue" };
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink to="/pizza" style={defaultStyle} activeStyle={inactiveStyle}>
+            Pizza!
+          </NavLink>
+        </MemoryRouter>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.style.color).toBe(inactiveStyle.color);
+    });
+
     it("applies the default aria-current", () => {
       renderStrict(
         <MemoryRouter initialEntries={["/pizza"]}>
@@ -215,6 +246,41 @@ describe("A <NavLink>", () => {
       const a = node.querySelector("a");
 
       expect(a.style.color).toBe(defaultStyle.color);
+    });
+
+    it("applies its inactiveClassName", () => {
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink to="/salad" inactiveClassName="unselected">
+            Salad?
+          </NavLink>
+        </MemoryRouter>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.className).toContain("unselected");
+    });
+
+    it("applies its inactiveStyle", () => {
+      const defaultStyle = { color: "black" };
+      const inactiveStyle = { color: "blue" };
+
+      renderStrict(
+        <MemoryRouter initialEntries={["/pizza"]}>
+          <NavLink
+            to="/salad"
+            style={defaultStyle}
+            inactiveStyle={inactiveStyle}
+          >
+            Salad?
+          </NavLink>
+        </MemoryRouter>,
+        node
+      );
+
+      const a = node.querySelector("a");
+      expect(a.style.color).toBe(inactiveStyle.color);
     });
 
     it("does not apply an aria-current value if no override value is given", () => {


### PR DESCRIPTION
This PR adds two new props for v5 to add an optional class name and style prop when a `NavLink` is inactive. Resolves #7194.