### PR TITLE
[v6] `NavLink`: replace `activeClassName` + `activeStyle` props

### DIFF
--- a/packages/react-router-dom/__tests__/nav-link-active-test.tsx
+++ b/packages/react-router-dom/__tests__/nav-link-active-test.tsx
@@ -10,13 +10,11 @@ import type { ReactTestRenderer } from "react-test-renderer";
 
 describe("NavLink", () => {
   describe("when it does not match", () => {
-    it("does not apply its activeClassName to the underlying <a>", () => {
+    it("does not apply an 'active' className to the underlying <a>", () => {
       function Home() {
         return (
           <div>
-            <NavLink to="somewhere-else" activeClassName="active">
-              Somewhere else
-            </NavLink>
+            <NavLink to="somewhere-else">Somewhere else</NavLink>
           </div>
         );
       }
@@ -37,47 +35,43 @@ describe("NavLink", () => {
       expect(anchor).not.toBeNull();
       expect(anchor.props.className).not.toMatch("active");
     });
+  });
 
-    it("does not apply its activeStyle to the underlying <a>", () => {
+  describe("when it matches to the end", () => {
+    it("applies the default 'active' className to the underlying <a>", () => {
+      function Home() {
+        return (
+          <div>
+            <NavLink to=".">Home</NavLink>
+          </div>
+        );
+      }
+
+      let renderer!: ReactTestRenderer;
+      act(() => {
+        renderer = createTestRenderer(
+          <Router initialEntries={["/home"]}>
+            <Routes>
+              <Route path="/home" element={<Home />} />
+            </Routes>
+          </Router>
+        );
+      });
+
+      let anchor = renderer.root.findByType("a");
+      expect(anchor.props.className).toMatch("active");
+    });
+
+    it("applies its className correctly when provided as a function", () => {
       function Home() {
         return (
           <div>
             <NavLink
-              to="somewhere-else"
-              activeStyle={{ textTransform: "uppercase" }}
+              to="."
+              className={isActive =>
+                "nav-link" + (isActive ? " highlighted" : " plain")
+              }
             >
-              Somewhere else
-            </NavLink>
-          </div>
-        );
-      }
-
-      let renderer!: ReactTestRenderer;
-      act(() => {
-        renderer = createTestRenderer(
-          <Router initialEntries={["/home"]}>
-            <Routes>
-              <Route path="/home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
-      });
-
-      let anchor = renderer.root.findByType("a");
-
-      expect(anchor).not.toBeNull();
-      expect(anchor.props.style).not.toMatchObject({
-        textTransform: "uppercase"
-      });
-    });
-  });
-
-  describe("when it matches to the end", () => {
-    it("applies its activeClassName to the underlying <a>", () => {
-      function Home() {
-        return (
-          <div>
-            <NavLink to="." activeClassName="active">
               Home
             </NavLink>
           </div>
@@ -98,14 +92,21 @@ describe("NavLink", () => {
       let anchor = renderer.root.findByType("a");
 
       expect(anchor).not.toBeNull();
-      expect(anchor.props.className).toMatch("active");
+      expect(anchor.props.className.includes("nav-link")).toBe(true);
+      expect(anchor.props.className.includes("highlighted")).toBe(true);
+      expect(anchor.props.className.includes("plain")).toBe(false);
     });
 
-    it("applies its activeStyle to the underlying <a>", () => {
+    it("applies its style correctly when provided as a function", () => {
       function Home() {
         return (
           <div>
-            <NavLink to="." activeStyle={{ textTransform: "uppercase" }}>
+            <NavLink
+              to="."
+              style={isActive =>
+                isActive ? { textTransform: "uppercase" } : {}
+              }
+            >
               Home
             </NavLink>
           </div>
@@ -124,7 +125,6 @@ describe("NavLink", () => {
       });
 
       let anchor = renderer.root.findByType("a");
-
       expect(anchor).not.toBeNull();
       expect(anchor.props.style).toMatchObject({ textTransform: "uppercase" });
     });
@@ -132,13 +132,11 @@ describe("NavLink", () => {
 
   describe("when it matches just the beginning but not to the end", () => {
     describe("by default", () => {
-      it("applies its activeClassName to the underlying <a>", () => {
+      it("applies the default 'active' className to the underlying <a>", () => {
         function Home() {
           return (
             <div>
-              <NavLink to="." activeClassName="active">
-                Home
-              </NavLink>
+              <NavLink to=".">Home</NavLink>
             </div>
           );
         }
@@ -165,50 +163,14 @@ describe("NavLink", () => {
         expect(anchor).not.toBeNull();
         expect(anchor.props.className).toMatch("active");
       });
-
-      it("applies its activeStyle to the underlying <a>", () => {
-        function Home() {
-          return (
-            <div>
-              <NavLink to="." activeStyle={{ textTransform: "uppercase" }}>
-                Home
-              </NavLink>
-            </div>
-          );
-        }
-
-        function Child() {
-          return <div>Child</div>;
-        }
-
-        let renderer!: ReactTestRenderer;
-        act(() => {
-          renderer = createTestRenderer(
-            <Router initialEntries={["/home/child"]}>
-              <Routes>
-                <Route path="home" element={<Home />}>
-                  <Route path="child" element={<Child />} />
-                </Route>
-              </Routes>
-            </Router>
-          );
-        });
-
-        let anchor = renderer.root.findByType("a");
-
-        expect(anchor).not.toBeNull();
-        expect(anchor.props.style).toMatchObject({
-          textTransform: "uppercase"
-        });
-      });
     });
 
     describe("when end=true", () => {
-      it("does not apply its activeClassName to the underlying <a>", () => {
+      it("does not apply the default 'active' className to the underlying <a>", () => {
         function Home() {
           return (
             <div>
-              <NavLink to="." end={true} activeClassName="active">
+              <NavLink to="." end={true}>
                 Home
               </NavLink>
             </div>
@@ -236,59 +198,17 @@ describe("NavLink", () => {
 
         expect(anchor).not.toBeNull();
         expect(anchor.props.className).not.toMatch("active");
-      });
-
-      it("does not apply its activeStyle to the underlying <a>", () => {
-        function Home() {
-          return (
-            <div>
-              <NavLink
-                to="."
-                end={true}
-                activeStyle={{ textTransform: "uppercase" }}
-              >
-                Home
-              </NavLink>
-            </div>
-          );
-        }
-
-        function Child() {
-          return <div>Child</div>;
-        }
-
-        let renderer!: ReactTestRenderer;
-        act(() => {
-          renderer = createTestRenderer(
-            <Router initialEntries={["/home/child"]}>
-              <Routes>
-                <Route path="home" element={<Home />}>
-                  <Route path="child" element={<Child />} />
-                </Route>
-              </Routes>
-            </Router>
-          );
-        });
-
-        let anchor = renderer.root.findByType("a");
-
-        expect(anchor).not.toBeNull();
-        expect(anchor.props.style).not.toMatchObject({
-          textTransform: "uppercase"
-        });
       });
     });
   });
 
   describe("when it matches without matching case", () => {
     describe("by default", () => {
-      it("applies its activeClassName to the underlying <a>", () => {
+      it("applies the default 'active' className to the underlying <a>", () => {
         function Home() {
           return (
             <div>
-              <NavLink to="." activeClassName="active">
-                Home
-              </NavLink>
+              <NavLink to=".">Home</NavLink>
             </div>
           );
         }
@@ -309,44 +229,14 @@ describe("NavLink", () => {
         expect(anchor).not.toBeNull();
         expect(anchor.props.className).toMatch("active");
       });
-
-      it("applies its activeStyle to the underlying <a>", () => {
-        function Home() {
-          return (
-            <div>
-              <NavLink to="." activeStyle={{ textTransform: "uppercase" }}>
-                Home
-              </NavLink>
-            </div>
-          );
-        }
-
-        let renderer!: ReactTestRenderer;
-        act(() => {
-          renderer = createTestRenderer(
-            <Router initialEntries={["/Home"]}>
-              <Routes>
-                <Route path="home" element={<Home />} />
-              </Routes>
-            </Router>
-          );
-        });
-
-        let anchor = renderer.root.findByType("a");
-
-        expect(anchor).not.toBeNull();
-        expect(anchor.props.style).toMatchObject({
-          textTransform: "uppercase"
-        });
-      });
     });
 
     describe("when caseSensitive=true", () => {
-      it("does not apply its activeClassName to the underlying <a>", () => {
+      it("does not apply the default 'active' className to the underlying <a>", () => {
         function Home() {
           return (
             <div>
-              <NavLink to="/home" caseSensitive={true} activeClassName="active">
+              <NavLink to="/home" caseSensitive={true}>
                 Home
               </NavLink>
             </div>
@@ -368,40 +258,6 @@ describe("NavLink", () => {
 
         expect(anchor).not.toBeNull();
         expect(anchor.props.className).not.toMatch("active");
-      });
-
-      it("does not apply its activeStyle to the underlying <a>", () => {
-        function Home() {
-          return (
-            <div>
-              <NavLink
-                to="/home"
-                caseSensitive={true}
-                activeStyle={{ textTransform: "uppercase" }}
-              >
-                Home
-              </NavLink>
-            </div>
-          );
-        }
-
-        let renderer!: ReactTestRenderer;
-        act(() => {
-          renderer = createTestRenderer(
-            <Router initialEntries={["/Home"]}>
-              <Routes>
-                <Route path="home" element={<Home />} />
-              </Routes>
-            </Router>
-          );
-        });
-
-        let anchor = renderer.root.findByType("a");
-
-        expect(anchor).not.toBeNull();
-        expect(anchor.props.style).not.toMatchObject({
-          textTransform: "uppercase"
-        });
       });
     });
   });
@@ -409,13 +265,11 @@ describe("NavLink", () => {
 
 describe("NavLink under a Routes with a basename", () => {
   describe("when it does not match", () => {
-    it("does not apply its activeClassName to the underlying <a>", () => {
+    it("does not apply the default 'active' className to the underlying <a>", () => {
       function Home() {
         return (
           <div>
-            <NavLink to="somewhere-else" activeClassName="active">
-              Somewhere else
-            </NavLink>
+            <NavLink to="somewhere-else">Somewhere else</NavLink>
           </div>
         );
       }
@@ -436,49 +290,14 @@ describe("NavLink under a Routes with a basename", () => {
       expect(anchor).not.toBeNull();
       expect(anchor.props.className).not.toMatch("active");
     });
-
-    it("does not apply its activeStyle to the underlying <a>", () => {
-      function Home() {
-        return (
-          <div>
-            <NavLink
-              to="somewhere-else"
-              activeStyle={{ textTransform: "uppercase" }}
-            >
-              Somewhere else
-            </NavLink>
-          </div>
-        );
-      }
-
-      let renderer!: ReactTestRenderer;
-      act(() => {
-        renderer = createTestRenderer(
-          <Router initialEntries={["/app/home"]}>
-            <Routes basename="app">
-              <Route path="home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
-      });
-
-      let anchor = renderer.root.findByType("a");
-
-      expect(anchor).not.toBeNull();
-      expect(anchor.props.style).not.toMatchObject({
-        textTransform: "uppercase"
-      });
-    });
   });
 
   describe("when it matches", () => {
-    it("applies its activeClassName to the underlying <a>", () => {
+    it("applies the default 'active' className to the underlying <a>", () => {
       function Home() {
         return (
           <div>
-            <NavLink to="." activeClassName="active">
-              Home
-            </NavLink>
+            <NavLink to=".">Home</NavLink>
           </div>
         );
       }
@@ -498,34 +317,6 @@ describe("NavLink under a Routes with a basename", () => {
 
       expect(anchor).not.toBeNull();
       expect(anchor.props.className).toMatch("active");
-    });
-
-    it("applies its activeStyle to the underlying <a>", () => {
-      function Home() {
-        return (
-          <div>
-            <NavLink to="." activeStyle={{ textTransform: "uppercase" }}>
-              Home
-            </NavLink>
-          </div>
-        );
-      }
-
-      let renderer!: ReactTestRenderer;
-      act(() => {
-        renderer = createTestRenderer(
-          <Router initialEntries={["/app/home"]}>
-            <Routes basename="app">
-              <Route path="home" element={<Home />} />
-            </Routes>
-          </Router>
-        );
-      });
-
-      let anchor = renderer.root.findByType("a");
-
-      expect(anchor).not.toBeNull();
-      expect(anchor.props.style).toMatchObject({ textTransform: "uppercase" });
     });
   });
 });


### PR DESCRIPTION
See #7983 for context.

This change will remove the `activeClassName` and `activeStyle` props from `NavLink` and replace them by allowing either `style` or `className` to accept functions with the active state. Updated tests and documentation to support the change!