### PR TITLE
`useRoutes`: add support for `location` override

### DIFF
--- a/packages/react-router/__tests__/useRoutes-test.tsx
+++ b/packages/react-router/__tests__/useRoutes-test.tsx
@@ -61,7 +61,7 @@ function RoutesRenderer({
 }: {
   routes: PartialRouteObject[];
   basename?: string;
-  location?: Partial<Location>;
+  location?: Partial<Location> & { pathname: string };
 }) {
   return useRoutes(routes, basename, location);
 }

--- a/packages/react-router/__tests__/useRoutes-test.tsx
+++ b/packages/react-router/__tests__/useRoutes-test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { create as createTestRenderer } from "react-test-renderer";
 import { MemoryRouter as Router, useRoutes } from "react-router";
+import { act } from "react-dom/test-utils";
 import type { PartialRouteObject } from "react-router";
 
 describe("useRoutes", () => {
@@ -26,14 +28,40 @@ describe("useRoutes", () => {
 
     expect(renderer.toJSON()).toMatchSnapshot();
   });
+
+  it("Uses the `location` prop instead of context location`", () => {
+    let node = document.createElement("div");
+    document.body.appendChild(node);
+
+    let routes = [
+      { path: "one", element: <h1>one</h1> },
+      { path: "two", element: <h1>two</h1> }
+    ];
+
+    act(() => {
+      ReactDOM.render(
+        <Router initialEntries={["/one"]}>
+          <RoutesRenderer routes={routes} location={{ pathname: "/two" }} />
+        </Router>,
+        node
+      );
+    });
+
+    expect(node.innerHTML).toMatch(/two/);
+
+    // cleanup
+    document.body.removeChild(node);
+  });
 });
 
 function RoutesRenderer({
   routes,
-  basename
+  basename,
+  location
 }: {
   routes: PartialRouteObject[];
   basename?: string;
+  location?: Partial<Location>;
 }) {
-  return useRoutes(routes, basename);
+  return useRoutes(routes, basename, location);
 }

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -249,10 +249,15 @@ export function Router({
   );
 }
 
+interface PartialLocation<S extends State = State>
+  extends Omit<Partial<Location<S>>, "pathname"> {
+  pathname: string;
+}
+
 export interface RoutesProps {
   basename?: string;
   children?: React.ReactNode;
-  location?: Partial<Location>;
+  location?: PartialLocation;
 }
 
 /**
@@ -491,7 +496,7 @@ export function useResolvedPath(to: To): Path {
 export function useRoutes(
   partialRoutes: PartialRouteObject[],
   basename = "",
-  location?: Partial<Location>
+  location?: PartialLocation
 ): React.ReactElement | null {
   invariant(
     useInRouterContext(),
@@ -510,7 +515,7 @@ export function useRoutes(
 
 function useRoutes_(
   routes: RouteObject[],
-  locationOverride?: Partial<Location>,
+  locationOverride?: PartialLocation,
   basename = ""
 ): React.ReactElement | null {
   let {
@@ -542,11 +547,7 @@ function useRoutes_(
     : parentPathname;
 
   let contextLocation = useLocation();
-  let location = React.useMemo(() => {
-    return locationOverride
-      ? { ...contextLocation, ...locationOverride }
-      : contextLocation;
-  }, [locationOverride, contextLocation]);
+  let location = locationOverride ?? contextLocation;
 
   let matches = React.useMemo(
     () => matchRoutes(routes, location, basenameForMatching),


### PR DESCRIPTION
This tweaks the implementation a bit for a custom `location` prop on `Routes` and adds support for the same location override with `useRoutes`.