### PR TITLE
test: rerun tests without rebuilding / add support for --watchAll

### DIFF
--- a/packages/react-router-dom/jest.config.js
+++ b/packages/react-router-dom/jest.config.js
@@ -5,11 +5,5 @@ module.exports = {
   },
   globals: {
     __DEV__: true
-  },
-  moduleNameMapper: {
-    "^react-router$": "<rootDir>/../../build/react-router",
-    "^react-router-dom$": "<rootDir>/../../build/react-router-dom",
-    "^react-router-dom\\/server$":
-      "<rootDir>/../../build/react-router-dom/server"
   }
 };

--- a/packages/react-router-native/jest.config.js
+++ b/packages/react-router-native/jest.config.js
@@ -7,10 +7,6 @@ module.exports = {
   globals: {
     __DEV__: true
   },
-  moduleNameMapper: {
-    "^react-router$": "<rootDir>/../../build/react-router",
-    "^react-router-native$": "<rootDir>/../../build/react-router-native"
-  },
   modulePaths: [
     "<rootDir>/node_modules" // for react-native
   ],

--- a/packages/react-router/jest.config.js
+++ b/packages/react-router/jest.config.js
@@ -5,8 +5,5 @@ module.exports = {
   },
   globals: {
     __DEV__: true
-  },
-  moduleNameMapper: {
-    "^react-router$": "<rootDir>/../../build/react-router"
   }
 };

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -22,6 +22,10 @@ if (args.includes("--watch")) {
   jestArgs.push("--watch");
 }
 
+if (args.includes("--watchAll")) {
+  jestArgs.push("--watchAll");
+}
+
 if (args.includes("-u")) {
   jestArgs.push("-u");
 }


### PR DESCRIPTION
closes REM-250

This PR adds the ability for you to not need to rebuild react-router before running the tests

This PR also adds `jest --watchAll` so jest will auto rerun the tests on file changes

https://user-images.githubusercontent.com/11698668/134251774-36c251fe-6349-4b6b-890c-a9e4a0212a4e.mp4
 