### PR TITLE
Fix relative <Link to>

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       "none": "8 kB"
     },
     "build/node_modules/react-router/umd/react-router.production.min.js": {
-      "none": "8 kB"
+      "none": "9 kB"
     },
     "build/node_modules/react-router-dom/react-router-dom.production.min.js": {
       "none": "4 kB"

--- a/packages/react-router-dom/__tests__/link-href-test.tsx
+++ b/packages/react-router-dom/__tests__/link-href-test.tsx
@@ -1,131 +1,454 @@
 import * as React from "react";
 import { create as createTestRenderer } from "react-test-renderer";
-import { MemoryRouter as Router, Routes, Route, Link } from "react-router-dom";
+import { MemoryRouter, Routes, Route, Link, Outlet } from "react-router-dom";
 
-describe("<Link> anchor href", () => {
-  test("absolute <Link to> resolves relative to the root URL", () => {
-    let renderer = createTestRenderer(
-      <Router initialEntries={["/home"]}>
-        <Routes>
-          <Route path="home" element={<Link to="/about" />} />
-        </Routes>
-      </Router>
-    );
+describe("<Link> href", () => {
+  describe("in a static route", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox" element={<Link to="/about" />} />
+          </Routes>
+        </MemoryRouter>
+      );
 
-    let anchor = renderer.root.findByType("a");
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
 
-    expect(anchor.props.href).toEqual("/about");
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox" element={<Link to="." />} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> resolves relative to the parent route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages" element={<Link to=".." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages" element={<Link to="../../about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
   });
 
-  test("absolute <Link to> in an index route resolves relative to the root URL", () => {
-    let renderer = createTestRenderer(
-      <Router initialEntries={["/home"]}>
-        <Routes>
-          <Route path="home">
-            <Route index element={<Link to="/about" />} />
-          </Route>
-        </Routes>
-      </Router>
-    );
+  describe("in a dynamic route", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/:id" element={<Link to="/about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
 
-    let anchor = renderer.root.findByType("a");
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
 
-    expect(anchor.props.href).toEqual("/about");
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/:id" element={<Link to="." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/inbox/messages/abc"
+      );
+    });
+
+    test('<Link to=".."> resolves relative to the parent route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/:id" element={<Link to=".." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/:id" element={<Link to="../../about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
   });
 
-  test("absolute <Link to> in descendant <Routes> resolves relative to the root URL", () => {
-    let renderer = createTestRenderer(
-      <Router initialEntries={["/auth/login"]}>
-        <Routes>
-          <Route
-            path="auth/*"
-            element={
-              <Routes>
-                <Route
-                  path="login"
-                  element={<Link to="/auth/forgot-password" />}
-                />
-              </Routes>
-            }
-          />
-        </Routes>
-      </Router>
-    );
+  describe("in an index route", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route index element={<Link to="/home" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
 
-    let anchor = renderer.root.findByType("a");
+      expect(renderer.root.findByType("a").props.href).toEqual("/home");
+    });
 
-    expect(anchor.props.href).toEqual("/auth/forgot-password");
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route index element={<Link to="." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> resolves relative to the parent route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route index element={<Link to=".." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route index element={<Link to="../../about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
   });
 
-  test('<Link to="."> resolves relative to the current route', () => {
-    let renderer = createTestRenderer(
-      <Router initialEntries={["/home"]}>
-        <Routes>
-          <Route path="home" element={<Link to="." />} />
-        </Routes>
-      </Router>
-    );
+  describe("in a layout route", () => {
+    function MessagesLayout({ link }: { link: React.ReactElement }) {
+      return (
+        <div>
+          {link}
+          <Outlet />
+        </div>
+      );
+    }
 
-    let anchor = renderer.root.findByType("a");
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route element={<MessagesLayout link={<Link to="/home" />} />}>
+                <Route path="messages" element={<h1>Messages</h1>} />
+              </Route>
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
 
-    expect(anchor.props.href).toEqual("/home");
+      expect(renderer.root.findByType("a").props.href).toEqual("/home");
+    });
+
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route element={<MessagesLayout link={<Link to="." />} />}>
+                <Route path="messages" element={<h1>Messages</h1>} />
+              </Route>
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> resolves relative to the parent route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route element={<MessagesLayout link={<Link to=".." />} />}>
+                <Route path="messages" element={<h1>Messages</h1>} />
+              </Route>
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route
+                element={<MessagesLayout link={<Link to="../../about" />} />}
+              >
+                <Route path="messages" element={<h1>Messages</h1>} />
+              </Route>
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
   });
 
-  test('<Link to="."> in a splat route resolves relative to the current route', () => {
-    let renderer = createTestRenderer(
-      <Router initialEntries={["/home/inbox"]}>
-        <Routes>
-          <Route path="home/*" element={<Link to="." />} />
-        </Routes>
-      </Router>
-    );
+  describe("in a splat route", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/123"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/*" element={<Link to="/about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
 
-    let anchor = renderer.root.findByType("a");
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
 
-    expect(anchor.props.href).toEqual("/home/inbox");
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/*" element={<Link to="." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/inbox/messages"
+      );
+    });
+
+    test('<Link to=".."> resolves relative to the parent route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/*" element={<Link to=".." />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test("<Link to> pointing to a sibling route resolves relative to its parent route", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages/abc"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route
+                path="messages/*"
+                element={<Link to="../messages/def" />}
+              />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/inbox/messages/def"
+      );
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/inbox/messages"]}>
+          <Routes>
+            <Route path="inbox">
+              <Route path="messages/*" element={<Link to="../../../about" />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
   });
 
   describe("under a <Router basename>", () => {
     test("absolute <Link to> resolves relative to the basename", () => {
       let renderer = createTestRenderer(
-        <Router basename="/app" initialEntries={["/app/home"]}>
+        <MemoryRouter basename="/app" initialEntries={["/app/inbox"]}>
           <Routes>
-            <Route path="home" element={<Link to="/about" />} />
+            <Route path="inbox" element={<Link to="/about" />} />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      let anchor = renderer.root.findByType("a");
-
-      expect(anchor.props.href).toEqual("/app/about");
+      expect(renderer.root.findByType("a").props.href).toEqual("/app/about");
     });
 
     test('<Link to="."> resolves relative to the current route', () => {
       let renderer = createTestRenderer(
-        <Router basename="/app" initialEntries={["/app/home"]}>
+        <MemoryRouter basename="/app" initialEntries={["/app/inbox"]}>
           <Routes>
-            <Route path="home" element={<Link to="." />} />
+            <Route path="inbox" element={<Link to="." />} />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      let anchor = renderer.root.findByType("a");
-
-      expect(anchor.props.href).toEqual("/app/home");
+      expect(renderer.root.findByType("a").props.href).toEqual("/app/inbox");
     });
 
     test('<Link to=".."> with no parent route resolves relative to the basename', () => {
       let renderer = createTestRenderer(
-        <Router basename="/app" initialEntries={["/app/home"]}>
+        <MemoryRouter basename="/app" initialEntries={["/app/inbox"]}>
           <Routes>
-            <Route path="home" element={<Link to="../about" />} />
+            <Route path="inbox" element={<Link to="../about" />} />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      let anchor = renderer.root.findByType("a");
+      expect(renderer.root.findByType("a").props.href).toEqual("/app/about");
+    });
+  });
 
-      expect(anchor.props.href).toEqual("/app/about");
+  describe("in a descendant <Routes>", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/auth/login"]}>
+          <Routes>
+            <Route
+              path="auth/*"
+              element={
+                <Routes>
+                  <Route
+                    path="login"
+                    element={<Link to="/auth/forgot-password" />}
+                  />
+                </Routes>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/auth/forgot-password"
+      );
+    });
+
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/auth/login"]}>
+          <Routes>
+            <Route
+              path="auth/*"
+              element={
+                <Routes>
+                  <Route path="login" element={<Link to="." />} />
+                </Routes>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/auth/login");
+    });
+
+    test('<Link to=".."> resolves relative to the ancestor route', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/auth/login"]}>
+          <Routes>
+            <Route
+              path="auth/*"
+              element={
+                <Routes>
+                  <Route path="login" element={<Link to=".." />} />
+                </Routes>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/auth");
+    });
+
+    test('<Link to=".."> with more .. segments than ancestor routes resolves relative to the root URL', () => {
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/auth/login"]}>
+          <Routes>
+            <Route
+              path="auth/*"
+              element={
+                <Routes>
+                  <Route path="login" element={<Link to="../../../about" />} />
+                </Routes>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
     });
   });
 });

--- a/packages/react-router/__tests__/useHref-test.tsx
+++ b/packages/react-router/__tests__/useHref-test.tsx
@@ -140,7 +140,9 @@ describe("useHref", () => {
       createTestRenderer(
         <Router initialEntries={["/courses/advanced-react"]}>
           <Routes>
-            <Route path="courses/advanced-react" element={<AdvancedReact />} />
+            <Route path="courses">
+              <Route path="advanced-react" element={<AdvancedReact />} />
+            </Route>
           </Routes>
         </Router>
       );
@@ -159,10 +161,9 @@ describe("useHref", () => {
         createTestRenderer(
           <Router initialEntries={["/courses/advanced-react/"]}>
             <Routes>
-              <Route
-                path="courses/advanced-react"
-                element={<AdvancedReact />}
-              />
+              <Route path="courses">
+                <Route path="advanced-react" element={<AdvancedReact />} />
+              </Route>
             </Routes>
           </Router>
         );
@@ -182,10 +183,9 @@ describe("useHref", () => {
         createTestRenderer(
           <Router initialEntries={["/courses/advanced-react"]}>
             <Routes>
-              <Route
-                path="courses/advanced-react"
-                element={<AdvancedReact />}
-              />
+              <Route path="courses">
+                <Route path="advanced-react" element={<AdvancedReact />} />
+              </Route>
             </Routes>
           </Router>
         );

--- a/packages/react-router/__tests__/useHref-test.tsx
+++ b/packages/react-router/__tests__/useHref-test.tsx
@@ -1,270 +1,244 @@
 import * as React from "react";
 import { create as createTestRenderer } from "react-test-renderer";
-import {
-  MemoryRouter as Router,
-  Routes,
-  Route,
-  Outlet,
-  useHref
-} from "react-router";
+import { MemoryRouter, Routes, Route, useHref } from "react-router";
+
+function ShowHref({ to }: { to: string }) {
+  return <p>{useHref(to)}</p>;
+}
 
 describe("useHref", () => {
   describe("to a child route", () => {
     it("returns the correct href", () => {
-      let href = "";
-      function Courses() {
-        href = useHref("advanced-react");
-        return <h1>Courses</h1>;
-      }
-
-      createTestRenderer(
-        <Router initialEntries={["/courses"]}>
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/courses"]}>
           <Routes>
-            <Route path="courses" element={<Courses />} />
+            <Route path="courses" element={<ShowHref to="advanced-react" />} />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      expect(href).toBe("/courses/advanced-react");
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          /courses/advanced-react
+        </p>
+      `);
     });
 
     describe("when the URL has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function Courses() {
-          href = useHref("advanced-react");
-          return <h1>Courses</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses/"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses/"]}>
             <Routes>
-              <Route path="courses" element={<Courses />} />
+              <Route
+                path="courses"
+                element={<ShowHref to="advanced-react" />}
+              />
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/courses/advanced-react");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /courses/advanced-react
+          </p>
+        `);
       });
     });
 
     describe("when the href has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function Courses() {
-          href = useHref("advanced-react/");
-          return <h1>Courses</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses"]}>
             <Routes>
-              <Route path="courses" element={<Courses />} />
+              <Route
+                path="courses"
+                element={<ShowHref to="advanced-react/" />}
+              />
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/courses/advanced-react/");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /courses/advanced-react/
+          </p>
+        `);
       });
     });
   });
 
   describe("to a sibling route", () => {
     it("returns the correct href", () => {
-      let href = "";
-      function Courses() {
-        href = useHref("../about");
-        return <h1>Courses</h1>;
-      }
-
-      createTestRenderer(
-        <Router initialEntries={["/courses"]}>
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/courses"]}>
           <Routes>
-            <Route path="courses" element={<Courses />} />
+            <Route path="courses" element={<ShowHref to="../about" />} />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      expect(href).toBe("/about");
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          /about
+        </p>
+      `);
     });
 
     describe("when the URL has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function Courses() {
-          href = useHref("../about");
-          return <h1>Courses</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses/"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses/"]}>
             <Routes>
-              <Route path="/courses/" element={<Courses />} />
+              <Route path="/courses/" element={<ShowHref to="../about" />} />
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/about");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /about
+          </p>
+        `);
       });
     });
 
     describe("when the href has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function Courses() {
-          href = useHref("../about/");
-          return <h1>Courses</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses"]}>
             <Routes>
-              <Route path="courses" element={<Courses />} />
+              <Route path="courses" element={<ShowHref to="../about/" />} />
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/about/");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /about/
+          </p>
+        `);
       });
     });
   });
 
   describe("to a parent route", () => {
     it("returns the correct href", () => {
-      let href = "";
-      function AdvancedReact() {
-        href = useHref("..");
-        return <h1>Advanced React</h1>;
-      }
-
-      createTestRenderer(
-        <Router initialEntries={["/courses/advanced-react"]}>
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/courses/advanced-react"]}>
           <Routes>
             <Route path="courses">
-              <Route path="advanced-react" element={<AdvancedReact />} />
+              <Route path="advanced-react" element={<ShowHref to=".." />} />
             </Route>
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      expect(href).toBe("/courses");
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          /courses
+        </p>
+      `);
     });
 
     describe("when the URL has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function AdvancedReact() {
-          href = useHref("..");
-          return <h1>Advanced React</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses/advanced-react/"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses/advanced-react/"]}>
             <Routes>
               <Route path="courses">
-                <Route path="advanced-react" element={<AdvancedReact />} />
+                <Route path="advanced-react" element={<ShowHref to=".." />} />
               </Route>
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/courses");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /courses
+          </p>
+        `);
       });
     });
 
     describe("when the href has a trailing slash", () => {
       it("returns the correct href", () => {
-        let href = "";
-        function AdvancedReact() {
-          href = useHref("../");
-          return <h1>Advanced React</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/courses/advanced-react"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/courses/advanced-react"]}>
             <Routes>
               <Route path="courses">
-                <Route path="advanced-react" element={<AdvancedReact />} />
+                <Route path="advanced-react" element={<ShowHref to="../" />} />
               </Route>
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/courses/");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /courses/
+          </p>
+        `);
       });
     });
   });
 
   describe("to an absolute route", () => {
     it("returns the correct href", () => {
-      let href = "";
-      function AdvancedReact() {
-        href = useHref("/users");
-        return <h1>Advanced React</h1>;
-      }
-
-      createTestRenderer(
-        <Router initialEntries={["/courses/advanced-react"]}>
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/courses/advanced-react"]}>
           <Routes>
-            <Route path="courses/advanced-react" element={<AdvancedReact />} />
+            <Route
+              path="courses/advanced-react"
+              element={<ShowHref to="/users" />}
+            />
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      expect(href).toBe("/users");
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          /users
+        </p>
+      `);
     });
   });
 
   describe("with a to value that has more .. segments than are in the URL", () => {
     it("returns the correct href", () => {
-      function Courses() {
-        return (
-          <div>
-            <h1>Courses</h1>
-            <Outlet />
-          </div>
-        );
-      }
-
-      let href = "";
-      function ReactFundamentals() {
-        href = useHref("../../../courses");
-        return <p>React Fundamentals</p>;
-      }
-
-      createTestRenderer(
-        <Router initialEntries={["/courses/react-fundamentals"]}>
+      let renderer = createTestRenderer(
+        <MemoryRouter initialEntries={["/courses/react-fundamentals"]}>
           <Routes>
-            <Route path="courses" element={<Courses />}>
+            <Route path="courses">
               <Route
                 path="react-fundamentals"
-                element={<ReactFundamentals />}
+                element={<ShowHref to="../../../courses" />}
               />
             </Route>
           </Routes>
-        </Router>
+        </MemoryRouter>
       );
 
-      expect(href).toBe("/courses");
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          /courses
+        </p>
+      `);
     });
 
     describe("and no additional segments", () => {
       it("links to the root /", () => {
-        let href = "";
-        function Home() {
-          href = useHref("../../..");
-          return <h1>Home</h1>;
-        }
-
-        createTestRenderer(
-          <Router initialEntries={["/home"]}>
+        let renderer = createTestRenderer(
+          <MemoryRouter initialEntries={["/home"]}>
             <Routes>
-              <Route path="/home" element={<Home />} />
+              <Route path="/home" element={<ShowHref to="../../.." />} />
             </Routes>
-          </Router>
+          </MemoryRouter>
         );
 
-        expect(href).toBe("/");
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <p>
+            /
+          </p>
+        `);
       });
     });
   });

--- a/packages/react-router/__tests__/useResolvedPath-test.tsx
+++ b/packages/react-router/__tests__/useResolvedPath-test.tsx
@@ -94,7 +94,7 @@ describe("useResolvedPath", () => {
 
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <pre>
-          {"pathname":"/users/mj","search":"","hash":""}
+          {"pathname":"/users","search":"","hash":""}
         </pre>
       `);
     });


### PR DESCRIPTION
Fixes relative `<Link to>` values so that `..` traverses up by route instead of by URL segment.

Fixes #8086