### PR TITLE
chore: add repository directory for all packages.json [skip ci]

### DIFF
--- a/packages/react-router-config/package.json
+++ b/packages/react-router-config/package.json
@@ -2,7 +2,12 @@
   "name": "react-router-config",
   "version": "5.2.1",
   "description": "Static route config matching for React Router",
-  "repository": "remix-run/react-router",
+  "homepage": "https://reactrouter.com/",
+  "repository": {
+    "url": "https://github.com/remix-run/react-router.git",
+    "type": "git",
+    "directory": "packages/react-router-config"
+  },
   "license": "MIT",
   "author": "React Training <hello@reacttraining.com>",
   "files": [

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -2,7 +2,12 @@
   "name": "react-router-dom",
   "version": "5.3.0",
   "description": "DOM bindings for React Router",
-  "repository": "remix-run/react-router",
+  "homepage": "https://reactrouter.com/",
+  "repository": {
+    "url": "https://github.com/remix-run/react-router.git",
+    "type": "git",
+    "directory": "packages/react-router-dom"
+  },
   "license": "MIT",
   "author": "React Training <hello@reacttraining.com>",
   "files": [

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -2,7 +2,12 @@
   "name": "react-router-native",
   "version": "5.2.1",
   "description": "React Native bindings for React Router",
-  "repository": "remix-run/react-router",
+  "homepage": "https://reactrouter.com/",
+  "repository": {
+    "url": "https://github.com/remix-run/react-router.git",
+    "type": "git",
+    "directory": "packages/react-router-native"
+  },
   "license": "MIT",
   "author": "React Training <hello@reacttraining.com>",
   "main": "main.js",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -2,7 +2,12 @@
   "name": "react-router",
   "version": "5.2.1",
   "description": "Declarative routing for React",
-  "repository": "remix-run/react-router",
+  "homepage": "https://reactrouter.com/",
+  "repository": {
+    "url": "https://github.com/remix-run/react-router.git",
+    "type": "git",
+    "directory": "packages/react-router"
+  },
   "license": "MIT",
   "author": "React Training <hello@reacttraining.com>",
   "files": [


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79