### PR TITLE
docs: Replace broken links from README fils

### DIFF
--- a/packages/react-router-dom/README.md
+++ b/packages/react-router-dom/README.md
@@ -2,6 +2,4 @@
 
 The `react-router-dom` package contains bindings for using [React
 Router](https://github.com/ReactTraining/react-router) in web applications.
-Please see [the main
-README](https://github.com/ReactTraining/react-router/README.md) for more
-information on how to get started with React Router.
+Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/getting-started/tutorial.md) for more information on how to get started with React Router.

--- a/packages/react-router-native/README.md
+++ b/packages/react-router-native/README.md
@@ -2,6 +2,5 @@
 
 The `react-router-native` package contains bindings for using [React
 Router](https://github.com/ReactTraining/react-router) in [React
-Native](https://facebook.github.io/react-native/) applications. Please see [the
-main README](https://github.com/ReactTraining/react-router/README.md) for more
-information on how to get started with React Router.
+Native](https://facebook.github.io/react-native/) applications.
+Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/getting-started/tutorial.md) for more information on how to get started with React Router.


### PR DESCRIPTION
Thanks for the great lib!

Not sure if this would be the most fitting link, but it should be at least more useful than the broken ones, I guess?