### PR TITLE
feat: attach original route object inside routesMeta so matchRouteBranch don't need  routesArg

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -955,7 +955,6 @@ function matchRouteBranch<ParamKey extends string = string>(
     if (match.pathnameBase !== "/") {
       matchedPathname = joinPaths([matchedPathname, match.pathnameBase]);
     }
-
   }
 
   return matches;


### PR DESCRIPTION
Hi! 👋
I saw the `matchRouteBranch` with a todo.

So I add the `route: RouteObject;` to the interface `RouteMeta` so that the `matchRouteBranch` needn't to pass in  `routesArg`。

It's convenient to get the `route` if match in the function `matchRouteBranch`！