### PR TITLE
Removed history from install scripts

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,7 +21,7 @@ Most modern React projects manage their dependencies using a package manager lik
 <summary>npm</summary>
 
 ```sh
-$ npm install history@5 react-router-dom@6
+$ npm install react-router-dom@6
 ```
 
 </details>
@@ -30,7 +30,7 @@ $ npm install history@5 react-router-dom@6
 <summary>Yarn</summary>
 
 ```sh
-$ yarn add history@5 react-router-dom@6
+$ yarn add react-router-dom@6
 ```
 
 </details>
@@ -39,7 +39,7 @@ $ yarn add history@5 react-router-dom@6
 <summary>pnpm</summary>
 
 ```sh
-$ pnpm add history@5 react-router-dom@6
+$ pnpm add react-router-dom@6
 ```
 
 </details>

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -16,7 +16,7 @@ If you're familiar with the JavaScript ecosystem, React, and React Router, this 
 ## Installation
 
 ```sh
-npm add react-router-dom@6 history@5
+npm add react-router-dom@6
 ```
 
 ## Configuring Routes

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -55,7 +55,7 @@ Then install React Router dependencies:
 
 ```sh
 cd router-tutorial
-npm add react-router-dom@6 history@5
+npm add react-router-dom@6
 ```
 
 Then edit your App.js to be pretty boring:

--- a/docs/guides/upgrading-5-to-6.md
+++ b/docs/guides/upgrading-5-to-6.md
@@ -135,13 +135,12 @@ pick this guide back up when you're ready to continue.
 **Heads up:** This is the biggest step in the migration and will probably take
 the most time and effort.
 
-For this step, you'll need to install React Router v6 and the history library,
-which is now a peer dependency. If you're managing dependencies via npm:
+For this step, you'll need to install React Router v6. If you're managing dependencies via npm:
 
 ```bash
-$ npm install react-router@next react-router-dom@next history
+$ npm install react-router-dom@next
 # or, for a React Native app
-$ npm install react-router@next react-router-native@next history
+$ npm install react-router-native@next
 ```
 
 ### Upgrade all `<Switch>` elements to `<Routes>`


### PR DESCRIPTION
History is now a regular dependency. So these are not needed, right?