### PR TITLE
Minor doc change: fixing routes for example

### DIFF
--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -158,7 +158,7 @@ This route config defined three route paths:
 
 - `"/invoices"`
 - `"/invoices/sent"`
-- `"/invoices/sent/:invoiceId"`
+- `"/invoices/:invoiceId"`
 
 When the URL is `"/invoices/sent"` the component tree will be:
 


### PR DESCRIPTION
I noticed a minor mismatch in the docs. I think this example is listing an incorrect route for the dynamic `:invoiceId` example. 

Thanks for all of the great work!

