### PR TITLE
Fix “programmatically” typo in the docs

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -35,7 +35,7 @@ Here are some words we use a lot when we talk about React Router. The rest of th
 
 - <a id="csr">**Client Side Routing (CSR)**</a> - A plain HTML document can link to other documents and the browser handles the [history stack](#history-stack) itself. Client Side Routing enables developers to manipulate the browser history stack without making document request to the server.
 
-- <a id="history-object">**History**</a> - An object allows React Router to subscribe to changes in the [URL](#url) as well as providing APIs to manipulate the browser [history stack](#history-stack) programatically.
+- <a id="history-object">**History**</a> - An object allows React Router to subscribe to changes in the [URL](#url) as well as providing APIs to manipulate the browser [history stack](#history-stack) programmatically.
 
 - <a id="history-action">**History Action**</a> - One of `POP`, `PUSH`, or `REPLACE`. Users can arrive at a [URL](#url) for one of these three reasons. A push when a new entry is added to the history stack (typically a link click or the programmer forced a navigation). A replace is similar except it replaces the current entry on the stack instead of pushing a new one. Finally, a pop happens when the user clicks the back or forward buttons in the browser chrome.
 
@@ -95,7 +95,7 @@ The history stack will change as follows where **bold** entries denote the curre
 
 ### History Object
 
-With **client side routing**, developers are able to manipulate the browser [history stack](#history-stack) programatically. For example, we can write some code like this to change the [URL](#url) without the browsers default behavior of making a request to the server:
+With **client side routing**, developers are able to manipulate the browser [history stack](#history-stack) programmatically. For example, we can write some code like this to change the [URL](#url) without the browsers default behavior of making a request to the server:
 
 ```jsx
 <a

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -21,7 +21,7 @@ While building a little bookeeping app we'll cover:
 - Navigating with Link
 - Creating Links with active styling
 - Using Nested Routes for Layout
-- Navigating programatically
+- Navigating programmatically
 - Using URL params for data loading
 - Using URL Search params
 - Creating your own behaviors through composition
@@ -787,7 +787,7 @@ function BrandLink({ brand, ...props }) {
 
 As you can see, even in this fairly simple example there are a lot of valid behaviors you might want. React Router doesn't try to solve every use-case we've ever heard of directly. Instead, we give you the components and hooks to compose whatever behavior you need.
 
-## Navigating Programatically
+## Navigating Programmatically
 
 Okay, back to our app. Hang in there, you're almost done!
 


### PR DESCRIPTION
Noticed this small [typo](https://en.wiktionary.org/wiki/programatically) while going through the v6 docs. The new website looks great, congrats y’all!