### PR TITLE
history was missed as a peer dep

### DIFF
--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "react-dom": ">=16.8"
+    "react-dom": ">=16.8",
+    "history": ">=5"
   },
   "sideEffects": false,
   "keywords": [

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -14,12 +14,12 @@
   "types": "./index.d.ts",
   "unpkg": "./umd/react-router-dom.production.min.js",
   "dependencies": {
-    "react-router": "6.0.0"
+    "react-router": "6.0.0",
+    "history": "^5.1.0"
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "react-dom": ">=16.8",
-    "history": ">=5"
+    "react-dom": ">=16.8"
   },
   "sideEffects": false,
   "keywords": [

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -13,7 +13,8 @@
   "types": "./index.d.ts",
   "dependencies": {
     "@ungap/url-search-params": "^0.1.4",
-    "react-router": "6.0.0"
+    "react-router": "6.0.0",
+    "history": "^5.1.0"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -17,7 +17,7 @@
     "react": ">=16.8"
   },
   "dependencies": {
-    "history": "^5.0.3"
+    "history": "^5.1.0"
   },
   "sideEffects": false,
   "keywords": [


### PR DESCRIPTION
Check;
https://github.com/remix-run/react-router/blob/4ae8f4662592080c089454ab274c230d8e169aaf/packages/react-router-dom/server.tsx#L2

Currently not able to bundle react-rotuer-dom, as there is no dep on `history` in the file tree.

Worth noting seems to be only if pnpm is used, maybe just different linking strategy between it and yarn/npm.