### PR TITLE
Update descendant routes warning message

### DIFF
--- a/packages/react-router/__tests__/descendant-routes-warning-test.tsx
+++ b/packages/react-router/__tests__/descendant-routes-warning-test.tsx
@@ -52,9 +52,47 @@ describe("Descendant <Routes>", () => {
       });
 
       expect(consoleWarn).toHaveBeenCalledTimes(1);
-      expect(consoleWarn).toHaveBeenCalledWith(
-        expect.stringContaining("child routes will never render")
-      );
+
+      expect(consoleWarn.mock.calls[0][0])
+        .toMatch(`You rendered descendant <Routes> (or called \`useRoutes()\`) at "/courses/react" (under <Route path="react">) but the parent route path has no trailing "*". This means if you navigate deeper, the parent won't match anymore and therefore the child routes will never render.
+
+Please change the parent <Route path="react"> to <Route path="react/*">.`);
+    });
+  });
+
+  describe("when the parent route path does not have a trailing * and is the root", () => {
+    it("warns once when you visit the parent route and only shows a hint like *", () => {
+      function ReactCourses() {
+        return (
+          <div>
+            <h1>React</h1>
+
+            <Routes>
+              <Route
+                path="/react-fundamentals"
+                element={<h1>React Fundamentals</h1>}
+              />
+            </Routes>
+          </div>
+        );
+      }
+
+      TestRenderer.act(() => {
+        TestRenderer.create(
+          <MemoryRouter initialEntries={["/"]}>
+            <Routes>
+              <Route path="/" element={<ReactCourses />} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+      expect(consoleWarn.mock.calls[0][0])
+        .toMatch(`You rendered descendant <Routes> (or called \`useRoutes()\`) at "/" (under <Route path="/">) but the parent route path has no trailing "*". This means if you navigate deeper, the parent won't match anymore and therefore the child routes will never render.
+
+Please change the parent <Route path="/"> to <Route path="*">.`);
     });
   });
 

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -610,7 +610,7 @@ export function useRoutes(
         `deeper, the parent won't match anymore and therefore the child ` +
         `routes will never render.\n\n` +
         `Please change the parent <Route path="${parentPath}"> to <Route ` +
-        `path="${parentPath}/*">.`
+        `path="${parentPath === "/" ? "*" : `${parentPath}/*`}">.`
     );
   }
 


### PR DESCRIPTION
This slightly modifies the error message for silly people like me that might see this, which would also be an error:

![image](https://user-images.githubusercontent.com/784953/140267887-e898b62b-a0d7-4f47-93da-374d94041874.png)

This would show if you were in the middle of a v5->6 migration and had this:

```jsx
<Routes>
  <Route to="/" element={<SomeSectionWithLotsOfNestedRoutes />} />
</Routes>
```

As an aside, it might make sense to do `toMatchInlineSnapshot` checks of the `consoleWarn` in the test to cover both of these cases.