### PR TITLE
Improve title of `useNavigate` section in v5 -> v6 migration docs

### DIFF
--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -564,7 +564,7 @@ We encourage you to give both `<Routes>` and `useRoutes` a shot and decide for y
 
 If you had cooked up some of your own logic around data fetching and rendering server-side, we have a low-level `matchRoutes` function available as well similar to the one we had in react-router-config.
 
-## Use `useNavigate` instead of `history`
+## Use `useNavigate` instead of `useHistory`
 
 React Router v6 introduces a new navigation API that is synonymous with `<Link>` and provides better compatibility with suspense-enabled apps. We include both imperative and declarative versions of this API depending on your style and needs.
 


### PR DESCRIPTION
The section is about replacing one hook with another, so it makes sense that the title reflects that.