### PR TITLE
Fixed layout of documentation for desktop view

### DIFF
--- a/website/modules/base.css
+++ b/website/modules/base.css
@@ -78,7 +78,7 @@ a {
   display: block;
   clear: both;
   float: left;
-  width: 500px;
+  width: 490px;
   padding-right: 40px;
 }
 


### PR DESCRIPTION
Fixes #8208 
Updated the paragraph width inside markdown for Desktop view of screen width more than 1270px
So the alignment of code snippets in right half of the page in now fixed.
Now the documentation layout is correct for all the resolutions. 