### PR TITLE
style: fix typo in docs (layotus -> layouts)

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -662,7 +662,7 @@ And the resulting element tree rendered will be:
 </App>
 ```
 
-The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layotus in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
+The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
 
 <docs-error>You can do it like this, but we recommend using a layout route</docs-error>
 


### PR DESCRIPTION
Found a typo while reading the docs. 