### PR TITLE
Fix spelling for components

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -324,7 +324,7 @@ if (__DEV__) {
 
 /**
  * Handles the click behavior for router `<Link>` components. This is useful if
- * you need to create custom `<Link>` compoments with the same click behavior we
+ * you need to create custom `<Link>` components with the same click behavior we
  * use in our exported `<Link>`.
  */
 export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -160,7 +160,7 @@ const URLEventType = "url";
 
 /**
  * Handles the press behavior for router `<Link>` components. This is useful if
- * you need to create custom `<Link>` compoments with the same press behavior we
+ * you need to create custom `<Link>` components with the same press behavior we
  * use in our exported `<Link>`.
  */
 export function useLinkPressHandler(


### PR DESCRIPTION
Minor spelling fix from `compoments` -> `components`