### PR TITLE
Docs: Add `useMatch` section in upgrade docs

### DIFF
--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -821,6 +821,20 @@ import { StaticRouter } from "react-router-dom/server";
 
 This change was made both to follow more closely the convention established by the `react-dom` package and to help users understand better what a `<StaticRouter>` is for and when it should be used (on the server).
 
+## Replace `useRouteMatch` with `useMatch`
+
+`useMatch` is very similar to v5's `useRouteMatch`, with a few key differences:
+
+- It uses our new [path pattern matching algorithm](#note-on-route-path-patterns)
+- The pattern argument is now required
+- No longer accepts an array of patterns
+- When passing a pattern as an object, some of the options have been renamed to better align with other APIs in v6
+  - `useRouteMatch({ strict })` is now `useMatch({ end })`
+  - `useRouteMatch({ sensitive })` is now `useMatch({ caseSensitive })`
+- It returns a match object with a different shape
+
+To see the exact API of the new `useMatch` hook and its type declaration, check out our [API Reference](../api.md#usematch). <!-- TODO: Show examples for refactoring useRouteMatch -->
+
 ## What did we miss?
 
 Despite our best attempts at being thorough, it's very likely that we missed something. If you follow this upgrade guide and find that to be the case, please let us know. We are happy to help you figure out what to do with your v5 code to be able to upgrade and take advantage of all of the cool stuff in v6.


### PR DESCRIPTION
Our v5 migration docs do not mention that we replaced `useRouteMatch` with `useMatch` (thanks to @eps1lon for pointing that out in [#7133](https://github.com/remix-run/react-router/issues/7133#issuecomment-963017207)).

This change begins to address it, though we should probably add a few code examples to make refactoring much simpler. I'm actually not 100% sure how to capture the nuance in a few situations, but I think this is better than nothing for now. Will circle back to that later after discussing with the team.