### PR TITLE
Support base64 encoded ids on nested routes

### DIFF
--- a/packages/react-router/__tests__/matchRoutes-test.tsx
+++ b/packages/react-router/__tests__/matchRoutes-test.tsx
@@ -100,7 +100,7 @@ describe("matchRoutes", () => {
     ]);
   });
 
-  it("matches nested dynamic routes with base64 encoded ids", () => {
+  it("matches nested dynamic routes with params ending in = (e.x. base64 encoded Id)", () => {
     expect(pickPaths(routes, "/users/VXNlcnM6MQ==")).toEqual(["/users", ":id"]);
     expect(pickPaths(routes, "/users/VXNlcnM6MQ==/edit")).toEqual([
       "/users",

--- a/packages/react-router/__tests__/matchRoutes-test.tsx
+++ b/packages/react-router/__tests__/matchRoutes-test.tsx
@@ -12,9 +12,14 @@ function pickPaths(
 }
 
 describe("matchRoutes", () => {
+  let userEditRoute: RouteObject = {
+    path: "edit",
+    element: <h1>User Edit</h1>
+  };
   let userProfileRoute: RouteObject = {
     path: ":id",
-    element: <h1>User Profile</h1>
+    element: <h1>User Profile</h1>,
+    children: [userEditRoute]
   };
   let usersRoute: RouteObject = {
     path: "/users",
@@ -88,6 +93,20 @@ describe("matchRoutes", () => {
 
   it("matches nested dynamic routes correctly", () => {
     expect(pickPaths(routes, "/users/mj")).toEqual(["/users", ":id"]);
+    expect(pickPaths(routes, "/users/mj/edit")).toEqual([
+      "/users",
+      ":id",
+      "edit"
+    ]);
+  });
+
+  it("matches nested dynamic routes with base64 encoded ids", () => {
+    expect(pickPaths(routes, "/users/VXNlcnM6MQ==")).toEqual(["/users", ":id"]);
+    expect(pickPaths(routes, "/users/VXNlcnM6MQ==/edit")).toEqual([
+      "/users",
+      ":id",
+      "edit"
+    ]);
   });
 
   it("matches nested * routes correctly", () => {

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1150,10 +1150,10 @@ function compilePath(
   } else {
     regexpSource += end
       ? "\\/*$" // When matching to the end, ignore trailing slashes
-      : // Otherwise, at least match a word boundary. This restricts parent
-        // routes to matching only their own words and nothing more, e.g. parent
+      : // Otherwise, match a word boundary or a proceeding /. The word boundary restricts
+        // parent routes to matching only their own words and nothing more, e.g. parent
         // route "/home" should not match "/home2".
-        "(?:\\b|$)";
+        "(?:\\b|\\/|$)";
   }
 
   let matcher = new RegExp(regexpSource, caseSensitive ? undefined : "i");


### PR DESCRIPTION
Resolves #8288 

This PR modifies `compilePath`'s non-capturing group to match up to the proceeding `/` so that paths with base64 encoded ids  (e.x.`users/RGFzaGJvYXJkOjE1Nzk=/edit` when using `graphql-relay` globalIds) properly match up to the `/` and not at the word break before the `=` character.