### PR TITLE
fix: inconsistency with the previous step

### DIFF
--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -109,7 +109,7 @@ Remove any `<Redirect>` elements that are directly inside a `<Switch>`.
 
 If you want to redirect on the initial render, you should move the redirect logic to your server (we [wrote more about this here](https://gist.github.com/mjackson/b5748add2795ce7448a366ae8f8ae3bb)).
 
-If you want to redirect client-side, move your `<Redirect>` into a `<Route render>` prop.
+If you want to redirect client-side, move your `<Redirect>` into a `<Route children>` prop.
 
 ```tsx
 // Change this:
@@ -119,7 +119,7 @@ If you want to redirect client-side, move your `<Redirect>` into a `<Route rende
 
 // to this:
 <Switch>
-  <Route path="about" render={() => <Redirect to="about-us" />} />
+  <Route path="about" children={() => <Redirect to="about-us" />} />
 </Switch>
 ```
 


### PR DESCRIPTION
As it goes from the previous step - ```<Route render>``` shouldn't be used anymore. Is it correct fix?