### PR TITLE
chore(docs): use children instead of render props  for `<Redirect>`

### DIFF
--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -109,7 +109,7 @@ Remove any `<Redirect>` elements that are directly inside a `<Switch>`.
 
 If you want to redirect on the initial render, you should move the redirect logic to your server (we [wrote more about this here](https://gist.github.com/mjackson/b5748add2795ce7448a366ae8f8ae3bb)).
 
-If you want to redirect client-side, move your `<Redirect>` into a `<Route render>` prop.
+If you want to redirect client-side, move your `<Redirect>` into a `<Route>`.
 
 ```tsx
 // Change this:
@@ -119,7 +119,9 @@ If you want to redirect client-side, move your `<Redirect>` into a `<Route rende
 
 // to this:
 <Switch>
-  <Route path="about" render={() => <Redirect to="about-us" />} />
+  <Route path="about">
+    <Redirect to="about-us" />
+  </Route>
 </Switch>
 ```
 


### PR DESCRIPTION
paragraph above just tells users to 

>  **Instead of using `<Route component>` and `<Route render>` props, just use regular element `<Route children>` everywhere and use hooks to access the router's internal state.**

But here uses `render` props which makes people find it very confusing.