### PR TITLE
Allow navigate to compute next location from current

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -452,7 +452,7 @@ If the `end` prop is used, it will ensure this component isn't matched as "activ
 declare function Navigate(props: NavigateProps): null;
 
 interface NavigateProps {
-  to: To;
+  to: NextTo;
   replace?: boolean;
   state?: State;
 }
@@ -1095,9 +1095,11 @@ See [`matchPath`](#matchpath) for more information.
 ```tsx
 declare function useNavigate(): NavigateFunction;
 
+type NextTo = To | ((current: Location) => To);
+
 interface NavigateFunction {
   (
-    to: To,
+    to: NextTo,
     options?: { replace?: boolean; state?: State }
   ): void;
   (delta: number): void;
@@ -1126,7 +1128,7 @@ function SignupForm() {
 
 The `navigate` function has two signatures:
 
-- Either pass a `To` value (same type as `<Link to>`) with an optional second `{ replace, state }` arg or
+- Either pass a `NextTo` value (same type as `<Link to>`, or a function from the current location to a `To`) with an optional second `{ replace, state }` arg or
 - Pass the delta you want to go in the history stack. For example, `navigate(-1)` is equivalent to hitting the back button.
 
 ### `useOutlet`
@@ -1263,9 +1265,15 @@ type URLSearchParamsInit =
   | Record<string, string | string[]>
   | URLSearchParams;
 
+type NextURLSearchParams =
+  | URLSearchParamsInit
+  | ((
+      current: URLSearchParams
+    ) => URLSearchParamsInit | void);
+
 interface URLSearchParamsSetter {
   (
-    nextInit: URLSearchParamsInit,
+    nextInit: NextURLSearchParams,
     navigateOptions?: { replace?: boolean; state?: State }
   ): void;
 }
@@ -1306,6 +1314,21 @@ function App() {
 > of the URL. Also note that the second arg to `setSearchParams` is
 > the same type as the second arg to `navigate`.
 
+Similar to `useState`, the setter function returned by the hook also accepts a function that is passed the current search params and produces the next search params to use. This function can also mutate the given `URLSearchParams` instead of returning a new value, as a convenience for this common pattern:
+
+```tsx
+setSearchParams(params => {
+  params.set("q", value);
+  return params;
+});
+```
+
+This can instead be written:
+
+```tsx
+setSearchParams(params => params.set("q", value));
+```
+
 ### `useSearchParams` (React Native)
 
 > **Note:**
@@ -1328,6 +1351,12 @@ type URLSearchParamsInit =
   | ParamKeyValuePair[]
   | Record<string, string | string[]>
   | URLSearchParams;
+
+type NextURLSearchParams =
+  | URLSearchParamsInit
+  | ((
+      current: URLSearchParams
+    ) => URLSearchParamsInit | void);
 
 interface URLSearchParamsSetter {
   (
@@ -1364,6 +1393,21 @@ function App() {
     </View>
   );
 }
+```
+
+Similar to `useState`, the setter function returned by the hook also accepts a function that is passed the current search params and produces the next search params to use. This function can also mutate the given `URLSearchParams` instead of returning a new value, as a convenience for this common pattern:
+
+```tsx
+setSearchParams(params => {
+  params.set("q", value);
+  return params;
+});
+```
+
+This can instead be written:
+
+```tsx
+setSearchParams(params => params.set("q", value));
 ```
 
 ### `createSearchParams`

--- a/packages/react-router-dom/__tests__/search-params-test.tsx
+++ b/packages/react-router-dom/__tests__/search-params-test.tsx
@@ -4,28 +4,6 @@ import { act } from "react-dom/test-utils";
 import { MemoryRouter, Routes, Route, useSearchParams } from "react-router-dom";
 
 describe("useSearchParams", () => {
-  function SearchPage() {
-    let queryRef = React.useRef<HTMLInputElement>(null);
-    let [searchParams, setSearchParams] = useSearchParams({ q: "" });
-    let query = searchParams.get("q")!;
-
-    function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-      event.preventDefault();
-      if (queryRef.current) {
-        setSearchParams({ q: queryRef.current.value });
-      }
-    }
-
-    return (
-      <div>
-        <p>The current query is "{query}".</p>
-        <form onSubmit={handleSubmit}>
-          <input name="q" defaultValue={query} ref={queryRef} />
-        </form>
-      </div>
-    );
-  }
-
   let node: HTMLDivElement;
   beforeEach(() => {
     node = document.createElement("div");
@@ -37,33 +15,133 @@ describe("useSearchParams", () => {
     node = null!;
   });
 
-  it("reads and writes the search string", () => {
-    act(() => {
-      ReactDOM.render(
-        <MemoryRouter initialEntries={["/search?q=Michael+Jackson"]}>
-          <Routes>
-            <Route path="search" element={<SearchPage />} />
-          </Routes>
-        </MemoryRouter>,
-        node
+  describe("get and set", () => {
+    function SearchPage() {
+      let queryRef = React.useRef<HTMLInputElement>(null);
+      let [searchParams, setSearchParams] = useSearchParams({ q: "" });
+      let query = searchParams.get("q")!;
+
+      function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (queryRef.current) {
+          setSearchParams({ q: queryRef.current.value });
+        }
+      }
+
+      return (
+        <div>
+          <p>The current query is "{query}".</p>
+          <form onSubmit={handleSubmit}>
+            <input name="q" defaultValue={query} ref={queryRef} />
+          </form>
+        </div>
+      );
+    }
+
+    it("reads and writes the search string", () => {
+      act(() => {
+        ReactDOM.render(
+          <MemoryRouter initialEntries={["/search?q=Michael+Jackson"]}>
+            <Routes>
+              <Route path="search" element={<SearchPage />} />
+            </Routes>
+          </MemoryRouter>,
+          node
+        );
+      });
+
+      let form = node.querySelector("form")!;
+      expect(form).toBeDefined();
+
+      let queryInput = node.querySelector<HTMLInputElement>("input[name=q]")!;
+      expect(queryInput).toBeDefined();
+
+      expect(node.innerHTML).toMatch(/The current query is "Michael Jackson"/);
+
+      act(() => {
+        queryInput.value = "Ryan Florence";
+        form.dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true })
+        );
+      });
+
+      expect(node.innerHTML).toMatch(/The current query is "Ryan Florence"/);
+    });
+  });
+
+  describe("update function", () => {
+    function ParamsPage() {
+      let aRef = React.useRef<HTMLInputElement>(null);
+      let bRef = React.useRef<HTMLInputElement>(null);
+      let [searchParams, setSearchParams] = useSearchParams();
+      let a = searchParams.get("a")!;
+      let b = searchParams.get("b")!;
+
+      const handleSubmit = React.useCallback(
+        (event: React.FormEvent<HTMLFormElement>) => {
+          event.preventDefault();
+          if (aRef.current) {
+            setSearchParams(params => params.set("a", aRef.current.value));
+          }
+          if (bRef.current) {
+            setSearchParams(params => ({
+              a: params.get("a"),
+              b: bRef.current.value
+            }));
+          }
+        },
+        [setSearchParams]
+      );
+
+      return (
+        <div>
+          <p>
+            The current params are "{a}" and "{b}".
+          </p>
+          <form onSubmit={handleSubmit}>
+            <input name="a" defaultValue={a} ref={aRef} />
+            <input name="b" defaultValue={b} ref={bRef} />
+          </form>
+        </div>
+      );
+    }
+
+    it("writes search string with correctly updated state", () => {
+      act(() => {
+        ReactDOM.render(
+          <MemoryRouter initialEntries={["/params?a=Simon&b=Garfunkel"]}>
+            <Routes>
+              <Route path="params" element={<ParamsPage />} />
+            </Routes>
+          </MemoryRouter>,
+          node
+        );
+      });
+
+      let form = node.querySelector("form")!;
+      expect(form).toBeDefined();
+
+      let aInput = node.querySelector<HTMLInputElement>("input[name=a]")!;
+      expect(aInput).toBeDefined();
+
+      let bInput = node.querySelector<HTMLInputElement>("input[name=b]")!;
+      expect(bInput).toBeDefined();
+
+      expect(node.innerHTML).toMatch(
+        /The current params are "Simon" and "Garfunkel"/
+      );
+
+      act(() => {
+        aInput.value = "Bert";
+        bInput.value = "Ernie";
+        form.dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true })
+        );
+      });
+
+      expect(node.innerHTML).toMatch(
+        /The current params are "Bert" and "Ernie"/
       );
     });
-
-    let form = node.querySelector("form")!;
-    expect(form).toBeDefined();
-
-    let queryInput = node.querySelector<HTMLInputElement>("input[name=q]")!;
-    expect(queryInput).toBeDefined();
-
-    expect(node.innerHTML).toMatch(/The current query is "Michael Jackson"/);
-
-    act(() => {
-      queryInput.value = "Ryan Florence";
-      form.dispatchEvent(
-        new Event("submit", { bubbles: true, cancelable: true })
-      );
-    });
-
-    expect(node.innerHTML).toMatch(/The current query is "Ryan Florence"/);
   });
 });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -366,6 +366,15 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
 }
 
 /**
+ * Type of the input to a search params setter. Either provides the next value
+ * directly or provides an update function that computes a new search param
+ * value from the current one.
+ */
+export type NextSearchParams =
+  | URLSearchParamsInit
+  | ((current: URLSearchParams) => URLSearchParamsInit | void);
+
+/**
  * A convenient wrapper for reading and writing search parameters via the
  * URLSearchParams interface.
  */
@@ -402,10 +411,19 @@ export function useSearchParams(defaultInit?: URLSearchParamsInit) {
   let navigate = useNavigate();
   let setSearchParams = React.useCallback(
     (
-      nextInit: URLSearchParamsInit,
+      nextInit: NextSearchParams,
       navigateOptions?: { replace?: boolean; state?: any }
     ) => {
-      navigate("?" + createSearchParams(nextInit), navigateOptions);
+      navigate(
+        typeof nextInit === "function"
+          ? ({ search }) => {
+              let current = createSearchParams(search);
+              let next = nextInit(current);
+              return "?" + (next != null ? createSearchParams(next) : current);
+            }
+          : "?" + createSearchParams(nextInit),
+        navigateOptions
+      );
     },
     [navigate]
   );

--- a/packages/react-router-native/__tests__/__snapshots__/search-params-test.tsx.snap
+++ b/packages/react-router-native/__tests__/__snapshots__/search-params-test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useSearchParams reads and writes the search string 1`] = `
+exports[`useSearchParams get and set reads and writes the search string 1`] = `
 <View>
   <Text>
     The current query is "
@@ -19,7 +19,7 @@ exports[`useSearchParams reads and writes the search string 1`] = `
 </View>
 `;
 
-exports[`useSearchParams reads and writes the search string 2`] = `
+exports[`useSearchParams get and set reads and writes the search string 2`] = `
 <View>
   <Text>
     The current query is "
@@ -35,5 +35,57 @@ exports[`useSearchParams reads and writes the search string 2`] = `
       value="Ryan Florence"
     />
   </View>
+</View>
+`;
+
+exports[`useSearchParams update function writes search string with correctly updated state 1`] = `
+<View>
+  <Text>
+    The current params are "
+    Simon
+    " and "
+    Garfunkel
+    ".
+  </Text>
+  <TextInput
+    allowFontScaling={true}
+    onChangeText={[Function]}
+    rejectResponderTermination={true}
+    underlineColorAndroid="transparent"
+    value="Simon"
+  />
+  <TextInput
+    allowFontScaling={true}
+    onChangeText={[Function]}
+    rejectResponderTermination={true}
+    underlineColorAndroid="transparent"
+    value="Garfunkel"
+  />
+</View>
+`;
+
+exports[`useSearchParams update function writes search string with correctly updated state 2`] = `
+<View>
+  <Text>
+    The current params are "
+    Bert
+    " and "
+    Ernie
+    ".
+  </Text>
+  <TextInput
+    allowFontScaling={true}
+    onChangeText={[Function]}
+    rejectResponderTermination={true}
+    underlineColorAndroid="transparent"
+    value="Bert"
+  />
+  <TextInput
+    allowFontScaling={true}
+    onChangeText={[Function]}
+    rejectResponderTermination={true}
+    underlineColorAndroid="transparent"
+    value="Ernie"
+  />
 </View>
 `;

--- a/packages/react-router-native/__tests__/search-params-test.tsx
+++ b/packages/react-router-native/__tests__/search-params-test.tsx
@@ -18,51 +18,109 @@ describe("useSearchParams", () => {
     return <View>{children}</View>;
   }
 
-  function SearchPage() {
-    let [searchParams, setSearchParams] = useSearchParams({ q: "" });
-    let [query, setQuery] = React.useState(searchParams.get("q")!);
+  describe("get and set", () => {
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams({ q: "" });
+      let [query, setQuery] = React.useState(searchParams.get("q")!);
 
-    function handleSubmit() {
-      setSearchParams({ q: query });
+      function handleSubmit() {
+        setSearchParams({ q: query });
+      }
+
+      return (
+        <View>
+          <Text>The current query is "{searchParams.get("q")}".</Text>
+
+          <SearchForm onSubmit={handleSubmit}>
+            <TextInput value={query} onChangeText={setQuery} />
+          </SearchForm>
+        </View>
+      );
     }
 
-    return (
-      <View>
-        <Text>The current query is "{searchParams.get("q")}".</Text>
+    it("reads and writes the search string", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <NativeRouter initialEntries={["/search?q=Michael+Jackson"]}>
+            <Routes>
+              <Route path="search" element={<SearchPage />} />
+            </Routes>
+          </NativeRouter>
+        );
+      });
 
-        <SearchForm onSubmit={handleSubmit}>
-          <TextInput value={query} onChangeText={setQuery} />
-        </SearchForm>
-      </View>
-    );
-  }
+      expect(renderer.toJSON()).toMatchSnapshot();
 
-  it("reads and writes the search string", () => {
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(
-        <NativeRouter initialEntries={["/search?q=Michael+Jackson"]}>
-          <Routes>
-            <Route path="search" element={<SearchPage />} />
-          </Routes>
-        </NativeRouter>
+      let textInput = renderer.root.findByType(TextInput);
+
+      TestRenderer.act(() => {
+        textInput.props.onChangeText("Ryan Florence");
+      });
+
+      let searchForm = renderer.root.findByType(SearchForm);
+
+      TestRenderer.act(() => {
+        searchForm.props.onSubmit();
+      });
+
+      expect(renderer.toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe("update function", () => {
+    function ParamsPage() {
+      let [searchParams, setSearchParams] = useSearchParams();
+
+      const setA = React.useCallback(
+        a => {
+          setSearchParams(params => params.set("a", a));
+        },
+        [setSearchParams]
       );
+
+      const setB = React.useCallback(
+        b => {
+          setSearchParams(params => ({ a: params.get("a"), b }));
+        },
+        [setSearchParams]
+      );
+
+      return (
+        <View>
+          <Text>
+            The current params are "{searchParams.get("a")}" and "
+            {searchParams.get("b")}".
+          </Text>
+
+          <TextInput value={searchParams.get("a")} onChangeText={setA} />
+          <TextInput value={searchParams.get("b")} onChangeText={setB} />
+        </View>
+      );
+    }
+
+    it("writes search string with correctly updated state", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <NativeRouter initialEntries={["/params?a=Simon&b=Garfunkel"]}>
+            <Routes>
+              <Route path="params" element={<ParamsPage />} />
+            </Routes>
+          </NativeRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchSnapshot();
+
+      let [aInput, bInput] = renderer.root.findAllByType(TextInput);
+
+      TestRenderer.act(() => {
+        aInput.props.onChangeText("Bert");
+        bInput.props.onChangeText("Ernie");
+      });
+
+      expect(renderer.toJSON()).toMatchSnapshot();
     });
-
-    expect(renderer.toJSON()).toMatchSnapshot();
-
-    let textInput = renderer.root.findByType(TextInput);
-
-    TestRenderer.act(() => {
-      textInput.props.onChangeText("Ryan Florence");
-    });
-
-    let searchForm = renderer.root.findByType(SearchForm);
-
-    TestRenderer.act(() => {
-      searchForm.props.onSubmit();
-    });
-
-    expect(renderer.toJSON()).toMatchSnapshot();
   });
 });

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -97,4 +97,49 @@ describe("useNavigate", () => {
       `);
     });
   });
+
+  describe("update function", () => {
+    it("transitions to the location derived from the current one", () => {
+      function Home() {
+        let navigate = useNavigate();
+        let { search } = useLocation();
+        let clickable = !new URLSearchParams(search).get("x");
+
+        let handleClick = React.useCallback(() => {
+          navigate(({ search }) => `${search}&x=y`);
+        }, [navigate]);
+
+        return (
+          <>
+            <p>The current search is: {search}</p>
+            {clickable && <button onClick={handleClick}>click me</button>}
+          </>
+        );
+      }
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home?a=b"]}>
+            <Routes>
+              <Route path="home" element={<Home />} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      let button = renderer.root.findByType("button");
+
+      TestRenderer.act(() => {
+        button.props.onClick();
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          The current search is: 
+          ?a=b&x=y
+        </p>
+      `);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,10 +4476,10 @@ history@^5.0.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-history@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/history/-/history-5.0.3.tgz#23d0b3046f695623c95a870506545e2b67e82edb"
-  integrity sha512-LoyCVOpCBkNAgrsdpTDZP77fys7lFDg8JdxTr7s6GHueZbTplKf8NAJu3y6/QuJIjk6TFsEGrhtILVP814X8+A==
+history@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.1.0.tgz#2e93c09c064194d38d52ed62afd0afc9d9b01ece"
+  integrity sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==
   dependencies:
     "@babel/runtime" "^7.7.6"
 


### PR DESCRIPTION
Resolves #8287.

Updates the functionality of navigate functions to allow them to take a function that computes a new location from the current one, then utilises that functionality in `useSearchParams` to build the same sort of feature.

I've used a new ref in the location context to retain the current location consistently during event handling, rather than exposing the mutable `location` on the navigator. It's a little more complex but avoids reconstructing the immutable location from the mutable one and does not open up the potential for tearing as mentioned in the comment on the `Navigator` type.

I've added a special case to the search params update function (along with a corresponding entry in the docs) that allows you to mutate the given `URLSearchParams` object directly and return nothing, since I'm expecting that most uses of the update function will mutate and then return that object. It's a little bit more convenient but happy to drop it if it's controversial.