### PR TITLE
Improve the type of useParams

### DIFF
--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -526,8 +526,10 @@ export function useOutlet(): React.ReactElement | null {
  *
  * @see https://reactrouter.com/docs/en/v6/api#useparams
  */
-export function useParams<Key extends string = string>(): Readonly<
-  Params<Key>
+export function useParams<
+  ParamsOrKey extends string | Record<string, string | undefined> = string
+>(): Readonly<
+  [ParamsOrKey] extends [string] ? Params<ParamsOrKey> : Partial<ParamsOrKey>
 > {
   let { matches } = React.useContext(RouteContext);
   let routeMatch = matches[matches.length - 1];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,10 +4476,10 @@ history@^5.0.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-history@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/history/-/history-5.0.3.tgz#23d0b3046f695623c95a870506545e2b67e82edb"
-  integrity sha512-LoyCVOpCBkNAgrsdpTDZP77fys7lFDg8JdxTr7s6GHueZbTplKf8NAJu3y6/QuJIjk6TFsEGrhtILVP814X8+A==
+history@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.1.0.tgz#2e93c09c064194d38d52ed62afd0afc9d9b01ece"
+  integrity sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==
   dependencies:
     "@babel/runtime" "^7.7.6"
 


### PR DESCRIPTION
Improve the type of useParams

According  https://github.com/remix-run/react-router/issues/8200#issuecomment-972680683 comment

The main purpose is to support the declaration of the type of parameter value as a union string