### PR TITLE
Add link to props reference for TouchableHighlight

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,2 +1,3 @@
 - mcansh
 - kkirsche
+- noisypigeon

--- a/docs/api.md
+++ b/docs/api.md
@@ -317,7 +317,7 @@ interface LinkProps extends TouchableHighlightProps {
 
 </details>
 
-A `<Link>` is an element that lets the user navigate to another view by tapping it, similar to how `<a>` elements work in a web app. In `react-router-native`, a `<Link>` renders a `TouchableHighlight`.
+A `<Link>` is an element that lets the user navigate to another view by tapping it, similar to how `<a>` elements work in a web app. In `react-router-native`, a `<Link>` renders a `TouchableHighlight`. To override default styling and behaviour, please refer to the [Props reference for `TouchableHighlight`](https://reactnative.dev/docs/touchablehighlight#props).
 
 ```tsx
 import * as React from "react";


### PR DESCRIPTION
I ran into an issue (documented in https://github.com/remix-run/react-router/issues/8360) with the `<Link>` component and I think this would help future travellers. Love the project! Thanks.