### PR TITLE
Fix(Docs): Broken links of README file in Server-side Rendering

### DIFF
--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -9,11 +9,11 @@ This example adds [server-side rendering](https://reactjs.org/docs/react-dom-ser
 
 With SSR, the server renders your app and sends real HTML to the browser instead of an empty HTML document with a bunch of `<script>` tags. After the browser loads the HTML and JavaScript from the server, React "hydrates" the HTML document using the same components it used to render the app on the server.
 
-This example contains a server (see [server.js](server.js)) that can run in both development and production modes.
+This example contains a server (see [server.js](https://github.com/remix-run/react-router/blob/main/examples/ssr/server.js)) that can run in both development and production modes.
 
-In the browser entry point (see [src/entry.client.tsx](src/entry.client.tsx)), we use React Router like we would traditionally do in a purely client-side app and render a `<BrowserRouter>` to provide routing context to the rest of the app. The main difference is that instead of using `ReactDOM.render()` to render the app, since the HTML was already sent by the server, all we need is `ReactDOM.hydrate()`.
+In the browser entry point (see [src/entry.client.tsx](https://github.com/remix-run/react-router/blob/main/examples/ssr/src/entry.client.tsx)), we use React Router like we would traditionally do in a purely client-side app and render a `<BrowserRouter>` to provide routing context to the rest of the app. The main difference is that instead of using `ReactDOM.render()` to render the app, since the HTML was already sent by the server, all we need is `ReactDOM.hydrate()`.
 
-On the server (see [src/entry.server.tsx](src/entry.server.tsx)), we use React Router's `<StaticRouter>` to render the app and plug in the URL we get from the incoming HTTP request.
+On the server (see [src/entry.server.tsx](https://github.com/remix-run/react-router/blob/main/examples/ssr/src/entry.server.tsx)), we use React Router's `<StaticRouter>` to render the app and plug in the URL we get from the incoming HTTP request.
 
 ## Preview
 


### PR DESCRIPTION
Replace broken links of `README` file in Server-side Rendering