### PR TITLE
Fix type of NavigateFunction in api.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,3 +3,4 @@
 - paulsmithkc
 - noisypigeon
 - elylucas
+- hongji00

--- a/docs/api.md
+++ b/docs/api.md
@@ -1098,7 +1098,7 @@ declare function useNavigate(): NavigateFunction;
 interface NavigateFunction {
   (
     to: To,
-    options?: { replace?: boolean; state?: State }
+    options?: { replace?: boolean; state?: any }
   ): void;
   (delta: number): void;
 }


### PR DESCRIPTION
Interface `NavigateOptions` in `/packages/react-router/index.tsx` 
```ts
export interface NavigateOptions {
  replace?: boolean;
  state?: any;
}
```

Changed NavigateFunction in `docs/api.md`

`options?: { replace?: boolean; state?: State }` to `options?: { replace?: boolean; state?: any }`