### PR TITLE
docs: emphasize v5 and v6 navigation difference

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,3 +6,4 @@
 - elylucas
 - hongji00
 - JakubDrozd
+- markivancho

--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -650,6 +650,18 @@ function App() {
 }
 ```
 
+**Note**: Be aware that the v5 `<Redirect />` uses `replace` logic by default (you may change it via `push` prop), on the other hand, the v6 `<Navigate />` uses `push` logic by default and you may change it via `replace` prop.
+
+```js
+// Change this:
+<Redirect to="about" />
+<Redirect to="home" push />
+
+// to this:
+<Navigate to="about" replace />
+<Navigate to="home" />
+```
+
 If you're currently using `go`, `goBack` or `goForward` from `useHistory` to navigate backwards and forwards, you should also replace these with `navigate` with a numerical argument indicating where to move the pointer in the history stack. For example, here is some code using v5's `useHistory` hook:
 
 ```js


### PR DESCRIPTION
Guess that this PR is self-explainable. While upgrading I think people would benefit on this note, cause it's easy to miss, especially for folks that are not using TS
[v5 logic](https://github.com/remix-run/react-router/blob/78249eb6ce9a28df4691cc61caa0467fed8b7ac0/packages/react-router/modules/Redirect.js#L21)
[v6 logic](https://github.com/remix-run/react-router/blob/6cbb99db85767d752ec8eb3b34ef8f88f067aeb3/packages/react-router/index.tsx#L502)