### PR TITLE
Note that `<Prompt>` support is missing from v6

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -9,3 +9,4 @@
 - shivamsinghchahar
 - timdorr
 - turansky
+- petersendidit

--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -881,6 +881,10 @@ This change was made both to follow more closely the convention established by t
 
 To see the exact API of the new `useMatch` hook and its type declaration, check out our [API Reference](../api.md#usematch). <!-- TODO: Show examples for refactoring useRouteMatch -->
 
+## `<Prompt>` is not currently supported
+
+`<Prompt>` from v5 (along with `usePrompt` and `useBlocker` from the v6 betas) are not included in the current released version of v6. We decided we'd rather ship with what we have than take even more time to nail down a feature that isn't fully baked. We will absolutely be working on adding this back in to v6 at some point in the near future, but not for our first stable release of 6.x.
+
 ## What did we miss?
 
 Despite our best attempts at being thorough, it's very likely that we missed something. If you follow this upgrade guide and find that to be the case, please let us know. We are happy to help you figure out what to do with your v5 code to be able to upgrade and take advantage of all of the cool stuff in v6.


### PR DESCRIPTION
Many code bases use the `<Prompt>` component from v5 but don't find out that support is currently missing from v6 until after attempting to upgrade.  This adds this information to the upgrade guide so that is more likely that I would be discovered before lots of effort is invested. 

Fixes #8330