### PR TITLE
Update actions/setup-node to version 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,15 @@ jobs:
     if: github.repository == 'remix-run/react-router'
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
+          check-latest: true
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
+          check-latest: true
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,6 +1,7 @@
 - elylucas
 - hongji00
 - JakubDrozd
+- jonkoops
 - kkirsche
 - markivancho
 - mcansh


### PR DESCRIPTION
Other changes:
- Remove matrix as only a single Node version is ever used
- Always check for latest version of Node in version range (14.x)
- Cache Yarn dependencies between runs
