### PR TITLE
Restore [v5] HashRouter 'hashType' prop

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -11,3 +11,4 @@
 - shivamsinghchahar
 - timdorr
 - turansky
+- thejohnhoffer

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -161,6 +161,7 @@ export function BrowserRouter({
 
 export interface HashRouterProps {
   basename?: string;
+  hashType?: "noslash";
   children?: React.ReactNode;
   window?: Window;
 }
@@ -169,7 +170,7 @@ export interface HashRouterProps {
  * A <Router> for use in web browsers. Stores the location in the hash
  * portion of the URL so it is not sent to the server.
  */
-export function HashRouter({ basename, children, window }: HashRouterProps) {
+export function HashRouter({ basename, hashType, children, window }: HashRouterProps) {
   let historyRef = React.useRef<HashHistory>();
   if (historyRef.current == null) {
     historyRef.current = createHashHistory({ window });
@@ -182,10 +183,11 @@ export function HashRouter({ basename, children, window }: HashRouterProps) {
   });
 
   React.useLayoutEffect(() => history.listen(setState), [history]);
+  let hashTypeBasename = hashType && hashType === "noslash" ? "" : "/"
 
   return (
     <Router
-      basename={basename}
+      basename={basename || hashTypeBasename}
       children={children}
       location={state.location}
       navigationType={state.action}

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -64,6 +64,7 @@ export type Navigator = Omit<
 
 interface NavigationContextObject {
   basename: string;
+  rootPath: string;
   navigator: Navigator;
   static: boolean;
 }
@@ -267,10 +268,11 @@ export function Router({
       ` You should never have more than one in your app.`
   );
 
-  let basename = normalizePathname(basenameProp);
+  let rootPath = !basenameProp ? "" : "/";
+  let basename = rootPath? normalizePathname(basenameProp) : rootPath;
   let navigationContext = React.useMemo(
-    () => ({ basename, navigator, static: staticProp }),
-    [basename, navigator, staticProp]
+    () => ({ basename, rootPath, navigator, static: staticProp }),
+    [rootPath, basename, navigator, staticProp]
   );
 
   if (typeof locationProp === "string") {
@@ -462,7 +464,7 @@ export function useNavigate(): NavigateFunction {
     `useNavigate() may be used only in the context of a <Router> component.`
   );
 
-  let { basename, navigator } = React.useContext(NavigationContext);
+  let { basename, rootPath, navigator } = React.useContext(NavigationContext);
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
 
@@ -493,10 +495,11 @@ export function useNavigate(): NavigateFunction {
       let path = resolveTo(
         to,
         JSON.parse(routePathnamesJson),
-        locationPathname
+        locationPathname,
+        rootPath
       );
 
-      if (basename !== "/") {
+      if (basename !== rootPath) {
         path.pathname = joinPaths([basename, path.pathname]);
       }
 
@@ -505,7 +508,7 @@ export function useNavigate(): NavigateFunction {
         options.state
       );
     },
-    [basename, navigator, routePathnamesJson, locationPathname]
+    [rootPath, basename, navigator, routePathnamesJson, locationPathname]
   );
 
   return navigate;
@@ -545,14 +548,14 @@ export function useParams<
 export function useResolvedPath(to: To): Path {
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
+  let { rootPath } = React.useContext(NavigationContext);
 
   let routePathnamesJson = JSON.stringify(
     matches.map(match => match.pathnameBase)
   );
-
   return React.useMemo(
-    () => resolveTo(to, JSON.parse(routePathnamesJson), locationPathname),
-    [to, routePathnamesJson, locationPathname]
+    () => resolveTo(to, JSON.parse(routePathnamesJson), locationPathname, rootPath),
+    [to, rootPath, routePathnamesJson, locationPathname]
   );
 }
 
@@ -1184,7 +1187,7 @@ function safelyDecodeURIComponent(value: string, paramName: string) {
  *
  * @see https://reactrouter.com/docs/en/v6/api#resolvepath
  */
-export function resolvePath(to: To, fromPathname = "/"): Path {
+export function resolvePath(to: To, fromPathname = "/", rootPath = "/"): Path {
   let {
     pathname: toPathname,
     search = "",
@@ -1192,7 +1195,7 @@ export function resolvePath(to: To, fromPathname = "/"): Path {
   } = typeof to === "string" ? parsePath(to) : to;
 
   let pathname = toPathname
-    ? toPathname.startsWith("/")
+    ? toPathname.startsWith(rootPath)
       ? toPathname
       : resolvePathname(toPathname, fromPathname)
     : fromPathname;
@@ -1223,10 +1226,11 @@ function resolvePathname(relativePath: string, fromPathname: string): string {
 function resolveTo(
   toArg: To,
   routePathnames: string[],
-  locationPathname: string
+  locationPathname: string,
+  rootPath: string
 ): Path {
   let to = typeof toArg === "string" ? parsePath(toArg) : toArg;
-  let toPathname = toArg === "" || to.pathname === "" ? "/" : to.pathname;
+  let toPathname = toArg === "" || to.pathname === "" ? rootPath : to.pathname;
 
   // If a pathname is explicitly provided in `to`, it should be relative to the
   // route context. This is explained in `Note on `<Link to>` values` in our
@@ -1257,14 +1261,15 @@ function resolveTo(
 
     // If there are more ".." segments than parent routes, resolve relative to
     // the root / URL.
-    from = routePathnameIndex >= 0 ? routePathnames[routePathnameIndex] : "/";
+    from = routePathnameIndex >= 0 ? routePathnames[routePathnameIndex] : rootPath;
   }
 
-  let path = resolvePath(to, from);
+  let path = resolvePath(to, from, rootPath);
 
   // Ensure the pathname has a trailing slash if the original to value had one.
   if (
     toPathname &&
+    rootPath &&
     toPathname !== "/" &&
     toPathname.endsWith("/") &&
     !path.pathname.endsWith("/")
@@ -1285,7 +1290,7 @@ function getToPathname(to: To): string | undefined {
 }
 
 function stripBasename(pathname: string, basename: string): string | null {
-  if (basename === "/") return pathname;
+  if (basename.length <= 1) return pathname;
 
   if (!pathname.toLowerCase().startsWith(basename.toLowerCase())) {
     return null;


### PR DESCRIPTION
Resolves #7703

### Context

The [v5 API page documenting `HashRouter`](https://v5.reactrouter.com/web/api/HashRouter) allows hashes to begin as `#` rather than `#/`. The v6 `HashRouter` no longer supports this because [history@5](https://github.com/remix-run/history/blob/main/packages/history/index.ts#L571) lost that property of [history@4](https://github.com/remix-run/history/blob/v4/modules/createHashHistory.js#L64). Ten days ago, a contributor [closed](https://github.com/remix-run/react-router/issues/7703#issuecomment-735033961) #7703. The contributor suggested the issue should be brought to the attention of with [remix-run/history/](https://github.com/remix-run/history/), but noted "it was specifically removed in v5" of `history` while warning "it's not likely to return."

This is a request to replicate that feature of `HashRouter` that we lost in `history@5` and `react-router@6`.

### Solution

Only when `<Router basename="">`, this PR now supports `To` objects without a leading slash. Since the [v5 docs claim](https://v5.reactrouter.com/web/api/HashRouter/basename-string) that a "properly formatted basename should have a leading slash," this PR has no change to documented usage.

To support `<HashState hashType="noslash">`, that syntax is mapped to `<Router basename="">`.

So, the concept of a `hashType` is limited to the `HashState` constructor.