### PR TITLE
docs: Fixed pathname typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -19,3 +19,4 @@
 - shivamsinghchahar
 - timdorr
 - turansky
+- thisiskartik

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -698,7 +698,7 @@ Like `useSearchParams`, `useLocation` returns a location that tells us informati
 
 ```js
 {
-  pathame: "/invoices",
+  pathname: "/invoices",
   search: "?filter=sa",
   hash: "",
   state: null,


### PR DESCRIPTION
Updated "pathame" to "pathname" type in tutorial docs.