### PR TITLE
doc: updated reach migration guide for Route Components

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -20,3 +20,4 @@
 - thisiskartik
 - timdorr
 - turansky
+- vijaypushkin

--- a/docs/upgrading/reach.md
+++ b/docs/upgrading/reach.md
@@ -204,10 +204,10 @@ import { Router } from "@reach/router";
 </Router>;
 
 // React Router v6
-import { Routes } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 
 <Routes>
-  <Home path="/" />
+  <Route path="/" element={<Home />} />
   {/* ... */}
 </Routes>;
 ```
@@ -225,8 +225,8 @@ The `default` prop told `@reach/router` to use that route if no other routes mat
 
 // React Router v6
 <Routes>
-  <Home path="/" />
-  <NotFound path="*" />
+  <Route path="/" element={<Home />} />
+  <Route path="*" element={<NotFound />} />
 </Routes>
 ```
 
@@ -306,9 +306,9 @@ function Redirect({ to }) {
 
 // usage
 <Routes>
-  <Home path="/" />
-  <Users path="/events" />
-  <Redirect path="/dashboard" to="/events" />
+  <Route path="/" element={<Home />} />
+  <Route path="/events" element={<Users />} />
+  <Route path="/dashboard" element={<Redirect to="/events" />} />
 </Routes>;
 ```
 


### PR DESCRIPTION
Upon going through the source code, I found only `Route` components are allowed inside `Routes`, Hence updated the doc examples as such