### PR TITLE
Fix NavLink Aliasing

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -21,3 +21,4 @@
 - timdorr
 - turansky
 - vijaypushkin
+- Seth10001

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -22,6 +22,7 @@ import {
   useNavigationType,
   useOutlet,
   useParams,
+  usePath,
   useResolvedPath,
   useRoutes,
   useOutletContext
@@ -322,7 +323,7 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     }
 
     let isActive =
-      locationPathname === toPathname ||
+      !!usePath(toPathname) ||
       (!end &&
         locationPathname.startsWith(toPathname) &&
         locationPathname.charAt(toPathname.length) === "/");


### PR DESCRIPTION
When I was referring to the `NavLink` implementation I noticed an issue similar to #8277. I had a setup similar to the following:

```
<NavLink to="/path/to">Link 1</NavLink>
<NavLink to="/path/to/board">Link 2</NavLink>
```

When navigating to `/path/to/board` both links were being matched.
