### PR TITLE
docs: Fix useOutletContext typescript example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -2,6 +2,7 @@
 - brockross
 - chaance
 - chasinhues
+- edwin177
 - elylucas
 - hongji00
 - JakubDrozd

--- a/docs/api.md
+++ b/docs/api.md
@@ -613,7 +613,7 @@ export default function Dashboard() {
   return (
     <div>
       <h1>Dashboard</h1>
-      <Outlet context={user} />
+      <Outlet context={{user}} />
     </div>
   );
 }
@@ -627,7 +627,7 @@ export function useUser() {
 import { useUser } from "../dashboard";
 
 export default function DashboardMessages() {
-  const user = useUser();
+  const { user } = useUser();
   return (
     <div>
       <h2>Messages</h2>


### PR DESCRIPTION
Making the typescript example consistent with the associated `ContextType`:

`type ContextType = { user: User | null };`