### PR TITLE
fix: Normalize pathnameBase when matching

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -4,6 +4,7 @@
 - chrisngobanh
 - elylucas
 - hongji00
+- Isammoc
 - JakubDrozd
 - jonkoops
 - kddnewton

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -242,4 +242,27 @@ describe("path matching with splats", () => {
       pathnameBase: "/",
     });
   });
+
+  test("nested routes with partial matching", () => {
+    let routes = [{ path: '/', children: [{ path: 'courses', children: [{ path: '*' }] }] }];
+    let match = matchRoutes(routes, "/courses/abc")
+
+    expect(match).not.toBeNull();
+    expect(match).toHaveLength(3);
+    expect(match[0]).toMatchObject({
+      params: { "*": "abc" },
+      pathname: "/",
+      pathnameBase: "/"
+    });
+    expect(match[1]).toMatchObject({
+      params: { "*": "abc" },
+      pathname: "/courses",
+      pathnameBase: "/courses"
+    });
+    expect(match[2]).toMatchObject({
+      params: { "*": "abc" },
+      pathname: "/courses/abc",
+      pathnameBase: "/courses"
+    });
+  });
 });

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1040,7 +1040,7 @@ function matchRouteBranch<ParamKey extends string = string>(
     matches.push({
       params: matchedParams,
       pathname: joinPaths([matchedPathname, match.pathname]),
-      pathnameBase: joinPaths([matchedPathname, match.pathnameBase]),
+      pathnameBase: normalizePathname(joinPaths([matchedPathname, match.pathnameBase])),
       route,
     });
 


### PR DESCRIPTION
As no member confirm or refuse my issue #8458.
Here a PR that fix the bug for me.

Not sure if this is the best place to call normalizePathname, though.

Do not hesitate to comment, I will gladly change my PR.


----- Commit message -----
Motivation:
When matching with "*", the `pathnameBase` had a trailing slash `/`.

Modifications:
 * Call normalizePathname for pathnameBase

Result:
We can use an element that call useRoutes to define another alternative router for matching with "*".

Closes: #8458