### PR TITLE
Avoid visiting login page again on back button click

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -23,3 +23,4 @@
 - turansky
 - underager
 - vijaypushkin
+- kantuni

--- a/examples/auth/src/App.tsx
+++ b/examples/auth/src/App.tsx
@@ -136,7 +136,7 @@ function RequireAuth({ children }: { children: JSX.Element }) {
     // trying to go to when they were redirected. This allows us to send them
     // along to that page after they login, which is a nicer user experience
     // than dropping them off on the home page.
-    return <Navigate to="/login" state={{ from: location }} replace={true} />;
+    return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
   return children;

--- a/examples/auth/src/App.tsx
+++ b/examples/auth/src/App.tsx
@@ -136,7 +136,7 @@ function RequireAuth({ children }: { children: JSX.Element }) {
     // trying to go to when they were redirected. This allows us to send them
     // along to that page after they login, which is a nicer user experience
     // than dropping them off on the home page.
-    return <Navigate to="/login" state={{ from: location }} />;
+    return <Navigate to="/login" state={{ from: location }} replace={true} />;
   }
 
   return children;


### PR DESCRIPTION
Add `replace={true}` to avoid creating a new entry in the history. Thus, when they click back on the login page, they won't end up on the login page again, but rather on the page they were before trying to access the protected page.