### PR TITLE
Fix minor typos in the "Matching generally static values" FAQ example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -5,6 +5,7 @@
 - elylucas
 - hongji00
 - JakubDrozd
+- jmargeta
 - jonkoops
 - kantuni
 - kddnewton

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -296,9 +296,9 @@ These are all actually just static paths, so in v6 you can make three routes and
 function App() {
   return (
     <Routes>
-      <Route path="en" element={<Lang code="en" />} />
-      <Route path="es" element={<Lang code="en" />} />
-      <Route path="fr" element={<Lang code="en" />} />
+      <Route path="en" element={<Lang lang="en" />} />
+      <Route path="es" element={<Lang lang="es" />} />
+      <Route path="fr" element={<Lang lang="fr" />} />
     </Routes>
   );
 }


### PR DESCRIPTION
This fixes the example by using `<Lang lang="…"/>`  instead of `<Lang code="…"/>` (to respect Lang's signature) and by setting the language codes to correspond with the paths.