### PR TITLE
Fix: allow nested splat routes to begin with "special" url-safe characters

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,6 +16,7 @@
 - petersendidit
 - RobHannay
 - sergiodxa
+- shamsup
 - shivamsinghchahar
 - thisiskartik
 - timdorr

--- a/packages/react-router/__tests__/descendant-routes-splat-matching-test.tsx
+++ b/packages/react-router/__tests__/descendant-routes-splat-matching-test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as TestRenderer from "react-test-renderer";
-import { MemoryRouter, Outlet, Routes, Route } from "react-router";
+import { MemoryRouter, Outlet, Routes, Route, useParams } from "react-router";
 
 describe("Descendant <Routes> splat matching", () => {
   describe("when the parent route path ends with /*", () => {
@@ -53,6 +53,73 @@ describe("Descendant <Routes> splat matching", () => {
             <h1>
               React Fundamentals
             </h1>
+          </div>
+        </div>
+      `);
+    });
+    it("works with paths beginning with special characters", () => {
+      function PrintParams() {
+        return <p>The params are {JSON.stringify(useParams())}</p>;
+      }
+      function ReactCourses() {
+        return (
+          <div>
+            <h1>React</h1>
+            <Routes>
+              <Route
+                path=":splat"
+                element={
+                  <div>
+                    <h1>React Fundamentals</h1>
+                    <PrintParams />
+                  </div>
+                }
+              />
+            </Routes>
+          </div>
+        );
+      }
+
+      function Courses() {
+        return (
+          <div>
+            <h1>Courses</h1>
+            <Outlet />
+          </div>
+        );
+      }
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/courses/react/-react-fundamentals"]}>
+            <Routes>
+              <Route path="courses" element={<Courses />}>
+                <Route path="react/*" element={<ReactCourses />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Courses
+          </h1>
+          <div>
+            <h1>
+              React
+            </h1>
+            <div>
+              <h1>
+                React Fundamentals
+              </h1>
+              <p>
+                The params are 
+                {"*":"-react-fundamentals","splat":"-react-fundamentals"}
+              </p>
+            </div>
           </div>
         </div>
       `);

--- a/packages/react-router/__tests__/layout-routes-test.tsx
+++ b/packages/react-router/__tests__/layout-routes-test.tsx
@@ -31,4 +31,211 @@ describe("A layout route", () => {
       </h1>
     `);
   });
+  describe("matches when a nested splat route begins with a special character", () => {
+    it("allows routes starting with `-`", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/-splat"]}>
+            <Routes>
+              <Route
+                element={
+                  <div>
+                    <h1>Layout</h1>
+                    <Outlet />
+                  </div>
+                }
+              >
+                <Route
+                  path="*"
+                  element={
+                    <div>
+                      <h1>Splat</h1>
+                    </div>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Layout
+          </h1>
+          <div>
+            <h1>
+              Splat
+            </h1>
+          </div>
+        </div>
+      `);
+    });
+    it("allows routes starting with `~`", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/~splat"]}>
+            <Routes>
+              <Route
+                element={
+                  <div>
+                    <h1>Layout</h1>
+                    <Outlet />
+                  </div>
+                }
+              >
+                <Route
+                  path="*"
+                  element={
+                    <div>
+                      <h1>Splat</h1>
+                    </div>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Layout
+          </h1>
+          <div>
+            <h1>
+              Splat
+            </h1>
+          </div>
+        </div>
+      `);
+    });
+    it("allows routes starting with `_`", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/_splat"]}>
+            <Routes>
+              <Route
+                element={
+                  <div>
+                    <h1>Layout</h1>
+                    <Outlet />
+                  </div>
+                }
+              >
+                <Route
+                  path="*"
+                  element={
+                    <div>
+                      <h1>Splat</h1>
+                    </div>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Layout
+          </h1>
+          <div>
+            <h1>
+              Splat
+            </h1>
+          </div>
+        </div>
+      `);
+    });
+    it("allows routes starting with `.`", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/.splat"]}>
+            <Routes>
+              <Route
+                element={
+                  <div>
+                    <h1>Layout</h1>
+                    <Outlet />
+                  </div>
+                }
+              >
+                <Route
+                  path="*"
+                  element={
+                    <div>
+                      <h1>Splat</h1>
+                    </div>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Layout
+          </h1>
+          <div>
+            <h1>
+              Splat
+            </h1>
+          </div>
+        </div>
+      `);
+    });
+    it("allows routes starting with url-encoded entities", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/%20splat"]}>
+            <Routes>
+              <Route
+                element={
+                  <div>
+                    <h1>Layout</h1>
+                    <Outlet />
+                  </div>
+                }
+              >
+                <Route
+                  path="*"
+                  element={
+                    <div>
+                      <h1>Splat</h1>
+                    </div>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Layout
+          </h1>
+          <div>
+            <h1>
+              Splat
+            </h1>
+          </div>
+        </div>
+      `);
+    });
+  });
 });

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1225,7 +1225,7 @@ function compilePath(
         // Additionally, allow paths starting with `.`, `-`, `~`, and url-encoded entities,
         // but do not consume the character in the matched path so they can match against
         // nested paths.
-        "(?:(?=[.~-]|%[0-7][0-9A-F])|(?:\\b|\\/|$))";
+        "(?:(?=[.~-]|%[0-9A-F]{2})|(?:\\b|\\/|$))";
   }
 
   let matcher = new RegExp(regexpSource, caseSensitive ? undefined : "i");

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1222,7 +1222,10 @@ function compilePath(
       : // Otherwise, match a word boundary or a proceeding /. The word boundary restricts
         // parent routes to matching only their own words and nothing more, e.g. parent
         // route "/home" should not match "/home2".
-        "(?:\\b|\\/|$)";
+        // Additionally, allow paths starting with `.`, `-`, `~`, and url-encoded entities,
+        // but do not consume the character in the matched path so they can match against
+        // nested paths.
+        "(?:(?=[.~-]|%[0-7][0-9A-F])|(?:\\b|\\/|$))";
   }
 
   let matcher = new RegExp(regexpSource, caseSensitive ? undefined : "i");

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -1225,7 +1225,7 @@ function compilePath(
         // Additionally, allow paths starting with `.`, `-`, `~`, and url-encoded entities,
         // but do not consume the character in the matched path so they can match against
         // nested paths.
-        "(?:(?=[.~-]|%[0-9A-F]{2})|(?:\\b|\\/|$))";
+        "(?:(?=[.~-]|%[0-9A-F]{2})|\\b|\\/|$)";
   }
 
   let matcher = new RegExp(regexpSource, caseSensitive ? undefined : "i");


### PR DESCRIPTION
closes #8525 and #8561

Fixes route matching to allow valid, but non-word-boundary characters(`.`, `-`, `~`) and url-encoded entities to appear at the beginning of a nested `*` route.

I pulled this character set from [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), section 2.3 Unreserved Characters:

> 2.3.  Unreserved Characters
> 
>    Characters that are allowed in a URI but do not have a reserved
>    purpose are called unreserved.  These include uppercase and lowercase
>    letters, decimal digits, hyphen, period, underscore, and tilde.
> 
>       unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"

I extended this to include url-encoded entities (ie `%20`), but I am not 100% confident I made the character range wide enough. ([0-7][0-9A-F]). It is probably safe to expand this to any 2-digit hex code, but I wasn't able to find any concrete resources.

Let me know if additional test cases are needed for this, since I'm not _too_ familiar with the codebase and possible untested behaviors.