### PR TITLE
ci: format dev branch and checkout repo using custom token

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   format:
@@ -15,6 +16,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.FORMAT_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@v2
@@ -29,7 +32,7 @@ jobs:
 
       - name: Commit
         run: |
-          git config --local user.email "github-actions@remix.run"
+          git config --local user.email "hello@remix.run"
           git config --local user.name "Remix Run Bot"
 
           git add .


### PR DESCRIPTION
this PR enables the format workflow on the `dev` branch allows us to push to the protected branches. I've also updated the email address for "Remix Run Bot" so that commits are properly assigned to it and allows this whole thing to work.

x-ref: https://github.com/remix-run/remix/pull/1455