### PR TITLE
Updates type declaration for RouteProps in API docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,6 +1,7 @@
 - Ajayff4
 - brockross
 - chaance
+- chrisngobanh
 - elylucas
 - hongji00
 - JakubDrozd

--- a/docs/api.md
+++ b/docs/api.md
@@ -691,7 +691,7 @@ declare function Route(
 interface RouteProps {
   caseSensitive?: boolean;
   children?: React.ReactNode;
-  element?: React.ReactElement | null;
+  element?: React.ReactNode | null;
   index?: boolean;
   path?: string;
 }


### PR DESCRIPTION
Changes RouteProps.element type in API docs from `React.ReactElement | null` to `React.ReactNode | null`.

The code change being documented was done in #8473