### PR TITLE
fix(tutorial): use "root" as root div id

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -2,6 +2,7 @@
 - brockross
 - chaance
 - chasinhues
+- christopherchudzicki
 - elylucas
 - hongji00
 - JakubDrozd

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -6,7 +6,7 @@
     <title>React Router - Tutorial</title>
   </head>
   <body>
-    <div id="app"><!--app-html--></div>
+    <div id="root"><!--app-html--></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/tutorial/src/main.jsx
+++ b/tutorial/src/main.jsx
@@ -3,5 +3,5 @@ import * as ReactDOM from "react-dom";
 import App from "./App";
 import "./main.css";
 
-let rootElement = document.getElementById("app");
+let rootElement = document.getElementById("root");
 ReactDOM.render(<App />, rootElement);


### PR DESCRIPTION
Fixes #8581 

The documentation in /docs/getting-started uses "root" as the root element id, including in code snippets. So if a learner is following the tutorial documentation, they'll break their app when they copy-paste the tutorial snippets (which use "root") into the template (which was using "app", prior to this PR).

Now the docs and the template both use "root".