### PR TITLE
Update faq.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - Ajayff4
+- awreese
 - brockross
 - chaance
 - chasinhues

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -335,7 +335,7 @@ function App() {
   return (
     <Routes>
       <Route path="/users/:id" element={<ValidateUser />} />
-      <Route path="/users/*" component={NotFound} />
+      <Route path="/users/*" element={<NotFound />} />
     </Routes>
   );
 }


### PR DESCRIPTION
Example `Route` component from a v6 example was still using a `component` prop and component reference vs `element` prop and JSX.