### PR TITLE
Adds key to PathRouteProps type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -22,3 +22,4 @@
 - timdorr
 - turansky
 - vijaypushkin
+- ImanMh

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -206,6 +206,7 @@ export interface PathRouteProps {
   children?: React.ReactNode;
   element?: React.ReactNode | null;
   index?: false;
+  key?: string;
   path: string;
 }
 


### PR DESCRIPTION
PathRouteProps is missing the key prop. This is useful when you want to map over a JSON route config and generate routes.

(Sorry I was not able to install the dependencies of the project due to sanctions from Google for Iranian developers but I'm almost sure that this is going to work since I tested by making the same changes over a built version of react router inside my node_modules of another project)