### PR TITLE
docs(faq): withRouter TypeScript example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -30,3 +30,4 @@
 - turansky
 - underager
 - vijaypushkin
+- egor-xyz

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,6 +35,58 @@ function withRouter(Component) {
 }
 ```
 
+### TypeScript example
+
+```typescript
+// withRouter.tsx
+
+import { ComponentType } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+export interface WithRouterProps<T = ReturnType<typeof useParams>> {
+  history: {
+    back: () => void;
+    goBack: () => void;
+    location: ReturnType<typeof useLocation>;
+    push: (url: string, state?: any) => void;
+  }
+  location: ReturnType<typeof useLocation>;
+  match: {
+    params: T;
+  };
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export const withRouter = <P extends object>(Component: ComponentType<P>) => {
+  return (props: Omit<P, keyof WithRouterProps>) => {
+    const location = useLocation();
+    const match = { params: useParams() };
+    const navigate = useNavigate();
+
+    const history = {
+      back: () => navigate(-1),
+      goBack: () => navigate(-1),
+      location,
+      push: (url: string, state?: any) => navigate(url, { state }),
+      replace: (url: string, state?: any) => navigate(url, {
+        replace: true,
+        state
+      })
+    };
+
+    return (
+      <Component
+        history={history}
+        location={location}
+        match={match}
+        navigate={navigate}
+        {...props as P}
+      />
+    );
+  };
+};
+```
+
 ## Why does `<Route>` have an `element` prop instead of `render` or `component`?
 
 We mentioned this [in the migration guide from v5 to v6](../guides/migrating-5-to-6#advantages-of-route-element), but it's worth repeating here.


### PR DESCRIPTION
A lot of projects in the world are still using classes. I suggest adding a TypeScript example to the FAQ documentation. This is an example with generic params.