### PR TITLE
fixed small typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -31,3 +31,4 @@
 - turansky
 - underager
 - vijaypushkin
+- janpaepke

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -668,7 +668,7 @@ The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-
 
 ```jsx bad lines=[14-16,22-24]
 <Routes>
-  <Routes path="/" element={<App />}>
+  <Route path="/" element={<App />}>
     <Route index element={<Home />} />
     <Route path="teams" element={<Teams />}>
       <Route path=":teamId" element={<Team />} />


### PR DESCRIPTION
The opening tag in the anti-example for layout routes should be `Route` instead of `Routes`

The closing tag is correct.