### PR TITLE
docs: Fix react-router/README.md's link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -35,3 +35,4 @@
 - turansky
 - underager
 - vijaypushkin
+- hyesungoh

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -1,6 +1,6 @@
 # React Router
 
-The `react-router` package is the heart of [React Router](/) and provides all
+The `react-router` package is the heart of [React Router](https://github.com/remix-run/react-router) and provides all
 the core functionality for both
 [`react-router-dom`](/packages/react-router-dom)
 and


### PR DESCRIPTION
## problem

when click "react-router" of `react-router/packages/react-router/README.md` file it comes 404 error !

>`packages/react-router-dom` and `packages/react-router-native` doesn't come error

##  So I

I updateed it like other packages README.md