### PR TITLE
Add import statement to useOutletContext example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -2,6 +2,7 @@
 - Ajayff4
 - awreese
 - bhbs
+- BrianT1414
 - brockross
 - chaance
 - chasinhues

--- a/docs/api.md
+++ b/docs/api.md
@@ -646,7 +646,7 @@ If you're using TypeScript, we recommend the parent component provide a custom h
 ```tsx filename=src/routes/dashboard.tsx lines=[12,17-19]
 import * as React from "react";
 import type { User } from "./types";
-import { useOutletContext } from "react-router-dom";
+import { Outlet, useOutletContext } from "react-router-dom";
 
 type ContextType = { user: User | null };
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -646,6 +646,7 @@ If you're using TypeScript, we recommend the parent component provide a custom h
 ```tsx filename=src/routes/dashboard.tsx lines=[12,17-19]
 import * as React from "react";
 import type { User } from "./types";
+import { useOutletContext } from "react-router-dom";
 
 type ContextType = { user: User | null };
 


### PR DESCRIPTION
I added an import for the `useOutletContext` hook API documentation example to be consistent with other examples. Also based on [this SO question](https://stackoverflow.com/questions/71165826/failing-to-access-outlet-context-in-react) the absence of the import has caused some confusion.