### PR TITLE
Persist query string when navigating

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,6 +13,7 @@
 - hongji00
 - hsbtr
 - hyesungoh
+- IbraRouisDev
 - JakubDrozd
 - jmargeta
 - jonkoops
@@ -37,4 +38,3 @@
 - turansky
 - underager
 - vijaypushkin
-- IbraRouisDev

--- a/contributors.yml
+++ b/contributors.yml
@@ -37,3 +37,4 @@
 - turansky
 - underager
 - vijaypushkin
+- IbraRouisDev

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -812,6 +812,7 @@ import { getInvoice, deleteInvoice } from "../data";
 
 export default function Invoice() {
   let navigate = useNavigate();
+  let location = useLocation();
   let params = useParams();
   let invoice = getInvoice(parseInt(params.invoiceId, 10));
 
@@ -826,7 +827,7 @@ export default function Invoice() {
         <button
           onClick={() => {
             deleteInvoice(invoice.number);
-            navigate("/invoices");
+            navigate("/invoices" + location.search);
           }}
         >
           Delete
@@ -836,6 +837,8 @@ export default function Invoice() {
   );
 }
 ```
+
+Notice we used `useLocation` again to persist the query string by adding `location.search` to the navigation link.
 
 ## Getting Help
 


### PR DESCRIPTION
It would make the UI more consistent if we pass the query string to navigation function route after deleting and item.