### PR TITLE
Fix: Update docs to use staticContext.statusCode instead of staticContext.status

### DIFF
--- a/packages/react-router-dom/docs/guides/server-rendering.md
+++ b/packages/react-router-dom/docs/guides/server-rendering.md
@@ -93,7 +93,7 @@ function Status({ code, children }) {
   return (
     <Route
       render={({ staticContext }) => {
-        if (staticContext) staticContext.status = code;
+        if (staticContext) staticContext.statusCode = code;
         return children;
       }}
     />


### PR DESCRIPTION
Apologies if there's a template I should use for this.

Was troubleshooting why our RedirectWithStatus component wasn't working with SSR based on the v5 documentation, and realized that the docs should use `staticContext.statusCode` instead of `staticContext.status` to set the status code for the redirect.

I wasn't sure if this is the right branch, or if it should be `v5-website` -- let me know if I need to open this elsewhere. Or perhaps the docs were correct and we're just on a version of v5.x before a change?