### PR TITLE
feat: add history package and createMemoryHistory implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "workspaces": {
     "packages": [
+      "packages/history",
       "packages/react-router",
       "packages/react-router-dom",
       "packages/react-router-native"

--- a/packages/history/.eslintrc
+++ b/packages/history/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true
+  },
+  "globals": {
+    "__DEV__": true
+  },
+  "rules": {
+    "strict": 0
+  }
+}

--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -1,0 +1,3 @@
+# history
+
+TODO

--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -1,3 +1,5 @@
 # history
 
-TODO
+The `history` library lets you easily manage session history anywhere JavaScript runs. A `history` object abstracts away the differences in various environments and provides a minimal API that lets you manage the history stack, navigate, and persist state between sessions.
+
+This internal package is an evolution of the [`history`](https://www.npmjs.com/package/history) `npm` package from https://github.com/remix-run/history, and has now been internalized to `react-router`.

--- a/packages/history/__tests__/.eslintrc
+++ b/packages/history/__tests__/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "jest": true
+  },
+  "rules": {
+    "no-console": 0
+  }
+}

--- a/packages/history/__tests__/TestSequences/EncodedReservedCharacters.ts
+++ b/packages/history/__tests__/TestSequences/EncodedReservedCharacters.ts
@@ -1,0 +1,27 @@
+import type { History } from "../../index";
+
+export default function EncodeReservedCharacters(history: History) {
+  let pathname;
+
+  // encoded string
+  pathname = "/view/%23abc";
+  history.replace(pathname);
+  expect(history.location).toMatchObject({
+    pathname: "/view/%23abc",
+  });
+
+  // encoded object
+  pathname = "/view/%23abc";
+  history.replace({ pathname });
+  expect(history.location).toMatchObject({
+    pathname: "/view/%23abc",
+  });
+
+  // unencoded string
+  pathname = "/view/#abc";
+  history.replace(pathname);
+  expect(history.location).toMatchObject({
+    pathname: "/view/",
+    hash: "#abc",
+  });
+}

--- a/packages/history/__tests__/TestSequences/GoBack.ts
+++ b/packages/history/__tests__/TestSequences/GoBack.ts
@@ -1,6 +1,6 @@
 import type { History } from "../../index";
 
-export default function GoBack(history: History) {
+export default function GoBack(history: History, spy: jest.SpyInstance) {
   expect(history.location).toMatchObject({
     pathname: "/",
   });
@@ -10,10 +10,22 @@ export default function GoBack(history: History) {
   expect(history.location).toMatchObject({
     pathname: "/home",
   });
+  expect(spy).not.toHaveBeenCalled();
 
   history.go(-1);
   expect(history.action).toEqual("POP");
   expect(history.location).toMatchObject({
     pathname: "/",
   });
+  expect(spy).toHaveBeenCalledWith({
+    action: "POP",
+    location: {
+      hash: "",
+      key: expect.any(String),
+      pathname: "/",
+      search: "",
+      state: null,
+    },
+  });
+  expect(spy.mock.calls.length).toBe(1);
 }

--- a/packages/history/__tests__/TestSequences/GoBack.ts
+++ b/packages/history/__tests__/TestSequences/GoBack.ts
@@ -1,0 +1,19 @@
+import type { History } from "../../index";
+
+export default function GoBack(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home");
+  expect(history.action).toEqual("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  history.go(-1);
+  expect(history.action).toEqual("POP");
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+}

--- a/packages/history/__tests__/TestSequences/GoForward.ts
+++ b/packages/history/__tests__/TestSequences/GoForward.ts
@@ -1,0 +1,25 @@
+import type { History } from "../../index";
+
+export default function GoForward(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home");
+  expect(history.action).toEqual("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  history.go(-1);
+  expect(history.action).toEqual("POP");
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.go(1);
+  expect(history.action).toEqual("POP");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+}

--- a/packages/history/__tests__/TestSequences/GoForward.ts
+++ b/packages/history/__tests__/TestSequences/GoForward.ts
@@ -1,6 +1,6 @@
 import type { History } from "../../index";
 
-export default function GoForward(history: History) {
+export default function GoForward(history: History, spy: jest.SpyInstance) {
   expect(history.location).toMatchObject({
     pathname: "/",
   });
@@ -10,16 +10,39 @@ export default function GoForward(history: History) {
   expect(history.location).toMatchObject({
     pathname: "/home",
   });
+  expect(spy).not.toHaveBeenCalled();
 
   history.go(-1);
   expect(history.action).toEqual("POP");
   expect(history.location).toMatchObject({
     pathname: "/",
   });
+  expect(spy).toHaveBeenCalledWith({
+    action: "POP",
+    location: {
+      hash: "",
+      key: expect.any(String),
+      pathname: "/",
+      search: "",
+      state: null,
+    },
+  });
+  expect(spy.mock.calls.length).toBe(1);
 
   history.go(1);
   expect(history.action).toEqual("POP");
   expect(history.location).toMatchObject({
     pathname: "/home",
   });
+  expect(spy).toHaveBeenCalledWith({
+    action: "POP",
+    location: {
+      hash: "",
+      key: expect.any(String),
+      pathname: "/home",
+      search: "",
+      state: null,
+    },
+  });
+  expect(spy.mock.calls.length).toBe(2);
 }

--- a/packages/history/__tests__/TestSequences/InitialLocationDefaultKey.ts
+++ b/packages/history/__tests__/TestSequences/InitialLocationDefaultKey.ts
@@ -1,0 +1,5 @@
+import type { History } from "../../index";
+
+export default function InitialLocationDefaultKey(history: History) {
+  expect(history.location.key).toBe("default");
+}

--- a/packages/history/__tests__/TestSequences/InitialLocationHasKey.ts
+++ b/packages/history/__tests__/TestSequences/InitialLocationHasKey.ts
@@ -1,0 +1,5 @@
+import type { History } from "../../index";
+
+export default function InitialLocationHasKey(history: History) {
+  expect(history.location.key).toBeTruthy();
+}

--- a/packages/history/__tests__/TestSequences/Listen.ts
+++ b/packages/history/__tests__/TestSequences/Listen.ts
@@ -1,0 +1,11 @@
+import type { History } from '../../index' ;
+
+export default function Listen(history: History, done: () => void) {
+  let spy = jest.fn();
+  let unlisten = history.listen(spy);
+
+  expect(spy).not.toHaveBeenCalled();
+
+  unlisten();
+  done();
+}

--- a/packages/history/__tests__/TestSequences/Listen.ts
+++ b/packages/history/__tests__/TestSequences/Listen.ts
@@ -1,11 +1,10 @@
-import type { History } from '../../index' ;
+import type { History } from "../../index";
 
-export default function Listen(history: History, done: () => void) {
+export default function Listen(history: History) {
   let spy = jest.fn();
   let unlisten = history.listen(spy);
 
   expect(spy).not.toHaveBeenCalled();
 
   unlisten();
-  done();
 }

--- a/packages/history/__tests__/TestSequences/ListenPopOnly.ts
+++ b/packages/history/__tests__/TestSequences/ListenPopOnly.ts
@@ -1,0 +1,14 @@
+import type { History } from "../../index";
+
+export default function Listen(history: History) {
+  let spy = jest.fn();
+  let unlisten = history.listen(spy);
+
+  history.push("/2");
+  expect(history.location.pathname).toBe("/2");
+  history.replace("/3");
+  expect(history.location.pathname).toBe("/3");
+
+  expect(spy).not.toHaveBeenCalled();
+  unlisten();
+}

--- a/packages/history/__tests__/TestSequences/PushMissingPathname.ts
+++ b/packages/history/__tests__/TestSequences/PushMissingPathname.ts
@@ -1,0 +1,23 @@
+import type { History } from "../../index";
+
+export default function PushMissingPathname(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home?the=query#the-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?the=query",
+    hash: "#the-hash",
+  });
+
+  history.push("?another=query#another-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?another=query",
+    hash: "#another-hash",
+  });
+}

--- a/packages/history/__tests__/TestSequences/PushNewLocation.ts
+++ b/packages/history/__tests__/TestSequences/PushNewLocation.ts
@@ -1,0 +1,17 @@
+import type { History } from "../../index";
+
+export default function PushNewLocation(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home?the=query#the-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?the=query",
+    hash: "#the-hash",
+    state: null,
+    key: expect.any(String),
+  });
+}

--- a/packages/history/__tests__/TestSequences/PushRelativePathname.ts
+++ b/packages/history/__tests__/TestSequences/PushRelativePathname.ts
@@ -1,0 +1,23 @@
+import type { History } from "../../index";
+
+export default function PushRelativePathname(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/the/path?the=query#the-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/the/path",
+    search: "?the=query",
+    hash: "#the-hash",
+  });
+
+  history.push("../other/path?another=query#another-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/other/path",
+    search: "?another=query",
+    hash: "#another-hash",
+  });
+}

--- a/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.ts
+++ b/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.ts
@@ -13,7 +13,7 @@ export default function PushRelativePathnameWarning(history: History) {
     hash: "#the-hash",
   });
 
-  let spy = jest.spyOn(console, "warn");
+  let spy = jest.spyOn(console, "warn").mockImplementation(() => {});
   history.push("../other/path?another=query#another-hash");
   expect(spy).toHaveBeenCalledWith(
     expect.stringContaining("relative pathnames are not supported")

--- a/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.ts
+++ b/packages/history/__tests__/TestSequences/PushRelativePathnameWarning.ts
@@ -1,0 +1,28 @@
+import type { History } from "../../index";
+
+export default function PushRelativePathnameWarning(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/the/path?the=query#the-hash");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/the/path",
+    search: "?the=query",
+    hash: "#the-hash",
+  });
+
+  let spy = jest.spyOn(console, "warn");
+  history.push("../other/path?another=query#another-hash");
+  expect(spy).toHaveBeenCalledWith(
+    expect.stringContaining("relative pathnames are not supported")
+  );
+  spy.mockReset();
+
+  expect(history.location).toMatchObject({
+    pathname: "../other/path",
+    search: "?another=query",
+    hash: "#another-hash",
+  });
+}

--- a/packages/history/__tests__/TestSequences/PushSamePath.ts
+++ b/packages/history/__tests__/TestSequences/PushSamePath.ts
@@ -1,0 +1,25 @@
+import type { History } from "../../index";
+
+export default function PushSamePath(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  history.push("/home");
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  history.go(-1);
+  expect(history.action).toBe("POP");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+}

--- a/packages/history/__tests__/TestSequences/PushState.ts
+++ b/packages/history/__tests__/TestSequences/PushState.ts
@@ -1,0 +1,16 @@
+import type { History } from "../../index";
+
+export default function PushState(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.push("/home?the=query#the-hash", { the: "state" });
+  expect(history.action).toBe("PUSH");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?the=query",
+    hash: "#the-hash",
+    state: { the: "state" },
+  });
+}

--- a/packages/history/__tests__/TestSequences/ReplaceNewLocation.ts
+++ b/packages/history/__tests__/TestSequences/ReplaceNewLocation.ts
@@ -1,0 +1,26 @@
+import type { History } from "../../index";
+
+export default function ReplaceNewLocation(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.replace("/home?the=query#the-hash");
+  expect(history.action).toBe("REPLACE");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?the=query",
+    hash: "#the-hash",
+    state: null,
+    key: expect.any(String),
+  });
+
+  history.replace("/");
+  expect(history.action).toBe("REPLACE");
+  expect(history.location).toMatchObject({
+    pathname: "/",
+    search: "",
+    state: null,
+    key: expect.any(String),
+  });
+}

--- a/packages/history/__tests__/TestSequences/ReplaceSamePath.ts
+++ b/packages/history/__tests__/TestSequences/ReplaceSamePath.ts
@@ -1,0 +1,23 @@
+import type { History } from "../../index";
+
+export default function ReplaceSamePath(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.replace("/home");
+  expect(history.action).toBe("REPLACE");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  let prevLocation = history.location;
+
+  history.replace("/home");
+  expect(history.action).toBe("REPLACE");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+  });
+
+  expect(history.location).not.toBe(prevLocation);
+}

--- a/packages/history/__tests__/TestSequences/ReplaceState.ts
+++ b/packages/history/__tests__/TestSequences/ReplaceState.ts
@@ -1,0 +1,16 @@
+import type { History } from "../../index";
+
+export default function ReplaceState(history: History) {
+  expect(history.location).toMatchObject({
+    pathname: "/",
+  });
+
+  history.replace("/home?the=query#the-hash", { the: "state" });
+  expect(history.action).toBe("REPLACE");
+  expect(history.location).toMatchObject({
+    pathname: "/home",
+    search: "?the=query",
+    hash: "#the-hash",
+    state: { the: "state" },
+  });
+}

--- a/packages/history/__tests__/memory-test.ts
+++ b/packages/history/__tests__/memory-test.ts
@@ -1,0 +1,155 @@
+import { createMemoryHistory, MemoryHistory } from "../index";
+
+import Listen from "./TestSequences/Listen";
+import InitialLocationHasKey from "./TestSequences/InitialLocationHasKey";
+import PushNewLocation from "./TestSequences/PushNewLocation";
+import PushSamePath from "./TestSequences/PushSamePath";
+import PushState from "./TestSequences/PushState";
+import PushMissingPathname from "./TestSequences/PushMissingPathname";
+import PushRelativePathnameWarning from "./TestSequences/PushRelativePathnameWarning";
+import ReplaceNewLocation from "./TestSequences/ReplaceNewLocation";
+import ReplaceSamePath from "./TestSequences/ReplaceSamePath";
+import ReplaceState from "./TestSequences/ReplaceState";
+import EncodedReservedCharacters from "./TestSequences/EncodedReservedCharacters";
+import GoBack from "./TestSequences/GoBack";
+import GoForward from "./TestSequences/GoForward";
+
+describe("a memory history", () => {
+  let history: MemoryHistory;
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+  });
+
+  it("has an index property", () => {
+    expect(typeof history.index).toBe("number");
+  });
+
+  it("knows how to create hrefs", () => {
+    const href = history.createHref({
+      pathname: "/the/path",
+      search: "?the=query",
+      hash: "#the-hash",
+    });
+
+    expect(href).toEqual("/the/path?the=query#the-hash");
+  });
+
+  it("knows how to create hrefs from strings", () => {
+    const href = history.createHref("/the/path?the=query#the-hash");
+    expect(href).toEqual("/the/path?the=query#the-hash");
+  });
+
+  it("does not encode the generated path", () => {
+    const encodedHref = history.createHref({
+      pathname: "/%23abc",
+    });
+    expect(encodedHref).toEqual("/%23abc");
+
+    const unencodedHref = history.createHref({
+      pathname: "/#abc",
+    });
+    expect(unencodedHref).toEqual("/#abc");
+  });
+
+  describe("the initial location", () => {
+    it("has a key", () => {
+      InitialLocationHasKey(history);
+    });
+  });
+
+  describe("listen", () => {
+    it("does not immediately call listeners", (done) => {
+      Listen(history, done);
+    });
+  });
+
+  describe("push", () => {
+    it("pushes the new location", () => {
+      PushNewLocation(history);
+    });
+
+    it("pushes the same location", () => {
+      PushSamePath(history);
+    });
+
+    it("pushes with state", () => {
+      PushState(history);
+    });
+
+    it("reuses the current location pathname", () => {
+      PushMissingPathname(history);
+    });
+
+    it("issues a warning on relative pathnames", () => {
+      PushRelativePathnameWarning(history);
+    });
+  });
+
+  describe("replace", () => {
+    it("replaces with a new location", () => {
+      ReplaceNewLocation(history);
+    });
+  });
+
+  describe("replace the same path", () => {
+    it("replaces with the same location", () => {
+      ReplaceSamePath(history);
+    });
+
+    it("replaces the state", () => {
+      ReplaceState(history);
+    });
+  });
+
+  describe("location created with encoded/unencoded reserved characters", () => {
+    it("produces different location objects", () => {
+      EncodedReservedCharacters(history);
+    });
+  });
+
+  describe("go", () => {
+    it("goes back", () => {
+      GoBack(history);
+    });
+    it("goes forward", () => {
+      GoForward(history);
+    });
+  });
+});
+
+describe("a memory history with some initial entries", () => {
+  it("clamps the initial index to a valid value", () => {
+    let history = createMemoryHistory({
+      initialEntries: ["/one", "/two", "/three"],
+      initialIndex: 3, // invalid
+    });
+
+    expect(history.index).toBe(2);
+  });
+
+  it("starts at the last entry by default", () => {
+    let history = createMemoryHistory({
+      initialEntries: ["/one", "/two", "/three"],
+    });
+
+    expect(history.index).toBe(2);
+    expect(history.location).toMatchObject({
+      pathname: "/three",
+      search: "",
+      hash: "",
+      state: null,
+      key: expect.any(String),
+    });
+
+    history.go(-1);
+    expect(history.index).toBe(1);
+    expect(history.location).toMatchObject({
+      pathname: "/two",
+      search: "",
+      hash: "",
+      state: null,
+      key: expect.any(String),
+    });
+  });
+});

--- a/packages/history/__tests__/memory-test.ts
+++ b/packages/history/__tests__/memory-test.ts
@@ -1,4 +1,4 @@
-import type { Location, MemoryHistory } from "../index";
+import type { MemoryHistory } from "../index";
 import { createMemoryHistory } from "../index";
 
 import Listen from "./TestSequences/Listen";

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -59,7 +59,7 @@ export type Hash = string;
  * @deprecated
  * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
  */
-export type State = unknown;
+export type State = any;
 
 /**
  * A unique string associated with a location. May be used to safely store
@@ -107,7 +107,7 @@ export interface Location extends Path {
    *
    * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
    */
-  state: unknown;
+  state: any;
 
   /**
    * A unique string associated with this location. May be used to safely store

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -4,8 +4,6 @@
 
 /**
  * Actions represent the type of change to a location value.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#action
  */
 export enum Action {
   /**
@@ -32,80 +30,32 @@ export enum Action {
 }
 
 /**
- * A URL pathname, beginning with a /.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.pathname
- */
-export type Pathname = string;
-
-/**
- * A URL search string, beginning with a ?.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.search
- */
-export type Search = string;
-
-/**
- * A URL fragment identifier, beginning with a #.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.hash
- */
-export type Hash = string;
-
-/**
- * An object that is used to associate some arbitrary data with a location, but
- * that does not appear in the URL path.
- *
- * @deprecated
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
- */
-export type State = any;
-
-/**
- * A unique string associated with a location. May be used to safely store
- * and retrieve data in some other storage API, like `localStorage`.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.key
- */
-export type Key = string;
-
-/**
  * The pathname, search, and hash values of a URL.
  */
 export interface Path {
   /**
    * A URL pathname, beginning with a /.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.pathname
    */
-  pathname: Pathname;
+  pathname: string;
 
   /**
    * A URL search string, beginning with a ?.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.search
    */
-  search: Search;
+  search: string;
 
   /**
    * A URL fragment identifier, beginning with a #.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.hash
    */
-  hash: Hash;
+  hash: string;
 }
 
 /**
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location
  */
 export interface Location extends Path {
   /**
    * A value of arbitrary data associated with this location.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
    */
   state: any;
 
@@ -114,10 +64,8 @@ export interface Location extends Path {
    * and retrieve data in some other storage API, like `localStorage`.
    *
    * Note: This value is always "default" on the initial location.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.key
    */
-  key: Key;
+  key: string;
 }
 
 /**
@@ -161,15 +109,11 @@ export interface History {
   /**
    * The last action that modified the current location. This will always be
    * Action.Pop when a history instance is first created. This value is mutable.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.action
    */
   readonly action: Action;
 
   /**
    * The current location. This value is mutable.
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.location
    */
   readonly location: Location;
 
@@ -178,8 +122,6 @@ export interface History {
    * the value of an <a href> attribute.
    *
    * @param to - The destination URL
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.createHref
    */
   createHref(to: To): string;
 
@@ -190,8 +132,6 @@ export interface History {
    *
    * @param to - The new URL
    * @param state - Data to associate with the new location
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.push
    */
   push(to: To, state?: any): void;
 
@@ -201,8 +141,6 @@ export interface History {
    *
    * @param to - The new URL
    * @param state - Data to associate with the new location
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.replace
    */
   replace(to: To, state?: any): void;
 
@@ -211,8 +149,6 @@ export interface History {
    * current index. For example, a "back" navigation would use go(-1).
    *
    * @param delta - The delta in the stack index
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.go
    */
   go(delta: number): void;
 
@@ -222,8 +158,6 @@ export interface History {
    *
    * @param listener - A function that will be called when the location changes
    * @returns unlisten - A function that may be used to stop listening
-   *
-   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.listen
    */
   listen(listener: Listener): () => void;
 }
@@ -232,10 +166,11 @@ export interface History {
  * A memory history stores locations in memory. This is useful in stateful
  * environments where there is no web browser, such as node tests or React
  * Native.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#memoryhistory
  */
 export interface MemoryHistory extends History {
+  /**
+   * The current index in the history stack.
+   */
   readonly index: number;
 }
 //#endregion
@@ -258,8 +193,6 @@ export type MemoryHistoryOptions = {
 /**
  * Memory history stores the current location in memory. It is designed for use
  * in stateful non-browser environments like tests and React Native.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#creatememoryhistory
  */
 export function createMemoryHistory(
   options: MemoryHistoryOptions = {}
@@ -280,7 +213,7 @@ export function createMemoryHistory(
     return entries[index];
   }
   function createLocation(to: To, state: any = null): Location {
-    const location = readOnly<Location>({
+    let location = readOnly<Location>({
       pathname: entries ? getCurrentLocation().pathname : "/",
       search: "",
       hash: "",
@@ -312,13 +245,13 @@ export function createMemoryHistory(
     },
     push(to, state) {
       action = Action.Push;
-      const nextLocation = createLocation(to, state);
+      let nextLocation = createLocation(to, state);
       index += 1;
       entries.splice(index, entries.length, nextLocation);
     },
     replace(to, state) {
       action = Action.Replace;
-      const nextLocation = createLocation(to, state);
+      let nextLocation = createLocation(to, state);
       entries[index] = nextLocation;
     },
     go(delta) {
@@ -391,8 +324,6 @@ function createKey() {
 
 /**
  * Creates a string URL path from the given pathname, search, and hash components.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#createpath
  */
 export function createPath({
   pathname = "/",
@@ -408,8 +339,6 @@ export function createPath({
 
 /**
  * Parses a string URL path into its separate pathname, search, and hash components.
- *
- * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#parsepath
  */
 export function parsePath(path: string): Partial<Path> {
   let parsedPath: Partial<Path> = {};

--- a/packages/history/index.ts
+++ b/packages/history/index.ts
@@ -1,0 +1,437 @@
+////////////////////////////////////////////////////////////////////////////////
+//#region TYPES
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Actions represent the type of change to a location value.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#action
+ */
+export enum Action {
+  /**
+   * A POP indicates a change to an arbitrary index in the history stack, such
+   * as a back or forward navigation. It does not describe the direction of the
+   * navigation, only that the current index changed.
+   *
+   * Note: This is the default action for newly created history objects.
+   */
+  Pop = "POP",
+
+  /**
+   * A PUSH indicates a new entry being added to the history stack, such as when
+   * a link is clicked and a new page loads. When this happens, all subsequent
+   * entries in the stack are lost.
+   */
+  Push = "PUSH",
+
+  /**
+   * A REPLACE indicates the entry at the current index in the history stack
+   * being replaced by a new one.
+   */
+  Replace = "REPLACE",
+}
+
+/**
+ * A URL pathname, beginning with a /.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.pathname
+ */
+export type Pathname = string;
+
+/**
+ * A URL search string, beginning with a ?.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.search
+ */
+export type Search = string;
+
+/**
+ * A URL fragment identifier, beginning with a #.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.hash
+ */
+export type Hash = string;
+
+/**
+ * An object that is used to associate some arbitrary data with a location, but
+ * that does not appear in the URL path.
+ *
+ * @deprecated
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
+ */
+export type State = unknown;
+
+/**
+ * A unique string associated with a location. May be used to safely store
+ * and retrieve data in some other storage API, like `localStorage`.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.key
+ */
+export type Key = string;
+
+/**
+ * The pathname, search, and hash values of a URL.
+ */
+export interface Path {
+  /**
+   * A URL pathname, beginning with a /.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.pathname
+   */
+  pathname: Pathname;
+
+  /**
+   * A URL search string, beginning with a ?.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.search
+   */
+  search: Search;
+
+  /**
+   * A URL fragment identifier, beginning with a #.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.hash
+   */
+  hash: Hash;
+}
+
+/**
+ * An entry in a history stack. A location contains information about the
+ * URL path, as well as possibly some arbitrary state and a key.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location
+ */
+export interface Location extends Path {
+  /**
+   * A value of arbitrary data associated with this location.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.state
+   */
+  state: unknown;
+
+  /**
+   * A unique string associated with this location. May be used to safely store
+   * and retrieve data in some other storage API, like `localStorage`.
+   *
+   * Note: This value is always "default" on the initial location.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#location.key
+   */
+  key: Key;
+}
+
+/**
+ * A change to the current location.
+ */
+export interface Update {
+  /**
+   * The action that triggered the change.
+   */
+  action: Action;
+
+  /**
+   * The new location.
+   */
+  location: Location;
+}
+
+/**
+ * A function that receives notifications about location changes.
+ */
+export interface Listener {
+  (update: Update): void;
+}
+
+/**
+ * Describes a location that is the destination of some navigation, either via
+ * `history.push` or `history.replace`. May be either a URL or the pieces of a
+ * URL path.
+ */
+export type To = string | Partial<Path>;
+
+/**
+ * A history is an interface to the navigation stack. The history serves as the
+ * source of truth for the current location, as well as provides a set of
+ * methods that may be used to change it.
+ *
+ * It is similar to the DOM's `window.history` object, but with a smaller, more
+ * focused API.
+ */
+export interface History {
+  /**
+   * The last action that modified the current location. This will always be
+   * Action.Pop when a history instance is first created. This value is mutable.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.action
+   */
+  readonly action: Action;
+
+  /**
+   * The current location. This value is mutable.
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.location
+   */
+  readonly location: Location;
+
+  /**
+   * Returns a valid href for the given `to` value that may be used as
+   * the value of an <a href> attribute.
+   *
+   * @param to - The destination URL
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.createHref
+   */
+  createHref(to: To): string;
+
+  /**
+   * Pushes a new location onto the history stack, increasing its length by one.
+   * If there were any entries in the stack after the current one, they are
+   * lost.
+   *
+   * @param to - The new URL
+   * @param state - Data to associate with the new location
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.push
+   */
+  push(to: To, state?: any): void;
+
+  /**
+   * Replaces the current location in the history stack with a new one.  The
+   * location that was replaced will no longer be available.
+   *
+   * @param to - The new URL
+   * @param state - Data to associate with the new location
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.replace
+   */
+  replace(to: To, state?: any): void;
+
+  /**
+   * Navigates `n` entries backward/forward in the history stack relative to the
+   * current index. For example, a "back" navigation would use go(-1).
+   *
+   * @param delta - The delta in the stack index
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.go
+   */
+  go(delta: number): void;
+
+  /**
+   * Sets up a listener that will be called whenever the current location
+   * changes.
+   *
+   * @param listener - A function that will be called when the location changes
+   * @returns unlisten - A function that may be used to stop listening
+   *
+   * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#history.listen
+   */
+  listen(listener: Listener): () => void;
+}
+
+/**
+ * A memory history stores locations in memory. This is useful in stateful
+ * environments where there is no web browser, such as node tests or React
+ * Native.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#memoryhistory
+ */
+export interface MemoryHistory extends History {
+  readonly index: number;
+}
+//#endregion
+
+////////////////////////////////////////////////////////////////////////////////
+//#region MEMORY
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A user-supplied object that describes a location. Used when providing
+ * entries to `createMemoryHistory` via its `initialEntries` option.
+ */
+export type InitialEntry = string | Partial<Location>;
+
+export type MemoryHistoryOptions = {
+  initialEntries?: InitialEntry[];
+  initialIndex?: number;
+};
+
+/**
+ * Memory history stores the current location in memory. It is designed for use
+ * in stateful non-browser environments like tests and React Native.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#creatememoryhistory
+ */
+export function createMemoryHistory(
+  options: MemoryHistoryOptions = {}
+): MemoryHistory {
+  let { initialEntries = ["/"], initialIndex } = options;
+  let entries: Location[]; // Declare so we can access from createLocation
+  entries = initialEntries.map((entry) => createLocation(entry));
+  let index = clamp(
+    initialIndex == null ? entries.length - 1 : initialIndex,
+    0,
+    entries.length - 1
+  );
+  let action = Action.Pop;
+  let getCurrentLocation = (): Location => entries[index];
+  let listeners = createEvents<Listener>();
+
+  function createLocation(to: To, state: any = null): Location {
+    const location = readOnly<Location>({
+      pathname: entries ? getCurrentLocation().pathname : "/",
+      search: "",
+      hash: "",
+      ...(typeof to === "string" ? parsePath(to) : to),
+      state,
+      key: createKey(),
+    });
+    warning(
+      location.pathname.charAt(0) === "/",
+      `relative pathnames are not supported in memory history: ${JSON.stringify(
+        to
+      )}`
+    );
+    return location;
+  }
+
+  let history: MemoryHistory = {
+    get index() {
+      return index;
+    },
+    get action() {
+      return action;
+    },
+    get location() {
+      return getCurrentLocation();
+    },
+    createHref(to: To) {
+      return typeof to === "string" ? to : createPath(to);
+    },
+    push(to: To, state?: any) {
+      action = Action.Push;
+      const nextLocation = createLocation(to, state);
+      index += 1;
+      entries.splice(index, entries.length, nextLocation);
+    },
+    replace(to: To, state?: any) {
+      action = Action.Replace;
+      entries[index] = createLocation(to, state);
+    },
+    go(delta: number) {
+      let nextIndex = clamp(index + delta, 0, entries.length - 1);
+      action = Action.Pop;
+      index = nextIndex;
+    },
+    listen(listener) {
+      return listeners.push(listener);
+    },
+  };
+
+  return history;
+}
+//#endregion
+
+////////////////////////////////////////////////////////////////////////////////
+//#region UTILS
+////////////////////////////////////////////////////////////////////////////////
+
+const readOnly: <T>(obj: T) => Readonly<T> = __DEV__
+  ? (obj) => Object.freeze(obj)
+  : (obj) => obj;
+
+function warning(cond: any, message: string) {
+  if (!cond) {
+    // eslint-disable-next-line no-console
+    if (typeof console !== "undefined") console.warn(message);
+
+    try {
+      // Welcome to debugging history!
+      //
+      // This error is thrown as a convenience so you can more easily
+      // find the source for a warning that appears in the console by
+      // enabling "pause on exceptions" in your JavaScript debugger.
+      throw new Error(message);
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
+}
+
+function clamp(n: number, lowerBound: number, upperBound: number) {
+  return Math.min(Math.max(n, lowerBound), upperBound);
+}
+
+type Events<F> = {
+  length: number;
+  push: (fn: F) => () => void;
+  call: (arg: any) => void;
+};
+
+function createEvents<F extends Function>(): Events<F> {
+  let handlers: F[] = [];
+
+  return {
+    get length() {
+      return handlers.length;
+    },
+    push(fn: F) {
+      handlers.push(fn);
+      return function () {
+        handlers = handlers.filter((handler) => handler !== fn);
+      };
+    },
+    call(arg) {
+      handlers.forEach((fn) => fn && fn(arg));
+    },
+  };
+}
+
+function createKey() {
+  return Math.random().toString(36).substr(2, 8);
+}
+
+/**
+ * Creates a string URL path from the given pathname, search, and hash components.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#createpath
+ */
+export function createPath({
+  pathname = "/",
+  search = "",
+  hash = "",
+}: Partial<Path>) {
+  if (search && search !== "?")
+    pathname += search.charAt(0) === "?" ? search : "?" + search;
+  if (hash && hash !== "#")
+    pathname += hash.charAt(0) === "#" ? hash : "#" + hash;
+  return pathname;
+}
+
+/**
+ * Parses a string URL path into its separate pathname, search, and hash components.
+ *
+ * @see https://github.com/remix-run/history/tree/main/docs/api-reference.md#parsepath
+ */
+export function parsePath(path: string): Partial<Path> {
+  let parsedPath: Partial<Path> = {};
+
+  if (path) {
+    let hashIndex = path.indexOf("#");
+    if (hashIndex >= 0) {
+      parsedPath.hash = path.substr(hashIndex);
+      path = path.substr(0, hashIndex);
+    }
+
+    let searchIndex = path.indexOf("?");
+    if (searchIndex >= 0) {
+      parsedPath.search = path.substr(searchIndex);
+      path = path.substr(0, searchIndex);
+    }
+
+    if (path) {
+      parsedPath.pathname = path;
+    }
+  }
+
+  return parsedPath;
+}
+//#endregion

--- a/packages/history/jest.config.js
+++ b/packages/history/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testMatch: ["**/__tests__/*-test.(js|ts)"],
+  preset: "ts-jest",
+  globals: {
+    __DEV__: true,
+  },
+};

--- a/packages/history/node-main.js
+++ b/packages/history/node-main.js
@@ -1,0 +1,7 @@
+/* eslint-env node */
+
+if (process.env.NODE_ENV === "production") {
+  module.exports = require("./umd/history.production.min.js");
+} else {
+  module.exports = require("./umd/history.development.js");
+}

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "history",
+  "version": "6.0.0",
+  "author": "Remix Software <hello@remix.run>",
+  "description": "Manage session history with JavaScript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remix-run/react-router.git",
+    "directory": "packages/history"
+  },
+  "license": "MIT",
+  "main": "./main.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
+  "unpkg": "./umd/history.production.min.js",
+  "sideEffects": false,
+  "keywords": [
+    "history",
+    "location"
+  ]
+}

--- a/packages/history/tsconfig.json
+++ b/packages/history/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "files": ["index.ts"],
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+
+    "strict": true,
+
+    "declaration": true,
+    "emitDeclarationOnly": true,
+
+    "skipLibCheck": true,
+
+    "outDir": "../../build/node_modules/history",
+    "rootDir": "."
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,172 @@ function getVersion(sourceDir) {
   return require(`./${sourceDir}/package.json`).version;
 }
 
+function history() {
+  const SOURCE_DIR = "packages/history";
+  const OUTPUT_DIR = "build/node_modules/history";
+  const version = getVersion(SOURCE_DIR);
+
+  // JS modules for bundlers
+  const modules = [
+    {
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        file: `${OUTPUT_DIR}/index.js`,
+        format: "esm",
+        sourcemap: !PRETTY,
+        banner: createBanner("history", version),
+      },
+      plugins: [
+        babel({
+          exclude: /node_modules/,
+          presets: [
+            ["@babel/preset-env", { loose: true }],
+            "@babel/preset-typescript",
+          ],
+          plugins: ["babel-plugin-dev-expression"],
+          extensions: [".ts"],
+        }),
+        copy({
+          targets: [
+            { src: `${SOURCE_DIR}/package.json`, dest: OUTPUT_DIR },
+            { src: `${SOURCE_DIR}/README.md`, dest: OUTPUT_DIR },
+            { src: "LICENSE.md", dest: OUTPUT_DIR },
+          ],
+          verbose: true,
+        }),
+      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+  ];
+
+  // JS modules for <script type=module>
+  const webModules = [
+    {
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        file: `${OUTPUT_DIR}/history.development.js`,
+        format: "esm",
+        sourcemap: !PRETTY,
+        banner: createBanner("history", version),
+      },
+      plugins: [
+        babel({
+          exclude: /node_modules/,
+          presets: ["@babel/preset-modules", "@babel/preset-typescript"],
+          plugins: ["babel-plugin-dev-expression"],
+          extensions: [".ts"],
+        }),
+        replace({
+          preventAssignment: true,
+          values: { "process.env.NODE_ENV": JSON.stringify("development") },
+        }),
+      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+    {
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        file: `${OUTPUT_DIR}/history.production.min.js`,
+        format: "esm",
+        sourcemap: !PRETTY,
+        banner: createBanner("history", version),
+      },
+      plugins: [
+        babel({
+          exclude: /node_modules/,
+          presets: [
+            [
+              "@babel/preset-modules",
+              {
+                // Don't spoof `.name` for Arrow Functions, which breaks when minified anyway.
+                loose: true,
+              },
+            ],
+            "@babel/preset-typescript",
+          ],
+          plugins: ["babel-plugin-dev-expression"],
+          extensions: [".ts"],
+        }),
+        replace({
+          preventAssignment: true,
+          values: { "process.env.NODE_ENV": JSON.stringify("production") },
+        }),
+        // compiler(),
+        terser({ ecma: 8, safari10: true }),
+      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+  ];
+
+  // UMD modules for <script> tags and CommonJS (node)
+  const globals = [
+    {
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        file: `${OUTPUT_DIR}/umd/history.development.js`,
+        format: "umd",
+        sourcemap: !PRETTY,
+        banner: createBanner("history", version),
+        name: "HistoryLibrary",
+      },
+      plugins: [
+        babel({
+          exclude: /node_modules/,
+          presets: [
+            ["@babel/preset-env", { loose: true }],
+            "@babel/preset-typescript",
+          ],
+          plugins: ["babel-plugin-dev-expression"],
+          extensions: [".ts"],
+        }),
+        replace({
+          preventAssignment: true,
+          values: { "process.env.NODE_ENV": JSON.stringify("development") },
+        }),
+      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+    {
+      input: `${SOURCE_DIR}/index.ts`,
+      output: {
+        file: `${OUTPUT_DIR}/umd/history.production.min.js`,
+        format: "umd",
+        sourcemap: !PRETTY,
+        banner: createBanner("history", version),
+        name: "HistoryLibrary",
+      },
+      plugins: [
+        babel({
+          exclude: /node_modules/,
+          presets: [
+            ["@babel/preset-env", { loose: true }],
+            "@babel/preset-typescript",
+          ],
+          plugins: ["babel-plugin-dev-expression"],
+          extensions: [".ts"],
+        }),
+        replace({
+          preventAssignment: true,
+          values: { "process.env.NODE_ENV": JSON.stringify("production") },
+        }),
+        // compiler(),
+        terser(),
+      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+  ];
+
+  // Node entry points
+  const node = [
+    {
+      input: `${SOURCE_DIR}/node-main.js`,
+      output: {
+        file: `${OUTPUT_DIR}/main.js`,
+        format: "cjs",
+        banner: createBanner("history", version),
+      },
+      plugins: [].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+    },
+  ];
+
+  return [...modules, ...webModules, ...globals, ...node];
+}
+
 function reactRouter() {
   const SOURCE_DIR = "packages/react-router";
   const OUTPUT_DIR = "build/node_modules/react-router";
@@ -531,6 +697,7 @@ function reactRouterNative() {
 
 export default function rollup(options) {
   let builds = [
+    ...history(options),
     ...reactRouter(options),
     ...reactRouterDom(options),
     ...reactRouterNative(options),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
+    { "path": "packages/history" },
     { "path": "packages/react-router" },
     { "path": "packages/react-router-dom" },
     { "path": "packages/react-router-native" }


### PR DESCRIPTION
* Adds `packages/history`
* Implements `createMemoryHistory`
* Leverages the same test suite + sequences from https://github.com/remix-run/history, simplified down based on the new API