### PR TITLE
feat: add useMatchRoutes hook implementation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1470,6 +1470,21 @@ function App() {
 }
 ```
 
+### `useMatchRoutes`
+
+<details>
+  <summary>Type declaration</summary>
+
+```tsx
+declare function useMatchRoutes(): RouteMatch[];
+```
+
+</details>
+
+Returns an array of `RouteMatch` objects, one for each route that matched.
+
+See [`matchRoutes`](#matchroutes) for more information.
+
 ### `createSearchParams`
 
 <details>

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -27,6 +27,7 @@ import {
   useResolvedPath,
   useRoutes,
   useOutletContext,
+  useMatchRoutes,
 } from "react-router";
 import type { To } from "react-router";
 
@@ -78,6 +79,7 @@ export {
   useResolvedPath,
   useRoutes,
   useOutletContext,
+  useMatchRoutes,
 };
 
 export { NavigationType } from "react-router";

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -34,6 +34,7 @@ import {
   useResolvedPath,
   useRoutes,
   useOutletContext,
+  useMatchRoutes,
 } from "react-router";
 import type { To } from "react-router";
 
@@ -70,6 +71,7 @@ export {
   useResolvedPath,
   useRoutes,
   useOutletContext,
+  useMatchRoutes,
 };
 
 export { NavigationType } from "react-router";

--- a/packages/react-router/index.tsx
+++ b/packages/react-router/index.tsx
@@ -90,11 +90,13 @@ if (__DEV__) {
 interface RouteContextObject {
   outlet: React.ReactElement | null;
   matches: RouteMatch[];
+  matchRoutes: RouteMatch[];
 }
 
 const RouteContext = React.createContext<RouteContextObject>({
   outlet: null,
   matches: [],
+  matchRoutes: []
 });
 
 if (__DEV__) {
@@ -746,6 +748,24 @@ export function useRoutes(
   );
 }
 
+/**
+ * Returns an array of `RouteMatch` objects, one for each route that matched.
+ * 
+ * @see https://reactrouter.com/docs/en/v6/api#usematchroutes
+ */
+ export function useMatchRoutes(): RouteMatch[] {
+  invariant(
+    useInRouterContext(),
+    // TODO: This error is probably because they somehow have 2 versions of the
+    // router loaded. We can help them understand how to avoid that.
+    `useMatchRoutes() may be used only in the context of a <Router> component.`
+  );
+
+  let { matchRoutes } = React.useContext(RouteContext);
+
+  return matchRoutes;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // UTILS
 ///////////////////////////////////////////////////////////////////////////////
@@ -1081,6 +1101,7 @@ function _renderMatches(
         }
         value={{
           outlet,
+          matchRoutes: matches,
           matches: parentMatches.concat(matches.slice(0, index + 1)),
         }}
       />


### PR DESCRIPTION
- `useMatchRoutes` is similar to `matchRoutes`, but the matching result is obtained directly from the Context and supports component route.