### PR TITLE
docs: fix the usage of history.listen

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - turansky
 - underager
 - vijaypushkin
+- ThornWu

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -127,7 +127,7 @@ That's where a React Router specific `history` object comes into play. It provid
 
 ```js
 let history = createBrowserHistory();
-history.listen((location, action) => {
+history.listen(({location, action}) => {
   // this is called whenever new locations come in
   // the action is POP, PUSH, or REPLACE
 });


### PR DESCRIPTION
`history.listen` accepts two parameters in the preceding document: `location` and `action`. 

However, I discovered the type declaration below while reading the [docs of `history`](https://github.com/remix-run/history/blob/dev/docs/api-reference.md#historylistenlistener-listener). Instead of two parameters, `history.listen` allows one parameter with two properties.
```
interface Listener {
  (update: Update): void;
}

interface Update {
  action: Action;
  location: Location;
}
```