### PR TITLE
Fix: change children prop on navlink props to be optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,9 +16,9 @@ body:
         you ask a question, here are some resources to get help first:
 
         - Read the docs: https://reactrouter.com
-        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/getting-started/faq
+        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/faq
         - Explore examples: https://reactrouter.com/docs/en/v6/examples/basic
-        - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/ask?tags=react-router
+        - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/tagged/react-router
         - Ask in chat: https://discord.gg/6RyV8n8yyM
 
         ### Test Case Starter:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,9 +16,9 @@ body:
         you ask a question, here are some resources to get help first:
 
         - Read the docs: https://reactrouter.com
-        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/getting-started/faq
-        - Explore examples: hhttps://reactrouter.com/docs/en/v6/examples/basic
-        - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/ask?tags=react-router
+        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/faq
+        - Explore examples: https://reactrouter.com/docs/en/v6/examples/basic
+        - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/tagged/react-router
         - Ask in chat: https://discord.gg/6RyV8n8yyM
   - type: textarea
     attributes:

--- a/contributors.yml
+++ b/contributors.yml
@@ -31,6 +31,7 @@
 - lukerSpringTree
 - markivancho
 - mcansh
+- mfijas
 - noisypigeon
 - paulsmithkc
 - petersendidit
@@ -45,4 +46,3 @@
 - turansky
 - underager
 - vijaypushkin
-- mfijas

--- a/contributors.yml
+++ b/contributors.yml
@@ -46,3 +46,4 @@
 - turansky
 - underager
 - vijaypushkin
+- ThornWu

--- a/contributors.yml
+++ b/contributors.yml
@@ -25,6 +25,7 @@
 - kentcdodds
 - kkirsche
 - koojaa
+- KutnerUri
 - latin-1
 - liuhanqu
 - lukerSpringTree
@@ -44,4 +45,3 @@
 - turansky
 - underager
 - vijaypushkin
-- KutnerUri

--- a/contributors.yml
+++ b/contributors.yml
@@ -45,3 +45,4 @@
 - turansky
 - underager
 - vijaypushkin
+- mfijas

--- a/contributors.yml
+++ b/contributors.yml
@@ -47,3 +47,4 @@
 - turansky
 - underager
 - vijaypushkin
+- janpaepke

--- a/contributors.yml
+++ b/contributors.yml
@@ -18,6 +18,7 @@
 - IbraRouisDev
 - Isammoc
 - JakubDrozd
+- janpaepke
 - jmargeta
 - jonkoops
 - kantuni
@@ -47,4 +48,3 @@
 - turansky
 - underager
 - vijaypushkin
-- janpaepke

--- a/contributors.yml
+++ b/contributors.yml
@@ -42,8 +42,8 @@
 - shihanng
 - shivamsinghchahar
 - thisiskartik
+- ThornWu
 - timdorr
 - turansky
 - underager
 - vijaypushkin
-- ThornWu

--- a/contributors.yml
+++ b/contributors.yml
@@ -48,3 +48,4 @@
 - turansky
 - underager
 - vijaypushkin
+- rtmann

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -127,7 +127,7 @@ That's where a React Router specific `history` object comes into play. It provid
 
 ```js
 let history = createBrowserHistory();
-history.listen(({location, action}) => {
+history.listen(({ location, action }) => {
   // this is called whenever new locations come in
   // the action is POP, PUSH, or REPLACE
 });

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -127,7 +127,7 @@ That's where a React Router specific `history` object comes into play. It provid
 
 ```js
 let history = createBrowserHistory();
-history.listen((location, action) => {
+history.listen(({location, action}) => {
   // this is called whenever new locations come in
   // the action is POP, PUSH, or REPLACE
 });

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -668,7 +668,7 @@ The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-
 
 ```jsx bad lines=[14-16,22-24]
 <Routes>
-  <Routes path="/" element={<App />}>
+  <Route path="/" element={<App />}>
     <Route index element={<Home />} />
     <Route path="teams" element={<Teams />}>
       <Route path=":teamId" element={<Team />} />

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -172,7 +172,7 @@ export default function Invoices() {
 
 Finally, let's teach React Router how to render our app at different URLs by creating our first "Route Config" inside of `main.jsx` or `index.js`.
 
-```tsx lines=[2,4-5,13-19] filename=src/main.jsx
+```tsx lines=[2,4-5,8-9,13-19] filename=src/main.jsx
 import { render } from "react-dom";
 import {
   BrowserRouter,
@@ -806,7 +806,7 @@ export function deleteInvoice(number) {
 
 Now let's add the delete button, call our new function, and navigate to the index route:
 
-```js lines=[1-2,5-6,17-26] filename=src/routes/invoice.jsx
+```js lines=[1-6,20-29] filename=src/routes/invoice.jsx
 import {
   useParams,
   useNavigate,

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -290,7 +290,7 @@ if (__DEV__) {
 
 export interface NavLinkProps
   extends Omit<LinkProps, "className" | "style" | "children"> {
-  children:
+  children?:
     | React.ReactNode
     | ((props: { isActive: boolean }) => React.ReactNode);
   caseSensitive?: boolean;


### PR DESCRIPTION
#8719

This is a simple PR to allow children on navlink to be optional so a NavLink can be used in type script projects without requiring the children attribute to be set on the NavLink.  Currently it's impossible to use a NavLink in typescript projects on version 6.2 as you can't set jsx children as an attribute, and you can't use NavLink without doing so...