### PR TITLE
fix: `Navigate` causes infinite loop

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -21,6 +21,7 @@
 - janpaepke
 - jmargeta
 - jonkoops
+- jordan-burnett
 - kantuni
 - kddnewton
 - kentcdodds

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -23,6 +23,32 @@ describe("<Navigate>", () => {
         </h1>
       `);
     });
+
+    it("does not cause an infinite loop when navigation does not change the current route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter>
+            <Routes>
+              <Route
+                path="/*"
+                element={
+                  <>
+                    <h1>Home</h1>
+                    <Navigate to="/about" />
+                  </>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Home
+        </h1>
+      `);
+    });
   });
 
   describe("with a relative href", () => {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -90,9 +90,16 @@ export function Navigate({ to, replace, state }: NavigateProps): null {
   );
 
   let navigate = useNavigate();
+
+  const navigateRef = React.useRef(navigate);
+
   React.useEffect(() => {
-    navigate(to, { replace, state });
-  }, [navigate, to, replace, state]);
+    navigateRef.current = navigate;
+  }, [navigate]);
+
+  React.useEffect(() => {
+    navigateRef.current(to, { replace, state });
+  }, [to, replace, state]);
 
   return null;
 }

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -92,7 +92,7 @@ export function Navigate({ to, replace, state }: NavigateProps): null {
   let navigate = useNavigate();
   React.useEffect(() => {
     navigate(to, { replace, state });
-  });
+  }, [navigate, to, replace, state]);
 
   return null;
 }


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/8733

Currently `Navigate` will cause an infinite rendering loop if it remains mounted after the navigation has occurred.  