### PR TITLE
Docs: Typo in tutorial.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -48,3 +48,4 @@
 - turansky
 - underager
 - vijaypushkin
+- lqze

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -196,7 +196,7 @@ render(
 );
 ```
 
-Notice at `"/"` it renders `<App>`. At `"/invoices"` it render `<Invoices>`. Nice work!
+Notice at `"/"` it renders `<App>`. At `"/invoices"` it renders `<Invoices>`. Nice work!
 
 <docs-info>Remember if you're using StackBlitz to click the "Open in New Window" button in the inline browser's toolbar to be able to click the back/forward buttons in your browser.</docs-info>
 


### PR DESCRIPTION
Simple typo, missing `s` on `it render`. Should say `it renders ....`.