### PR TITLE
Removing unwanted ")" from Navlink sample code

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -49,3 +49,4 @@
 - turansky
 - underager
 - vijaypushkin
+- gijo-varghese

--- a/docs/api.md
+++ b/docs/api.md
@@ -457,7 +457,7 @@ function NavList() {
               <span className={isActive ? activeClassName : undefined}>
                 Tasks
               </span>
-            ))}
+            )}
           </NavLink>
         </li>
       </ul>


### PR DESCRIPTION
There is an unwanted ")" in Navlink sample code which throws syntax error