### PR TITLE
Fix: make v5 Router compatible with v18 StrictMode

### DIFF
--- a/packages/react-router/modules/Router.js
+++ b/packages/react-router/modules/Router.js
@@ -30,11 +30,7 @@ class Router extends React.Component {
 
     if (!props.staticContext) {
       this.unlisten = props.history.listen(location => {
-        if (this._isMounted) {
-          this.setState({ location });
-        } else {
-          this._pendingLocation = location;
-        }
+        this._pendingLocation = location;
       });
     }
   }
@@ -42,6 +38,18 @@ class Router extends React.Component {
   componentDidMount() {
     this._isMounted = true;
 
+    if (this.unlisten) {
+      // Any pre-mount location changes have been captured at
+      // this point, so unregister the listener.
+      this.unlisten();
+    }
+    if (!this.props.staticContext) {
+      this.unlisten = this.props.history.listen(location => {
+        if (this._isMounted) {
+          this.setState({ location });
+        }
+      });
+    }
     if (this._pendingLocation) {
       this.setState({ location: this._pendingLocation });
     }

--- a/packages/react-router/modules/__tests__/Router-test.js
+++ b/packages/react-router/modules/__tests__/Router-test.js
@@ -46,4 +46,66 @@ describe("A <Router>", () => {
       }).not.toThrow();
     });
   });
+
+  describe("with react v18 StrictMode semantics", () => {
+    function simulateV18StrictModeRender(props, afterRender) {
+      // Constructor gets called twice
+      let router = new Router(props);
+      router = new Router(props);
+
+      // Swap out setState since we're not actually mounting the component
+      router.setState = jest.fn();
+
+      // Render is called twice
+      router.render();
+      router.render();
+
+      if (afterRender) afterRender();
+
+      router.componentDidMount();
+
+      // Effects are invoked twice
+      router.componentWillUnmount();
+      router.componentDidMount();
+
+      return router;
+    }
+
+    it("responds to history changes", () => {
+      const history = createHistory();
+      const props = { history, children: <p>Foo</p> };
+
+      const router = simulateV18StrictModeRender(props);
+
+      history.push("/foo");
+
+      expect(router.setState).toHaveBeenCalledTimes(1);
+      expect(router.setState).toHaveBeenCalledWith({
+        location: expect.objectContaining({ pathname: "/foo" })
+      });
+    });
+
+    it("can handle path changes on child mount", () => {
+      const history = createHistory();
+      const props = { history, children: <p>Foo</p> };
+
+      const router = simulateV18StrictModeRender(props, () => {
+        history.push("/baz");
+        history.push("/qux");
+        history.push("/foo");
+      });
+
+      expect(router.setState).toHaveBeenCalledTimes(1);
+      expect(router.setState).toHaveBeenCalledWith({
+        location: expect.objectContaining({ pathname: "/foo" })
+      });
+
+      history.push("/bar");
+
+      expect(router.setState).toHaveBeenCalledTimes(2);
+      expect(router.setState).toHaveBeenCalledWith({
+        location: expect.objectContaining({ pathname: "/bar" })
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #7870.

In React 18, Strict Mode [attempts to detect unexpected side effects](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects) that might happen when rendering in concurrent mode. For class components, it intentionally double-invokes the constructor, `render()`, and `shouldComponentUpdate()`. It also double-invokes both layout and passive effects by mounting, unmounting, and then remounting.

Router in v5 was not compatible with this primarily because the main history subscription was created in the component constructor. Here is a simplified outline of the component lifecycle in StrictMode in v5.3.1:

- constructor &mdash; listen (this instance is not used)
- constructor &mdash; listen
- render
- render
- componentDidMount
- componentWillUnmount &mdash; unlisten(!)
- componentDidMount

At this point, there were no history subscriptions, so `setState` was never being invoked.

The fix presented in this PR moves the main history subscription into componentDidMount to make it resilient to unmount/remount cycles. Here is the new simplified outline as of this PR:

- constructor &mdash; listen (this instance is not used)
- constructor &mdash; listen
- render
- render
- componentDidMount &mdash; unlisten, listen
- componentWillUnmount &mdash; unlisten
- componentDidMount &mdash; listen

The listener in the constructor is only used for detecting redirects caused by child mounts and the subscription is only active until componentDidMount, at which point it is disposed and replaced with the main listener. Since the main listener is attached in componentDidMount, it will be recreated if the component is unmounted and then remounted without being fully reconstructed.

**Tests**

Rather than changing the local react dependency to v18, I added synthetic tests that simulate the new StrictMode behavior. If the maintainers would prefer to see tests using actual rendering in v18, I'd be happy to amend this.