### PR TITLE
fix: resolveTo should not mutate the provided pathname

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -50,6 +50,7 @@
 - thisiskartik
 - ThornWu
 - timdorr
+- tkindy
 - turansky
 - underager
 - vijaypushkin

--- a/contributors.yml
+++ b/contributors.yml
@@ -40,8 +40,8 @@
 - paulsmithkc
 - petersendidit
 - RobHannay
-- ryanflorence
 - rtmann
+- ryanflorence
 - sanketshah19
 - sergiodxa
 - shamsup

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abhi-kr-2100
 - Ajayff4
+- avipatel97
 - awreese
 - bhbs
 - BrianT1414

--- a/contributors.yml
+++ b/contributors.yml
@@ -31,6 +31,7 @@
 - KutnerUri
 - latin-1
 - liuhanqu
+- loun4
 - lqze
 - lukerSpringTree
 - markivancho

--- a/docs/upgrading/reach.md
+++ b/docs/upgrading/reach.md
@@ -125,10 +125,6 @@ Not polluting props also helps with TypeScript a bit and also prevents you from 
 
 Also, as a page grows, you naturally break it into multiple components and end up "prop drilling" that data all the way down the tree. Now you can access the route data anywhere in the tree. Not only is it more convenient, but it makes creating router-centric composable abstractions possible. If a custom hook needs the location, it can now simply ask for it with `useLocation()` etc..
 
-```sh
-npm install react-router@6 react-router-dom@6
-```
-
 ### Add a LocationProvider
 
 While `@reach/router` doesn't require a location provider at the top of the application tree, React Router v6 does, so might as well get ready for that now.
@@ -163,7 +159,7 @@ You can pull a trick though and use both routers at the same time as you migrate
 ### Install React Router v6
 
 ```sh
-npm install react-router@next
+npm install react-router@6 react-router-dom@6
 ```
 
 ### Update `LocationProvider` to `BrowserRouter`

--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -7,11 +7,9 @@ order: 1
 
 ## Backwards Compatibility Package
 
-We are actively working on a backwards compatibility layer that implements the v5 API on top of the v6 implementation. This will make upgrading as smooth as possible. You'll be able to upgrade to v6 with minimal changes to your application code. Then, you can incrementally update your code to the v6 API.
+Instead of upgrading and updating all of your code at once (which is incredibly difficult and prone to bugs), the backwards compatibility package enables you to upgrade one component, one hook, and one route at a time by running both v5 and v6 in parallel. Any code you haven't touched is still running the very same code it was before. Once all components are exclusively using the v6 APIs, your app no longer needs the compatibility package and is running on v6. The official guide can be found [here](../../packages/react-router-dom-v5-compat/README.md).
 
-<docs-error>We recommend waiting for the backwards compatibility package to be released before upgrading apps that have more than a few routes.</docs-error>
-
-Until then, we hope this guide will help you do the upgrade all at once!
+We recommend using the backwards compatibility package to upgrade apps that have more than a few routes. Otherwise, we hope this guide will help you do the upgrade all at once!
 
 ## Introduction
 

--- a/packages/react-router/__tests__/resolveTo-test.tsx
+++ b/packages/react-router/__tests__/resolveTo-test.tsx
@@ -1,0 +1,26 @@
+import { resolveTo } from "../lib/router";
+
+describe("resolveTo", () => {
+  it('resolve path without mutating the "to" argument', () => {
+    const toArg = {
+      pathname: "../../create",
+    };
+
+    const routePathnames = ["/", "/user", "/user/1", "/user/1/edit"];
+    const locationPathname = "/user/1/edit/";
+
+    let resolvedPath = resolveTo(toArg, routePathnames, locationPathname);
+    expect(resolvedPath).toEqual({
+      pathname: "/user/create",
+      search: "",
+      hash: "",
+    });
+
+    resolvedPath = resolveTo(toArg, routePathnames, locationPathname);
+    expect(resolvedPath).toEqual({
+      pathname: "/user/create",
+      search: "",
+      hash: "",
+    });
+  });
+});

--- a/packages/react-router/lib/router.ts
+++ b/packages/react-router/lib/router.ts
@@ -545,7 +545,7 @@ export function resolveTo(
   routePathnames: string[],
   locationPathname: string
 ): Path {
-  let to = typeof toArg === "string" ? parsePath(toArg) : toArg;
+  let to = typeof toArg === "string" ? parsePath(toArg) : {...toArg};
   let toPathname = toArg === "" || to.pathname === "" ? "/" : to.pathname;
 
   // If a pathname is explicitly provided in `to`, it should be relative to the


### PR DESCRIPTION
fix #8175

The following assignment
https://github.com/remix-run/react-router/blob/0f9435a8134b2b5dddfd716a18d17aefe4461fe1/packages/react-router/lib/router.ts#L575
leads to the mutation of the provided `toArg` and the original `pathname` is _accidentally_ replaced: `../../../myPath` will always be `myPath`.