### PR TITLE
update documentation to match react 18

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -55,3 +55,4 @@
 - turansky
 - underager
 - vijaypushkin
+- chensokheng

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -509,7 +509,8 @@ React Router will create an array of [matches](#match) from these routes and the
 The final concept is rendering. Consider that the entry to your app looks like this:
 
 ```jsx
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<App />}>
@@ -526,8 +527,7 @@ ReactDOM.render(
       </Route>
       <Route path="contact-us" element={<Contact />} />
     </Routes>
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );
 ```
 
@@ -787,7 +787,8 @@ Let's put it all together from the top!
 1. You render your app:
 
    ```jsx
-   ReactDOM.render(
+   const root = ReactDOM.createRoot(document.getElementById("root"));
+   root.render(
      <BrowserRouter>
        <Routes>
          <Route path="/" element={<App />}>
@@ -804,8 +805,7 @@ Let's put it all together from the top!
          </Route>
          <Route path="contact-us" element={<Contact />} />
        </Routes>
-     </BrowserRouter>,
-     document.getElementById("root")
+     </BrowserRouter>
    );
    ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,19 +50,21 @@ Follow the instructions in the [React documentation to set up a new project with
 
 Once your project is set up and React Router is installed as a dependency, open the `src/index.js` in your text editor. Import `BrowserRouter` from `react-router-dom` near the top of your file and wrap your app in a `<BrowserRouter>`:
 
-```js [3, 9-11]
+```js [3, 11-13]
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App";
-import * as serviceWorker from "./serviceWorker";
+import reportWebVitals from "./reportWebVitals";
 
-ReactDOM.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
-  document.getElementById("root")
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
 );
 ```
 
@@ -151,15 +153,17 @@ Go to the `index.js` file in your project and import the necessary functions fro
 ```js
 // index.js
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.js";
 
-ReactDOM.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
-  document.getElementById("root")
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
 );
 ```
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -20,7 +20,7 @@ npm install react-router-dom@6
 ## Configuring Routes
 
 ```jsx
-import { render } from "react-dom";
+import ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
   Routes,
@@ -28,7 +28,8 @@ import {
 } from "react-router-dom";
 // import your route components too
 
-render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<App />}>
@@ -40,8 +41,7 @@ render(
         </Route>
       </Route>
     </Routes>
-  </BrowserRouter>,
-  document.getElementById("root")
+  </BrowserRouter>
 );
 ```
 

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -73,11 +73,11 @@ Actually, that "!" doesn't look boring at all. This is pretty exciting. We sat o
 Finally, go make sure `index.js` or `main.jsx` (depending on the bundler you used) is actually boring:
 
 ```tsx filename=src/main.jsx
-import { render } from "react-dom";
+import ReactDOM from "react-dom/client";
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(<App />, rootElement);
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<App />);
 ```
 
 Finally, start your app:
@@ -95,16 +95,15 @@ npm run dev
 First things first, we want to connect your app to the browser's URL: import `BrowserRouter` and render it around your whole app.
 
 ```tsx lines=[2,7-9] filename=src/main.jsx
-import { render } from "react-dom";
+import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
-const rootElement = document.getElementById("root");
-render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <App />
-  </BrowserRouter>,
-  rootElement
+  </BrowserRouter>
 );
 ```
 
@@ -173,7 +172,7 @@ export default function Invoices() {
 Finally, let's teach React Router how to render our app at different URLs by creating our first "Route Config" inside of `main.jsx` or `index.js`.
 
 ```tsx lines=[2,4-5,8-9,13-19] filename=src/main.jsx
-import { render } from "react-dom";
+import ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
   Routes,
@@ -183,16 +182,15 @@ import App from "./App";
 import Expenses from "./routes/expenses";
 import Invoices from "./routes/invoices";
 
-const rootElement = document.getElementById("root");
-render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<App />} />
       <Route path="expenses" element={<Expenses />} />
       <Route path="invoices" element={<Invoices />} />
     </Routes>
-  </BrowserRouter>,
-  rootElement
+  </BrowserRouter>
 );
 ```
 
@@ -212,7 +210,7 @@ Let's get some automatic, persistent layout handling by doing just two things:
 First let's nest the routes. Right now the expenses and invoices routes are siblings to the app, we want to make them _children_ of the app route:
 
 ```jsx lines=[15-18] filename=src/main.jsx
-import { render } from "react-dom";
+import ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
   Routes,
@@ -222,8 +220,8 @@ import App from "./App";
 import Expenses from "./routes/expenses";
 import Invoices from "./routes/invoices";
 
-const rootElement = document.getElementById("root");
-render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/" element={<App />}>
@@ -231,8 +229,7 @@ render(
         <Route path="invoices" element={<Invoices />} />
       </Route>
     </Routes>
-  </BrowserRouter>,
-  rootElement
+  </BrowserRouter>
 );
 ```
 


### PR DESCRIPTION
to avoid user copy and get the warning from react 18.

>**Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot.**