### PR TITLE
fix: documentation code lines highlight

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ Follow the instructions in the [React documentation to set up a new project with
 
 Once your project is set up and React Router is installed as a dependency, open the `src/index.js` in your text editor. Import `BrowserRouter` from `react-router-dom` near the top of your file and wrap your app in a `<BrowserRouter>`:
 
-```js [3, 11-13]
+```js [3, 13-15]
 import * as React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -96,7 +96,7 @@ npm run dev
 
 First things first, we want to connect your app to the browser's URL: import `BrowserRouter` and render it around your whole app.
 
-```tsx lines=[2,7-9] filename=src/main.jsx
+```tsx lines=[2,9-11] filename=src/main.jsx
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
@@ -175,7 +175,7 @@ export default function Invoices() {
 
 Finally, let's teach React Router how to render our app at different URLs by creating our first "Route Config" inside of `main.jsx` or `index.js`.
 
-```tsx lines=[2,4-5,8-9,13-19] filename=src/main.jsx
+```tsx lines=[2,4-5,8-9,15-21] filename=src/main.jsx
 import ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
@@ -215,7 +215,7 @@ Let's get some automatic, persistent layout handling by doing just two things:
 
 First let's nest the routes. Right now the expenses and invoices routes are siblings to the app, we want to make them _children_ of the app route:
 
-```jsx lines=[15-18] filename=src/main.jsx
+```jsx lines=[17-20] filename=src/main.jsx
 import ReactDOM from "react-dom/client";
 import {
   BrowserRouter,


### PR DESCRIPTION
After changing the format of the doc. The code line highlight is messed up.
![Screen Shot 2022-05-06 at 1 15 15 AM](https://user-images.githubusercontent.com/52232579/166987227-66b6564b-cf76-4cc2-a83a-19f71964e8a9.png)
