### PR TITLE
Fix some typos in docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -14,6 +14,7 @@
 - cvbuelow
 - edwin177
 - elylucas
+- emzoumpo
 - gijo-varghese
 - hongji00
 - hsbtr

--- a/docs/api.md
+++ b/docs/api.md
@@ -357,7 +357,7 @@ interface LinkProps extends TouchableHighlightProps {
 
 </details>
 
-A `<Link>` is an element that lets the user navigate to another view by tapping it, similar to how `<a>` elements work in a web app. In `react-router-native`, a `<Link>` renders a `TouchableHighlight`. To override default styling and behaviour, please refer to the [Props reference for `TouchableHighlight`](https://reactnative.dev/docs/touchablehighlight#props).
+A `<Link>` is an element that lets the user navigate to another view by tapping it, similar to how `<a>` elements work in a web app. In `react-router-native`, a `<Link>` renders a `TouchableHighlight`. To override default styling and behavior, please refer to the [Props reference for `TouchableHighlight`](https://reactnative.dev/docs/touchablehighlight#props).
 
 ```tsx
 import * as React from "react";

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -815,7 +815,7 @@ Let's put it all together from the top!
 
 2. `<BrowserRouter>` creates a [history](#history), puts the initial [location](#location) in to state, and subscribes to the [URL](#url).
 
-3. `<Routes>` recurses it's [child routes](#child-route) to build a [route config](#route-config), matches those routes against the [location](#location), creates some route [matches](#match), and renders the first match's route element.
+3. `<Routes>` recurses its [child routes](#child-route) to build a [route config](#route-config), matches those routes against the [location](#location), creates some route [matches](#match), and renders the first match's route element.
 
 4. You render an [`<Outlet/>`](#outlet) in each [parent route](#parent-route).
 

--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -423,7 +423,7 @@ The following RegExp-style route paths are **not valid** in v6:
 
 We added the dependency on path-to-regexp in v4 to enable more advanced pattern matching. In v6 we are using a simpler syntax that allows us to predictably parse the path for ranking purposes. It also means we can stop depending on path-to-regexp, which is nice for bundle size.
 
-If you were using any of path-to-regexp's more advanced syntax, you'll have to remove it and simplify your route paths. If you were using the RegExp syntax to do URL param validation (e.g. to ensure an id is all numeric characters) please know that we plan to add some more advanced param validation in v6 at some point. For now, you'll need to move that logic to the component the route renders, and let it branch it's rendered tree after you parse the params.
+If you were using any of path-to-regexp's more advanced syntax, you'll have to remove it and simplify your route paths. If you were using the RegExp syntax to do URL param validation (e.g. to ensure an id is all numeric characters) please know that we plan to add some more advanced param validation in v6 at some point. For now, you'll need to move that logic to the component the route renders, and let it branch its rendered tree after you parse the params.
 
 If you were using `<Route sensitive>` you should move it to its containing `<Routes caseSensitive>` prop. Either all routes in a `<Routes>` element are case-sensitive or they are not.
 


### PR DESCRIPTION
• `it's` -> `its`
• `behaviour` -> `behavior` (to be in line with the rest of its uses in the docs)