### PR TITLE
fix: Pass along `location` prop from `CompatRoute` to the `Routes` it renders

### DIFF
--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -14,10 +14,10 @@ import { Router, Routes, Route } from "../react-router-dom";
 // v5 isn't in TypeScript, they'll also lose the @types/react-router with this
 // but not worried about that for now.
 export function CompatRoute(props: any) {
-  let { path } = props;
+  let { location, path } = props;
   if (!props.exact) path += "/*";
   return (
-    <Routes>
+    <Routes {...(location && { location })}>
       <Route path={path} element={<RouteV5 {...props} />} />
     </Routes>
   );


### PR DESCRIPTION
This PR enables `CompatRoute` to drill down the `location` prop to the `Routes` it renders. This is needed to migrate apps which rely on `Switch` elements with different `location` props, like this example:

https://github.com/xavier-lc/my-app/blob/e9adc7d17e508d68ba96250c88cbf7820d38618e/src/App.js#L44-L59

You can get more details on this discussion: https://github.com/remix-run/react-router/discussions/8850

I tried to add a test, but for that I'd need to render the `CompatRoute` under a `Switch` and I didn't want to mess up `package.json` in order to be able to resolve `react-router` v5 inside the test. If someone knows an easy way to do that I'd be more than happy to add the test.