### PR TITLE
fix: highlight code diff for invoice.jsx

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -23,6 +23,7 @@
 - Isammoc
 - JakubDrozd
 - janpaepke
+- jimniels
 - jmargeta
 - jonkoops
 - kantuni

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -811,7 +811,7 @@ export function deleteInvoice(number) {
 
 Now let's add the delete button, call our new function, and navigate to the index route:
 
-```js lines=[1-6,20-29] filename=src/routes/invoice.jsx
+```js lines=[1-6,9-10,21-30] filename=src/routes/invoice.jsx
 import {
   useParams,
   useNavigate,


### PR DESCRIPTION
The very last example in the tutorial is highlighting the wrong lines of code.

The last time this file was touched in the tutorial, it looked like this:

<img width="849" alt="CleanShot 2022-05-12 at 11 16 27@2x" src="https://user-images.githubusercontent.com/1316441/168131926-352bd415-ce93-43f5-a01e-4b9d408c26ad.png">

Then, when you get to the next place `invoices.jsx` is edited, the diff highlights are incorrect. Note:

- 👍 The import diffs is right
- 👎 Lines 9 and 10 (`useNavigate()` and `useLocation()`) were added but not highlighted as additions
- 👎 Lines 20-29 are highlighted, but line 20 was already there and line 30 was added (but not highlighted).

So this request makes it so the actual code differences are highlighted correctly. Current vs. proposed:

<img width="1425" alt="CleanShot 2022-05-12 at 11 22 23@2x" src="https://user-images.githubusercontent.com/1316441/168132971-802876ac-cdd1-4a70-8af6-75651764bbe5.png">


