### PR TITLE
Fix: prefixed params

### DIFF
--- a/packages/react-router/lib/router.ts
+++ b/packages/react-router/lib/router.ts
@@ -63,8 +63,9 @@ type ParamParseSegment<Segment extends string> =
       : ParamParseFailed
     : // If there's no forward slash, then check if this segment starts with a
     // colon. If it does, then this is a dynamic segment, so the result is
-    // just the remainder of the string. Otherwise, it's a failure.
-    Segment extends `:${infer Remaining}`
+    // just the remainder of the string, optionally prefixed with another string.
+    // Otherwise, it's a failure.
+    Segment extends `${string}:${infer Remaining}`
     ? Remaining
     : ParamParseFailed;
 


### PR DESCRIPTION
It's awesome, that `generatePath` can help you to know what params you need to supply for interpolation.

However it currently breaks, if the param isn't immediately following the slash, i.e. `path/item-:param`, although this is technically valid in react router (and with good use cases).

This PR fixes this.

Before:
<img width="464" alt="image" src="https://user-images.githubusercontent.com/3076177/168435830-2a5ef6dd-d757-4ccb-b401-da3c8dda1588.png">

After:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/3076177/168435916-9f63188d-789b-41b2-a44a-7504a6693d87.png">
