### PR TITLE
feat: add pending logic to NavLink

### DIFF
--- a/examples/custom-link/src/App.tsx
+++ b/examples/custom-link/src/App.tsx
@@ -17,7 +17,7 @@ export default function App() {
       <p>
         This example demonstrates how to create a custom{" "}
         <code>&lt;Link&gt;</code> component that knows whether or not it is
-        "active" using the low-level <code>useResolvedPath()</code> and
+        "active" using the low-level <code>useResolvedPath()</code> and{" "}
         <code>useMatch()</code> hooks.
       </p>
 

--- a/packages/react-router-dom/__tests__/nav-link-active-test.tsx
+++ b/packages/react-router-dom/__tests__/nav-link-active-test.tsx
@@ -1,6 +1,21 @@
+/**
+ * @jest-environment ./__tests__/custom-environment.js
+ */
+
+import { render, fireEvent, waitFor, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { JSDOM } from "jsdom";
 import * as React from "react";
 import * as TestRenderer from "react-test-renderer";
-import { MemoryRouter, Routes, Route, NavLink, Outlet } from "react-router-dom";
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  NavLink,
+  Outlet,
+  DataBrowserRouter,
+} from "react-router-dom";
+import { _resetModuleScope } from "react-router/lib/components";
 
 describe("NavLink", () => {
   describe("when it does not match", () => {
@@ -310,6 +325,250 @@ describe("NavLink", () => {
   });
 });
 
+describe("NavLink using a data router", () => {
+  afterEach(() => {
+    _resetModuleScope();
+  });
+
+  it("applies the default 'active'/'pending' classNames to the underlying <a>", async () => {
+    let deferred = defer();
+    render(
+      <DataBrowserRouter
+        window={getWindow("/foo")}
+        hydrationData={{}}
+        fallbackElement={<span />}
+      >
+        <Route path="/" element={<Layout />}>
+          <Route path="foo" element={<p>Foo page</p>} />
+          <Route
+            path="bar"
+            loader={() => deferred.promise}
+            element={<p>Bar page</p>}
+          />
+        </Route>
+      </DataBrowserRouter>
+    );
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/foo">Link to Foo</NavLink>
+          <NavLink to="/bar">Link to Bar</NavLink>
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Link to Bar").className).toBe("");
+
+    fireEvent.click(screen.getByText("Link to Bar"));
+    expect(screen.getByText("Link to Bar").className).toBe("pending");
+
+    deferred.resolve();
+    await waitFor(() => screen.getByText("Bar page"));
+    expect(screen.getByText("Link to Bar").className).toBe("active");
+  });
+
+  it("applies its className correctly when provided as a function", async () => {
+    let deferred = defer();
+    render(
+      <DataBrowserRouter
+        window={getWindow("/foo")}
+        hydrationData={{}}
+        fallbackElement={<span />}
+      >
+        <Route path="/" element={<Layout />}>
+          <Route path="foo" element={<p>Foo page</p>} />
+          <Route
+            path="bar"
+            loader={() => deferred.promise}
+            element={<p>Bar page</p>}
+          />
+        </Route>
+      </DataBrowserRouter>
+    );
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/foo">Link to Foo</NavLink>
+          <NavLink
+            to="/bar"
+            className={({ isActive, isPending }) =>
+              isPending
+                ? "some-pending-classname"
+                : isActive
+                ? "some-active-classname"
+                : undefined
+            }
+          >
+            Link to Bar
+          </NavLink>
+
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Link to Bar").className).toBe("");
+
+    fireEvent.click(screen.getByText("Link to Bar"));
+    expect(screen.getByText("Link to Bar").className).toBe(
+      "some-pending-classname"
+    );
+
+    deferred.resolve();
+    await waitFor(() => screen.getByText("Bar page"));
+    expect(screen.getByText("Link to Bar").className).toBe(
+      "some-active-classname"
+    );
+  });
+
+  it("applies its style correctly when provided as a function", async () => {
+    let deferred = defer();
+    render(
+      <DataBrowserRouter
+        window={getWindow("/foo")}
+        hydrationData={{}}
+        fallbackElement={<span />}
+      >
+        <Route path="/" element={<Layout />}>
+          <Route path="foo" element={<p>Foo page</p>} />
+          <Route
+            path="bar"
+            loader={() => deferred.promise}
+            element={<p>Bar page</p>}
+          />
+        </Route>
+      </DataBrowserRouter>
+    );
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/foo">Link to Foo</NavLink>
+          <NavLink
+            to="/bar"
+            style={({ isActive, isPending }) =>
+              isPending
+                ? { textTransform: "underline" }
+                : isActive
+                ? { textTransform: "uppercase" }
+                : undefined
+            }
+          >
+            Link to Bar
+          </NavLink>
+
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Link to Bar").style.textTransform).toBe("");
+
+    fireEvent.click(screen.getByText("Link to Bar"));
+    expect(screen.getByText("Link to Bar").style.textTransform).toBe(
+      "underline"
+    );
+
+    deferred.resolve();
+    await waitFor(() => screen.getByText("Bar page"));
+    expect(screen.getByText("Link to Bar").style.textTransform).toBe(
+      "uppercase"
+    );
+  });
+
+  it("applies its children correctly when provided as a function", async () => {
+    let deferred = defer();
+    render(
+      <DataBrowserRouter
+        window={getWindow("/foo")}
+        hydrationData={{}}
+        fallbackElement={<span />}
+      >
+        <Route path="/" element={<Layout />}>
+          <Route path="foo" element={<p>Foo page</p>} />
+          <Route
+            path="bar"
+            loader={() => deferred.promise}
+            element={<p>Bar page</p>}
+          />
+        </Route>
+      </DataBrowserRouter>
+    );
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/foo">Link to Foo</NavLink>
+          <NavLink to="/bar">
+            {({ isActive, isPending }) =>
+              isPending
+                ? "Link to Bar (loading...)"
+                : isActive
+                ? "Link to Bar (current)"
+                : "Link to Bar (idle)"
+            }
+          </NavLink>
+
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Link to Bar (idle)")).toBeDefined();
+
+    fireEvent.click(screen.getByText("Link to Bar (idle)"));
+    expect(screen.getByText("Link to Bar (loading...)")).toBeDefined();
+
+    deferred.resolve();
+    await waitFor(() => screen.getByText("Bar page"));
+    expect(screen.getByText("Link to Bar (current)")).toBeDefined();
+  });
+
+  it("does not apply during transitions to non-matching locations", async () => {
+    let deferred = defer();
+    render(
+      <DataBrowserRouter
+        window={getWindow("/foo")}
+        hydrationData={{}}
+        fallbackElement={<span />}
+      >
+        <Route path="/" element={<Layout />}>
+          <Route path="foo" element={<p>Foo page</p>} />
+          <Route path="bar" element={<p>Bar page</p>} />
+          <Route
+            path="baz"
+            loader={() => deferred.promise}
+            element={<p>Baz page</p>}
+          />
+        </Route>
+      </DataBrowserRouter>
+    );
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/foo">Link to Foo</NavLink>
+          <NavLink to="/bar">Link to Bar</NavLink>
+          <NavLink to="/baz">Link to Baz</NavLink>
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Link to Bar").className).toBe("");
+
+    fireEvent.click(screen.getByText("Link to Baz"));
+    expect(screen.getByText("Link to Bar").className).toBe("");
+
+    deferred.resolve();
+    await waitFor(() => screen.getByText("Baz page"));
+    expect(screen.getByText("Link to Bar").className).toBe("");
+  });
+});
+
 describe("NavLink under a Routes with a basename", () => {
   describe("when it does not match", () => {
     it("does not apply the default 'active' className to the underlying <a>", () => {
@@ -352,3 +611,36 @@ describe("NavLink under a Routes with a basename", () => {
     });
   });
 });
+
+function defer() {
+  let resolve: (val?: any) => Promise<void>;
+  let reject: (error?: Error) => Promise<void>;
+  let promise = new Promise((res, rej) => {
+    resolve = async (val: any) => {
+      res(val);
+      try {
+        await promise;
+      } catch (e) {}
+    };
+    reject = async (error?: Error) => {
+      rej(error);
+      try {
+        await promise;
+      } catch (e) {}
+    };
+  });
+  return {
+    promise,
+    //@ts-ignore
+    resolve,
+    //@ts-ignore
+    reject,
+  };
+}
+
+function getWindow(initialUrl: string): Window {
+  // Need to use our own custom DOM in order to get a working history
+  const dom = new JSDOM(`<!DOCTYPE html>`, { url: "https://remix.run/" });
+  dom.window.history.replaceState(null, "", initialUrl);
+  return dom.window as unknown as Window;
+}

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -17,24 +17,24 @@ import {
   UNSAFE_DataRouterStateContext,
 } from "react-router";
 import type { To } from "react-router";
-import {
+import type {
   BrowserHistory,
   Fetcher,
+  FormEncType,
+  FormMethod,
   HashHistory,
   History,
+  HydrationState,
   GetScrollRestorationKeyFunction,
-  matchPath,
+  RouteObject,
 } from "@remix-run/router";
 import {
   createBrowserHistory,
   createHashHistory,
   createBrowserRouter,
   createHashRouter,
-  FormEncType,
-  FormMethod,
-  HydrationState,
   invariant,
-  RouteObject,
+  matchPath,
 } from "@remix-run/router";
 
 import type {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -417,13 +417,18 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     let match = useMatch({ path: path.pathname, end, caseSensitive });
 
     let routerState = React.useContext(UNSAFE_DataRouterStateContext);
-    let nextPath = useResolvedPath(routerState?.navigation.location || "");
-    let nextMatch = routerState?.navigation.location
-      ? matchPath(
-          { path: path.pathname, end, caseSensitive },
-          nextPath.pathname
-        )
-      : null;
+    let nextLocation = routerState?.navigation.location;
+    let nextPath = useResolvedPath(nextLocation || "");
+    let nextMatch = React.useMemo(
+      () =>
+        nextLocation
+          ? matchPath(
+              { path: path.pathname, end, caseSensitive },
+              nextPath.pathname
+            )
+          : null,
+      [nextLocation, path.pathname, caseSensitive, end, nextPath.pathname]
+    );
 
     let isPending = nextMatch != null;
     let isActive = match != null;


### PR DESCRIPTION
Adds `isPending` logic to `NavLink` for styling links during navigations.  This also adds the internal refactor for `isActive` discussed in https://github.com/remix-run/react-router/pull/8567#issuecomment-1054471899
 