### PR TITLE
docs: Add info about changes in matchPath() to upgrading/v5 guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -61,3 +61,4 @@
 - underager
 - vijaypushkin
 - vikingviolinist
+- michal-antczak

--- a/docs/upgrading/v5.md
+++ b/docs/upgrading/v5.md
@@ -891,6 +891,41 @@ To see the exact API of the new `useMatch` hook and its type declaration, check 
 
 <!-- TODO: Show examples for refactoring useRouteMatch -->
 
+## Change the order of arguments passed to `matchPath`. Change pathPattern options.
+
+Since version 6 the order of arguments passed to `matchPath` function has changed. Also pattern options has changed. 
+
+- first argument is pathPattern object, then comes pathname
+- pathPattern doesn't include `exact` and `strict` options any more. New `caseSensitive` and `end` options has been added.
+
+Please refactor it as follows:
+
+Before:
+```js
+// This is a React Router v5 app
+import { matchPath } from "react-router-dom";
+
+const match = matchPath("/users/123", {
+  path: "/users/:id",
+  exact: true,        // Optional, defaults to false
+  strict: false       // Optional, defaults to false
+});
+```
+
+After:
+```js
+// This is a React Router v6 app
+import { matchPath } from "react-router-dom";
+
+const match = matchPath({
+  path: "/users/:id",
+  caseSensitive: false,  // Optional. Should be `true` if the static portions of the `path` should be matched in the same case.
+  end: true            // Optional. Should be `true` if this pattern should match the entire URL pathname
+}, "/users/123");
+```
+
+
+
 ## `<Prompt>` is not currently supported
 
 `<Prompt>` from v5 (along with `usePrompt` and `useBlocker` from the v6 betas) are not included in the current released version of v6. We decided we'd rather ship with what we have than take even more time to nail down a feature that isn't fully baked. We will absolutely be working on adding this back in to v6 at some point in the near future, but not for our first stable release of 6.x.


### PR DESCRIPTION
Added to migration guide v5 -> v6:

- information about changes to `matchPath` function