### PR TITLE
fix(react-router-dom): allow returning `undefined` in `NavLink`'s `style` prop

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -41,6 +41,7 @@
 - markivancho
 - mcansh
 - mfijas
+- MichaelDeBoey
 - minami-minami
 - morleytatro
 - noisypigeon

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -403,7 +403,7 @@ export interface NavLinkProps
     | ((props: {
         isActive: boolean;
         isPending: boolean;
-      }) => React.CSSProperties);
+      }) => React.CSSProperties | undefined);
 }
 
 /**


### PR DESCRIPTION
`style` can be `React.CSSProperties` or `undefined`, so I think it should be able to return these values when using a function as well.