### PR TITLE
fix: webpack error export not found cuz of rollup output

### DIFF
--- a/packages/react-router/lib/use-sync-external-store-shim/index.ts
+++ b/packages/react-router/lib/use-sync-external-store-shim/index.ts
@@ -27,5 +27,7 @@ const isServerEnvironment = !canUseDOM;
 const shim = isServerEnvironment ? server : client;
 
 export const useSyncExternalStore =
-  // @ts-expect-error
-  React.useSyncExternalStore !== undefined ? React.useSyncExternalStore : shim;
+  "useSyncExternalStore" in React
+    ? // @ts-expect-error
+      ((module) => module.useSyncExternalStore)(React)
+    : shim;

--- a/packages/react-router/lib/use-sync-external-store-shim/useSyncExternalStoreShimClient.ts
+++ b/packages/react-router/lib/use-sync-external-store-shim/useSyncExternalStoreShimClient.ts
@@ -48,8 +48,7 @@ export function useSyncExternalStore<T>(
 ): T {
   if (__DEV__) {
     if (!didWarnOld18Alpha) {
-      // @ts-expect-error
-      if (React.startTransition !== undefined) {
+      if ("startTransition" in React) {
         didWarnOld18Alpha = true;
         console.error(
           "You are using an outdated, pre-release alpha of React 18 that " +


### PR DESCRIPTION
Fixes #8931 
In current build, rollup outputs these named exports: `useSyncExternalStore`, `startTransition` from React. If the user's React version doesn't export them, Webpack won't build:
```
ERROR in ./node_modules/react-router/index.js 61:10-25
export 'startTransition' (imported as 'startTransition') was not found in 'react'
```

This fix prevents rollup from outputting these named exports.
`node_modules/react-router/index.js`:

```js
//before
import { startTransition, useSyncExternalStore as useSyncExternalStore$3, createContext, useContext, useMemo, useRef, useEffect as useEffect$1, useCallback, createElement, Fragment, Component, useState as useState$1, useLayoutEffect as useLayoutEffect$1, Children, isValidElement } from 'react';

//after
import { createContext, useContext, useMemo, useRef, useEffect as useEffect$1, useCallback, createElement, Fragment, Component, useState as useState$1, useLayoutEffect as useLayoutEffect$1, Children, isValidElement } from 'react';
```


https://rollupjs.org/guide/en/#outputinterop
https://github.dev/webpack/webpack/blob/f9e6b682aba059d13aa3e170ac42b7a797a0ef3f/lib/dependencies/HarmonyImportDependency.js#L141