### PR TITLE
fix: Minor updates for 6.4.0-pre.2 reports

### DIFF
--- a/docs/routers/data-browser-router.md
+++ b/docs/routers/data-browser-router.md
@@ -35,7 +35,8 @@ declare function DataBrowserRouter(
 export interface DataBrowserRouterProps {
   children?: React.ReactNode;
   hydrationData?: HydrationState;
-  fallbackElement?: React.ReactElement;
+  fallbackElement?: React.ReactNode;
+  routes?: RouteObject[];
   window?: Window;
 }
 ```

--- a/docs/routers/data-hash-router.md
+++ b/docs/routers/data-hash-router.md
@@ -37,7 +37,8 @@ declare function DataHashRouter(
 export interface DataHashRouterProps {
   children?: React.ReactNode;
   hydrationData?: HydrationState;
-  fallbackElement?: React.ReactElement;
+  fallbackElement?: React.ReactNode;
+  routes?: RouteObject[];
   window?: Window;
 }
 ```

--- a/docs/routers/data-memory-router.md
+++ b/docs/routers/data-memory-router.md
@@ -50,7 +50,8 @@ export interface DataMemoryRouterProps {
   initialEntries?: InitialEntry[];
   initialIndex?: number;
   hydrationData?: HydrationState;
-  fallbackElement: React.ReactElement;
+  fallbackElement?: React.ReactNode;
+  routes?: RouteObject[];
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/react-native": "*",
     "@types/react-test-renderer": "16.x",
     "@types/semver": "^7.3.8",
-    "@types/use-sync-external-store": "0.0.3",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
     "babel-eslint": "^10.1.0",

--- a/packages/react-router-dom/__tests__/nav-link-active-test.tsx
+++ b/packages/react-router-dom/__tests__/nav-link-active-test.tsx
@@ -333,11 +333,7 @@ describe("NavLink using a data router", () => {
   it("applies the default 'active'/'pending' classNames to the underlying <a>", async () => {
     let deferred = defer();
     render(
-      <DataBrowserRouter
-        window={getWindow("/foo")}
-        hydrationData={{}}
-        fallbackElement={<span />}
-      >
+      <DataBrowserRouter window={getWindow("/foo")} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<p>Foo page</p>} />
           <Route
@@ -372,11 +368,7 @@ describe("NavLink using a data router", () => {
   it("applies its className correctly when provided as a function", async () => {
     let deferred = defer();
     render(
-      <DataBrowserRouter
-        window={getWindow("/foo")}
-        hydrationData={{}}
-        fallbackElement={<span />}
-      >
+      <DataBrowserRouter window={getWindow("/foo")} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<p>Foo page</p>} />
           <Route
@@ -427,11 +419,7 @@ describe("NavLink using a data router", () => {
   it("applies its style correctly when provided as a function", async () => {
     let deferred = defer();
     render(
-      <DataBrowserRouter
-        window={getWindow("/foo")}
-        hydrationData={{}}
-        fallbackElement={<span />}
-      >
+      <DataBrowserRouter window={getWindow("/foo")} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<p>Foo page</p>} />
           <Route
@@ -482,11 +470,7 @@ describe("NavLink using a data router", () => {
   it("applies its children correctly when provided as a function", async () => {
     let deferred = defer();
     render(
-      <DataBrowserRouter
-        window={getWindow("/foo")}
-        hydrationData={{}}
-        fallbackElement={<span />}
-      >
+      <DataBrowserRouter window={getWindow("/foo")} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<p>Foo page</p>} />
           <Route
@@ -530,11 +514,7 @@ describe("NavLink using a data router", () => {
   it("does not apply during transitions to non-matching locations", async () => {
     let deferred = defer();
     render(
-      <DataBrowserRouter
-        window={getWindow("/foo")}
-        hydrationData={{}}
-        fallbackElement={<span />}
-      >
+      <DataBrowserRouter window={getWindow("/foo")} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<p>Foo page</p>} />
           <Route path="bar" element={<p>Bar page</p>} />

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -163,7 +163,7 @@ export {
 export interface DataBrowserRouterProps {
   children?: React.ReactNode;
   hydrationData?: HydrationState;
-  fallbackElement: React.ReactElement;
+  fallbackElement?: React.ReactNode;
   routes?: RouteObject[];
   window?: Window;
 }
@@ -191,7 +191,7 @@ export function DataBrowserRouter({
 export interface DataHashRouterProps {
   children?: React.ReactNode;
   hydrationData?: HydrationState;
-  fallbackElement: React.ReactElement;
+  fallbackElement?: React.ReactNode;
   routes?: RouteObject[];
   window?: Window;
 }

--- a/packages/react-router/__tests__/DataMemoryRouter-test.tsx
+++ b/packages/react-router/__tests__/DataMemoryRouter-test.tsx
@@ -46,11 +46,7 @@ describe("<DataMemoryRouter>", () => {
 
   it("renders the first route that matches the URL", () => {
     let { container } = render(
-      <DataMemoryRouter
-        fallbackElement={<span />}
-        initialEntries={["/"]}
-        hydrationData={{}}
-      >
+      <DataMemoryRouter initialEntries={["/"]} hydrationData={{}}>
         <Route path="/" element={<h1>Home</h1>} />
       </DataMemoryRouter>
     );
@@ -73,7 +69,6 @@ describe("<DataMemoryRouter>", () => {
     ];
     let { container } = render(
       <DataMemoryRouter
-        fallbackElement={<span />}
         initialEntries={["/"]}
         hydrationData={{}}
         routes={routes}
@@ -93,7 +88,6 @@ describe("<DataMemoryRouter>", () => {
     // In data routers there is no basename and you should instead use a root route
     let { container } = render(
       <DataMemoryRouter
-        fallbackElement={<span />}
         initialEntries={["/my/base/path/thing"]}
         hydrationData={{}}
       >
@@ -117,7 +111,6 @@ describe("<DataMemoryRouter>", () => {
   it("renders with hydration data", async () => {
     let { container } = render(
       <DataMemoryRouter
-        fallbackElement={<span />}
         initialEntries={["/child"]}
         hydrationData={{
           loaderData: {
@@ -215,7 +208,6 @@ describe("<DataMemoryRouter>", () => {
   it("renders a null fallbackElement if none is provided", async () => {
     let fooDefer = defer();
     let { container } = render(
-      // @ts-expect-error
       <DataMemoryRouter initialEntries={["/foo"]}>
         <Route path="/" element={<Outlet />}>
           <Route path="foo" loader={() => fooDefer.promise} element={<Foo />} />
@@ -285,11 +277,7 @@ describe("<DataMemoryRouter>", () => {
 
   it("handles link navigations", async () => {
     render(
-      <DataMemoryRouter
-        fallbackElement={<span />}
-        initialEntries={["/foo"]}
-        hydrationData={{}}
-      >
+      <DataMemoryRouter initialEntries={["/foo"]} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<Foo />} />
           <Route path="bar" element={<Bar />} />
@@ -327,11 +315,7 @@ describe("<DataMemoryRouter>", () => {
     let barDefer = defer();
 
     let { container } = render(
-      <DataMemoryRouter
-        fallbackElement={<span />}
-        initialEntries={["/foo"]}
-        hydrationData={{}}
-      >
+      <DataMemoryRouter initialEntries={["/foo"]} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<Foo />} />
           <Route path="bar" loader={() => barDefer.promise} element={<Bar />} />
@@ -423,11 +407,7 @@ describe("<DataMemoryRouter>", () => {
     formData.append("test", "value");
 
     let { container } = render(
-      <DataMemoryRouter
-        fallbackElement={<span />}
-        initialEntries={["/foo"]}
-        hydrationData={{}}
-      >
+      <DataMemoryRouter initialEntries={["/foo"]} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route path="foo" element={<Foo />} />
           <Route
@@ -542,11 +522,7 @@ describe("<DataMemoryRouter>", () => {
     let spy = jest.fn();
 
     render(
-      <DataMemoryRouter
-        fallbackElement={<span />}
-        initialEntries={["/"]}
-        hydrationData={{}}
-      >
+      <DataMemoryRouter initialEntries={["/"]} hydrationData={{}}>
         <Route path="/" element={<Layout />}>
           <Route
             path="foo"
@@ -692,7 +668,6 @@ describe("<DataMemoryRouter>", () => {
 
     let { container } = render(
       <DataMemoryRouter
-        fallbackElement={<span />}
         initialEntries={["/foo"]}
         hydrationData={{
           loaderData: {
@@ -812,7 +787,6 @@ describe("<DataMemoryRouter>", () => {
 
     let { container } = render(
       <DataMemoryRouter
-        fallbackElement={<span />}
         initialEntries={["/deep/path/to/descendant/routes"]}
         hydrationData={{}}
       >
@@ -835,7 +809,6 @@ describe("<DataMemoryRouter>", () => {
     it("renders hydration errors on leaf elements", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/child"]}
           hydrationData={{
             loaderData: {
@@ -895,7 +868,6 @@ describe("<DataMemoryRouter>", () => {
     it("renders hydration errors on parent elements", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/child"]}
           hydrationData={{
             loaderData: {},
@@ -945,7 +917,6 @@ describe("<DataMemoryRouter>", () => {
 
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1086,7 +1057,6 @@ describe("<DataMemoryRouter>", () => {
 
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1180,7 +1150,6 @@ describe("<DataMemoryRouter>", () => {
     it("renders 404 errors using path='/' error boundary", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1233,7 +1202,6 @@ describe("<DataMemoryRouter>", () => {
     it("renders 404 errors using index error boundary", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1286,7 +1254,6 @@ describe("<DataMemoryRouter>", () => {
     it("renders 404 errors using fallback boundary if no root layout route exists", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1346,7 +1313,6 @@ describe("<DataMemoryRouter>", () => {
 
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/foo"]}
           hydrationData={{
             loaderData: {
@@ -1459,7 +1425,6 @@ describe("<DataMemoryRouter>", () => {
     it("handles render errors in parent errorElement", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/child"]}
           hydrationData={{
             loaderData: {},
@@ -1502,7 +1467,6 @@ describe("<DataMemoryRouter>", () => {
     it("handles render errors in child errorElement", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/child"]}
           hydrationData={{
             loaderData: {},
@@ -1554,7 +1518,6 @@ describe("<DataMemoryRouter>", () => {
     it("handles render errors in default errorElement", async () => {
       let { container } = render(
         <DataMemoryRouter
-          fallbackElement={<span />}
           initialEntries={["/child"]}
           hydrationData={{
             loaderData: {},
@@ -1674,7 +1637,6 @@ describe("<DataMemoryRouter>", () => {
       let { container } = render(
         <div>
           <LocalDataMemoryRouter
-            fallbackElement={<span />}
             initialEntries={["/"]}
             hydrationData={{ loaderData: {} }}
           >
@@ -1781,7 +1743,6 @@ describe("<DataMemoryRouter>", () => {
       let { container } = render(
         <div>
           <LocalDataMemoryRouter
-            fallbackElement={<span />}
             initialEntries={["/"]}
             hydrationData={{ loaderData: {} }}
           >

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -62,7 +62,7 @@ export function useRenderDataRouter({
   createRouter,
 }: {
   children?: React.ReactNode;
-  fallbackElement: React.ReactElement;
+  fallbackElement?: React.ReactNode;
   routes?: RouteObject[];
   createRouter: (routes: RouteObject[]) => DataRouter;
 }): React.ReactElement {
@@ -95,7 +95,7 @@ export function useRenderDataRouter({
   }, [router]);
 
   if (!state.initialized) {
-    return fallbackElement || null;
+    return <>{fallbackElement}</>;
   }
 
   return (
@@ -118,7 +118,7 @@ export interface DataMemoryRouterProps {
   initialEntries?: InitialEntry[];
   initialIndex?: number;
   hydrationData?: HydrationState;
-  fallbackElement: React.ReactElement;
+  fallbackElement?: React.ReactNode;
   routes?: RouteObject[];
 }
 

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -17,8 +17,7 @@
     "react": ">=16.8"
   },
   "dependencies": {
-    "@remix-run/router": "^0.1.0",
-    "use-sync-external-store": "1.1.0"
+    "@remix-run/router": "0.1.0"
   },
   "sideEffects": false,
   "keywords": [

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -12,37 +12,49 @@ packages re-export everything from `@remix-run/router` and `react-router`.
 A Router instance can be created using `createRouter`:
 
 ```js
+// Create and initialize a router.  "initialize" contains all side effects
+// including history listeners and kicking off the initial data fetch
 let router = createRouter({
   // Routes array using react-router RouteObject's
   routes,
   // History instance
   history,
-  // Callback function executed on every state change
-  onChange: (state) => { ... },
   // Optional hydration data for SSR apps
   hydrationData?: HydrationState;
-}
+}).initialize()
 ```
 
-Internally, the Router represents the state in an object of the following format, which is available through `router.state` or via the `onChange` callback function:
+Internally, the Router represents the state in an object of the following format, which is available through `router.state`. You can also register a subscriber of the signature `(state: RouterState) => void` to execute when the state updates via `router.subscribe()`;
 
 ```ts
 interface RouterState {
   // The `history` action of the most recently completed navigation
-  action: Action;
+  historyAction: Action;
   // The current location of the router.  During a navigation this reflects
   // the "old" location and is updated upon completion of the navigation
   location: Location;
   // The current set of route matches
-  matches: RouteMatch[];
+  matches: DataRouteMatch[];
+  // False during the initial data load, true once we have our initial data
+  initialized: boolean;
   // The state of the current navigation
   navigation: Navigation;
+  // The state of an in-progress router.revalidate() calls
+  revalidation: RevalidationState;
+  // Scroll position to restore to for the active Location, false if we
+  // should not restore,m or null if we don't have a saved position
+  // Note: must be enabled via router.enableScrollRestoration()
+  restoreScrollPosition: number | false | null;
+  // Proxied `resetScroll` value passed to router.navigate() (default true)
+  resetScrollPosition: boolean;
   // Data from the loaders for the current matches
   loaderData: RouteData;
   // Data from the action for the current matches
   actionData: RouteData | null;
   // Errors thrown from loaders/actions for the current matches
   errors: RouteData | null;
+  // Map of all active fetchers
+  fetchers: Map<string, Fetcher>;
 }
 ```
 
@@ -52,104 +64,40 @@ All navigations are done through the `router.navigate` API which is overloaded t
 
 ```js
 // Link navigation (pushes onto the history stack by default)
-router.navigate('/page');
+router.navigate("/page");
 
 // Link navigation (replacing the history stack)
-router.navigate('/page', { replace: true });
+router.navigate("/page", { replace: true });
 
 // Pop navigation (moving backward/forward in the history stack)
 router.navigate(-1);
 
-// Form navigation
-router.navigate('/page', {
-  formMethod: 'GET',
-  formData: new FormData(...),
+// Form submission navigation
+let formData = new FormData();
+formData.append(key, value);
+router.navigate("/page", {
+  formMethod: "post",
+  formData,
 });
 ```
 
-## Navigation Flows
+### Fetchers
 
-Each navigation (link click or form submission) in the Router is reflected via an internal `state.navigation` that indicates the state of the navigation. This concept of a `navigation` is a complex and heavily async bit of logic that is foundational to the Router's ability to manage data loading, submission, error handling, redirects, interruptions, and so on. Due to the user-driven nature of interruptions we don't quite believe it can be modeled as a finite state machine, however we have modeled some of the happy path flows below for clarity.
+Fetchers are a mechanism to call loaders/actions without triggering a navigation, and are done through the `router.fetch()` API. All fetch calls require a unique key to identify the fetcher.
 
-_Note: This does not depict error or interruption flows._
+```js
+// Execute the loader for /page
+router.fetch("key", "/page");
 
-```mermaid
-graph LR
-  %% Link click
-  idle -->|link clicked| loading/normalLoad
-  subgraph "&lt;Link&gt; click"
-  loading/normalLoad -->|loader redirected| loading/normalRedirect
-  loading/normalRedirect --> loading/normalRedirect
-  end
-  loading/normalLoad -->|loaders completed| idle
-  loading/normalRedirect -->|loaders completed| idle
-
-  %% Form method=get
-  idle -->|form method=get| submitting/loaderSubmission
-  subgraph "&lt;Form method=get&gt;"
-  submitting/loaderSubmission -->|loader redirected| R1[loading/submissionRedirect]
-  R1[loading/submissionRedirect] --> R1[loading/submissionRedirect]
-  end
-  submitting/loaderSubmission -->|loaders completed| idle
-  R1[loading/submissionRedirect] -->|loaders completed| idle
-
-  %% Form method=post
-  idle -->|form method=post| submitting/actionSubmission
-  subgraph "&lt;Form method=post&gt;"
-  submitting/actionSubmission -->|action returned| loading/actionReload
-  submitting/actionSubmission -->|action redirected| R2[loading/submissionRedirect]
-  loading/actionReload -->|loader redirected| R2[loading/submissionRedirect]
-  R2[loading/submissionRedirect] --> R2[loading/submissionRedirect]
-  end
-  loading/actionReload -->|loaders completed| idle
-  R2[loading/submissionRedirect] -->|loaders completed| idle
-
-  idle -->|fetcher action redirect| R3[loading/submissionRedirect]
-  subgraph "Fetcher action redirect"
-  R3[loading/submissionRedirect] --> R3[loading/submissionRedirect]
-  end
-  R3[loading/submissionRedirect] -->|loaders completed| idle
+// Submit to the action for /page
+let formData = new FormData();
+formData.append(key, value);
+router.fetch("key", "/page", {
+  formMethod: "post",
+  formData,
+});
 ```
 
-## Fetcher Flows
+## Revalidation
 
-Fetcher submissions and loads in the Router can each have their own internal states, indicated on `fetcher.state` and `fetcher.type`. As with navigations, these states are a complex and heavily async bit of logic that is foundational to the Router's ability to manage data loading, submission, error handling, redirects, interruptions, and so on. Due to the user-driven nature of interruptions we don't quite believe it can be modeled as a finite state machine, however we have modeled some of the happy path flows below for clarity.
-
-_Note: This does not depict error or interruption flows, nor the ability to re-use fetchers once they've reached `idle/done`._
-
-```mermaid
-graph LR
-  idle/init -->|"load"| loading/normalLoad
-  subgraph "Normal Fetch"
-  loading/normalLoad -.->|loader redirected| T1{{navigation}}
-  end
-  loading/normalLoad -->|loader completed| idle/done
-  T1{{navigation}} -.-> idle/done
-
-  idle/init -->|"submit (get)"| submitting/loaderSubmission
-  subgraph "Loader Submission"
-  submitting/loaderSubmission -.->|"loader redirected"| T2{{navigation}}
-  end
-  submitting/loaderSubmission -->|loader completed| idle/done
-  T2{{navigation}} -.-> idle/done
-
-  idle/init -->|"submit (post)"| submitting/actionSubmission
-  subgraph "Action Submission"
-  submitting/actionSubmission -->|action completed| loading/actionReload
-  submitting/actionSubmission -->|action redirected| loading/submissionRedirect
-  loading/submissionRedirect -.-> T3{{navigation}}
-  loading/actionReload -.-> |loaders redirected| T3{{navigation}}
-  end
-  T3{{navigation}} -.-> idle/done
-  loading/actionReload --> |loaders completed| idle/done
-
-  idle/done -->|"revalidate"| loading/revalidate
-  subgraph "Fetcher Revalidation"
-  loading/revalidate -.->|loader redirected| T4{{navigation}}
-  end
-  loading/revalidate -->|loader completed| idle/done
-  T4{{navigation}} -.-> idle/done
-
-  classDef navigation fill:lightgreen;
-  class T1,T2,T3,T4 navigation;
-```
+By default, active loaders will revalidate after any navigation or fetcher mutation. If you need to kick off a revalidation for other use-cases, you can use `router.revalidate()` to re-execute all active loaders.

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1184,8 +1184,8 @@ export function createRouter(init: RouterInit): Router {
       submission,
       nextLocation,
       isRevalidationRequired,
-      null,
-      null,
+      { [match.route.id]: actionResult.data },
+      null, // No need to send through errors since we short circuit above
       fetchLoadMatches
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,11 +1890,6 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
 
-"@types/use-sync-external-store@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
-  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
-
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz"
@@ -8933,11 +8928,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-use-sync-external-store@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
-  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Minor updates + cleanup in preparation for `6.4.0-pre.3`

* Removes stale/unused `use-sync-external-store` dependency in `package.json`
* Change `fallbackElement` type to `ReactNode` for more flexible typing (REM-1146)
* Make `fallbackElement` optional for SSR use-case and to match what the docs currently show (#8896)
* Pass fetcher `actionResult` through to shouldRevalidate on fetcher submissions (REM-1159)
* Brings `packages/router/README.md` up to date

Closes: #8896