### PR TITLE
Updated path and route parameters

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -19,6 +19,7 @@
 - gijo-varghese
 - hongji00
 - hsbtr
+- Carl Omondi
 - hyesungoh
 - IbraRouisDev
 - Isammoc

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -115,6 +115,7 @@ export interface RouteProps {
   children?: React.ReactNode;
   element?: React.ReactNode | null;
   index?: boolean;
+  exact?: boolean;
   path?: string;
 }
 
@@ -123,6 +124,7 @@ export interface PathRouteProps {
   children?: React.ReactNode;
   element?: React.ReactNode | null;
   index?: false;
+  exact?: boolean;
   path: string;
 }
 


### PR DESCRIPTION
On typescript, exact and index are not there as parameters which causes issues when using typescript
<img width="1355" alt="Screen Shot 2022-06-06 at 5 15 03 PM" src="https://user-images.githubusercontent.com/98195031/172258175-5a83adc0-d1cc-4fbd-bc6b-01dbfb685ed0.png">

The tiny update adds "exact" and "index" as parameter options for path route in typescript
