### PR TITLE
fix: Capture fetcher errors at contextual route error boundaries

### DIFF
--- a/packages/react-router-dom/__tests__/DataBrowserRouter-test.tsx
+++ b/packages/react-router-dom/__tests__/DataBrowserRouter-test.tsx
@@ -1805,6 +1805,188 @@ function testDomRouter(name, TestDataRouter, getWindow) {
           </p>"
         `);
       });
+
+      it("handles fetcher.load errors at the correct spot in the route hierarchy", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/child")}
+            hydrationData={{ loaderData: { "0": null } }}
+          >
+            <Route path="/" element={<Outlet />} errorElement={<p>Not I!</p>}>
+              <Route
+                path="child"
+                element={<Comp />}
+                errorElement={<ErrorElement />}
+              />
+              <Route
+                path="fetch"
+                loader={() => {
+                  throw new Error("Kaboom!");
+                }}
+                errorElement={<p>Not I!</p>}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        function Comp() {
+          let fetcher = useFetcher();
+          return <button onClick={() => fetcher.load("/fetch")}>load</button>;
+        }
+
+        function ErrorElement() {
+          return <p>contextual error:{useRouteError().message}</p>;
+        }
+
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+          "<div>
+            <button>
+              load
+            </button>
+          </div>"
+        `);
+
+        fireEvent.click(screen.getByText("load"));
+        await waitFor(() => screen.getByText(/Kaboom!/));
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+          "<div>
+            <p>
+              contextual error:
+              Kaboom!
+            </p>
+          </div>"
+        `);
+      });
+
+      it("handles fetcher.submit errors at the correct spot in the route hierarchy", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/child")}
+            hydrationData={{ loaderData: { "0": null } }}
+          >
+            <Route path="/" element={<Outlet />} errorElement={<p>Not I!</p>}>
+              <Route
+                path="child"
+                element={<Comp />}
+                errorElement={<ErrorElement />}
+              />
+              <Route
+                path="fetch"
+                action={() => {
+                  throw new Error("Kaboom!");
+                }}
+                errorElement={<p>Not I!</p>}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        function Comp() {
+          let fetcher = useFetcher();
+          return (
+            <button
+              onClick={() =>
+                fetcher.submit(
+                  { key: "value" },
+                  { method: "post", action: "/fetch" }
+                )
+              }
+            >
+              submit
+            </button>
+          );
+        }
+
+        function ErrorElement() {
+          return <p>contextual error:{useRouteError().message}</p>;
+        }
+
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <button>
+                submit
+              </button>
+            </div>"
+          `);
+
+        fireEvent.click(screen.getByText("submit"));
+        await waitFor(() => screen.getByText(/Kaboom!/));
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                contextual error:
+                Kaboom!
+              </p>
+            </div>"
+          `);
+      });
+
+      it("handles fetcher.Form errors at the correct spot in the route hierarchy", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/child")}
+            hydrationData={{ loaderData: { "0": null } }}
+          >
+            <Route path="/" element={<Outlet />} errorElement={<p>Not I!</p>}>
+              <Route
+                path="child"
+                element={<Comp />}
+                errorElement={<ErrorElement />}
+              />
+              <Route
+                path="fetch"
+                action={() => {
+                  throw new Error("Kaboom!");
+                }}
+                errorElement={<p>Not I!</p>}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        function Comp() {
+          let fetcher = useFetcher();
+          return (
+            <fetcher.Form method="post" action="/fetch">
+              <button type="submit" name="key" value="value">
+                submit
+              </button>
+            </fetcher.Form>
+          );
+        }
+
+        function ErrorElement() {
+          return <p>contextual error:{useRouteError().message}</p>;
+        }
+
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+          "<div>
+            <form
+              action=\\"/fetch\\"
+              method=\\"post\\"
+            >
+              <button
+                name=\\"key\\"
+                type=\\"submit\\"
+                value=\\"value\\"
+              >
+                submit
+              </button>
+            </form>
+          </div>"
+        `);
+
+        fireEvent.click(screen.getByText("submit"));
+        await waitFor(() => screen.getByText(/Kaboom!/));
+        expect(getHtml(container)).toMatchInlineSnapshot(`
+          "<div>
+            <p>
+              contextual error:
+              Kaboom!
+            </p>
+          </div>"
+        `);
+      });
     });
 
     describe("errors", () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -578,7 +578,7 @@ function setup({
     }
 
     let helpers = getFetcherHelpers(key, href, navigationId, opts);
-    currentRouter.fetch(key, href, opts);
+    currentRouter.fetch(key, enhancedRoutes[0].id, href, opts);
     return helpers;
   }
 
@@ -1495,7 +1495,7 @@ describe("a router", () => {
       await tick();
 
       let key = "key";
-      router.fetch(key, "/fetch");
+      router.fetch(key, "root", "/fetch");
       await tick();
       expect(router.state.fetchers.get(key)).toMatchObject({
         state: "idle",
@@ -1572,7 +1572,7 @@ describe("a router", () => {
       await tick();
 
       let key = "key";
-      router.fetch(key, "/fetch", {
+      router.fetch(key, "root", "/fetch", {
         formMethod: "post",
         formData: createFormData({ key: "value" }),
       });
@@ -4948,7 +4948,7 @@ describe("a router", () => {
         });
 
         let key = "key";
-        router.fetch(key, "/");
+        router.fetch(key, "root", "/");
         expect(router.state.fetchers.get(key)).toEqual({
           state: "loading",
           formMethod: undefined,
@@ -6172,7 +6172,7 @@ describe("a router", () => {
         expect(router.getFetcher(key)).toBe(IDLE_FETCHER);
 
         // Fetch from a different route
-        router.fetch(key, "/fetch");
+        router.fetch(key, "root", "/fetch");
         await tick();
         expect(router.getFetcher(key)).toMatchObject({
           state: "idle",


### PR DESCRIPTION
Errors from `useFetcher()` should propagate upwards from the Route in which they were used and use the closest error boundary