### PR TITLE
ci: Update exports and fix linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
-/build/
 /fixtures/
 node_modules/
 /docs/api
 examples/**/dist/
+packages/**/dist/
 tutorial/dist/

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -60,6 +60,7 @@ export { createSearchParams };
 // Note: Keep in sync with react-router exports!
 export type {
   ActionFunction,
+  ActionFunctionArgs,
   DataMemoryRouterProps,
   DataRouteMatch,
   Fetcher,
@@ -68,6 +69,7 @@ export type {
   JsonFunction,
   LayoutRouteProps,
   LoaderFunction,
+  LoaderFunctionArgs,
   Location,
   MemoryRouterProps,
   NavigateFunction,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -24,6 +24,7 @@ import URLSearchParams from "@ungap/url-search-params";
 // Note: Keep in sync with react-router exports!
 export type {
   ActionFunction,
+  ActionFunctionArgs,
   DataMemoryRouterProps,
   DataRouteMatch,
   Fetcher,
@@ -32,6 +33,7 @@ export type {
   JsonFunction,
   LayoutRouteProps,
   LoaderFunction,
+  LoaderFunctionArgs,
   Location,
   MemoryRouterProps,
   NavigateFunction,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -1,9 +1,11 @@
 import type {
   ActionFunction,
+  ActionFunctionArgs,
   DataRouteMatch,
   Fetcher,
   JsonFunction,
   LoaderFunction,
+  LoaderFunctionArgs,
   Location,
   Navigation,
   Params,
@@ -92,6 +94,7 @@ type Search = string;
 // Expose react-router public API
 export type {
   ActionFunction,
+  ActionFunctionArgs,
   DataMemoryRouterProps,
   DataRouteMatch,
   Fetcher,
@@ -100,6 +103,7 @@ export type {
   JsonFunction,
   LayoutRouteProps,
   LoaderFunction,
+  LoaderFunctionArgs,
   Location,
   MemoryRouterProps,
   NavigateFunction,


### PR DESCRIPTION
* Forgot to export `ActionFunctionArgs`/`LoaderFunctionArgs` up through `react-router*` packages in https://github.com/remix-run/react-router/pull/8947.  
* Also noticed that the new `dist/` directories weren't added to `.eslintignore`

Closes #8942