### PR TITLE
fix: do not REPLACE if action redirected

### DIFF
--- a/.changeset/odd-yaks-kneel.md
+++ b/.changeset/odd-yaks-kneel.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: don't default to a `REPLACE` navigation on form submissions if the action redirected. The redirect takes care of avoiding the back-button-resubmit scenario, so by using a `PUSH` we allow the back button to go back to the pre-submission form page (#8979)

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -775,10 +775,7 @@ function useSubmitImpl(fetcherKey?: string, routeId?: string): SubmitFunction {
 
       let href = url.pathname + url.search;
       let opts = {
-        // If replace is not specified, we'll default to false for GET and
-        // true otherwise
-        replace:
-          options.replace != null ? options.replace === true : method !== "get",
+        replace: options.replace,
         formData,
         formMethod: method as FormMethod,
         formEncType: encType as FormEncType,

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -1861,6 +1861,7 @@ describe("a router", () => {
 
       // Navigate to /bar
       let B = await t.navigate("/bar");
+      let getBarKey = t.router.state.navigation.location?.key;
       await B.loaders.bar.resolve("BAR");
       expect(t.router.state.location.pathname).toEqual("/bar");
 
@@ -1869,6 +1870,7 @@ describe("a router", () => {
         formMethod: "post",
         formData: createFormData({ key: "value" }),
       });
+      let postBarKey = t.router.state.navigation.location?.key;
       let D = await C.actions.bar.redirect("/baz");
       await D.loaders.root.resolve("ROOT");
       await D.loaders.baz.resolve("BAZ");
@@ -1878,6 +1880,8 @@ describe("a router", () => {
       let E = await t.navigate(-1);
       await E.loaders.bar.resolve("BAR");
       expect(t.router.state.location.pathname).toEqual("/bar");
+      expect(t.router.state.location.key).toBe(getBarKey);
+      expect(t.router.state.location.key).not.toBe(postBarKey);
     });
 
     it("navigates correctly using POP navigations across <Form replace> redirects", async () => {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -656,9 +656,10 @@ export function createRouter(init: RouterInit): Router {
     );
 
     let location = createLocation(state.location, normalizedPath, opts?.state);
-    let historyAction = opts?.replace
-      ? HistoryAction.Replace
-      : HistoryAction.Push;
+    let historyAction =
+      opts?.replace === true || submission != null
+        ? HistoryAction.Replace
+        : HistoryAction.Push;
     let resetScroll =
       opts && "resetScroll" in opts ? opts.resetScroll : undefined;
 
@@ -668,6 +669,7 @@ export function createRouter(init: RouterInit): Router {
       // render at the right errorElement after we match routes
       pendingError: error,
       resetScroll,
+      replace: opts?.replace,
     });
   }
 
@@ -721,6 +723,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError?: ErrorResponse;
       startUninterruptedRevalidation?: boolean;
       resetScroll?: boolean;
+      replace?: boolean;
     }
   ): Promise<void> {
     // Abort any in-progress navigations and start a new one
@@ -784,7 +787,8 @@ export function createRouter(init: RouterInit): Router {
         historyAction,
         location,
         opts.submission,
-        matches
+        matches,
+        { replace: opts.replace }
       );
 
       if (actionOutput.shortCircuited) {
@@ -829,7 +833,8 @@ export function createRouter(init: RouterInit): Router {
     historyAction: HistoryAction,
     location: Location,
     submission: Submission,
-    matches: DataRouteMatch[]
+    matches: DataRouteMatch[],
+    opts?: { replace?: boolean }
   ): Promise<HandleActionResult> {
     isRevalidationRequired = true;
 
@@ -900,7 +905,12 @@ export function createRouter(init: RouterInit): Router {
         location: createLocation(state.location, result.location),
         ...submission,
       };
-      await startRedirectNavigation(result, redirectNavigation);
+      // By default we use a push redirect here since the user redirecting from
+      // the action already handles avoiding us backing into the POST navigation
+      // However, if they specifically used <Form replace={true}> we should
+      // respect that
+      let isPush = opts?.replace !== true;
+      await startRedirectNavigation(result, redirectNavigation, isPush);
       return { shortCircuited: true };
     }
 
@@ -1369,7 +1379,8 @@ export function createRouter(init: RouterInit): Router {
   // Utility function to handle redirects returned from an action or loader
   async function startRedirectNavigation(
     redirect: RedirectResult,
-    navigation: Navigation
+    navigation: Navigation,
+    isPush = false
   ) {
     if (redirect.revalidate) {
       isRevalidationRequired = true;
@@ -1378,9 +1389,11 @@ export function createRouter(init: RouterInit): Router {
       navigation.location,
       "Expected a location on the redirect navigation"
     );
-    await startNavigation(HistoryAction.Replace, navigation.location, {
-      overrideNavigation: navigation,
-    });
+    await startNavigation(
+      isPush ? HistoryAction.Push : HistoryAction.Replace,
+      navigation.location,
+      { overrideNavigation: navigation }
+    );
   }
 
   function deleteFetcher(key: string): void {


### PR DESCRIPTION
We are currently defaulting `<Form method="post">` to be a `REPLACE` navigation by default, but this is a bit aggressive because if the action redirects, then we lose the starting location. 

For example, without a redirect, the following is correct:
* User is on `/`
* Navigates to `/form`
* Submits to `/form` _and does not redirect_
* The submission should REPLACE so that POP does not re-play the post and goes back to `/`

However, if the action is redirecting, they're already handling the `REPLACE` and we should stay with `PUSH` so the user can back-navigate to the form:
* User is on `/`
* Navigates to `/form`
* Submits to `/form` _and redirects to `/results`_
* The submission should PUSH so that POP goes back to `/form`

This PR removes the push/replace logic from `useSubmitImpl` and lets the router handle it all
