### PR TITLE
Share logic between `useResolvedPath` and `useNavigate`

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -137,6 +137,17 @@ export interface NavigateFunction {
   (delta: number): void;
 }
 
+function getRoutePathnamesJson(matches: RouteMatch[]) {
+  // Ignore index + pathless matches
+  const pathContributingMatches = matches.filter(
+    (match, index) =>
+      index === 0 ||
+      (!match.route.index &&
+        match.pathnameBase !== matches[index - 1].pathnameBase)
+  )
+  return JSON.stringify(pathContributingMatches.map((match) => match.pathnameBase));
+}
+
 /**
  * Returns an imperative method for changing the location. Used by <Link>s, but
  * may also be used by other elements to change the location.
@@ -155,17 +166,7 @@ export function useNavigate(): NavigateFunction {
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
 
-  // Ignore index + pathless matches
-  let pathContributingMatches = matches.filter(
-    (match, index) =>
-      index === 0 ||
-      (!match.route.index &&
-        match.pathnameBase !== matches[index - 1].pathnameBase)
-  );
-
-  let routePathnamesJson = JSON.stringify(
-    pathContributingMatches.map((match) => match.pathnameBase)
-  );
+  let routePathnamesJson = getRoutePathnamesJson(matches)
 
   let activeRef = React.useRef(false);
   React.useEffect(() => {
@@ -261,9 +262,7 @@ export function useResolvedPath(to: To): Path {
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
 
-  let routePathnamesJson = JSON.stringify(
-    matches.map((match) => match.pathnameBase)
-  );
+  let routePathnamesJson = getRoutePathnamesJson(matches);
 
   return React.useMemo(
     () => resolveTo(to, JSON.parse(routePathnamesJson), locationPathname),


### PR DESCRIPTION
Discussed in Discord ([thread](https://discord.com/channels/770287896669978684/986363885760176158)). Recent commits updated the logic in `useNavigate` without making the corresponding change to `useResolvedPath`, which is used to set the `href` on `Link`s. Going to add a test that reproduces the bug I was seeing.