### PR TITLE
Add hint about "replace" in "useNavigate" documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -15,6 +15,7 @@
 - christopherchudzicki
 - cvbuelow
 - edwin177
+- elanis
 - elylucas
 - emzoumpo
 - gijo-varghese

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -21,7 +21,7 @@ interface NavigateFunction {
 
 </details>
 
-The `useNavigate` hook returns a function that lets you navigate programmatically, for example after a form is submitted.
+The `useNavigate` hook returns a function that lets you navigate programmatically, for example after a form is submitted. If using `replace: true`, the redirection will replace the current entry in the history stack instead of adding a new one.
 
 ```tsx
 import { useNavigate } from "react-router-dom";

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -21,7 +21,7 @@ interface NavigateFunction {
 
 </details>
 
-The `useNavigate` hook returns a function that lets you navigate programmatically, for example after a form is submitted. If using `replace: true`, the redirection will replace the current entry in the history stack instead of adding a new one.
+The `useNavigate` hook returns a function that lets you navigate programmatically, for example after a form is submitted. If using `replace: true`, the navigation will replace the current entry in the history stack instead of adding a new one.
 
 ```tsx
 import { useNavigate } from "react-router-dom";


### PR DESCRIPTION
When reading the v6 doc I noticed there were no mention of what "replace" is used for on the "useNavigate" page. This PR fixes this issue.