### PR TITLE
Feat: Add deferred support

### DIFF
--- a/examples/data-router/src/App.tsx
+++ b/examples/data-router/src/App.tsx
@@ -50,6 +50,8 @@ function Layout() {
         &nbsp;|&nbsp;
         <Link to="/deferred/child">Deferred Child</Link>
         &nbsp;|&nbsp;
+        <Link to="/long-load">Long Load</Link>
+        &nbsp;|&nbsp;
         <Link to="/404">404 Link</Link>
         &nbsp;&nbsp;
         <button onClick={() => revalidate()}>Revalidate</button>
@@ -343,6 +345,11 @@ function App() {
             element={<DeferredChild />}
           />
         </Route>
+        <Route
+          path="long-load"
+          loader={() => sleep(3000)}
+          element={<h1>👋</h1>}
+        />
         <Route
           path="todos"
           action={todosAction}

--- a/package.json
+++ b/package.json
@@ -100,13 +100,13 @@
   },
   "filesize": {
     "packages/router/dist/router.production.min.js": {
-      "none": "21 kB"
-    },
-    "packages/router/dist//umd/router.production.min.js": {
       "none": "23 kB"
     },
+    "packages/router/dist//umd/router.production.min.js": {
+      "none": "25 kB"
+    },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "10 kB"
+      "none": "11 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
       "none": "12 kB"

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -97,6 +97,7 @@ export type {
 } from "react-router";
 export {
   DataMemoryRouter,
+  Deferred,
   MemoryRouter,
   Navigate,
   NavigationType,
@@ -106,6 +107,8 @@ export {
   Routes,
   createPath,
   createRoutesFromChildren,
+  deferred,
+  isDeferredError,
   isRouteErrorResponse,
   generatePath,
   json,
@@ -116,6 +119,7 @@ export {
   renderMatches,
   resolvePath,
   useActionData,
+  useDeferred,
   useHref,
   useInRouterContext,
   useLoaderData,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -61,6 +61,7 @@ export type {
 } from "react-router";
 export {
   DataMemoryRouter,
+  Deferred,
   MemoryRouter,
   Navigate,
   NavigationType,
@@ -70,6 +71,8 @@ export {
   Routes,
   createPath,
   createRoutesFromChildren,
+  deferred,
+  isDeferredError,
   isRouteErrorResponse,
   generatePath,
   json,
@@ -80,6 +83,7 @@ export {
   renderMatches,
   resolvePath,
   useActionData,
+  useDeferred,
   useHref,
   useInRouterContext,
   useLoaderData,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -22,7 +22,9 @@ import type {
 import {
   Action as NavigationType,
   createPath,
+  deferred,
   generatePath,
+  isDeferredError,
   isRouteErrorResponse,
   json,
   matchPath,
@@ -47,8 +49,9 @@ import type {
 import {
   createRoutesFromChildren,
   renderMatches,
-  MemoryRouter,
   DataMemoryRouter,
+  Deferred,
+  MemoryRouter,
   Navigate,
   Outlet,
   Route,
@@ -78,6 +81,7 @@ import {
   useResolvedPath,
   useRoutes,
   useActionData,
+  useDeferred,
   useLoaderData,
   useMatches,
   useRouteLoaderData,
@@ -131,6 +135,7 @@ export type {
 };
 export {
   DataMemoryRouter,
+  Deferred,
   MemoryRouter,
   Navigate,
   NavigationType,
@@ -140,6 +145,8 @@ export {
   Routes,
   createPath,
   createRoutesFromChildren,
+  deferred,
+  isDeferredError,
   isRouteErrorResponse,
   generatePath,
   json,
@@ -150,6 +157,7 @@ export {
   renderMatches,
   resolvePath,
   useActionData,
+  useDeferred,
   useHref,
   useInRouterContext,
   useLoaderData,

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -21,6 +21,11 @@ if (__DEV__) {
   DataRouterStateContext.displayName = "DataRouterState";
 }
 
+export const DeferredContext = React.createContext<any | null>(null);
+if (__DEV__) {
+  DeferredContext.displayName = "Deferred";
+}
+
 export interface NavigateOptions {
   replace?: boolean;
   state?: any;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -32,6 +32,7 @@ import {
   NavigateOptions,
   RouteContext,
   RouteErrorContext,
+  DeferredContext,
 } from "./context";
 
 /**
@@ -685,6 +686,15 @@ export function useRouteError() {
 
   // Otherwise look for errors from our data router state
   return state.errors?.[thisRoute.route.id];
+}
+
+/**
+ * Returns the data from the nearest ancestor <Deferred /> value. `data` may be
+ * a `DeferredError` if no `errorBoundary` was specified, so usage should be
+ * guarded with `isDeferredError` in those scenarios.
+ */
+export function useDeferred() {
+  return React.useContext(DeferredContext);
 }
 
 const alreadyWarned: Record<string, boolean> = {};

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6515,6 +6515,7 @@ describe("a router", () => {
         })
       );
 
+      // Interrupt pending deferred's from /lazy navigation
       let B = await t.navigate("/");
       // During navigation - deferreds remain as promises
       expect(t.router.state.loaderData).toEqual({
@@ -6666,6 +6667,7 @@ describe("a router", () => {
     });
 
     it("should cancel all outstanding deferreds on router.revalidate()", async () => {
+      let shouldRevalidateSpy = jest.fn(() => false);
       let t = setup({
         routes: [
           {
@@ -6677,6 +6679,7 @@ describe("a router", () => {
             id: "parent",
             path: "parent",
             loader: true,
+            shouldRevalidate: shouldRevalidateSpy,
             children: [
               {
                 id: "index",
@@ -6782,6 +6785,8 @@ describe("a router", () => {
           lazy: "LAZY INDEX 2",
         },
       });
+
+      expect(shouldRevalidateSpy).not.toHaveBeenCalled();
     });
 
     it("cancels pending deferreds on 404 navigations", async () => {
@@ -6983,6 +6988,7 @@ describe("a router", () => {
     });
 
     it("cancels pending deferreds on action submissions", async () => {
+      let shouldRevalidateSpy = jest.fn(() => false);
       let t = setup({
         routes: [
           {
@@ -6994,7 +7000,7 @@ describe("a router", () => {
             id: "parent",
             path: "parent",
             loader: true,
-            shouldRevalidate: () => false,
+            shouldRevalidate: shouldRevalidateSpy,
             children: [
               {
                 id: "a",
@@ -7074,6 +7080,8 @@ describe("a router", () => {
           lazy: "Yep!",
         },
       });
+
+      expect(shouldRevalidateSpy).not.toHaveBeenCalled();
     });
 
     it("does not support deferred data on fetcher loads", async () => {

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -41,6 +41,7 @@ export * from "./router";
 export type {
   ActionFunction,
   ActionFunctionArgs,
+  DataRouteMatch,
   DataRouteObject,
   FormEncType,
   FormMethod,
@@ -59,9 +60,11 @@ export type {
 } from "./utils";
 
 export {
+  deferred,
   generatePath,
   getToPathname,
   invariant,
+  isDeferredError,
   isRouteErrorResponse,
   joinPaths,
   json,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -5,7 +5,6 @@ import {
   DataResult,
   DataRouteMatch,
   DataRouteObject,
-  deferred,
   DeferredData,
   DeferredResult,
   ErrorResult,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -651,6 +651,9 @@ export function createRouter(init: RouterInit): Router {
     // Toggle isRevalidationRequired so the next data load will call all loaders,
     // and mark us in a revalidating state
     isRevalidationRequired = true;
+    // Cancel all pending deferred on revalidations and mark cancelled routes
+    // for revalidation
+    cancelledDeferredRoutes.push(...cancelActiveDeferreds());
     updateState({ revalidation: "loading" });
 
     // If we're currently submitting an action, we don't need to start a new

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -885,6 +885,11 @@ export function createRouter(init: RouterInit): Router {
       };
     }
 
+    if (isDeferredResult(result)) {
+      // TODO: Do we plan to support this?
+      invariant(false, "deferred() is not supported in actions");
+    }
+
     return {
       pendingActionData: { [actionMatch.route.id]: result.data },
     };
@@ -1016,14 +1021,13 @@ export function createRouter(init: RouterInit): Router {
     );
 
     activeDeferreds.forEach((deferredCollection, routeId) => {
-      deferredCollection.subscribe((loaderDataKey) => {
+      deferredCollection.subscribe((loaderDataKey, data) => {
         updateState({
           loaderData: {
             ...state.loaderData,
             [routeId]: {
               ...state.loaderData[routeId],
-              [loaderDataKey]:
-                deferredCollection.deferreds.get(loaderDataKey)?.data,
+              [loaderDataKey]: data,
             },
           },
         });
@@ -1156,6 +1160,11 @@ export function createRouter(init: RouterInit): Router {
         },
       });
       return;
+    }
+
+    if (isDeferredResult(actionResult)) {
+      // TODO: Do we plan to support this?
+      invariant(false, "deferred() is not supported in actions");
     }
 
     // Start the data load for current matches, or the next location if we're
@@ -1340,6 +1349,11 @@ export function createRouter(init: RouterInit): Router {
         },
       });
       return;
+    }
+
+    if (isDeferredResult(result)) {
+      // TODO: implement
+      invariant(false, "deferred() is not supported in fetchers");
     }
 
     // Put the fetcher back into an idle state
@@ -1919,6 +1933,8 @@ function processLoaderData(
       // Should never get here, redirects should get processed above, but we
       // keep this to type narrow to a success result in the else
       invariant(false, "Unhandled fetcher revalidation redirect");
+    } else if (isDeferredResult(result)) {
+      invariant(false, "deferred() is not supported in fetchers");
     } else {
       let doneFetcher: FetcherStates["Idle"] = {
         state: "idle",

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1948,10 +1948,10 @@ async function processLoaderData(
   revalidatingFetchers: [string, string, DataRouteMatch][],
   fetcherResults: DataResult[],
   activeDeferreds: Map<string, DeferredData>
-): {
+): Promise<{
   loaderData: RouterState["loaderData"];
   errors: RouterState["errors"];
-} {
+}> {
   // Fill in loaderData/errors from our loaders
   let loaderData: RouterState["loaderData"] = {};
   let errors: RouterState["errors"] = null;
@@ -1994,7 +1994,7 @@ async function processLoaderData(
 
   // Process results from our revalidating fetchers
   for (let index = 0; index < revalidatingFetchers.length; index++) {
-    let [key, href, match] = revalidatingFetchers[index];
+    let [key, , match] = revalidatingFetchers[index];
     let result = fetcherResults[index];
 
     // Process fetcher non-redirect errors

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1,4 +1,3 @@
-import { SupportOptionRange } from "prettier";
 import type { Location, Path, To } from "./history";
 import { parsePath } from "./history";
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -31,7 +31,7 @@ export interface SuccessResult {
  */
 export interface DeferredResult {
   type: ResultType.deferred;
-  deferredCollection: DeferredCollection;
+  deferredData: DeferredData;
 }
 
 /**
@@ -842,7 +842,7 @@ export const json: JsonFunction = (data, init = {}) => {
   });
 };
 
-export class DeferredCollection {
+export class DeferredData {
   private pendingKeys: Set<string> = new Set<string>();
   private cancelled: boolean = false;
   private subscriber?: (key: string, data: any) => void = undefined;
@@ -908,7 +908,7 @@ export function isDeferredError(e: any): e is DeferredError {
 }
 
 export function deferred(data: Record<string, any>) {
-  return new DeferredCollection(data);
+  return new DeferredData(data);
 }
 
 export type RedirectFunction = (


### PR DESCRIPTION
* Add's `deferred()` support to `loader`'s in data routers
* Unit tests cover main usages
* Can be manually tested via the `examples/data-router` app using the `/deferred` and `/deferred/child` routes
  * probably need to run via `USE_SOURCE=true npm run dev`