### PR TITLE
[Docs]: Describing Layout route components structure

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -67,3 +67,4 @@
 - vijaypushkin
 - vikingviolinist
 - xcsnowcity
+- gowthamvbhat

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -654,6 +654,18 @@ Here's a part of our route config we haven't matched yet: `/privacy`. Let's look
 </Routes>
 ```
 
+A layout component should render an [outlet](#outlets) component for child route components to be mounted:
+```jsx
+function PageLayout() {
+  return (
+    <div>
+      <h1>Privacy and Terms<h1/>
+      <Outlet />
+    </div>
+  );
+}
+```
+
 And the resulting element tree rendered will be:
 
 ```jsx
@@ -664,7 +676,7 @@ And the resulting element tree rendered will be:
 </App>
 ```
 
-The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
+The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to reduce the repetition of layout components for multiple child routes. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
 
 <docs-error>You can do it like this, but we recommend using a layout route</docs-error>
 
@@ -682,17 +694,19 @@ The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-
   <Route
     path="/privacy"
     element={
-      <PageLayout>
+      <div>
+        <h1>Privacy and Terms<h1/>
         <Privacy />
-      </PageLayout>
+      </div>
     }
   />
   <Route
     path="/tos"
     element={
-      <PageLayout>
+      <div>
+        <h1>Privacy and Terms<h1/>
         <Tos />
-      </PageLayout>
+      </div>
     }
   />
   <Route path="contact-us" element={<Contact />} />

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -669,11 +669,9 @@ function PageLayout() {
 And the resulting element tree rendered will be:
 
 ```jsx
-<App>
-  <PageLayout>
-    <Privacy />
-  </PageLayout>
-</App>
+<PageLayout>
+ <Privacy />
+</PageLayout>
 ```
 
 The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to reduce the repetition of layout components for multiple child routes. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:


### PR DESCRIPTION
The current documentation for Layout routes gives a perception that they **wrap** around the child route components where as they require an **outlet** to render the child route components.

For example, we expect the layout component to be doing something like this:
```jsx
function Layout(props) {
  return (
    <div>
      {props.children}
    </div>
  );
}
```
where as it uses an outlet component to render the child route components:
```jsx
function Layout(props) {
  return (
    <div>
      <Outlet />
    </div>
  );
}
```

This has created some confusion in the community,
- [Stackoverflow Thread 1](https://stackoverflow.com/questions/70236929/react-router-v6-shared-layouts)
- [Stackoverflow Thread 2](https://stackoverflow.com/questions/70852993/children-wont-render-when-using-a-layout-in-reactjs)

This PR updates the docs to describe Layout component structure and the need for using an outlet component.