### PR TITLE
Fix broken tests from conflicting PRs

### DIFF
--- a/packages/react-router-dom/__tests__/trailing-slashes-test.tsx
+++ b/packages/react-router-dom/__tests__/trailing-slashes-test.tsx
@@ -126,10 +126,10 @@ describe("trailing slashes", () => {
                       index
                       element={
                         <>
-                          <Link to="../../.." />
-                          <Link to="../../../" />
-                          <Link to="../../child" />
-                          <Link to="../../child/" />
+                          <Link to="../.." />
+                          <Link to="../../" />
+                          <Link to="../../parent/child" />
+                          <Link to="../../parent/child/" />
                         </>
                       }
                     />
@@ -277,10 +277,10 @@ describe("trailing slashes", () => {
                       index
                       element={
                         <>
-                          <Link to="../../.." />
-                          <Link to="../../../" />
-                          <Link to="../../child" />
-                          <Link to="../../child/" />
+                          <Link to="../.." />
+                          <Link to="../../" />
+                          <Link to="../../parent/child" />
+                          <Link to="../../parent/child/" />
                         </>
                       }
                     />


### PR DESCRIPTION
We had parallel PRs for relative navigation (#8985) and trailing slashes (#8861), and these trailing slash tests relied on the previously broken relative nav behavior.  This fixes them.