### PR TITLE
chore: updated param of generate-path so its a string instead of int

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -67,3 +67,4 @@
 - vijaypushkin
 - vikingviolinist
 - xcsnowcity
+- MenouerBetty

--- a/docs/utils/generate-path.md
+++ b/docs/utils/generate-path.md
@@ -19,7 +19,7 @@ declare function generatePath(
 `generatePath` interpolates a set of params into a route path string with `:id` and `*` placeholders. This can be useful when you want to eliminate placeholders from a route path so it matches statically instead of using a dynamic parameter.
 
 ```tsx
-generatePath("/users/:id", { id: 42 }); // "/users/42"
+generatePath("/users/:id", { id: '42' }); // "/users/42"
 generatePath("/files/:type/*", {
   type: "img",
   "*": "cat.jpg",

--- a/docs/utils/generate-path.md
+++ b/docs/utils/generate-path.md
@@ -19,7 +19,7 @@ declare function generatePath(
 `generatePath` interpolates a set of params into a route path string with `:id` and `*` placeholders. This can be useful when you want to eliminate placeholders from a route path so it matches statically instead of using a dynamic parameter.
 
 ```tsx
-generatePath("/users/:id", { id: '42' }); // "/users/42"
+generatePath("/users/:id", { id: "42" }); // "/users/42"
 generatePath("/files/:type/*", {
   type: "img",
   "*": "cat.jpg",


### PR DESCRIPTION
as explained in this issue: https://github.com/remix-run/react-router/issues/9007 generatePath expects strings for params but are ints in the docs