### PR TITLE
fix docs typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,6 +3,7 @@
 - alexlbr
 - avipatel97
 - awreese
+- bavardage
 - bhbs
 - BrianT1414
 - brockross

--- a/docs/hooks/use-revalidator.md
+++ b/docs/hooks/use-revalidator.md
@@ -43,7 +43,7 @@ function useLivePageData() {
   let interval = useInterval(5000);
 
   useEffect(() => {
-    if (revalidate.state === "idle") {
+    if (revalidator.state === "idle") {
       revalidator.revalidate();
     }
   }, [interval]);


### PR DESCRIPTION
fix docs typo which uses `revalidate` instead of `revalidator`