### PR TITLE
fix: Handle fetcher 404s as normal boundary erorrs

### DIFF
--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1094,10 +1094,20 @@ export function createRouter(init: RouterInit): Router {
       );
     }
 
-    let matches = matchRoutes(dataRoutes, href);
-    invariant(matches, `No matches found for fetch url: ${href}`);
-
     if (fetchControllers.has(key)) abortFetcher(key);
+
+    let matches = matchRoutes(dataRoutes, href);
+    if (!matches) {
+      let boundaryMatch = findNearestBoundary(state.matches, routeId);
+      state.fetchers.set(key, IDLE_FETCHER);
+      updateState({
+        errors: {
+          [boundaryMatch.route.id]: new ErrorResponse(404, "Not Found", null),
+        },
+        fetchers: new Map(state.fetchers),
+      });
+      return;
+    }
 
     let match =
       matches[matches.length - 1].route.index &&


### PR DESCRIPTION
This used to just throw via an `invariant(matches)`, but we should handle this like any other error and bubble to the nearest boundary