### PR TITLE
ci: Simplify router rollup build and dist directory

### DIFF
--- a/.changeset/strong-bees-pay.md
+++ b/.changeset/strong-bees-pay.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+ci: simplify dist/ directory for CJS/ESM only

--- a/package.json
+++ b/package.json
@@ -99,11 +99,8 @@
     "typescript": "^4.7.3"
   },
   "filesize": {
-    "packages/router/dist/router.production.min.js": {
-      "none": "21 kB"
-    },
-    "packages/router/dist//umd/router.production.min.js": {
-      "none": "23 kB"
+    "packages/router/dist/router.js": {
+      "none": "77 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "10 kB"

--- a/packages/router/.eslintrc
+++ b/packages/router/.eslintrc
@@ -3,9 +3,6 @@
     "browser": true,
     "commonjs": true
   },
-  "globals": {
-    "__DEV__": true
-  },
   "rules": {
     "strict": 0
   }

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -426,10 +426,6 @@ export function createHashHistory(
 //#region UTILS
 ////////////////////////////////////////////////////////////////////////////////
 
-const readOnly: <T>(obj: T) => Readonly<T> = __DEV__
-  ? (obj) => Object.freeze(obj)
-  : (obj) => obj;
-
 function warning(cond: any, message: string) {
   if (!cond) {
     // eslint-disable-next-line no-console
@@ -469,8 +465,8 @@ export function createLocation(
   to: To,
   state: any = null,
   key?: string
-): Location {
-  return readOnly<Location>({
+): Readonly<Location> {
+  let location: Readonly<Location> = {
     pathname: typeof current === "string" ? current : current.pathname,
     search: "",
     hash: "",
@@ -481,7 +477,8 @@ export function createLocation(
     // But that's a pretty big refactor to the current test suite so going to
     // keep as is for the time being and just let any incoming keys take precedence
     key: (to as Location)?.key || key || createKey(),
-  });
+  };
+  return location;
 }
 
 /**

--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   transform: {
     "\\.[jt]sx?$": "./jest-transformer.js",
   },
-  globals: {
-    __DEV__: true,
-  },
   setupFiles: ["./__tests__/setup.ts"],
   moduleNameMapper: {
     "^@remix-run/router$": "<rootDir>/index.ts",

--- a/packages/router/node-main.js
+++ b/packages/router/node-main.js
@@ -1,7 +1,0 @@
-/* eslint-env node */
-
-if (process.env.NODE_ENV === "production") {
-  module.exports = require("./umd/router.production.min.js");
-} else {
-  module.exports = require("./umd/router.development.js");
-}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -20,9 +20,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "CHANGELOG.md",
-    "LICENSE.md",
-    "README.md"
+    "*.ts",
+    "CHANGELOG.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -15,9 +15,8 @@
   "license": "MIT",
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
-  "main": "./dist/main.js",
-  "unpkg": "./dist/umd/router.production.min.js",
-  "module": "./dist/index.js",
+  "main": "./dist/router.cjs.js",
+  "module": "./dist/router.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -3,8 +3,6 @@ const babel = require("@rollup/plugin-babel").default;
 const copy = require("rollup-plugin-copy");
 const extensions = require("rollup-plugin-extensions");
 const prettier = require("rollup-plugin-prettier");
-const replace = require("@rollup/plugin-replace");
-const { terser } = require("rollup-plugin-terser");
 const typescript = require("@rollup/plugin-typescript");
 const {
   createBanner,
@@ -13,185 +11,56 @@ const {
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
-module.exports = function rollup() {
+function getRollupConfig(format, filename, includeTypesAndCopy = false) {
   const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "router"
   );
 
-  // JS modules for bundlers
-  const modules = [
-    {
-      input: `${SOURCE_DIR}/index.ts`,
-      output: {
-        file: `${OUTPUT_DIR}/index.js`,
-        format: "esm",
-        sourcemap: !PRETTY,
-        banner: createBanner("@remix-run/router", version),
-      },
-      plugins: [
-        extensions({ extensions: [".ts"] }),
-        babel({
-          babelHelpers: "bundled",
-          exclude: /node_modules/,
-          presets: [
-            ["@babel/preset-env", { loose: true }],
-            "@babel/preset-typescript",
-          ],
-          plugins: ["babel-plugin-dev-expression"],
-          extensions: [".ts"],
-        }),
-        typescript({
-          tsconfig: path.join(__dirname, "tsconfig.json"),
-          exclude: ["__tests__"],
-          noEmitOnError: true,
-        }),
-        copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
-          verbose: true,
-        }),
-      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+  return {
+    input: `${SOURCE_DIR}/index.ts`,
+    output: {
+      file: `${OUTPUT_DIR}/${filename}`,
+      format,
+      sourcemap: !PRETTY,
+      banner: createBanner("@remix-run/router", version),
     },
-  ];
+    plugins: [
+      extensions({ extensions: [".ts"] }),
+      babel({
+        babelHelpers: "bundled",
+        exclude: /node_modules/,
+        presets: [
+          ["@babel/preset-env", { loose: true }],
+          "@babel/preset-typescript",
+        ],
+        extensions: [".ts"],
+      }),
+      ...(includeTypesAndCopy
+        ? [
+            typescript({
+              tsconfig: path.join(__dirname, "tsconfig.json"),
+              exclude: ["__tests__"],
+              noEmitOnError: true,
+            }),
+            copy({
+              targets: [
+                { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
+              ],
+              verbose: true,
+            }),
+          ]
+        : []),
+    ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
+  };
+}
 
-  // JS modules for <script type=module>
-  const webModules = [
-    {
-      input: `${SOURCE_DIR}/index.ts`,
-      output: {
-        file: `${OUTPUT_DIR}/router.development.js`,
-        format: "esm",
-        sourcemap: !PRETTY,
-        banner: createBanner("@remix-run/router", version),
-      },
-      plugins: [
-        extensions({ extensions: [".ts"] }),
-        babel({
-          babelHelpers: "bundled",
-          exclude: /node_modules/,
-          presets: ["@babel/preset-modules", "@babel/preset-typescript"],
-          plugins: ["babel-plugin-dev-expression"],
-          extensions: [".ts"],
-        }),
-        replace({
-          preventAssignment: true,
-          values: { "process.env.NODE_ENV": JSON.stringify("development") },
-        }),
-      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
-    },
-    {
-      input: `${SOURCE_DIR}/index.ts`,
-      output: {
-        file: `${OUTPUT_DIR}/router.production.min.js`,
-        format: "esm",
-        sourcemap: !PRETTY,
-        banner: createBanner("@remix-run/router", version),
-      },
-      plugins: [
-        extensions({ extensions: [".ts"] }),
-        babel({
-          babelHelpers: "bundled",
-          exclude: /node_modules/,
-          presets: [
-            [
-              "@babel/preset-modules",
-              {
-                // Don't spoof `.name` for Arrow Functions, which breaks when minified anyway.
-                loose: true,
-              },
-            ],
-            "@babel/preset-typescript",
-          ],
-          plugins: ["babel-plugin-dev-expression"],
-          extensions: [".ts"],
-        }),
-        replace({
-          preventAssignment: true,
-          values: { "process.env.NODE_ENV": JSON.stringify("production") },
-        }),
-        // compiler(),
-        terser({ ecma: 8, safari10: true }),
-      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
-    },
+module.exports = function rollup() {
+  return [
+    getRollupConfig("esm", "router.js", true),
+    getRollupConfig("cjs", "router.cjs.js", false),
   ];
-
-  // UMD modules for <script> tags and CommonJS (node)
-  const globals = [
-    {
-      input: `${SOURCE_DIR}/index.ts`,
-      output: {
-        file: `${OUTPUT_DIR}/umd/router.development.js`,
-        format: "umd",
-        sourcemap: !PRETTY,
-        banner: createBanner("@remix-run/router", version),
-        name: "Router",
-      },
-      plugins: [
-        extensions({ extensions: [".ts"] }),
-        babel({
-          babelHelpers: "bundled",
-          exclude: /node_modules/,
-          presets: [
-            ["@babel/preset-env", { loose: true }],
-            "@babel/preset-typescript",
-          ],
-          plugins: ["babel-plugin-dev-expression"],
-          extensions: [".ts"],
-        }),
-        replace({
-          preventAssignment: true,
-          values: { "process.env.NODE_ENV": JSON.stringify("development") },
-        }),
-      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
-    },
-    {
-      input: `${SOURCE_DIR}/index.ts`,
-      output: {
-        file: `${OUTPUT_DIR}/umd/router.production.min.js`,
-        format: "umd",
-        sourcemap: !PRETTY,
-        banner: createBanner("@remix-run/router", version),
-        name: "Router",
-      },
-      plugins: [
-        extensions({ extensions: [".ts"] }),
-        babel({
-          babelHelpers: "bundled",
-          exclude: /node_modules/,
-          presets: [
-            ["@babel/preset-env", { loose: true }],
-            "@babel/preset-typescript",
-          ],
-          plugins: ["babel-plugin-dev-expression"],
-          extensions: [".ts"],
-        }),
-        replace({
-          preventAssignment: true,
-          values: { "process.env.NODE_ENV": JSON.stringify("production") },
-        }),
-        // compiler(),
-        terser(),
-      ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
-    },
-  ];
-
-  // Node entry points
-  const node = [
-    {
-      input: `${SOURCE_DIR}/node-main.js`,
-      output: {
-        file: `${OUTPUT_DIR}/main.js`,
-        format: "cjs",
-        banner: createBanner("@remix-run/router", version),
-      },
-      plugins: [].concat(PRETTY ? prettier({ parser: "babel" }) : []),
-    },
-  ];
-
-  return [...modules, ...webModules, ...globals, ...node];
 };
 
 /**

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -872,13 +872,11 @@ export function createRouter(init: RouterInit): Router {
 
     let actionMatch = matches.slice(-1)[0];
     if (!actionMatch.route.action) {
-      if (__DEV__) {
-        console.warn(
-          "You're trying to submit to a route that does not have an action.  To " +
-            "fix this, please add an `action` function to the route for " +
-            `[${createHref(location)}]`
-        );
-      }
+      console.warn(
+        "You're trying to submit to a route that does not have an action.  To " +
+          "fix this, please add an `action` function to the route for " +
+          `[${createHref(location)}]`
+      );
       result = {
         type: ResultType.error,
         error: new ErrorResponse(


### PR DESCRIPTION
Simplify the `@remix-run/router` build down to remove all the various builds and just ship source code + ESM/CJS/d.ts files

```
package.json
index.ts         # TS source code for deno
dist/
  index.d.ts     ## Types for IDEs
  router.js      ## ESM build
  router.cjs.js  ## CJS build
```

To test, you can do the following:


```bash
cd packages/router
rm -rf dist
npx rollup -c
npm pack
tar -xzf remix-run-router-0.2.0-pre.3.tgz
ls package/

## cleanup artifacts
rm -rf package/
rm remix-run-router-0.2.0-pre.3.tgz
```