### PR TITLE
ci: prevent duplicate runs for Pull Requests

### DIFF
--- a/.changeset/four-lobsters-crash.md
+++ b/.changeset/four-lobsters-crash.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+ci: prevent duplicate runs for Pull Requests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ on:
       - "docs/**"
       - "**/README.md"
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     paths-ignore:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,19 @@
 name: test
+
 on:
   push:
     branches:
-      - "**"
+      - main
+      - dev
     tags-ignore:
       - v*
     paths-ignore:
       - "docs/**"
       - "**/README.md"
   pull_request:
-    types: [opened, synchronize]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   test:


### PR DESCRIPTION
prevent duplicate runs for Pull Requests

the real fix here was specifying which branches should trigger the "push" event, but also normalizing the action between react-router and remix