### PR TITLE
ci: add eslint-plugin-jest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,12 @@
   "extends": ["react-app"],
   "rules": {
     "import/first": 0
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/__tests__/**"],
+      "plugins": ["jest"],
+      "extends": ["plugin:jest/recommended"]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-flowtype": "^5.8.0",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-jest": "^26.5.3",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "next",

--- a/packages/react-router-dom/__tests__/DataBrowserRouter-test.tsx
+++ b/packages/react-router-dom/__tests__/DataBrowserRouter-test.tsx
@@ -47,7 +47,7 @@ function testDomRouter(
   TestDataRouter: typeof DataBrowserRouter,
   getWindow: (initialUrl: string, isHash?: boolean) => Window
 ) {
-  describe(name, () => {
+  describe(`Router: ${name}`, () => {
     let consoleWarn: jest.SpyInstance;
     let consoleError: jest.SpyInstance;
     beforeEach(() => {
@@ -316,8 +316,10 @@ function testDomRouter(
 
       function assertPathname(pathname) {
         if (name === "<DataHashRouter>") {
+          // eslint-disable-next-line jest/no-conditional-expect
           expect(testWindow.location.hash).toEqual("#" + pathname);
         } else {
+          // eslint-disable-next-line jest/no-conditional-expect
           expect(testWindow.location.pathname).toEqual(pathname);
         }
       }

--- a/packages/react-router-dom/__tests__/trailing-slashes-test.tsx
+++ b/packages/react-router-dom/__tests__/trailing-slashes-test.tsx
@@ -334,7 +334,7 @@ describe("trailing slashes", () => {
     describe("with a basename that does not contain a trailing slash", () => {
       test("never includes trailing slashes on root links (/)", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
         act(() => {
@@ -353,7 +353,7 @@ describe("trailing slashes", () => {
 
       test("never includes trailing slashes on root links (../)", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
         act(() => {
@@ -372,7 +372,7 @@ describe("trailing slashes", () => {
 
       test("allows non-root links to leave off trailing slashes", () => {
         let window = getWindowImpl("/foo");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo");
 
@@ -393,7 +393,7 @@ describe("trailing slashes", () => {
 
       test("allows non-root links to include trailing slashes", () => {
         let window = getWindowImpl("/foo");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo");
 
@@ -416,7 +416,7 @@ describe("trailing slashes", () => {
     describe("with a basename that contains a trailing slash", () => {
       test("always includes trailing slashes on root links (/)", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
         act(() => {
@@ -435,7 +435,7 @@ describe("trailing slashes", () => {
 
       test("always includes trailing slashes on root links (../)", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
         act(() => {
@@ -454,7 +454,7 @@ describe("trailing slashes", () => {
 
       test("allows non-root links to leave off trailing slashes", () => {
         let window = getWindowImpl("/foo/");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/");
 
@@ -475,7 +475,7 @@ describe("trailing slashes", () => {
 
       test("allows non-root links to include trailing slashes", () => {
         let window = getWindowImpl("/foo/");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/");
 
@@ -498,7 +498,7 @@ describe("trailing slashes", () => {
     describe("empty string paths", () => {
       it("should not add trailing slashes", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
@@ -519,7 +519,7 @@ describe("trailing slashes", () => {
 
       it("should preserve trailing slash", () => {
         let window = getWindowImpl("/foo/bar/");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/bar/");
 
@@ -542,7 +542,7 @@ describe("trailing slashes", () => {
     describe("current location '.' paths", () => {
       it("should not add trailing slash", () => {
         let window = getWindowImpl("/foo/bar");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/bar");
 
@@ -570,7 +570,7 @@ describe("trailing slashes", () => {
 
       it("should preserve trailing slash", () => {
         let window = getWindowImpl("/foo/bar/");
-        spyOn(window.history, "pushState").and.callThrough();
+        jest.spyOn(window.history, "pushState");
 
         expect(window.location.href).toBe("https://remix.run/foo/bar/");
 
@@ -601,7 +601,7 @@ describe("trailing slashes", () => {
   describe("when using setSearchParams", () => {
     it("should not include trailing slash via useSearchParams", () => {
       let window = getWindowImpl("/foo");
-      spyOn(window.history, "pushState").and.callThrough();
+      jest.spyOn(window.history, "pushState");
 
       expect(window.location.href).toBe("https://remix.run/foo");
 
@@ -630,7 +630,7 @@ describe("trailing slashes", () => {
 
     it("should include trailing slash via useSearchParams when basename has one", () => {
       let window = getWindowImpl("/foo/");
-      spyOn(window.history, "pushState").and.callThrough();
+      jest.spyOn(window.history, "pushState");
 
       expect(window.location.href).toBe("https://remix.run/foo/");
 

--- a/packages/router/__tests__/browser-test.ts
+++ b/packages/router/__tests__/browser-test.ts
@@ -2,6 +2,8 @@
  * @jest-environment ./__tests__/custom-environment.js
  */
 
+/* eslint-disable jest/expect-expect */
+
 import { JSDOM } from "jsdom";
 
 import type { BrowserHistory } from "@remix-run/router";

--- a/packages/router/__tests__/hash-test.ts
+++ b/packages/router/__tests__/hash-test.ts
@@ -2,6 +2,8 @@
  * @jest-environment ./__tests__/custom-environment.js
  */
 
+/* eslint-disable jest/expect-expect */
+
 import { JSDOM } from "jsdom";
 
 import type { HashHistory } from "@remix-run/router";

--- a/packages/router/__tests__/memory-test.ts
+++ b/packages/router/__tests__/memory-test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable jest/expect-expect */
+
 import type { MemoryHistory } from "@remix-run/router";
 import { createMemoryHistory } from "@remix-run/router";
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/valid-title */
 import type {
   ActionFunction,
   DataRouteObject,
@@ -101,12 +102,12 @@ async function tick() {
   await new Promise((r) => setImmediate(r));
 }
 
-export function invariant(value: boolean, message?: string): asserts value;
-export function invariant<T>(
+function invariant(value: boolean, message?: string): asserts value;
+function invariant<T>(
   value: T | null | undefined,
   message?: string
 ): asserts value is T;
-export function invariant(value: any, message?: string) {
+function invariant(value: any, message?: string) {
   if (value === false || value === null || typeof value === "undefined") {
     console.warn("Test invariant failed:", message);
     throw new Error(message);
@@ -769,7 +770,9 @@ beforeEach(() => {
 afterEach(() => {
   // Cleanup any routers created using setup()
   if (currentRouter) {
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(currentRouter._internalFetchControllers.size).toBe(0);
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(currentRouter._internalActiveDeferreds.size).toBe(0);
   }
   currentRouter?.dispose();
@@ -1009,6 +1012,10 @@ describe("a router", () => {
           },
         })
       );
+      expect(t.router.state.loaderData).toMatchObject({
+        root: "ROOT",
+        foo: { key: "value" },
+      });
     });
 
     it("unwraps non-redirect json Responses (json helper)", async () => {
@@ -3072,12 +3079,7 @@ describe("a router", () => {
           },
         });
       });
-    });
 
-    describe(`
-      A) POST /foo |--|--X
-      B) GET  /bar       |-----O
-    `, () => {
       it("forces all loaders to revalidate on interrupted submissionRedirect", async () => {
         let t = initializeTmTest();
         let A = await t.navigate("/foo", {
@@ -6613,12 +6615,7 @@ describe("a router", () => {
           expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
           expect(t.router.state.fetchers.get(key)?.data).toBe("A ACTION");
         });
-      });
 
-      describe(`
-        A) fetch POST /foo |--|--X
-        B) nav   GET  /bar       |-----O
-      `, () => {
         it("forces all loaders to revalidate on interrupted fetcher submissionRedirect", async () => {
           let key = "key";
           let t = initializeTmTest();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,7 +2288,7 @@
     "@types/parse5" "*"
     "@types/tough-cookie" "*"
 
-"@types/json-schema@^7.0.7":
+"@types/json-schema@^7.0.7", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -2480,10 +2480,23 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.30.6.tgz#ce1b49ff5ce47f55518d63dbe8fc9181ddbd1a33"
+  integrity sha512-Hkq5PhLgtVoW1obkqYH0i4iELctEKixkhWLPTYs55doGUKCASvkjOXOd/pisVeLdO24ZX9D6yymJ/twqpJiG3g==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.30.6.tgz#86369d0a7af8c67024115ac1da3e8fb2d38907e1"
+  integrity sha512-HdnP8HioL1F7CwVmT4RaaMX57RrfqsOMclZc08wGMiDYJBsLGBM7JwXM4cZJmbWLzIR/pXg1kkrBBVpxTOwfUg==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -2498,6 +2511,31 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.30.6.tgz#a84a0d6a486f9b54042da1de3d671a2c9f14484e"
+  integrity sha512-Z7TgPoeYUm06smfEfYF0RBkpF8csMyVnqQbLYiGgmUSTaSXTP57bt8f0UFXstbGxKIreTwQCujtaH0LY9w9B+A==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/visitor-keys" "5.30.6"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@^5.10.0":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.30.6.tgz#1de2da14f678e7d187daa6f2e4cdb558ed0609dc"
+  integrity sha512-xFBLc/esUbLOJLk9jKv0E9gD/OH966M40aY9jJ8GiqpSkP2xOV908cokJqqhVd85WoIvHVHYXxSFE4cCSDzVvA==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.30.6"
+    "@typescript-eslint/types" "5.30.6"
+    "@typescript-eslint/typescript-estree" "5.30.6"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
@@ -2505,6 +2543,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.30.6":
+  version "5.30.6"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.30.6.tgz#94dd10bb481c8083378d24de1742a14b38a2678c"
+  integrity sha512-41OiCjdL2mCaSDi2SvYbzFLlqqlm5v1ZW9Ym55wXKL/Rx6OOB1IbuFGo71Fj6Xy90gJDFTlgOS+vbmtGHPTQQA==
+  dependencies:
+    "@typescript-eslint/types" "5.30.6"
+    eslint-visitor-keys "^3.3.0"
 
 "@ungap/url-search-params@^0.1.4":
   version "0.1.4"
@@ -3985,7 +4031,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -4405,6 +4451,13 @@ eslint-plugin-import@^2.23.4:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-jest@^26.5.3:
+  version "26.5.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.5.3.tgz#a3ceeaf4a757878342b8b00eca92379b246e5505"
+  integrity sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
 eslint-plugin-jsx-a11y@^6.4.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz#cdbf2df901040ca140b6ec14715c988889c2a6d8"
@@ -4479,6 +4532,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^7.30.0:
   version "7.32.0"
@@ -5172,7 +5230,7 @@ globby@10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.0, globby@^11.0.3:
+globby@^11.0.0, globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -8770,7 +8828,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==


### PR DESCRIPTION
Adds [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) to the codebase, primarily to error on focused tests.  But the recommended set of rules exposed a few other things we can cleanup