### PR TITLE
docs: fix scroll position of History Object

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -72,3 +72,4 @@
 - vijaypushkin
 - vikingviolinist
 - xcsnowcity
+- yuleicul

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -35,7 +35,7 @@ Here are some words we use a lot when we talk about React Router. The rest of th
 
 - <a id="csr">**Client Side Routing (CSR)**</a> - A plain HTML document can link to other documents and the browser handles the [history stack](#history-stack) itself. Client Side Routing enables developers to manipulate the browser history stack without making a document request to the server.
 
-- <a id="history-object">**History**</a> - An object that allows React Router to subscribe to changes in the [URL](#url) as well as providing APIs to manipulate the browser [history stack](#history-stack) programmatically.
+- <a id="history">**History**</a> - An object that allows React Router to subscribe to changes in the [URL](#url) as well as providing APIs to manipulate the browser [history stack](#history-stack) programmatically.
 
 - <a id="history-action">**History Action**</a> - One of `POP`, `PUSH`, or `REPLACE`. Users can arrive at a [URL](#url) for one of these three reasons. A push when a new entry is added to the history stack (typically a link click or the programmer forced a navigation). A replace is similar except it replaces the current entry on the stack instead of pushing a new one. Finally, a pop happens when the user clicks the back or forward buttons in the browser chrome.
 


### PR DESCRIPTION
## Bug descriptions
![image](https://user-images.githubusercontent.com/27288153/179196704-b7fcdb61-b76e-4c34-8689-d731d915c1cd.png)
When I click `History Object` in the nav bar, the scroll position is as the screenshot above.

## What I expect
![image](https://user-images.githubusercontent.com/27288153/179197665-3e988512-8626-4e4c-a2b0-37e9179cbb65.png)
When I click `History Object` in the nav bar, the scroll position is on the title of History Object.

## What did I do
I change the `id` of `History` in Chapter Definitions to `history`, which ensures that there is just one `#history` and one `#history-object` on the current page.

