### PR TITLE
feat: improve generatePath arg type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -70,6 +70,7 @@
 - timdorr
 - tkindy
 - turansky
+- tyankatsu0105
 - underager
 - vijaypushkin
 - vikingviolinist

--- a/docs/hooks/use-match.md
+++ b/docs/hooks/use-match.md
@@ -8,8 +8,8 @@ title: useMatch
   <summary>Type declaration</summary>
 
 ```tsx
-declare function useMatch<ParamKey extends string = string>(
-  pattern: PathPattern | string
+declare function useMatch<ParamKey extends ParamParseKey<Path>, Path extends string>(
+  pattern: PathPattern<Path> | Path
 ): PathMatch<ParamKey> | null;
 ```
 

--- a/docs/utils/generate-path.md
+++ b/docs/utils/generate-path.md
@@ -8,9 +8,26 @@ title: generatePath
   <summary>Type declaration</summary>
 
 ```tsx
-declare function generatePath(
-  path: string,
-  params?: Params
+ type PathParams<
+ Path extends string
+> = Path extends `:${infer Param}/${infer Rest}`
+   ? Param | PathParams<Rest>
+   : Path extends `:${infer Param}`
+     ? Param
+     : Path extends `${any}:${infer Param}`
+         ? PathParams<`:${Param}`>
+         : Path extends `${any}/*`
+           ? "*"
+           : Path extends "*"
+             ? "*" 
+             : never
+
+
+declare function generatePath<Path extends string>(
+  path: Path,
+  params?: {
+    [key in PathParams<Path> | (string & {})]: string
+  }
 ): string;
 ```
 

--- a/docs/utils/generate-path.md
+++ b/docs/utils/generate-path.md
@@ -26,7 +26,7 @@ title: generatePath
 declare function generatePath<Path extends string>(
   path: Path,
   params?: {
-    [key in PathParams<Path> | (string & {})]: string
+    [key in PathParams<Path>]: string
   }
 ): string;
 ```

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -170,14 +170,19 @@ type Star = "*"
  type PathParam<
  Path extends string
 > = 
+    // Check path string starts with slash and a param string.
     Path extends `:${infer Param}/${infer Rest}`
       ? Param | PathParam<Rest>
+      // Check path string is a param string.
       : Path extends `:${infer Param}`
         ? Param
-        : Path extends `${any}:${infer Param}`
+        // Check path string ends with slash and a param string.
+        : Path extends `${any}/:${infer Param}`
             ? PathParam<`:${Param}`>
+            // Check path string ends with slash and a star.
             : Path extends `${any}/${Star}`
               ? Star
+              // Check string is star.
               : Path extends Star
                 ? Star 
                 : never

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -465,15 +465,19 @@ function matchRouteBranch<
  * @see https://reactrouter.com/docs/en/v6/utils/generate-path
  */
 export function generatePath<Path extends string>(path: Path, params: {
-  [key in PathParams<Path> | (string & {})]: string
+  [key in PathParams<Path>]: string
 } = {} as any): string {
   return path
-    .replace(/:(\w+)/g, (_, key) => {
+    .replace(/:(\w+)/g, (_, key: PathParams<Path>) => {
       invariant(params[key] != null, `Missing ":${key}" param`);
       return params[key]!;
     })
     .replace(/\/*\*$/, (_) =>
-      params["*"] == null ? "" : params["*"].replace(/^\/*/, "/")
+      {
+        const star = "*" as PathParams<Path>
+        
+        return params[star] == null ? "" : params[star].replace(/^\/*/, "/")
+      }
     );
 }
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -159,51 +159,35 @@ export interface DataRouteObject extends RouteObject {
   id: string;
 }
 
-type ParamParseFailed = { failed: true };
-
-type ParamParseSegment<Segment extends string> =
-  // Check here if there exists a forward slash in the string.
-  Segment extends `${infer LeftSegment}/${infer RightSegment}`
-    ? // If there is a forward slash, then attempt to parse each side of the
-      // forward slash.
-      ParamParseSegment<LeftSegment> extends infer LeftResult
-      ? ParamParseSegment<RightSegment> extends infer RightResult
-        ? LeftResult extends string
-          ? // If the left side is successfully parsed as a param, then check if
-            // the right side can be successfully parsed as well. If both sides
-            // can be parsed, then the result is a union of the two sides
-            // (read: "foo" | "bar").
-            RightResult extends string
-            ? LeftResult | RightResult
-            : LeftResult
-          : // If the left side is not successfully parsed as a param, then check
-          // if only the right side can be successfully parse as a param. If it
-          // can, then the result is just right, else it's a failure.
-          RightResult extends string
-          ? RightResult
-          : ParamParseFailed
-        : ParamParseFailed
-      : // If the left side didn't parse into a param, then just check the right
-      // side.
-      ParamParseSegment<RightSegment> extends infer RightResult
-      ? RightResult extends string
-        ? RightResult
-        : ParamParseFailed
-      : ParamParseFailed
-    : // If there's no forward slash, then check if this segment starts with a
-    // colon. If it does, then this is a dynamic segment, so the result is
-    // just the remainder of the string, optionally prefixed with another string.
-    // Otherwise, it's a failure.
-    Segment extends `${string}:${infer Remaining}`
-    ? Remaining
-    : ParamParseFailed;
+type Star = "*"
+/**
+ * @private
+ * Return string union from path string.
+ * @example
+ * PathParam<"/path/:a/:b"> // "a" | "b"
+ * PathParam<"/path/:a/:b/*"> // "a" | "b" | "*"
+ */
+ type PathParam<
+ Path extends string
+> = 
+    Path extends `:${infer Param}/${infer Rest}`
+      ? Param | PathParam<Rest>
+      : Path extends `:${infer Param}`
+        ? Param
+        : Path extends `${any}:${infer Param}`
+            ? PathParam<`:${Param}`>
+            : Path extends `${any}/${Star}`
+              ? Star
+              : Path extends Star
+                ? Star 
+                : never
 
 // Attempt to parse the given string segment. If it fails, then just return the
 // plain string type as a default fallback. Otherwise return the union of the
 // parsed string literals that were referenced as dynamic segments in the route.
 export type ParamParseKey<Segment extends string> =
-  ParamParseSegment<Segment> extends string
-    ? ParamParseSegment<Segment>
+  [PathParam<Segment>] extends [never]
+    ? PathParam<Segment>
     : string;
 
 /**
@@ -440,24 +424,6 @@ function matchRouteBranch<
 
   return matches;
 }
-
-/**
- * @private
- * Parameters in the path
- */
- type PathParam<
- Path extends string
-> = Path extends `:${infer Param}/${infer Rest}`
-   ? Param | PathParam<Rest>
-   : Path extends `:${infer Param}`
-     ? Param
-     : Path extends `${any}:${infer Param}`
-         ? PathParam<`:${Param}`>
-         : Path extends `${any}/*`
-           ? "*"
-           : Path extends "*"
-             ? "*" 
-             : never
 
 /**
  * Returns a path with params interpolated.

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -442,11 +442,31 @@ function matchRouteBranch<
 }
 
 /**
+ * @private
+ * Parameters in the path
+ */
+ type PathParams<
+ Path extends string
+> = Path extends `:${infer Param}/${infer Rest}`
+   ? Param | PathParams<Rest>
+   : Path extends `:${infer Param}`
+     ? Param
+     : Path extends `${any}:${infer Param}`
+         ? PathParams<`:${Param}`>
+         : Path extends `${any}/*`
+           ? "*"
+           : Path extends "*"
+             ? "*" 
+             : never
+
+/**
  * Returns a path with params interpolated.
  *
  * @see https://reactrouter.com/docs/en/v6/utils/generate-path
  */
-export function generatePath(path: string, params: Params = {}): string {
+export function generatePath<Path extends string>(path: Path, params: {
+  [key in PathParams<Path> | (string & {})]: string
+} = {} as any): string {
   return path
     .replace(/:(\w+)/g, (_, key) => {
       invariant(params[key] != null, `Missing ":${key}" param`);

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -445,14 +445,14 @@ function matchRouteBranch<
  * @private
  * Parameters in the path
  */
- type PathParams<
+ type PathParam<
  Path extends string
 > = Path extends `:${infer Param}/${infer Rest}`
-   ? Param | PathParams<Rest>
+   ? Param | PathParam<Rest>
    : Path extends `:${infer Param}`
      ? Param
      : Path extends `${any}:${infer Param}`
-         ? PathParams<`:${Param}`>
+         ? PathParam<`:${Param}`>
          : Path extends `${any}/*`
            ? "*"
            : Path extends "*"
@@ -465,16 +465,16 @@ function matchRouteBranch<
  * @see https://reactrouter.com/docs/en/v6/utils/generate-path
  */
 export function generatePath<Path extends string>(path: Path, params: {
-  [key in PathParams<Path>]: string
+  [key in PathParam<Path>]: string
 } = {} as any): string {
   return path
-    .replace(/:(\w+)/g, (_, key: PathParams<Path>) => {
+    .replace(/:(\w+)/g, (_, key: PathParam<Path>) => {
       invariant(params[key] != null, `Missing ":${key}" param`);
       return params[key]!;
     })
     .replace(/\/*\*$/, (_) =>
       {
-        const star = "*" as PathParams<Path>
+        const star = "*" as PathParam<Path>
         
         return params[star] == null ? "" : params[star].replace(/^\/*/, "/")
       }


### PR DESCRIPTION
# What
This PR improves the `params` type of `generatePath`'s argument.

```ts
type Star = "*"
type PathParam<
 Path extends string
> = Path extends `:${infer Param}/${infer Rest}`
   ? Param | PathParam<Rest>
   : Path extends `:${infer Param}`
     ? Param
     : Path extends `${any}/:${infer Param}`
         ? PathParam<`:${Param}`>
         : Path extends `${any}/${Star}`
           ? Star
           : Path extends Star
             ? Star 
             : never
export function generatePath<Path extends string>(path: Path, params: {
  [key in PathParam<Path>]: string
} = {} as any): string {
  return ""
}

generatePath("a", {}) // {}
//^?

generatePath(":a", {})// {"a": string;}
//^?

generatePath("/:a", {})// {"a": string;}
//^?

generatePath("/:a/b", {})// {"a": string;}
//^?

generatePath("/:a/:b", {})// {"a": string; "b": string;}
//^?

generatePath("/a/:b", {})// {"b": string;}
//^?

generatePath("/:a/b/:c", {})// {"a": string; "c": string;}
//^?

generatePath("*", {})// {"*": string;}
//^?

generatePath("/*", {})// {"*": string;}
//^?

generatePath("/a/*/b", {})// {}
//^?

generatePath("/a/b/*", {})// {"*": string;}
//^?
```

You can try on [TS Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAysCGAnKBeKAiAVOgUKSUACvMABbGLwC2APDkSaVBAB7AQB2AJgM5Q-BEASw4BzHAD5UDMszadeUAAYAuACQBvEQDMIyCtQC+Aek069UAEoQBhpfShQA-A0pUoAHxnkk1GtYEJBygVbzl2bj5VMw5dfV8qO2DHFwMqZJCw1gjFJU14DhATdS1YizSkxyrq1MY0mmiNCqUg6rbQ4llshSj8wpNNOCRKtraXIcQM0Y7GcJ7YBEnR5fHFqCnl0I4IADc9HFYwAHtEYChtAFcOAGNgISOOKFFOPRIITtIaD7nI-kERUQSAAUYEYMzIABooKC3DxQhoHABtADWEBAUBE3nqHwkAF1QgJhGIcIZpBpSfA+AUQABKAn-MRQBGORAQYAXRCPdC4Qw4HDPbaUdgfIHoUhHZ4qeDS9BQ8k0qDGYxM3lKgB6Tj5AtewsYoqlspVNKVTPQ8HQ9KJogA3KrjBqtS8he89ehjAa5YZjcqNGaLX8rbacOrNfynW8RW6pcYAEaG+Um33my0AoMhx2CiOu93wd1xz3e03JgOpjBxlNiNP20Pa52R4y5lT5o2J9DlkuVu0OsOZ3VkUU52Pu67xr2t4uE0voEcVm1dmvhvukUXYAut7Czqvd2tZ-tu1ctn1Yf2TzvB6sZnUuvcN4yYWOjwvk8-bxfX5du3Mxu+P9cnhlzi+oZAA)