### PR TITLE
docs: add code splitting example to examples/data-router

### DIFF
--- a/examples/data-router/src/code-splitting-component.tsx
+++ b/examples/data-router/src/code-splitting-component.tsx
@@ -1,0 +1,6 @@
+import { useLoaderData } from "react-router-dom";
+
+export default function CodeSplitting() {
+  let data = useLoaderData();
+  return <p>Code Splitting Loader Data Value: {data.value}</p>;
+}

--- a/examples/data-router/src/code-splitting-loader.ts
+++ b/examples/data-router/src/code-splitting-loader.ts
@@ -1,0 +1,10 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+
+import { sleep } from "./routes";
+
+export default async function loader({ request }: LoaderFunctionArgs) {
+  await sleep(500);
+  return {
+    value: Math.round(Math.random() * 100),
+  };
+}

--- a/examples/data-router/src/code-splitting.tsx
+++ b/examples/data-router/src/code-splitting.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import type { LoaderFunctionArgs } from "react-router-dom";
+
+// By default, we'll render the component via React.lazy().  We'll overwrite
+// this with a non-React.lazy() version if and only if the component chunk
+// finishes before the loader chunk + loader execution
+let CodeSplittingActual = React.lazy(
+  () => import("./code-splitting-component")
+);
+
+export async function codeSplittingLoader(args: LoaderFunctionArgs) {
+  let componentLoadController = new AbortController();
+
+  /*
+   * Kick off our component chunk load but don't await it
+   * This allows us to parallelize the component download with loader
+   * download and execution.
+   *
+   * Normal React.lazy()
+   *
+   *   load loader.ts     execute loader()   load component.ts
+   *   -----------------> -----------------> ----------------->
+   *
+   * Kicking off the component load _in_ your loader()
+   *
+   *   load loader.ts     execute loader()
+   *   -----------------> ----------------->
+   *                      load component.ts
+   *                      ----------------->
+   *
+   * Kicking off the component load _alongside_ your loader.ts chunk load
+   *
+   *   load loader.ts     execute loader()
+   *   -----------------> ----------------->
+   *   load component.ts
+   *   ----------------->
+   */
+  import("./code-splitting-component").then(
+    (componentModule) => {
+      if (!componentLoadController.signal.aborted) {
+        // We loaded the component _before_ our loader finished, so we can
+        // blow away React.lazy and just use it directly.  This avoids the
+        // flicker we'd otherwise get since React.lazy would need to throw
+        // the already-resolved promise up to the Suspense boundary one time
+        // to get the resolved value
+        CodeSplittingActual = componentModule.default;
+      }
+    },
+    () => {}
+  );
+
+  try {
+    // Load our loader chunk and call the loader
+    let { default: loader } = await import("./code-splitting-loader");
+    return await loader(args);
+  } finally {
+    // Abort the controller when our loader finishes.  If we finish before the
+    // component chunk loads, this will ensure we still use React.lazy to
+    // render the component since it's not yet available.  If the component
+    // chunk finishes first, it will have overwritten Lazy with the legit
+    // component so we'll never see the suspense fallback
+    componentLoadController.abort();
+  }
+}
+
+export function CodeSplittingWrapper() {
+  console.log(CodeSplittingActual);
+  return (
+    <React.Suspense fallback={<p>Loading component...</p>}>
+      <CodeSplittingActual />
+    </React.Suspense>
+  );
+}

--- a/examples/data-router/src/main.tsx
+++ b/examples/data-router/src/main.tsx
@@ -21,6 +21,7 @@ import {
   sleep,
 } from "./routes";
 import "./index.css";
+import { codeSplittingLoader, CodeSplittingWrapper } from "./code-splitting";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
@@ -53,6 +54,11 @@ ReactDOM.createRoot(document.getElementById("root")).render(
         >
           <Route path=":id" loader={todoLoader} element={<Todo />} />
         </Route>
+        <Route
+          path="code-splitting"
+          loader={codeSplittingLoader}
+          element={<CodeSplittingWrapper />}
+        />
       </Route>
     </DataBrowserRouter>
   </React.StrictMode>

--- a/examples/data-router/src/routes.tsx
+++ b/examples/data-router/src/routes.tsx
@@ -49,6 +49,8 @@ export function Layout() {
         &nbsp;|&nbsp;
         <Link to="/long-load">Long Load</Link>
         &nbsp;|&nbsp;
+        <Link to="/code-splitting">Code Splitting</Link>
+        &nbsp;|&nbsp;
         <Link to="/404">404 Link</Link>
         &nbsp;&nbsp;
         <button onClick={() => revalidate()}>Revalidate</button>


### PR DESCRIPTION
This has come up a few times in discord so I wanted to add an example of how this can be handled.  There's various ways to do this in increasing levels of complexity to achieve more parallelization and avoid CLS, I think the approach in this PR falls at the far end of that spectrum.  We may want to consider including examples of both the simple and complex ways?

Whatever we land on should be copied to https://beta.reactrouter.com/en/dev/guides/code-splitting as well

In loose order of simple to complex:

1. The _simplest_ approach is what [Ryan originally tweeted](https://twitter.com/ryanflorence/status/1531299852876849153)
   * The downside here is that the loader and component are in the same file, so there's no parallelization since the loader can't execute until the entire component+loader chunk has downloaded so you get:
     * `loader-and-component.ts -> loader fetch()`
   * You end up delaying rendering longer, but guarantee "no" fallback (although suspense will flicker it for one cycle) 
2. In order to parallelize these you can split them into their own files (`views/root/loader.ts` and `views/root/component.tsx`)
   * If you drop them in verbatim to Ryan's example, you can start the `loader fetch()` _sooner_ since it's not waiting on the component JS code to download
   * But you don't actually start downloading the component JS chunk until _after_ the fetch (it's kicked off at render time by `React.lazy`), so you still have no parallelization:
     * `loader.ts-> loader fetch() -> component.ts`
   * So you're now rendering the destination reoute _sooner_ but showing a fallback for longer 
3. In order to parallelize you need to kick off the `component.ts` download sooner, and reduce the amnount of time a fallback is displayed  
   * You could do it in the `loader()` and it runs in parallel with `loader fetch()`
     * `loader.ts -> loader fetch()  `
     * `.............component.ts`
   * Or you can move it even earlier and start it alongside the `loader.ts` import.  this gives you even more time to try to get it fully downloaded before render time
     * `loader.ts -> loader fetch()  `
     * `component.ts`
4. In the best case, by moving the component download you end up fully downloading it before the `loader fetch()` completes and there's no need for a Suspense fallback at all!
   * But - you can't quite do this 😞.  Even if it's already resolved, `React.lazy` will still throw the promise one time to unwrap the component so you'll get a single-frame flicker of the fallback.
   * This PR shows one way to avoid this and track the resolution of the component chunk load in the `loader` and replace the `React.lazy()` component with a non-lazy one if it resolves in time.  Thus, since it's no longer a promise it will render directly and skip the Suspense fallback entirely.
