### PR TITLE
fix: fix up default history push behavior on redirects

### DIFF
--- a/.changeset/lucky-olives-wonder.md
+++ b/.changeset/lucky-olives-wonder.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: fix default redirect push/replace behavior (#9117)

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "filesize": {
     "packages/router/dist/router.js": {
-      "none": "98 kB"
+      "none": "99 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12 kB"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "filesize": {
     "packages/router/dist/router.js": {
-      "none": "99 kB"
+      "none": "98 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12 kB"

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -771,6 +771,15 @@ type SetURLSearchParams = (
   navigateOpts?: NavigateOptions
 ) => void;
 
+type SubmitTarget =
+  | HTMLFormElement
+  | HTMLButtonElement
+  | HTMLInputElement
+  | FormData
+  | URLSearchParams
+  | { [name: string]: string }
+  | null;
+
 /**
  * Submits a HTML `<form>` to the server without reloading the page.
  */
@@ -784,14 +793,7 @@ export interface SubmitFunction {
      * Note: When using a `<button>` its `name` and `value` will also be
      * included in the form data that is submitted.
      */
-    target:
-      | HTMLFormElement
-      | HTMLButtonElement
-      | HTMLInputElement
-      | FormData
-      | URLSearchParams
-      | { [name: string]: string }
-      | null,
+    target: SubmitTarget,
 
     /**
      * Options that override the `<form>`'s own attributes. Required when
@@ -888,7 +890,11 @@ let fetcherId = 0;
 
 export type FetcherWithComponents<TData> = Fetcher<TData> & {
   Form: ReturnType<typeof createFetcherForm>;
-  submit: ReturnType<typeof useSubmitImpl>;
+  submit: (
+    target: SubmitTarget,
+    // Fetchers cannot replace because they are not navigation events
+    options?: Omit<SubmitOptions, "replace">
+  ) => void;
   load: (href: string) => void;
 };
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2237,7 +2237,7 @@ describe("a router", () => {
       let B = await A.actions.foo.redirect("/bar");
       await B.loaders.root.resolve("ROOT DATA");
       await B.loaders.bar.resolve("B LOADER");
-      expect(t.router.state.historyAction).toEqual("PUSH");
+      expect(t.router.state.historyAction).toEqual("REPLACE");
       expect(t.router.state.location.pathname).toEqual("/bar");
       expect(B.loaders.root.stub.mock.calls.length).toBe(1);
       expect(t.router.state.loaderData).toEqual({
@@ -4410,7 +4410,7 @@ describe("a router", () => {
 
       await nav2.loaders.tasksId.resolve("TASKS_ID_DATA");
       expect(t.router.state).toMatchObject({
-        historyAction: "PUSH",
+        historyAction: "REPLACE",
         location: {
           pathname: "/tasks/1",
         },
@@ -4421,6 +4421,9 @@ describe("a router", () => {
         },
         errors: null,
       });
+      // We pushed to history since we never moved history to the location that
+      // threw the redirect, but we expose router.state.historyAction as REPLACE
+      // above since technically we the flow was a PUSH that triggered a REPLACE
       expect(t.history.action).toEqual("PUSH");
       expect(t.history.location.pathname).toEqual("/tasks/1");
     });
@@ -4482,7 +4485,7 @@ describe("a router", () => {
 
       await nav2.loaders.tasksId.resolve("TASKS_ID_DATA");
       expect(t.router.state).toMatchObject({
-        historyAction: "PUSH",
+        historyAction: "REPLACE",
         location: {
           pathname: "/tasks/1",
         },
@@ -4493,6 +4496,9 @@ describe("a router", () => {
         },
         errors: null,
       });
+      // We pushed to history since we never moved history to the location that
+      // threw the redirect, but we expose router.state.historyAction as REPLACE
+      // above since technically we the flow was a PUSH that triggered a REPLACE
       expect(t.history.action).toEqual("PUSH");
       expect(t.history.location.pathname).toEqual("/tasks/1");
     });
@@ -5562,7 +5568,7 @@ describe("a router", () => {
       await N.loaders.root.resolve("ROOT_DATA redirect");
       await N.loaders.tasks.resolve("TASKS_DATA");
       expect(t.router.state).toMatchObject({
-        historyAction: "PUSH",
+        historyAction: "REPLACE",
         location: { pathname: "/tasks" },
         navigation: IDLE_NAVIGATION,
         revalidation: "idle",
@@ -6227,6 +6233,7 @@ describe("a router", () => {
 
         await B.loaders.bar.resolve("BAR");
         expect(t.router.state.navigation.state).toBe("idle");
+        expect(t.router.state.historyAction).toBe("PUSH");
         expect(t.router.state.location?.pathname).toBe("/bar");
 
         // Back button should take us back to location that triggered the fetch
@@ -6252,6 +6259,7 @@ describe("a router", () => {
 
         await B.loaders.bar.resolve("BAR");
         expect(t.router.state.navigation.state).toBe("idle");
+        expect(t.router.state.historyAction).toBe("PUSH");
         expect(t.router.state.location?.pathname).toBe("/bar");
 
         // Back button should take us back to location that triggered the fetch
@@ -6285,6 +6293,8 @@ describe("a router", () => {
           formEncType: undefined,
           formData: undefined,
         });
+        expect(t.router.state.historyAction).toBe("PUSH");
+        expect(t.router.state.location.pathname).toBe("/bar");
         // Root loader should be re-called after fetchActionRedirect
         expect(t.router.state.loaderData).toEqual({
           root: "ROOT*",
@@ -6316,6 +6326,7 @@ describe("a router", () => {
 
         await B.loaders.bar.resolve("BAR");
         expect(t.router.state.navigation.state).toBe("idle");
+        expect(t.router.state.historyAction).toBe("REPLACE");
         expect(t.router.state.location?.pathname).toBe("/bar");
 
         // Back button should take us back _through_ /baz and to the original
@@ -6347,6 +6358,7 @@ describe("a router", () => {
 
         await B.loaders.bar.resolve("BAR");
         expect(t.router.state.navigation.state).toBe("idle");
+        expect(t.router.state.historyAction).toBe("REPLACE");
         expect(t.router.state.location?.pathname).toBe("/bar");
 
         // Back button should take us back to location that triggered the fetch
@@ -6385,6 +6397,8 @@ describe("a router", () => {
           formEncType: undefined,
           formData: undefined,
         });
+        expect(t.router.state.historyAction).toBe("REPLACE");
+        expect(t.router.state.location.pathname).toBe("/bar");
         // Root loader should be re-called after fetchActionRedirect
         expect(t.router.state.loaderData).toEqual({
           root: "ROOT*",

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -890,11 +890,7 @@ export function createRouter(init: RouterInit): Router {
         location: createLocation(state.location, result.location),
         ...submission,
       };
-      await startRedirectNavigation(
-        result,
-        redirectNavigation,
-        opts?.replace === true
-      );
+      await startRedirectNavigation(result, redirectNavigation, opts?.replace);
       return { shortCircuited: true };
     }
 
@@ -1027,11 +1023,7 @@ export function createRouter(init: RouterInit): Router {
     let redirect = findRedirect(results);
     if (redirect) {
       let redirectNavigation = getLoaderRedirect(state, redirect);
-      await startRedirectNavigation(
-        redirect,
-        redirectNavigation,
-        replace === true
-      );
+      await startRedirectNavigation(redirect, redirectNavigation, replace);
       return { shortCircuited: true };
     }
 
@@ -1178,11 +1170,7 @@ export function createRouter(init: RouterInit): Router {
         location: createLocation(state.location, actionResult.location),
         ...submission,
       };
-      await startRedirectNavigation(
-        actionResult,
-        redirectNavigation,
-        replace === true
-      );
+      await startRedirectNavigation(actionResult, redirectNavigation, replace);
       return;
     }
 
@@ -1273,11 +1261,7 @@ export function createRouter(init: RouterInit): Router {
     let redirect = findRedirect(results);
     if (redirect) {
       let redirectNavigation = getLoaderRedirect(state, redirect);
-      await startRedirectNavigation(
-        redirect,
-        redirectNavigation,
-        replace === true
-      );
+      await startRedirectNavigation(redirect, redirectNavigation, replace);
       return;
     }
 
@@ -1387,11 +1371,7 @@ export function createRouter(init: RouterInit): Router {
     // If the loader threw a redirect Response, start a new REPLACE navigation
     if (isRedirectResult(result)) {
       let redirectNavigation = getLoaderRedirect(state, result);
-      await startRedirectNavigation(
-        result,
-        redirectNavigation,
-        replace === true
-      );
+      await startRedirectNavigation(result, redirectNavigation, replace);
       return;
     }
 
@@ -1440,7 +1420,7 @@ export function createRouter(init: RouterInit): Router {
   async function startRedirectNavigation(
     redirect: RedirectResult,
     navigation: Navigation,
-    replace: boolean
+    replace?: boolean
   ) {
     if (redirect.revalidate) {
       isRevalidationRequired = true;
@@ -1452,11 +1432,12 @@ export function createRouter(init: RouterInit): Router {
     // There's no need to abort on redirects, since we don't detect the
     // redirect until the action/loaders have settled
     pendingNavigationController = null;
-    await startNavigation(
-      replace === true ? HistoryAction.Replace : HistoryAction.Push,
-      navigation.location,
-      { overrideNavigation: navigation }
-    );
+
+    let redirectHistoryAction =
+      replace === true ? HistoryAction.Replace : HistoryAction.Push;
+    await startNavigation(redirectHistoryAction, navigation.location, {
+      overrideNavigation: navigation,
+    });
   }
 
   async function callLoadersAndMaybeResolveData(

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1421,23 +1421,9 @@ export function createRouter(init: RouterInit): Router {
    *
    * In client-side routing using pushState/replaceState, we aim to emulate
    * this behavior and we also do not update history until the end of the
-   * navigation (including processed redirects).  This means that even though
-   * we're "replacing" the original [PUSH /b] action with the [REPLACE /c],
-   * since we never pushed it into the history stack to begin with, it's not
-   * there to replace.  So we end up doing a history.pushState('/c')
-   *
-   * However, from the users standpoint and for backwards compatibility with
-   * react-router 6.3.0 and earlier, we want to expose state.historyAction as
-   * REPLACE if we encounter a redirect inside a normal navigation.  This is
-   * what the isNavigation flag is for - telling us that whenever this
-   * redirect navigation completes - we should call pushState() but we should
-   * expose state.historyAction as REPLACE.
-   *
-   * Redirects from fetch() and revalidate() currently default to normal PUSH
-   * unless the user passed replace:true, since we do not want to blow away a
-   * valid location the user visited.  USers can only send replace:true in
-   * fetchers currently, but that cn be added to revalidate() eventually if
-   * the need arises
+   * navigation (including processed redirects).  This means that we never
+   * actually touch history until we've processed redirects, so we just use
+   * the history action from the original navigation (PUSH or REPLACE).
    */
   async function startRedirectNavigation(
     redirect: RedirectResult,


### PR DESCRIPTION
Fixes some bugs with redirect history management and aligns on the navigation semantics of "replace is determined by the origin".  See https://github.com/remix-run/react-router/pull/9117#issuecomment-1209674666 and https://github.com/remix-run/react-router/pull/9117#issuecomment-1209688276 for rationale.

