### PR TITLE
fix: do not overwrite input value from button with same name

### DIFF
--- a/.changeset/eighty-horses-leave.md
+++ b/.changeset/eighty-horses-leave.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+fix: do not overwrite input value from button with same name (#9139)

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -202,9 +202,10 @@ export function getFormSubmissionInfo(
 
     formData = new FormData(form);
 
-    // Include name + value from a <button>
+    // Include name + value from a <button>, appending in case the button name
+    // matches an existing input name
     if (target.name) {
-      formData.set(target.name, target.value);
+      formData.append(target.name, target.value);
     }
   } else if (isHtmlElement(target)) {
     throw new Error(


### PR DESCRIPTION
Do not overwrite input values if a submitting button has the same name (same fix from https://github.com/remix-run/remix/pull/3611)