### PR TITLE
fix: expose loader/action headers on error responses in static handler

### DIFF
--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -9516,33 +9516,7 @@ describe("a router", () => {
       });
 
       describe("headers", () => {
-        it("should expose headers from loader responses", async () => {
-          let { query } = createStaticHandler([
-            {
-              id: "root",
-              path: "/",
-              loader: () => new Response(null, { headers: { one: "1" } }),
-              children: [
-                {
-                  id: "child",
-                  index: true,
-                  loader: () => new Response(null, { headers: { two: "2" } }),
-                },
-              ],
-            },
-          ]);
-          let context = (await query(
-            createRequest("/")
-          )) as StaticHandlerContext;
-          expect(Array.from(context.loaderHeaders.root.entries())).toEqual([
-            ["one", "1"],
-          ]);
-          expect(Array.from(context.loaderHeaders.child.entries())).toEqual([
-            ["two", "2"],
-          ]);
-        });
-
-        it("should expose headers from action responses", async () => {
+        it("should expose headers from action/loader responses", async () => {
           let { query } = createStaticHandler([
             {
               id: "root",
@@ -9569,6 +9543,58 @@ describe("a router", () => {
           ]);
           expect(Array.from(context.loaderHeaders.child.entries())).toEqual([
             ["three", "3"],
+          ]);
+        });
+
+        it("should expose headers from loader error responses", async () => {
+          let { query } = createStaticHandler([
+            {
+              id: "root",
+              path: "/",
+              loader: () => new Response(null, { headers: { one: "1" } }),
+              children: [
+                {
+                  id: "child",
+                  index: true,
+                  loader: () => {
+                    throw new Response(null, { headers: { two: "2" } });
+                  },
+                },
+              ],
+            },
+          ]);
+          let context = (await query(
+            createRequest("/")
+          )) as StaticHandlerContext;
+          expect(Array.from(context.loaderHeaders.root.entries())).toEqual([
+            ["one", "1"],
+          ]);
+          expect(Array.from(context.loaderHeaders.child.entries())).toEqual([
+            ["two", "2"],
+          ]);
+        });
+
+        it("should expose headers from action error responses", async () => {
+          let { query } = createStaticHandler([
+            {
+              id: "root",
+              path: "/",
+              children: [
+                {
+                  id: "child",
+                  index: true,
+                  action: () => {
+                    throw new Response(null, { headers: { one: "1" } });
+                  },
+                },
+              ],
+            },
+          ]);
+          let context = (await query(
+            createSubmitRequest("/?index")
+          )) as StaticHandlerContext;
+          expect(Array.from(context.actionHeaders.child.entries())).toEqual([
+            ["one", "1"],
           ]);
         });
       });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1803,8 +1803,8 @@ export function unstable_createStaticHandler(
           errors: {
             [boundaryMatch.route.id]: result.error,
           },
-          // Note: This is unused in queryRoute as we will return the raw error,
-          // or construct a response from the ErrorResponse
+          // Note: statusCode + headers are unused here since queryRoute will
+          // return the raw Response or value
           statusCode: 500,
           loaderHeaders: {},
           actionHeaders: {},
@@ -1816,13 +1816,11 @@ export function unstable_createStaticHandler(
         loaderData: {},
         actionData: { [actionMatch.route.id]: result.data },
         errors: null,
-        // Note: This is unused in queryRoute as we will return the raw
-        // Response or value
+        // Note: statusCode + headers are unused here since queryRoute will
+        // return the raw Response or value
         statusCode: 200,
         loaderHeaders: {},
-        actionHeaders: {
-          ...(result.headers ? { [actionMatch.route.id]: result.headers } : {}),
-        },
+        actionHeaders: {},
       };
     }
 
@@ -1841,7 +1839,9 @@ export function unstable_createStaticHandler(
           ? result.error.status
           : 500,
         actionData: null,
-        actionHeaders: {},
+        actionHeaders: {
+          ...(result.headers ? { [actionMatch.route.id]: result.headers } : {}),
+        },
       };
     }
 
@@ -2289,6 +2289,7 @@ async function callLoaderOrAction(
       return {
         type: resultType,
         error: new ErrorResponse(status, result.statusText, data),
+        headers: result.headers,
       };
     }
 
@@ -2399,9 +2400,13 @@ function processRouteLoaderData(
           ? result.error.status
           : 500;
       }
+      if (result.headers) {
+        loaderHeaders[id] = result.headers;
+      }
     } else if (isDeferredResult(result)) {
       activeDeferreds?.set(id, result.deferredData);
       loaderData[id] = result.deferredData.data;
+      // TODO: Add statusCode/headers once we wire up streaming in Remix
     } else {
       loaderData[id] = result.data;
       // Error status codes always override success status codes, but if all

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -51,6 +51,7 @@ export interface RedirectResult {
 export interface ErrorResult {
   type: ResultType.error;
   error: any;
+  headers?: Headers;
 }
 
 /**


### PR DESCRIPTION
For static handler `query()` calls, we propagate out the `headers` from any returned `Response` instances for eventual use in the SSR response (`getDocumentHeaders` in Remix).  This PR ensures we also capture those on error flows (i.e., `throw new Response`)