### PR TITLE
fix: useFormAction should not include pathless splat portion

### DIFF
--- a/.changeset/yellow-cherries-tell.md
+++ b/.changeset/yellow-cherries-tell.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+fix: useFormAction should not include pathless splat portion (#9144)

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -1230,7 +1230,7 @@ function testDomRouter(
       }
 
       describe("static routes", () => {
-        it("uses full URL when no action is specified", async () => {
+        it("includes search params + hash when no action is specified", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1249,7 +1249,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='.' is specified", async () => {
+        it("does not include search params + hash when action='.'", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1268,7 +1268,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='' is specified", async () => {
+        it("does not include search params + hash when action=''", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1289,7 +1289,7 @@ function testDomRouter(
       });
 
       describe("layout routes", () => {
-        it("uses full URL when no action is specified", async () => {
+        it("includes search params + hash when no action is specified", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1310,7 +1310,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='.' is specified", async () => {
+        it("does not include search params + hash when action='.'", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1331,7 +1331,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='' is specified", async () => {
+        it("does not include search params + hash when action=''", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1354,7 +1354,7 @@ function testDomRouter(
       });
 
       describe("index routes", () => {
-        it("uses full URL when no action is specified", async () => {
+        it("includes search params + hash when no action is specified", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1375,7 +1375,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='.' is specified", async () => {
+        it("does not include search params + hash action='.'", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1396,7 +1396,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='' is specified", async () => {
+        it("does not include search params + hash action=''", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1419,7 +1419,7 @@ function testDomRouter(
       });
 
       describe("dynamic routes", () => {
-        it("uses full URL when no action is specified", async () => {
+        it("includes search params + hash when no action is specified", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1438,7 +1438,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='.' is specified", async () => {
+        it("does not include search params + hash action='.'", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1457,7 +1457,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path when action='' is specified", async () => {
+        it("does not include search params + hash when action=''", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1478,7 +1478,7 @@ function testDomRouter(
       });
 
       describe("splat routes", () => {
-        it("uses full URL when no action is specified", async () => {
+        it("includes search params + hash when no action is specified", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1493,11 +1493,11 @@ function testDomRouter(
           );
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo/bar?a=1#hash"
+            "/foo?a=1#hash"
           );
         });
 
-        it("uses current route path (excluding splat) when action='.' is specified", async () => {
+        it("does not include search params + hash when action='.'", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}
@@ -1516,7 +1516,7 @@ function testDomRouter(
           );
         });
 
-        it("uses current route path (excluding splat) when action='' is specified", async () => {
+        it("does not include search params + hash when action=''", async () => {
           let { container } = render(
             <TestDataRouter
               window={getWindow("/foo/bar?a=1#hash")}

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -857,9 +857,23 @@ export function useFormAction(action?: string): string {
   let routeContext = React.useContext(RouteContext);
   invariant(routeContext, "useFormAction must be used inside a RouteContext");
 
-  let location = useLocation();
   let [match] = routeContext.matches.slice(-1);
-  let path = useResolvedPath(action ?? location);
+  let resolvedAction = action ?? ".";
+  let path = useResolvedPath(resolvedAction);
+
+  // Previously we set the default action to ".". The problem with this is that
+  // `useResolvedPath(".")` excludes search params and the hash of the resolved
+  // URL. This is the intended behavior of when "." is specifically provided as
+  // the form action, but inconsistent w/ browsers when the action is omitted.
+  // https://github.com/remix-run/remix/issues/927
+  let location = useLocation();
+  if (action === undefined) {
+    // Safe to write to these directly here since if action was undefined, we
+    // would have called useResolvedPath(".") which will never include a search
+    // or hash
+    path.search = location.search;
+    path.hash = location.hash;
+  }
 
   if ((!action || action === ".") && match.route.index) {
     path.search = path.search

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -867,7 +867,7 @@ export function useFormAction(action?: string): string {
   // the form action, but inconsistent w/ browsers when the action is omitted.
   // https://github.com/remix-run/remix/issues/927
   let location = useLocation();
-  if (action === undefined) {
+  if (action == null) {
     // Safe to write to these directly here since if action was undefined, we
     // would have called useResolvedPath(".") which will never include a search
     // or hash


### PR DESCRIPTION
Follow up to correct a small misunderstanding on https://github.com/remix-run/react-router/pull/9060 after chatting through with Chance and Ryan a bit more.