### PR TITLE
fixed react-native link typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -18,6 +18,7 @@
 - elanis
 - elylucas
 - emzoumpo
+- gianlucca
 - gijo-varghese
 - goldins
 - gowthamvbhat

--- a/docs/components/link-native.md
+++ b/docs/components/link-native.md
@@ -45,4 +45,4 @@ function Home() {
 }
 ```
 
-[link]: ./link-native
+[link]: ./link


### PR DESCRIPTION
I've found this typo while reading the docs.