### PR TITLE
Improve error message when calling useMatch without args

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -28,6 +28,7 @@
 - Isammoc
 - JaffParker
 - JakubDrozd
+- jackcook
 - janpaepke
 - jimniels
 - jmargeta

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -128,7 +128,7 @@ export function useMatch<
 
   invariant(
     pattern,
-    `useMatch() must be called with a matchPath argument.`
+    `useMatch() must be called with a pattern argument.`
   );
 
   let { pathname } = useLocation();

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -126,6 +126,11 @@ export function useMatch<
     `useMatch() may be used only in the context of a <Router> component.`
   );
 
+  invariant(
+    pattern,
+    `useMatch() must be called with a matchPath argument.`
+  );
+
   let { pathname } = useLocation();
   return React.useMemo(
     () => matchPath<ParamKey, Path>(pattern, pathname),


### PR DESCRIPTION
I don't know how common this mistake is (calling `useMatch` with no args), but it took me awhile to figure out what the cause of this error was:
<img width="547" alt="Screen Shot 2022-08-11 at 6 56 56 PM" src="https://user-images.githubusercontent.com/5024663/184256422-fecb6195-aba0-40f3-9023-38226d2a237b.png">

So now it looks like this:
<img width="549" alt="Screen Shot 2022-08-11 at 6 46 54 PM" src="https://user-images.githubusercontent.com/5024663/184256496-6274719c-0b4e-431c-8211-6cca9b018b92.png">

