### PR TITLE
fix: avoid uneccesary re-renders on defer resolution

### DIFF
--- a/.changeset/afraid-games-laugh.md
+++ b/.changeset/afraid-games-laugh.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: avoid uneccesary re-renders on defer resolution (#9155)

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -2392,7 +2392,7 @@ describe("<DataMemoryRouter>", () => {
       `);
 
       barValueDfd.resolve("LAZY");
-      await waitFor(() => !screen.getByText(/Loading.../));
+      await waitFor(() => screen.getByText(/oops is not defined/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
         "<div>
           <a
@@ -2466,7 +2466,7 @@ describe("<DataMemoryRouter>", () => {
       `);
 
       barValueDfd.resolve("LAZY");
-      await waitFor(() => !screen.getByText(/Loading.../));
+      await waitFor(() => screen.getByText(/oops is not defined/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
         "<div>
           <a

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1044,14 +1044,8 @@ export function createRouter(init: RouterInit): Router {
     // Wire up subscribers to update loaderData as promises settle
     activeDeferreds.forEach((deferredData, routeId) => {
       deferredData.subscribe((aborted) => {
-        if (!aborted) {
-          updateState({
-            loaderData: {
-              ...state.loaderData,
-              [routeId]: deferredData.data,
-            },
-          });
-        }
+        // Note: No need to updateState here since the TrackedPromise on
+        // loaderData is stable across resolve/reject
         // Remove this instance if we were aborted or if promises have settled
         if (aborted || deferredData.done) {
           activeDeferreds.delete(routeId);


### PR DESCRIPTION
Now that `loaderData` is stable across `defer` resolutions we don't need to `updateState` and can jut let the re-render happen at the Suspense boundary