### PR TITLE
feat: add relative=path option for url-relative routing

### DIFF
--- a/.changeset/big-bags-report.md
+++ b/.changeset/big-bags-report.md
@@ -1,0 +1,27 @@
+---
+"react-router": patch
+"react-router-dom": patch
+"react-router-native": patch
+---
+
+feat: add `relative=path` option for url-relative routing (#9160)
+
+Adds a `relative=path` option to navigation aspects to allow users to opt-into paths behaving relative to the current URL instead of the current route hierarchy. This is useful if you're sharing route patterns in a non-nested for UI reasons:
+
+```jsx
+// Contact and EditContact do not share UI layout
+<Route path="contacts/:id" element={<Contact />} />
+<Route path="contacts:id/edit" element={<EditContact />} />
+
+function EditContact() {
+  return <Link to=".." relative="path">Cancel</Link>
+}
+```
+
+Without this, the user would need to reconstruct the contacts/:id url using useParams and either hardcoding the /contacts prefix or parsing it from useLocation.
+
+This applies to all path-related hooks and components:
+
+- `react-router`: `useHref`, `useResolvedPath`, `useNavigate`, `Navigate`
+- `react-router-dom`: `useLinkClickHandler`, `useFormAction`, `useSubmit`, `Link`, `Form`
+- `react-router-native`: `useLinkPressHandler`, `Link`

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -1537,6 +1537,119 @@ function testDomRouter(
       });
     });
 
+    describe('<Form action relative="path">', () => {
+      it("navigates relative to the URL for static routes", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/inbox/messages/edit")}
+            hydrationData={{}}
+          >
+            <Route path="inbox">
+              <Route path="messages" />
+              <Route
+                path="messages/edit"
+                element={<Form action=".." relative="path" />}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        expect(container.querySelector("form")?.getAttribute("action")).toBe(
+          "/inbox/messages"
+        );
+      });
+
+      it("navigates relative to the URL for dynamic routes", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/inbox/messages/1")}
+            hydrationData={{}}
+          >
+            <Route path="inbox">
+              <Route path="messages" />
+              <Route
+                path="messages/:id"
+                element={<Form action=".." relative="path" />}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        expect(container.querySelector("form")?.getAttribute("action")).toBe(
+          "/inbox/messages"
+        );
+      });
+
+      it("navigates relative to the URL for layout routes", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/inbox/messages/1")}
+            hydrationData={{}}
+          >
+            <Route path="inbox">
+              <Route path="messages" />
+              <Route
+                path="messages/:id"
+                element={
+                  <>
+                    <Form action=".." relative="path" />
+                    <Outlet />
+                  </>
+                }
+              >
+                <Route index element={<h1>Form</h1>} />
+              </Route>
+            </Route>
+          </TestDataRouter>
+        );
+
+        expect(container.querySelector("form")?.getAttribute("action")).toBe(
+          "/inbox/messages"
+        );
+      });
+
+      it("navigates relative to the URL for index routes", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/inbox/messages/1")}
+            hydrationData={{}}
+          >
+            <Route path="inbox">
+              <Route path="messages" />
+              <Route path="messages/:id">
+                <Route index element={<Form action=".." relative="path" />} />
+              </Route>
+            </Route>
+          </TestDataRouter>
+        );
+
+        expect(container.querySelector("form")?.getAttribute("action")).toBe(
+          "/inbox/messages"
+        );
+      });
+
+      it("navigates relative to the URL for splat routes", async () => {
+        let { container } = render(
+          <TestDataRouter
+            window={getWindow("/inbox/messages/1/2/3")}
+            hydrationData={{}}
+          >
+            <Route path="inbox">
+              <Route path="messages" />
+              <Route
+                path="messages/*"
+                element={<Form action=".." relative="path" />}
+              />
+            </Route>
+          </TestDataRouter>
+        );
+
+        expect(container.querySelector("form")?.getAttribute("action")).toBe(
+          "/inbox/messages/1/2"
+        );
+      });
+    });
+
     describe("useSubmit/Form FormData", () => {
       it("gathers form data on <Form> submissions", async () => {
         let actionSpy = jest.fn();

--- a/packages/react-router-dom/__tests__/link-href-test.tsx
+++ b/packages/react-router-dom/__tests__/link-href-test.tsx
@@ -594,4 +594,89 @@ describe("<Link> href", () => {
       );
     });
   });
+
+  describe("when using relative=path", () => {
+    test("absolute <Link to> resolves relative to the root URL", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox"]}>
+            <Routes>
+              <Route
+                path="inbox"
+                element={<Link to="/about" relative="path" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/about");
+    });
+
+    test('<Link to="."> resolves relative to the current route', () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox"]}>
+            <Routes>
+              <Route path="inbox" element={<Link to="." relative="path" />} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
+    });
+
+    test.only('<Link to=".."> resolves relative to the parent URL segment', () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox/messages/1"]}>
+            <Routes>
+              <Route path="inbox" />
+              <Route path="inbox/messages" />
+              <Route
+                path="inbox/messages/:id"
+                element={<Link to=".." relative="path" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/inbox/messages"
+      );
+    });
+
+    test('<Link to=".."> with more .. segments than parent routes resolves to the root URL', () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox/messages"]}>
+            <Routes>
+              <Route path="inbox">
+                <Route
+                  path="messages"
+                  element={
+                    <>
+                      <Link to="../../about" relative="path" />
+                      {/* traverse past the root */}
+                      <Link to="../../../about" relative="path" />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findAllByType("a").map((a) => a.props.href)).toEqual(
+        ["/about", "/about"]
+      );
+    });
+  });
 });

--- a/packages/react-router-dom/__tests__/link-href-test.tsx
+++ b/packages/react-router-dom/__tests__/link-href-test.tsx
@@ -629,7 +629,7 @@ describe("<Link> href", () => {
       expect(renderer.root.findByType("a").props.href).toEqual("/inbox");
     });
 
-    test.only('<Link to=".."> resolves relative to the parent URL segment', () => {
+    test('<Link to=".."> resolves relative to the parent URL segment', () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -1,4 +1,5 @@
 import type { FormEncType, FormMethod } from "@remix-run/router";
+import { RelativeRoutingType } from "react-router";
 
 export const defaultMethod = "get";
 const defaultEncType = "application/x-www-form-urlencoded";
@@ -130,6 +131,13 @@ export interface SubmitOptions {
    * to `false`.
    */
   replace?: boolean;
+
+  /**
+   * Determines whether the form action is relative to the route hierarchy or
+   * the pathname.  Use this if you want to opt out of navigating the route
+   * hierarchy and want to instead route based on /-delimited URL segments
+   */
+  relative?: RelativeRoutingType;
 }
 
 export function getFormSubmissionInfo(

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -102,6 +102,7 @@ export type {
   PathPattern,
   PathRouteProps,
   RedirectFunction,
+  RelativeRoutingType,
   RouteMatch,
   RouteObject,
   RouteProps,

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -3,15 +3,16 @@
  * you'll need to update the rollup config for react-router-dom-v5-compat.
  */
 import * as React from "react";
-import {
-  createRoutesFromChildren,
+import type {
   NavigateOptions,
+  RelativeRoutingType,
   RouteObject,
   To,
 } from "react-router";
 import {
   Router,
   createPath,
+  createRoutesFromChildren,
   useHref,
   useLocation,
   useMatch,
@@ -400,6 +401,7 @@ export interface LinkProps
   replace?: boolean;
   state?: any;
   resetScroll?: boolean;
+  relative?: RelativeRoutingType;
   to: To;
 }
 
@@ -410,6 +412,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function LinkWithRef(
     {
       onClick,
+      relative,
       reloadDocument,
       replace,
       state,
@@ -420,12 +423,13 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     },
     ref
   ) {
-    let href = useHref(to);
+    let href = useHref(to, { relative });
     let internalOnClick = useLinkClickHandler(to, {
       replace,
       state,
       target,
       resetScroll,
+      relative,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -582,6 +586,13 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   replace?: boolean;
 
   /**
+   * Determines whether the form action is relative to the route hierarchy or
+   * the pathname.  Use this if you want to opt out of navigating the route
+   * hierarchy and want to instead route based on /-delimited URL segments
+   */
+  relative?: RelativeRoutingType;
+
+  /**
    * A function to call when the form is submitted. If you call
    * `event.preventDefault()` then this form will not do anything.
    */
@@ -627,6 +638,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       onSubmit,
       fetcherKey,
       routeId,
+      relative,
       ...props
     },
     forwardedRef
@@ -634,7 +646,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
     let submit = useSubmitImpl(fetcherKey, routeId);
     let formMethod: FormMethod =
       method.toLowerCase() === "get" ? "get" : "post";
-    let formAction = useFormAction(action);
+    let formAction = useFormAction(action, relative);
     let submitHandler: React.FormEventHandler<HTMLFormElement> = (event) => {
       onSubmit && onSubmit(event);
       if (event.defaultPrevented) return;
@@ -643,7 +655,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       let submitter = (event as unknown as HTMLSubmitEvent).nativeEvent
         .submitter as HTMLFormSubmitter | null;
 
-      submit(submitter || event.currentTarget, { method, replace });
+      submit(submitter || event.currentTarget, { method, replace, relative });
     };
 
     return (
@@ -700,16 +712,18 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     replace: replaceProp,
     state,
     resetScroll,
+    relative,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
     state?: any;
     resetScroll?: boolean;
+    relative?: RelativeRoutingType;
   } = {}
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
   let location = useLocation();
-  let path = useResolvedPath(to);
+  let path = useResolvedPath(to, { relative });
 
   return React.useCallback(
     (event: React.MouseEvent<E, MouseEvent>) => {
@@ -717,16 +731,26 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
         event.preventDefault();
 
         // If the URL hasn't changed, a regular <a> will do a replace instead of
-        // a push, so do the same here unless the replace prop is explcitly set
+        // a push, so do the same here unless the replace prop is explicitly set
         let replace =
           replaceProp !== undefined
             ? replaceProp
             : createPath(location) === createPath(path);
 
-        navigate(to, { replace, state, resetScroll });
+        navigate(to, { replace, state, resetScroll, relative });
       }
     },
-    [location, navigate, path, replaceProp, state, target, to, resetScroll]
+    [
+      location,
+      navigate,
+      path,
+      replaceProp,
+      state,
+      target,
+      to,
+      resetScroll,
+      relative,
+    ]
   );
 }
 
@@ -864,13 +888,16 @@ function useSubmitImpl(fetcherKey?: string, routeId?: string): SubmitFunction {
   );
 }
 
-export function useFormAction(action?: string): string {
+export function useFormAction(
+  action?: string,
+  relative?: RelativeRoutingType
+): string {
   let routeContext = React.useContext(RouteContext);
   invariant(routeContext, "useFormAction must be used inside a RouteContext");
 
   let [match] = routeContext.matches.slice(-1);
   let resolvedAction = action ?? ".";
-  let path = useResolvedPath(resolvedAction);
+  let path = useResolvedPath(resolvedAction, { relative });
 
   // Previously we set the default action to ".". The problem with this is that
   // `useResolvedPath(".")` excludes search params and the hash of the resolved

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -647,7 +647,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
     let submit = useSubmitImpl(fetcherKey, routeId);
     let formMethod: FormMethod =
       method.toLowerCase() === "get" ? "get" : "post";
-    let formAction = useFormAction(action, relative);
+    let formAction = useFormAction(action, { relative });
     let submitHandler: React.FormEventHandler<HTMLFormElement> = (event) => {
       onSubmit && onSubmit(event);
       if (event.defaultPrevented) return;
@@ -891,7 +891,7 @@ function useSubmitImpl(fetcherKey?: string, routeId?: string): SubmitFunction {
 
 export function useFormAction(
   action?: string,
-  relative?: RelativeRoutingType
+  { relative }: { relative?: RelativeRoutingType } = {}
 ): string {
   let routeContext = React.useContext(RouteContext);
   invariant(routeContext, "useFormAction must be used inside a RouteContext");

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -10,6 +10,7 @@ import {
   MemoryRouter,
   MemoryRouterProps,
   NavigateOptions,
+  RelativeRoutingType,
   useLocation,
   useNavigate,
 } from "react-router";
@@ -52,6 +53,7 @@ export type {
   PathPattern,
   PathRouteProps,
   RedirectFunction,
+  RelativeRoutingType,
   RouteMatch,
   RouteObject,
   RouteProps,
@@ -147,6 +149,7 @@ export function NativeRouter(props: NativeRouterProps) {
 export interface LinkProps extends TouchableHighlightProps {
   children?: React.ReactNode;
   onPress?: (event: GestureResponderEvent) => void;
+  relative?: RelativeRoutingType;
   replace?: boolean;
   state?: any;
   to: To;
@@ -157,12 +160,13 @@ export interface LinkProps extends TouchableHighlightProps {
  */
 export function Link({
   onPress,
+  relative,
   replace = false,
   state,
   to,
   ...rest
 }: LinkProps) {
-  let internalOnPress = useLinkPressHandler(to, { replace, state });
+  let internalOnPress = useLinkPressHandler(to, { replace, state, relative });
   function handlePress(event: GestureResponderEvent) {
     if (onPress) onPress(event);
     if (!event.defaultPrevented) {
@@ -190,14 +194,16 @@ export function useLinkPressHandler(
   {
     replace,
     state,
+    relative,
   }: {
     replace?: boolean;
     state?: any;
+    relative?: RelativeRoutingType;
   } = {}
 ): (event: GestureResponderEvent) => void {
   let navigate = useNavigate();
   return function handlePress() {
-    navigate(to, { replace, state });
+    navigate(to, { replace, state, relative });
   };
 }
 

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -65,6 +65,7 @@ import type {
   NavigateOptions,
   RouteMatch,
   RouteObject,
+  RelativeRoutingType,
 } from "./lib/context";
 import {
   DataRouterContext,
@@ -134,6 +135,7 @@ export type {
   PathPattern,
   PathRouteProps,
   RedirectFunction,
+  RelativeRoutingType,
   RouteMatch,
   RouteObject,
   RouteProps,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -26,6 +26,7 @@ import type {
   RouteMatch,
   RouteObject,
   Navigator,
+  RelativeRoutingType,
 } from "./context";
 import {
   LocationContext,
@@ -233,6 +234,7 @@ export interface NavigateProps {
   to: To;
   replace?: boolean;
   state?: any;
+  relative?: RelativeRoutingType;
 }
 
 /**
@@ -244,7 +246,12 @@ export interface NavigateProps {
  *
  * @see https://reactrouter.com/docs/en/v6/components/navigate
  */
-export function Navigate({ to, replace, state }: NavigateProps): null {
+export function Navigate({
+  to,
+  replace,
+  state,
+  relative,
+}: NavigateProps): null {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of
@@ -269,7 +276,7 @@ export function Navigate({ to, replace, state }: NavigateProps): null {
     if (dataRouterState && dataRouterState.navigation.state !== "idle") {
       return;
     }
-    navigate(to, { replace, state });
+    navigate(to, { replace, state, relative });
   });
 
   return null;

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -60,10 +60,13 @@ if (__DEV__) {
   AwaitContext.displayName = "Await";
 }
 
+export type RelativeRoutingType = "route" | "path";
+
 export interface NavigateOptions {
   replace?: boolean;
   state?: any;
   resetScroll?: boolean;
+  relative?: RelativeRoutingType;
 }
 
 /**

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -35,6 +35,7 @@ import {
   RouteMatch,
   RouteObject,
   DataRouteMatch,
+  RelativeRoutingType,
 } from "./context";
 
 /**
@@ -43,7 +44,10 @@ import {
  *
  * @see https://reactrouter.com/docs/en/v6/hooks/use-href
  */
-export function useHref(to: To): string {
+export function useHref(
+  to: To,
+  { relative }: { relative?: RelativeRoutingType } = {}
+): string {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the
@@ -52,7 +56,7 @@ export function useHref(to: To): string {
   );
 
   let { basename, navigator } = React.useContext(NavigationContext);
-  let { hash, pathname, search } = useResolvedPath(to);
+  let { hash, pathname, search } = useResolvedPath(to, { relative });
 
   let joinedPathname = pathname;
 
@@ -216,7 +220,8 @@ export function useNavigate(): NavigateFunction {
       let path = resolveTo(
         to,
         JSON.parse(routePathnamesJson),
-        locationPathname
+        locationPathname,
+        options.relative === "path"
       );
 
       // If we're operating within a basename, prepend it to the pathname prior
@@ -290,7 +295,10 @@ export function useParams<
  *
  * @see https://reactrouter.com/docs/en/v6/hooks/use-resolved-path
  */
-export function useResolvedPath(to: To): Path {
+export function useResolvedPath(
+  to: To,
+  { relative }: { relative?: RelativeRoutingType } = {}
+): Path {
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
 
@@ -299,8 +307,14 @@ export function useResolvedPath(to: To): Path {
   );
 
   return React.useMemo(
-    () => resolveTo(to, JSON.parse(routePathnamesJson), locationPathname),
-    [to, routePathnamesJson, locationPathname]
+    () =>
+      resolveTo(
+        to,
+        JSON.parse(routePathnamesJson),
+        locationPathname,
+        relative === "path"
+      ),
+    [to, routePathnamesJson, locationPathname, relative]
   );
 }
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -766,12 +766,17 @@ function resolvePathname(relativePath: string, fromPathname: string): string {
 export function resolveTo(
   toArg: To,
   routePathnames: string[],
-  locationPathname: string
+  locationPathname: string,
+  isPathRelative = false
 ): Path {
   let to = typeof toArg === "string" ? parsePath(toArg) : { ...toArg };
   let isEmptyPath = toArg === "" || to.pathname === "";
   let toPathname = isEmptyPath ? "/" : to.pathname;
 
+  let from: string;
+
+  // Routing is relative to the current pathname if explicitly requested.
+  //
   // If a pathname is explicitly provided in `to`, it should be relative to the
   // route context. This is explained in `Note on `<Link to>` values` in our
   // migration guide from v5 as a means of disambiguation between `to` values
@@ -779,8 +784,7 @@ export function resolveTo(
   // `to` values that do not provide a pathname. `to` can simply be a search or
   // hash string, in which case we should assume that the navigation is relative
   // to the current location's pathname and *not* the route pathname.
-  let from: string;
-  if (toPathname == null) {
+  if (isPathRelative || toPathname == null) {
     from = locationPathname;
   } else {
     let routePathnameIndex = routePathnames.length - 1;


### PR DESCRIPTION
Adds a `relative=path` option to navigation aspects to allow users to opt-into paths behaving relative to the _current URL_ instead of the _current route hierarchy_.  This is useful if you're sharing route patterns in a non-nested for UI reasons:

```jsx
// Contact and EditContact do not share additional UI layout
<Route path="/" element={<Layout />}>
  <Route path="contacts/:id" element={<Contact />} />
  <Route path="contacts:id/edit" element={<EditContact />} />
</Route>

function EditContact() {
  // ...
  return <Link to=".." relative="path">Cancel</Link>
}
```

Without this, a `..` link would navigate up to `Layout` so the user would need to reconstruct the `contacts/:id` url using `useParams` and either hardcoding the `/contacts` prefix or parsing it from `useLocation` 😕 

This applies to all path-related hooks and components:
* `react-router`: `useHref`, `useResolvedPath`, `useNavigate`, `Navigate`
* `react-router-dom`: `useLinkClickHandler`, `useFormAction`, `useSubmit`, `Link`, `Form`
* `react-router-native`: `useLinkPressHandler`, `Link`
