### PR TITLE
fix: use a push navigation on submission errors

### DIFF
--- a/.changeset/wise-scissors-hug.md
+++ b/.changeset/wise-scissors-hug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: use a push navigation on submission errors (#9162)

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -180,7 +180,8 @@ Instructs the form to replace the current entry in the history stack, instead of
 The default behavior is conditional on the form `method`:
 
 - `get` defaults to `false`
-- every other method defaults to `true`
+- every other method defaults to `true` if your `action` is successful
+- if your `action` redirects or throws, then it will still push by default
 
 We've found with `get` you often want the user to be able to click "back" to see the previous search results/filters, etc. But with the other methods the default is `true` to avoid the "are you sure you want to resubmit the form?" prompt. Note that even if `replace={false}` React Router _will not_ resubmit the form when the back button is clicked and the method is post, put, patch, or delete.
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2331,6 +2331,35 @@ describe("a router", () => {
       expect(t.router.state.location.pathname).toEqual("/foo");
     });
 
+    it("navigates correctly using POP navigations across action errors", async () => {
+      let t = initializeTmTest();
+
+      // Navigate to /foo
+      let A = await t.navigate("/foo");
+      await A.loaders.foo.resolve("FOO");
+      expect(t.router.state.location.pathname).toEqual("/foo");
+
+      // Navigate to /bar
+      let B = await t.navigate("/bar");
+      await B.loaders.bar.resolve("BAR");
+      expect(t.router.state.location.pathname).toEqual("/bar");
+
+      // Post to /bar (should push due to our error)
+      let C = await t.navigate("/bar", {
+        formMethod: "post",
+        formData: createFormData({ key: "value" }),
+      });
+      await C.actions.bar.reject("BAR ERROR");
+      await C.loaders.root.resolve("ROOT");
+      await C.loaders.bar.resolve("BAR");
+      expect(t.router.state.location.pathname).toEqual("/bar");
+
+      // POP to /bar
+      let D = await t.navigate(-1);
+      await D.loaders.bar.resolve("BAR");
+      expect(t.router.state.location.pathname).toEqual("/bar");
+    });
+
     it("navigates correctly using POP navigations across loader redirects", async () => {
       // Start at / (history stack: [/])
       let t = initializeTmTest();

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -901,6 +901,15 @@ export function createRouter(init: RouterInit): Router {
       // Store off the pending error - we use it to determine which loaders
       // to call and will commit it when we complete the navigation
       let boundaryMatch = findNearestBoundary(matches, actionMatch.route.id);
+
+      // By default, all submissions are REPLACE navigations, but if the
+      // action threw an error that'll be rendered in an errorElement, we fall
+      // back to PUSH so that the user can use the back button to get back to
+      // the pre-submission form location to try again
+      if (opts?.replace !== true) {
+        pendingAction = HistoryAction.Push;
+      }
+
       return {
         pendingActionError: { [boundaryMatch.route.id]: result.error },
       };


### PR DESCRIPTION
This default behavior allows users to back-button from the error page back to the form