### PR TITLE
fix: fetcher submission revalidating fetchers using wrong key

### DIFF
--- a/.changeset/sweet-eggs-hug.md
+++ b/.changeset/sweet-eggs-hug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: fetcher submission revalidating fetchers using wrong key (#9166)

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1233,7 +1233,7 @@ export function createRouter(init: RouterInit): Router {
       .forEach(([staleKey]) => {
         let revalidatingFetcher: FetcherStates["Loading"] = {
           state: "loading",
-          data: state.fetchers.get(key)?.data,
+          data: state.fetchers.get(staleKey)?.data,
           formMethod: undefined,
           formAction: undefined,
           formEncType: undefined,


### PR DESCRIPTION
Fixes a bug where revalidating fetchers triggered by a separate submitting fetcher would temporarily have their `data` messed up, and due to the wrong key usage it would reflect the submitting fetcher action data.