### PR TITLE
fix: move fallbackElement into router context

### DIFF
--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -31,6 +31,7 @@ import {
   useFetchers,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   defer,
+  useLocation,
 } from "react-router-dom";
 
 // Private API
@@ -307,6 +308,54 @@ function testDomRouter(
         "<div>
           <h1>
             Bar Heading
+          </h1>
+        </div>"
+      `);
+    });
+
+    it("renders fallbackElement within router contexts", async () => {
+      let fooDefer = createDeferred();
+      let { container } = render(
+        <TestDataRouter
+          window={getWindow("/foo")}
+          fallbackElement={<FallbackElement />}
+        >
+          <Route path="/" element={<Outlet />}>
+            <Route
+              path="foo"
+              loader={() => fooDefer.promise}
+              element={<Foo />}
+            />
+          </Route>
+        </TestDataRouter>
+      );
+
+      function FallbackElement() {
+        let location = useLocation();
+        return <p>Loading{location.pathname}</p>;
+      }
+
+      function Foo() {
+        let data = useLoaderData();
+        return <h1>Foo:{data?.message}</h1>;
+      }
+
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div>
+          <p>
+            Loading
+            /foo
+          </p>
+        </div>"
+      `);
+
+      fooDefer.resolve({ message: "From Foo Loader" });
+      await waitFor(() => screen.getByText("Foo:From Foo Loader"));
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div>
+          <h1>
+            Foo:
+            From Foo Loader
           </h1>
         </div>"
       `);

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -234,12 +234,8 @@ export function DataBrowserRouter({
   let router = routerSingleton;
 
   return (
-    <DataRouterProvider
-      router={router}
-      basename={basename}
-      fallbackElement={fallbackElement}
-    >
-      <DataRouter />
+    <DataRouterProvider router={router} basename={basename}>
+      <DataRouter fallbackElement={fallbackElement} />
     </DataRouterProvider>
   );
 }
@@ -274,12 +270,8 @@ export function DataHashRouter({
   let router = routerSingleton;
 
   return (
-    <DataRouterProvider
-      router={router}
-      basename={basename}
-      fallbackElement={fallbackElement}
-    >
-      <DataRouter />
+    <DataRouterProvider router={router} basename={basename}>
+      <DataRouter fallbackElement={fallbackElement} />
     </DataRouterProvider>
   );
 }


### PR DESCRIPTION
Move the `fallbackElement` down into the contexts so users can leverage hooks/components inside the fallback