### PR TITLE
fix: generating path when passed only slash and star

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -79,3 +79,4 @@
 - williamsdyyz
 - xavier-lc
 - fz6m
+- KostiantynPopovych

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "filesize": {
     "packages/router/dist/router.js": {
-      "none": "98 kB"
+      "none": "98.06 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12 kB"

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -42,4 +42,16 @@ describe("generatePath", () => {
       expect(generatePath("/courses/*", {})).toBe("/courses");
     });
   });
+
+  describe("with splat only", () => {
+    it("omits the spat", () => {
+      expect(generatePath("*")).toBe("");
+    });
+  });
+
+  describe("with slash and splat", () => {
+    it("omits the spat and returns slash", () => {
+      expect(generatePath("/*")).toBe("/");
+    });
+  });
 });

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -17,7 +17,7 @@ describe("generatePath", () => {
         "/courses/routing/grades"
       );
       expect(generatePath("*", { "*": "routing/grades" })).toBe(
-        "/routing/grades"
+        "routing/grades"
       );
     });
   });
@@ -43,15 +43,30 @@ describe("generatePath", () => {
     });
   });
 
-  describe("with splat only", () => {
-    it("omits the spat", () => {
-      expect(generatePath("*")).toBe("");
-    });
+  it("throws only on on missing named parameters, but not missing splat params", () => {
+    expect(() => generatePath(":foo")).toThrow();
+    expect(() => generatePath("/:foo")).toThrow();
+    expect(() => generatePath("*")).not.toThrow();
+    expect(() => generatePath("/*")).not.toThrow();
   });
 
-  describe("with slash and splat", () => {
-    it("omits the spat and returns slash", () => {
-      expect(generatePath("/*")).toBe("/");
-    });
+  it("only interpolates and does not add slashes", () => {
+    expect(generatePath("*")).toBe("");
+    expect(generatePath("/*")).toBe("/");
+
+    expect(generatePath("foo*")).toBe("foo");
+    expect(generatePath("/foo*")).toBe("/foo");
+
+    expect(generatePath(":foo", { foo: "bar" })).toBe("bar");
+    expect(generatePath("/:foo", { foo: "bar" })).toBe("/bar");
+
+    expect(generatePath("*", { "*": "bar" })).toBe("bar");
+    expect(generatePath("/*", { "*": "bar" })).toBe("/bar");
+
+    expect(generatePath("foo:bar", { bar: "baz" })).toBe("foobaz");
+    expect(generatePath("/foo:bar", { bar: "baz" })).toBe("/foobaz");
+
+    expect(generatePath("foo*", { "*": "bar" })).toBe("foobar");
+    expect(generatePath("/foo*", { "*": "bar" })).toBe("/foobar");
   });
 });

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -487,7 +487,10 @@ export function generatePath<Path extends string>(
     .replace(/\/*\*$/, (_) => {
       const star = "*" as PathParam<Path>;
 
-      return params[star] == null ? "" : params[star].replace(/^\/*/, "/");
+      if (params[star]) return params[star].replace(/^\/*/, "/");
+      const slashSplatRe = /^\/\*$/;
+
+      return path.match(slashSplatRe) ? path.replace(slashSplatRe, "/") : "";
     });
 }
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -484,13 +484,17 @@ export function generatePath<Path extends string>(
       invariant(params[key] != null, `Missing ":${key}" param`);
       return params[key]!;
     })
-    .replace(/\/*\*$/, (_) => {
+    .replace(/(\/?)\*/, (_, prefix, __, str) => {
       const star = "*" as PathParam<Path>;
 
-      if (params[star]) return params[star].replace(/^\/*/, "/");
-      const slashSplatRe = /^\/\*$/;
+      if (params[star] == null) {
+        // If no splat was provided, trim the trailing slash _unless_ it's
+        // the entire path
+        return str === "/*" ? "/" : "";
+      }
 
-      return path.match(slashSplatRe) ? path.replace(slashSplatRe, "/") : "";
+      // Apply the splat
+      return `${prefix}${params[star]}`;
     });
 }
 


### PR DESCRIPTION
Fix for #8883, a bit changed the logic of `generatePath` function, added handling of this particular edge case.