### PR TITLE
docs(tutorial): fix styles for Index route

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -79,3 +79,4 @@
 - williamsdyyz
 - xavier-lc
 - fz6m
+- TkDodo

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -1224,7 +1224,7 @@ Feel free to copy paste, nothing special here.
 ```jsx filename=src/routes/index.jsx
 export default function Index() {
   return (
-    <p id="index">
+    <p id="zero-state">
       This is a demo for React Router.
       <br />
       Check out{" "}


### PR DESCRIPTION
The stylesheet references the id as `zero-state`, but the code gave the id `index`