### PR TITLE
fix: Await should fallback on route params navigations

### DIFF
--- a/.changeset/wet-readers-mate.md
+++ b/.changeset/wet-readers-mate.md
@@ -2,4 +2,4 @@
 "@remix-run/router": patch
 ---
 
-fix: fallback on route params navigations (#9181)
+fix: Await should fallback on route params navigations (#9181)

--- a/.changeset/wet-readers-mate.md
+++ b/.changeset/wet-readers-mate.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: fallback on route params navigations (#9181)

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -194,13 +194,13 @@ It's all trade-offs, and what's neat about the API design is that it's well suit
 
 ### When does the `<Suspense/>` fallback render?
 
-The `<Await />` component will only throw the promise up the `<Suspense>` boundary on the initial render of the `<Await />` component with an unsettled promise. It will not re-render the fallback if props change. Effectively, this means that you will not get a fallback rendered when a user submits a form and loader data is revalidated and you will not get a fallback rendered when the user navigates to the same route with different params (in the context of our above example, if the user selects from a list of packages on the left to find their location on the right).
+The `<Await />` component will only throw the promise up the `<Suspense>` boundary on the initial render of the `<Await />` component with an unsettled promise. It will not re-render the fallback if props change. Effectively, this means that you _will not_ get a fallback rendered when a user submits a form and loader data is revalidated. You _will_ get a fallback rendered when the user navigates to the same route with different params (in the context of our above example, if the user selects from a list of packages on the left to find their location on the right).
 
-This may feel counter-intuitive at first, but stay with us, we really thought this through and it's important that it works this way. Let's imagine a world without the deferred API. For those scenarios you're probably going to want to implement Optimistic UI for form submissions/revalidation and some Pending UI for sibling route navigations.
+This may feel counter-intuitive at first, but stay with us, we really thought this through and it's important that it works this way. Let's imagine a world without the deferred API. For those scenarios you're probably going to want to implement Optimistic UI for form submissions/revalidation.
 
-When you decide you'd like to try the trade-offs of `defer`, we don't want you to have to change or remove those optimizations because we want you to be able to easily switch between deferring some data and not deferring it. So we ensure that your existing pending states work the same way. If we didn't do this, then you could experience what we call "Popcorn UI" where submissions of data trigger the fallback loading state instead of the optimistic UI you'd worked hard on.
+When you decide you'd like to try the trade-offs of `defer`, we don't want you to have to change or remove those optimizations because we want you to be able to easily switch between deferring some data and not deferring it. So we ensure that your existing optimistic states work the same way. If we didn't do this, then you could experience what we call "Popcorn UI" where submissions of data trigger the fallback loading state instead of the optimistic UI you'd worked hard on.
 
-So just keep this in mind: **Deferred is 100% only about the initial load of a route.**
+So just keep this in mind: **Deferred is 100% only about the initial load of a route and it's params.**
 
 [link]: ../components/link
 [usefetcher]: ../hooks/use-fetcher

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "filesize": {
     "packages/router/dist/router.js": {
-      "none": "98 kB"
+      "none": "99 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12 kB"


### PR DESCRIPTION
I was a bit naive in the "is revalidating" check to determine when to `await` all deferred values.  We need to distinguish current `loaderData` for the same route _and the same params_ versus same route but _different_ params since we do want to fallback by default in the latter case (i.e., navigating /invoices/1 -> /invoices/2`).

Closes #8914