### PR TITLE
feat: add typing for state of useLocation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -81,3 +81,4 @@
 - fz6m
 - TkDodo
 - infoxicator
+- tsunode

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -8,10 +8,10 @@ title: useLocation
   <summary>Type declaration</summary>
 
 ```tsx
-declare function useLocation(): Location;
+declare function useLocation<S = undefined>(): Location<S | undefined>;
 
-interface Location extends Path {
-  state: unknown;
+interface Location<S = undefined> extends Path {
+  state: S;
   key: Key;
 }
 ```

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -91,7 +91,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/docs/en/v6/hooks/use-location
  */
-export function useLocation(): Location {
+export function useLocation<S = undefined>(): Location<S | undefined> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -53,11 +53,11 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location extends Path {
+export interface Location<S = undefined> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: any;
+  state: S;
 
   /**
    * A unique string associated with this location. May be used to safely store

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -53,11 +53,11 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location extends Path {
+export interface Location<S = any> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: any;
+  state: S;
 
   /**
    * A unique string associated with this location. May be used to safely store

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -53,11 +53,11 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location<S = undefined> extends Path {
+export interface Location extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: S;
+  state: any;
 
   /**
    * A unique string associated with this location. May be used to safely store


### PR DESCRIPTION
It was not possible to inform the type of the state we have inside useLocation, making it a bit verbose to type it using "as".
This PR allows sending through useLocation an interface that will complement the state and if it is not informed, the undefined value will be defined, keeping the application functional as it is today.