### PR TITLE
fix: proxy defer resolve/reject values through tracked promises

### DIFF
--- a/.changeset/young-pumas-destroy.md
+++ b/.changeset/young-pumas-destroy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+fix: proxy defer resolve/reject values through tracked promises (#9200)

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "filesize": {
     "packages/router/dist/router.js": {
-      "none": "99 kB"
+      "none": "100 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12 kB"

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -7676,7 +7676,17 @@ describe("a router", () => {
       );
 
       // Interrupt pending deferred's from /lazy navigation
-      let B = await t.navigate("/");
+      let navPromise = t.navigate("/");
+
+      // Cancelled promises should reject immediately
+      let data = t.router.state.loaderData.lazy;
+      await expect(data.lazy1).rejects.toBeInstanceOf(AbortedDeferredError);
+      await expect(data.lazy2).rejects.toBeInstanceOf(AbortedDeferredError);
+      await expect(data.lazy1).rejects.toThrowError("Deferred data aborted");
+      await expect(data.lazy2).rejects.toThrowError("Deferred data aborted");
+
+      let B = await navPromise;
+
       // During navigation - deferreds remain as promises
       expect(t.router.state.loaderData).toEqual({
         lazy: {
@@ -7698,13 +7708,6 @@ describe("a router", () => {
           lazy2: expect.trackedPromise(),
         },
       });
-
-      // Cancelled promises should reject
-      let data = t.router.state.loaderData.lazy;
-      await expect(data.lazy1).rejects.toBeInstanceOf(AbortedDeferredError);
-      await expect(data.lazy2).rejects.toBeInstanceOf(AbortedDeferredError);
-      await expect(data.lazy1).rejects.toThrowError("Deferred data aborted");
-      await expect(data.lazy2).rejects.toThrowError("Deferred data aborted");
 
       await B.loaders.index.resolve("INDEX*");
       expect(t.router.state.loaderData).toEqual({

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -35,6 +35,7 @@ export type {
 } from "./utils";
 
 export {
+  AbortedDeferredError,
   ErrorResponse,
   defer,
   generatePath,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2688,7 +2688,7 @@ async function resolveDeferredData(
     try {
       return {
         type: ResultType.data,
-        data: result.deferredData.unwrappedData,
+        data: await result.deferredData.unwrapData(),
       };
     } catch (e) {
       // Handle any TrackedPromise._error values encountered while unwrapping

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2688,7 +2688,7 @@ async function resolveDeferredData(
     try {
       return {
         type: ResultType.data,
-        data: await result.deferredData.unwrapData(),
+        data: result.deferredData.unwrappedData,
       };
     } catch (e) {
       // Handle any TrackedPromise._error values encountered while unwrapping

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -980,7 +980,6 @@ export class DeferredData {
           }
         });
       });
-
     }
     return aborted;
   }

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -911,7 +911,7 @@ export class DeferredData {
       "defer() only accepts plain objects"
     );
 
-    // Setup an AbortController + Promise we can race against to exit earlY
+    // Set up an AbortController + Promise we can race against to exit early
     // cancellation
     let reject: (e: AbortedDeferredError) => void;
     this.abortPromise = new Promise((_, r) => (reject = r));

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -895,6 +895,8 @@ export interface TrackedPromise extends Promise<any> {
   _error?: any;
 }
 
+export class AbortedDeferredError extends Error {}
+
 export class DeferredData {
   private pendingKeys: Set<string | number> = new Set<string | number>();
   private cancelled: boolean = false;
@@ -947,7 +949,7 @@ export class DeferredData {
     data?: unknown
   ): unknown {
     if (this.cancelled) {
-      return Promise.reject(new Error("Deferred data aborted"));
+      return Promise.reject(new AbortedDeferredError("Deferred data aborted"));
     }
     this.pendingKeys.delete(key);
 


### PR DESCRIPTION
fix: tracked promises should resolve/reject with the value instead of swallowing it