### PR TITLE
fix: params explanation should say action

### DIFF
--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -42,7 +42,7 @@ fetcher.submit(data, {
 
 ## `params`
 
-Route params are parsed from [dynamic segments][dynamicsegments] and passed to your loader. This is useful for figuring out which resource to mutate:
+Route params are parsed from [dynamic segments][dynamicsegments] and passed to your action. This is useful for figuring out which resource to mutate:
 
 ```tsx
 <Route


### PR DESCRIPTION
This page is about `action`, so the explanation of `params` should specify `action`.