### PR TITLE
fix: prevent aborted defer values from starting a suspense render loop

### DIFF
--- a/.changeset/shy-guests-tickle.md
+++ b/.changeset/shy-guests-tickle.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+fix: Avoid suspense loops on promise aborted values

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
       "none": "100 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "12 kB"
+      "none": "12.5 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
       "none": "14.5 kB"

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -2031,16 +2031,23 @@ describe("<DataMemoryRouter>", () => {
       triggerRenderError = false,
       triggerFallbackError = false,
     } = {}) {
+      let awaitRenderCount = 0;
       let barDefer = createDeferred();
+      let bazDefer = createDeferred();
       let { container } = render(
         <DataMemoryRouter initialEntries={["/foo"]} hydrationData={{}}>
           <Route path="/" element={<Layout />}>
-            <Route path="foo" element={<Foo />} />
+            <Route path="foo" element={<h1>Foo</h1>} />
             <Route
               path="bar"
               loader={() => barDefer.promise}
               element={<Bar />}
               errorElement={hasRouteErrorElement ? <RouteError /> : null}
+            />
+            <Route
+              path="baz"
+              loader={() => bazDefer.promise}
+              element={<h1>Baz</h1>}
             />
           </Route>
         </DataMemoryRouter>
@@ -2051,28 +2058,37 @@ describe("<DataMemoryRouter>", () => {
         return (
           <>
             <MemoryNavigate to="/bar">Link to Bar</MemoryNavigate>
-            <p>{navigation.state}</p>
-            <Outlet />
+            <MemoryNavigate to="/baz">Link to Baz</MemoryNavigate>
+            <div id="content">
+              <p>{navigation.state}</p>
+              <Outlet />
+            </div>
           </>
         );
       }
 
-      function Foo() {
-        return <h1>Foo</h1>;
-      }
       function Bar() {
         let data = useLoaderData();
         return (
           <>
             <p>{data.critical}</p>
             <React.Suspense fallback={<LazyFallback />}>
-              <Await
-                resolve={data.lazy}
-                errorElement={hasAwaitErrorElement ? <LazyError /> : null}
-              >
-                {useRenderProp ? (value) => <p>{value}</p> : <LazyData />}
-              </Await>
+              <AwaitCounter data={data} />
             </React.Suspense>
+          </>
+        );
+      }
+
+      function AwaitCounter({ data }) {
+        awaitRenderCount++;
+        return (
+          <>
+            <Await
+              resolve={data.lazy}
+              errorElement={hasAwaitErrorElement ? <LazyError /> : null}
+            >
+              {useRenderProp ? (value) => <p>{value}</p> : <LazyData />}
+            </Await>
           </>
         );
       }
@@ -2104,19 +2120,23 @@ describe("<DataMemoryRouter>", () => {
         return <p>Await Error:{data.message}</p>;
       }
 
-      return { container, barDefer };
+      return {
+        container: container.querySelector("#content"),
+        barDefer,
+        bazDefer,
+        getAwaitRenderCount() {
+          return awaitRenderCount;
+        },
+      };
     }
 
     it("allows loaders to returned deferred data (child component)", async () => {
       let { barDefer, container } = setupDeferredTest();
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2135,12 +2155,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2156,12 +2173,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.resolve("LAZY");
       await waitFor(() => screen.getByText("LAZY"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2180,12 +2194,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2204,12 +2215,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2225,12 +2233,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.resolve("LAZY");
       await waitFor(() => screen.getByText("LAZY"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2252,12 +2257,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2276,12 +2278,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2297,12 +2296,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.reject(new Error("Kaboom!"));
       await waitFor(() => screen.getByText(/Kaboom!/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2325,12 +2321,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2349,12 +2342,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2370,12 +2360,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.reject(new Error("Kaboom!"));
       await waitFor(() => screen.getByText(/Kaboom!/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2396,12 +2383,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2420,12 +2404,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2441,12 +2422,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.resolve("LAZY");
       await waitFor(() => screen.getByText(/oops is not defined/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2470,12 +2448,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2494,12 +2469,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2515,12 +2487,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.resolve("LAZY");
       await waitFor(() => screen.getByText(/oops is not defined/));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2542,12 +2511,9 @@ describe("<DataMemoryRouter>", () => {
 
       fireEvent.click(screen.getByText("Link to Bar"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             loading
           </p>
@@ -2566,12 +2532,9 @@ describe("<DataMemoryRouter>", () => {
       );
       await waitFor(() => screen.getByText("idle"));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2586,12 +2549,9 @@ describe("<DataMemoryRouter>", () => {
       barValueDfd.resolve("LAZY");
       await new Promise((r) => setTimeout(r, 1));
       expect(getHtml(container)).toMatchInlineSnapshot(`
-        "<div>
-          <a
-            href=\\"/bar\\"
-          >
-            Link to Bar
-          </a>
+        "<div
+          id=\\"content\\"
+        >
           <p>
             idle
           </p>
@@ -2601,6 +2561,104 @@ describe("<DataMemoryRouter>", () => {
           </p>
         </div>"
       `);
+    });
+
+    it("freezes the UI for aborted deferreds", async () => {
+      let { barDefer, bazDefer, container, getAwaitRenderCount } =
+        setupDeferredTest();
+      fireEvent.click(screen.getByText("Link to Bar"));
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div
+          id=\\"content\\"
+        >
+          <p>
+            loading
+          </p>
+          <h1>
+            Foo
+          </h1>
+        </div>"
+      `);
+      expect(getAwaitRenderCount()).toBe(0);
+
+      let barValueDfd = createDeferred();
+      barDefer.resolve(
+        defer({
+          critical: "CRITICAL",
+          lazy: barValueDfd.promise,
+        })
+      );
+      await waitFor(() => screen.getByText("idle"));
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div
+          id=\\"content\\"
+        >
+          <p>
+            idle
+          </p>
+          <p>
+            CRITICAL
+          </p>
+          <p>
+            Loading...
+          </p>
+        </div>"
+      `);
+      expect(getAwaitRenderCount()).toBe(1);
+
+      // Abort the deferred by navigating to /baz
+      fireEvent.click(screen.getByText("Link to Baz"));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div
+          id=\\"content\\"
+        >
+          <p>
+            loading
+          </p>
+          <p>
+            CRITICAL
+          </p>
+          <p>
+            Loading...
+          </p>
+        </div>"
+      `);
+      // 2 more renders by now - once for the navigation and once for the
+      // promise abort rejection
+      expect(getAwaitRenderCount()).toBe(3);
+
+      // complete /baz navigation
+      bazDefer.resolve();
+      await waitFor(() => screen.getByText("Baz"));
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div
+          id=\\"content\\"
+        >
+          <p>
+            idle
+          </p>
+          <h1>
+            Baz
+          </h1>
+        </div>"
+      `);
+
+      // Does nothing now
+      barValueDfd.resolve("LAZY");
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div
+          id=\\"content\\"
+        >
+          <p>
+            idle
+          </p>
+          <h1>
+            Baz
+          </h1>
+        </div>"
+      `);
+      expect(getAwaitRenderCount()).toBe(3);
     });
 
     it("can render raw resolved promises with <Await>", async () => {

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -967,6 +967,7 @@ export class DeferredData {
       error instanceof AbortedDeferredError
     ) {
       this.unlistenAbortSignal();
+      Object.defineProperty(promise, "_error", { get: () => error });
       return Promise.reject(error);
     }
 


### PR DESCRIPTION
We need to send the `AbortedDeferredError` through the `TrackedPromise` in `_error` so `Await` can throw a never-resolving promise to `Suspense` to freeze the UI.  Otherwise, we end up throwing an already-rejected promise to `Suspense`, which sends it right back down to `Await`.  React does break out of this loop as soon as the next load or navigation finishes, but it's busted _during_ the transition