### PR TITLE
fix: ensure consistency in generatePath/compilePath for partial splats

### DIFF
--- a/.changeset/angry-pens-flow.md
+++ b/.changeset/angry-pens-flow.md
@@ -3,4 +3,4 @@
 "@remix-run/router": patch
 ---
 
-fix: Align behavior of generatePath with compilePath to not support partial splat params (#9238)
+fix: Permit partial splat route segment matching (i.e., `/prefix-*`) (#9238)

--- a/.changeset/angry-pens-flow.md
+++ b/.changeset/angry-pens-flow.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+fix: Align behavior of generatePath with compilePath to not support partial splat params (#9238)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Lint
+        run: yarn lint
+
       - name: Test
         run: yarn test
 

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -51,6 +51,8 @@ describe("generatePath", () => {
   });
 
   it("only interpolates and does not add slashes", () => {
+    let consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
     expect(generatePath("*")).toBe("");
     expect(generatePath("/*")).toBe("/");
 
@@ -66,7 +68,28 @@ describe("generatePath", () => {
     expect(generatePath("foo:bar", { bar: "baz" })).toBe("foobaz");
     expect(generatePath("/foo:bar", { bar: "baz" })).toBe("/foobaz");
 
-    expect(generatePath("foo*", { "*": "bar" })).toBe("foobar");
-    expect(generatePath("/foo*", { "*": "bar" })).toBe("/foobar");
+    // Partial splats are treated as independent path segments
+    expect(generatePath("foo*", { "*": "bar" })).toBe("foo/bar");
+    expect(generatePath("/foo*", { "*": "bar" })).toBe("/foo/bar");
+
+    // Ensure we warn on partial splat usages
+    expect(consoleWarn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "Route path \\"foo*\\" will be treated as if it were \\"foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"foo/*\\".",
+        ],
+        Array [
+          "Route path \\"/foo*\\" will be treated as if it were \\"/foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/foo/*\\".",
+        ],
+        Array [
+          "Route path \\"foo*\\" will be treated as if it were \\"foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"foo/*\\".",
+        ],
+        Array [
+          "Route path \\"/foo*\\" will be treated as if it were \\"/foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/foo/*\\".",
+        ],
+      ]
+    `);
+
+    consoleWarn.mockRestore();
   });
 });

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -51,8 +51,6 @@ describe("generatePath", () => {
   });
 
   it("only interpolates and does not add slashes", () => {
-    let consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
-
     expect(generatePath("*")).toBe("");
     expect(generatePath("/*")).toBe("/");
 
@@ -68,28 +66,7 @@ describe("generatePath", () => {
     expect(generatePath("foo:bar", { bar: "baz" })).toBe("foobaz");
     expect(generatePath("/foo:bar", { bar: "baz" })).toBe("/foobaz");
 
-    // Partial splats are treated as independent path segments
-    expect(generatePath("foo*", { "*": "bar" })).toBe("foo/bar");
-    expect(generatePath("/foo*", { "*": "bar" })).toBe("/foo/bar");
-
-    // Ensure we warn on partial splat usages
-    expect(consoleWarn.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "Route path \\"foo*\\" will be treated as if it were \\"foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"foo/*\\".",
-        ],
-        Array [
-          "Route path \\"/foo*\\" will be treated as if it were \\"/foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/foo/*\\".",
-        ],
-        Array [
-          "Route path \\"foo*\\" will be treated as if it were \\"foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"foo/*\\".",
-        ],
-        Array [
-          "Route path \\"/foo*\\" will be treated as if it were \\"/foo/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/foo/*\\".",
-        ],
-      ]
-    `);
-
-    consoleWarn.mockRestore();
+    expect(generatePath("foo*", { "*": "bar" })).toBe("foobar");
+    expect(generatePath("/foo*", { "*": "bar" })).toBe("/foobar");
   });
 });

--- a/packages/react-router/__tests__/matchPath-test.tsx
+++ b/packages/react-router/__tests__/matchPath-test.tsx
@@ -298,38 +298,24 @@ describe("matchPath *", () => {
   });
 });
 
-describe("matchPath warnings", () => {
-  let consoleWarn: jest.SpyInstance<void, any>;
-  beforeEach(() => {
-    consoleWarn = jest.spyOn(console, "warn").mockImplementation();
-  });
+describe("when the pattern has a trailing *", () => {
+  it("matches the remaining portion of the pathname", () => {
+    expect(matchPath("/files*", "/files/mj.jpg")).toMatchObject({
+      params: { "*": "/mj.jpg" },
+      pathname: "/files/mj.jpg",
+      pathnameBase: "/files",
+    });
 
-  afterEach(() => {
-    consoleWarn.mockRestore();
-  });
+    expect(matchPath("/files*", "/files/")).toMatchObject({
+      params: { "*": "/" },
+      pathname: "/files/",
+      pathnameBase: "/files",
+    });
 
-  describe("when the pattern has a trailing *", () => {
-    it("issues a warning and matches the remaining portion of the pathname", () => {
-      expect(matchPath("/files*", "/files/mj.jpg")).toMatchObject({
-        params: { "*": "mj.jpg" },
-        pathname: "/files/mj.jpg",
-        pathnameBase: "/files",
-      });
-      expect(consoleWarn).toHaveBeenCalledTimes(1);
-
-      expect(matchPath("/files*", "/files/")).toMatchObject({
-        params: { "*": "" },
-        pathname: "/files/",
-        pathnameBase: "/files",
-      });
-      expect(consoleWarn).toHaveBeenCalledTimes(2);
-
-      expect(matchPath("/files*", "/files")).toMatchObject({
-        params: { "*": "" },
-        pathname: "/files",
-        pathnameBase: "/files",
-      });
-      expect(consoleWarn).toHaveBeenCalledTimes(3);
+    expect(matchPath("/files*", "/files")).toMatchObject({
+      params: { "*": "" },
+      pathname: "/files",
+      pathnameBase: "/files",
     });
   });
 });

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -329,7 +329,7 @@ describe("path matching with splats", () => {
 });
 
 describe("route scoring", () => {
-  test.only("splat routes versus dynamic routes", () => {
+  test("splat routes versus dynamic routes", () => {
     let routes = [
       { path: "nested/prefix-:param/static/prefix-*" }, // Score 43
       { path: "nested/prefix-:param/static/*" }, // Score 33

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -267,4 +267,57 @@ describe("path matching with splats", () => {
       pathnameBase: "/courses",
     });
   });
+
+  test("supports partial path matching with named parameters", () => {
+    let routes = [{ path: "/prefix:id" }];
+    expect(matchRoutes(routes, "/prefixabc")).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "params": Object {
+            "id": "abc",
+          },
+          "pathname": "/prefixabc",
+          "pathnameBase": "/prefixabc",
+          "route": Object {
+            "path": "/prefix:id",
+          },
+        },
+      ]
+    `);
+    expect(matchRoutes(routes, "/prefix/abc")).toMatchInlineSnapshot(`null`);
+  });
+
+  test("does not support partial path matching with named parameters", () => {
+    let consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    let routes = [{ path: "/prefix*" }];
+    expect(matchRoutes(routes, "/prefix/abc")).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "params": Object {
+            "*": "abc",
+          },
+          "pathname": "/prefix/abc",
+          "pathnameBase": "/prefix",
+          "route": Object {
+            "path": "/prefix*",
+          },
+        },
+      ]
+    `);
+    expect(matchRoutes(routes, "/prefixabc")).toMatchInlineSnapshot(`null`);
+
+    // Should warn on each invocation of matchRoutes
+    expect(consoleWarn.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "Route path \\"/prefix*\\" will be treated as if it were \\"/prefix/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/prefix/*\\".",
+        ],
+        Array [
+          "Route path \\"/prefix*\\" will be treated as if it were \\"/prefix/*\\" because the \`*\` character must always follow a \`/\` in the pattern. To get rid of this warning, please change the route path to \\"/prefix/*\\".",
+        ],
+      ]
+    `);
+
+    consoleWarn.mockRestore();
+  });
 });

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -475,11 +475,23 @@ function matchRouteBranch<
  * @see https://reactrouter.com/docs/en/v6/utils/generate-path
  */
 export function generatePath<Path extends string>(
-  path: Path,
+  originalPath: Path,
   params: {
     [key in PathParam<Path>]: string;
   } = {} as any
 ): string {
+  let path = originalPath;
+  if (path.endsWith("*") && path !== "*" && !path.endsWith("/*")) {
+    warning(
+      false,
+      `Route path "${path}" will be treated as if it were ` +
+        `"${path.replace(/\*$/, "/*")}" because the \`*\` character must ` +
+        `always follow a \`/\` in the pattern. To get rid of this warning, ` +
+        `please change the route path to "${path.replace(/\*$/, "/*")}".`
+    );
+    path = path.replace(/\*$/, "/*") as Path;
+  }
+
   return path
     .replace(/:(\w+)/g, (_, key: PathParam<Path>) => {
       invariant(params[key] != null, `Missing ":${key}" param`);

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -642,7 +642,6 @@ function compilePath(
     // Partial splat segment
     paramNames.push("*");
     regexpSource += "(.*)$";
-    //regexpSource += "(?:\\/(.+)|\\/*)$";
   } else {
     regexpSource += end
       ? "\\/*$" // When matching to the end, ignore trailing slashes


### PR DESCRIPTION
~~This fixes a small inconsistency in `generatePath` w.r.t. `compilePath`.  We _do_ support partial named params but at the moment we do not support partial splat params, but `generatePath` was permitting them.  This aligns `generatePath` behavior and provides the same warning as `compilePath`~~

After chatting with @ryanflorence we decided that if possible we should look into removing that warning and supporting partial splat params (in path matching and `generatePath`), such the the path `/prefix-*` is matched by the URL `/prefix-thing`.  This PR adds specific scoring for both partial dynamic (`/prefix-:param`) and partial static (`/prefix-*`) path segments.  

There are I think 2 exiting unit tests that break, that rely on the behavior indicated by the previous warning.  So want to confirm those changes with @mjackson and @ryanflorence, but otherwise everything else passes and I added a decently sized test to try to really kick the tire son the scoring algorithm and potential conflicts.

Note: Recommend viewing the PR with [whitespace hidden](https://github.com/remix-run/react-router/pull/9238/files?diff=unified&w=1)