### PR TITLE
docs: update references to data router for clarity

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -45,7 +45,7 @@ Examples:
 
 <docs-info>`<Link to>` with a `..` behaves differently from a normal `<a href>` when the current URL ends with `/`. `<Link to>` ignores the trailing slash, and removes one URL segment for each `..`. But an `<a href>` value handles `..` differently when the current URL ends with `/` vs when it does not.</docs-info>
 
-<docs-warning>`useMatches` only works with Data Routers, since they know the full route tree up front and can provide all of the current matches. Additionally, `useMatches` will not match down into any descendant route trees since the router isn't aware of the descendant routes.</docs-warning>
+<docs-warning>`useMatches` only works with a data router like [`createBrowserRouter`][createbrowserrouter], since they know the full route tree up front and can provide all of the current matches. Additionally, `useMatches` will not match down into any descendant route trees since the router isn't aware of the descendant routes.</docs-warning>
 
 <docs-error>Do not do this</docs-error>
 
@@ -182,3 +182,4 @@ Lines that overflow:
 ---
 
 [$link]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+[createbrowserrouter]: ./routers/create-browser-router.md

--- a/docs/hooks/use-matches.md
+++ b/docs/hooks/use-matches.md
@@ -39,7 +39,7 @@ A `match` has the following shape:
 
 Pairing `<Route handle>` with `useMatches` gets very powerful since you can put whatever you want on a route `handle` and have access to `useMatches` anywhere.
 
-<docs-warning>`useMatches` only works with Data Routers, since they know the full route tree up front and can provide all of the current matches. Additionally, `useMatches` will not match down into any descendant route trees since the router isn't aware of the descendant routes.</docs-warning>
+<docs-warning>`useMatches` only works with a data router like [`createBrowserRouter`][createbrowserrouter], since they know the full route tree up front and can provide all of the current matches. Additionally, `useMatches` will not match down into any descendant route trees since the router isn't aware of the descendant routes.</docs-warning>
 
 ## Breadcrumbs
 
@@ -98,3 +98,5 @@ function Breadcrumbs() {
 ```
 
 Now you can render `<Breadcrumbs/>` anywhere you want, probably in the root component.
+
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -7,7 +7,7 @@ new: true
 
 Route actions are the "writes" to route [loader][loader] "reads". They provide a way for apps to perform data mutations with simple HTML and HTTP semantics while React Router abstracts away the complexity of asynchronous UI and revalidation. This gives you the simple mental model of HTML + HTTP (where the browser handles the asynchrony and revalidation) with the behavior and and UX capabilities of modern SPAs.
 
-<docs-error>This feature only works if using a data router</docs-error>
+<docs-error>This feature only works if using a data router like [`createBrowserRouter`][createbrowserrouter]</docs-error>
 
 ```tsx
 <Route
@@ -144,3 +144,4 @@ For more details and expanded use cases, read the [errorElement][errorelement] d
 [workingwithformdata]: ../guides/form-data
 [useactiondata]: ../hooks/use-action-data
 [returningresponses]: ./loader#returning-responses
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -7,7 +7,7 @@ new: true
 
 When exceptions are thrown in [loaders][loader], [actions][action], or component rendering, instead of the normal render path for your Routes (`<Route element>`), the error path will be rendered (`<Route errorElement>`) and the error made available with [`useRouteError`][userouteerror].
 
-<docs-error>This feature only works if using a data router</docs-error>
+<docs-error>This feature only works if using a data router like [`createBrowserRouter`][createbrowserrouter]</docs-error>
 
 ```tsx
 <Route
@@ -213,3 +213,4 @@ The project route doesn't have to think about errors at all. Between the loader 
 [response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [isrouteerrorresponse]: ../utils/is-route-error-response
 [json]: ../fetch/json
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -222,7 +222,7 @@ function Team() {
 }
 ```
 
-<docs-warning>If you are not using a Data router, this will do nothing</docs-warning>
+<docs-warning>If you are not using a data router like [`createBrowserRouter`][createbrowserrouter], this will do nothing</docs-warning>
 
 Please see the [loader][loader] documentation for more details.
 
@@ -240,7 +240,7 @@ The route action is called when a submission is sent to the route from a [Form][
 />
 ```
 
-<docs-warning>If you are not using a Data router, this will do nothing</docs-warning>
+<docs-warning>If you are not using a data router like [`createBrowserRouter`][createbrowserrouter], this will do nothing</docs-warning>
 
 Please see the [action][action] documentation for more details.
 
@@ -272,7 +272,7 @@ When a route throws an exception while rendering, in a `loader` or in an `action
 />
 ```
 
-<docs-warning>If you are not using a Data router, this will do nothing</docs-warning>
+<docs-warning>If you are not using a data router like [`createBrowserRouter`][createbrowserrouter], this will do nothing</docs-warning>
 
 Please see the [errorElement][errorelement] documentation for more details.
 
@@ -288,3 +288,4 @@ Please see the [errorElement][errorelement] documentation for more details.
 [fetcher]: ../hooks/use-fetcher
 [usesubmit]: ../hooks/use-submit
 [createroutesfromelements]: ../utils/create-routes-from-elements
+[createbrowserrouter]: ../routers/create-browser-router.md


### PR DESCRIPTION
Provide links to `createBrowserRouter` to help clarify what a "data router" is