### PR TITLE
Fixed broken getting started links on README

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -99,3 +99,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- btav

--- a/packages/react-router-dom/README.md
+++ b/packages/react-router-dom/README.md
@@ -2,4 +2,4 @@
 
 The `react-router-dom` package contains bindings for using [React
 Router](https://github.com/remix-run/react-router) in web applications.
-Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/getting-started/tutorial.md) for more information on how to get started with React Router.
+Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md) for more information on how to get started with React Router.

--- a/packages/react-router-native/README.md
+++ b/packages/react-router-native/README.md
@@ -3,4 +3,4 @@
 The `react-router-native` package contains bindings for using [React
 Router](https://github.com/remix-run/react-router) in [React
 Native](https://facebook.github.io/react-native/) applications.
-Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/getting-started/tutorial.md) for more information on how to get started with React Router.
+Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md) for more information on how to get started with React Router.


### PR DESCRIPTION
👋 At the moment, the getting started tutorial links on the package `README.md` are pointing to a `docs/getting-started/` directory that no longer exists. As a result, users viewing the package on NPM will be pointed to a broken getting started link. 

I have changed it to point to `docs/start/`. 

Question, previously the `react-router-dom` and `react-router-native` pointed to the same tutorial, should this still be the case? 