### PR TITLE
fix: route loader code example in docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,6 +1,7 @@
 - abhi-kr-2100
 - Ajayff4
 - alexlbr
+- andreiduca
 - avipatel97
 - awreese
 - bavardage

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -66,9 +66,11 @@ createBrowserRouter(
       <Route
         path="dashboard"
         element={<Dashboard />}
-        loader={fetch("/api/dashboard.json", {
-          signal: request.signal,
-        })}
+        loader={({ request }) =>
+          fetch("/api/dashboard.json", {
+            signal: request.signal,
+          })
+        }
       />
       <Route element={<AuthLayout />}>
         <Route


### PR DESCRIPTION
Fixed a code example for the Route loader on the Feature Overview page.

closes #9244 