### PR TITLE
docs: fix broken link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -58,6 +58,7 @@
 - lukerSpringTree
 - marc2332
 - markivancho
+- maxpou
 - mcansh
 - MenouerBetty
 - mfijas

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -182,4 +182,4 @@ Lines that overflow:
 ---
 
 [$link]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
-[createbrowserrouter]: ./routers/create-browser-router.md
+[createbrowserrouter]: ./routers/create-browser-router

--- a/docs/hooks/use-matches.md
+++ b/docs/hooks/use-matches.md
@@ -99,4 +99,4 @@ function Breadcrumbs() {
 
 Now you can render `<Breadcrumbs/>` anywhere you want, probably in the root component.
 
-[createbrowserrouter]: ../routers/create-browser-router.md
+[createbrowserrouter]: ../routers/create-browser-router

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -144,4 +144,4 @@ For more details and expanded use cases, read the [errorElement][errorelement] d
 [workingwithformdata]: ../guides/form-data
 [useactiondata]: ../hooks/use-action-data
 [returningresponses]: ./loader#returning-responses
-[createbrowserrouter]: ../routers/create-browser-router.md
+[createbrowserrouter]: ../routers/create-browser-router

--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -213,4 +213,4 @@ The project route doesn't have to think about errors at all. Between the loader 
 [response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [isrouteerrorresponse]: ../utils/is-route-error-response
 [json]: ../fetch/json
-[createbrowserrouter]: ../routers/create-browser-router.md
+[createbrowserrouter]: ../routers/create-browser-router

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -288,4 +288,4 @@ Please see the [errorElement][errorelement] documentation for more details.
 [fetcher]: ../hooks/use-fetcher
 [usesubmit]: ../hooks/use-submit
 [createroutesfromelements]: ../utils/create-routes-from-elements
-[createbrowserrouter]: ../routers/create-browser-router.md
+[createbrowserrouter]: ../routers/create-browser-router


### PR DESCRIPTION
Hi, you have some dead links in your documentation. Links pointing to `createbrowserrouter` point to 'https://reactrouter.com/en/main/routers/create-browser-router.md' which returns a 404.

Pages with broken links: (search for "createbrowserrouter")
* https://reactrouter.com/en/main/route/error-element
* https://reactrouter.com/en/main/hooks/use-matches
* https://reactrouter.com/en/main/route/action
* https://reactrouter.com/en/main/route/error-element
* https://reactrouter.com/en/main/route/route

// related 44736e9ae5fcab17e37b7c551499ac19a1a692c5