### PR TITLE
docs: fix deadlink in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 React Router is a lightweight, fully-featured routing library for the [React](https://reactjs.org) JavaScript library. React Router runs everywhere that React runs; on the web, on the server (using node.js), and on React Native.
 
-If you're new to React Router, we recommend you start with [the getting started guide](/docs/getting-started/installation.md).
+If you're new to React Router, we recommend you start with [the tutorial](/docs/start/tutorial.md).
 
 If you're migrating to v6 from v5 (or v4, which is the same as v5), check out [the migration guide](/docs/upgrading/v5.md). If you're migrating from Reach Router, check out [the migration guide for Reach Router](/docs/upgrading/reach.md). If you need to find the code for v5, [it is on the `v5` branch](https://github.com/remix-run/react-router/tree/v5).
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -20,6 +20,7 @@
 - david-crespo
 - dokeet
 - edwin177
+- ekaansharora
 - elanis
 - elylucas
 - emzoumpo


### PR DESCRIPTION
[The getting started guide](https://github.com/remix-run/react-router/blob/main/docs/getting-started/installation.md) is no longer available, I changed the link to direct users to the tutorial instead.