### PR TITLE
fix: useNavigate example

### DIFF
--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -12,6 +12,7 @@ The `useNavigate` hook returns a function that lets you navigate programmaticall
 import { useNavigate } from "react-router-dom";
 
 function useLogoutTimer() {
+  const navigate = useNavigate();
   const userIsInactive = useFakeInactiveUser();
 
   useEffect(() => {


### PR DESCRIPTION
# Fixing Docs Example

navigate variable declaration is missing on this page.