### PR TITLE
docs: fix useNavigate example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -42,6 +42,7 @@
 - janpaepke
 - jimniels
 - jmargeta
+- joaop221
 - johnpangalos
 - jonkoops
 - kantuni

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -12,6 +12,7 @@ The `useNavigate` hook returns a function that lets you navigate programmaticall
 import { useNavigate } from "react-router-dom";
 
 function useLogoutTimer() {
+  const navigate = useNavigate();
   const userIsInactive = useFakeInactiveUser();
 
   useEffect(() => {


### PR DESCRIPTION
# Fixing useNaviagate docs example

navigate variable declaration is missing on this page.