### PR TITLE
docs: fix ScrollRestoration getKey example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -104,3 +104,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- GraxMonzo

--- a/docs/components/scroll-restoration.md
+++ b/docs/components/scroll-restoration.md
@@ -58,7 +58,7 @@ A solid product decision here is to keep the users scroll position on the home f
 
 ```tsx
 <ScrollRestoration
-  getKey={({ location, matches }) => {
+  getKey={(location, matches) => {
     return location.pathname;
   }}
 />
@@ -68,7 +68,7 @@ Or you may want to only use the pathname for some paths, and use the normal beha
 
 ```tsx
 <ScrollRestoration
-  getKey={({ location, matches }) => {
+  getKey={(location, matches) => {
     const paths = ["/home", "/notifications"];
     return paths.includes(location.pathname)
       ? // home and notifications restore by pathname

--- a/docs/components/scroll-restoration.md
+++ b/docs/components/scroll-restoration.md
@@ -28,7 +28,7 @@ Optional prop that defines the key React Router should use to restore scroll pos
 
 ```tsx
 <ScrollRestoration
-  getKey={({ location, matches }) => {
+  getKey={(location, matches) => {
     // default behavior
     return location.key;
   }}


### PR DESCRIPTION
Removed unnecessary argument destructuring on `getKey` callback.
https://github.com/remix-run/react-router/blob/4d915e3305df5b01f51abdeb1c01bf442453522e/packages/router/router.ts#L321-L329