### PR TITLE
links fix (works in vscode but not on browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When v6 is stable we will publish the docs on our website.
 
 ## Contributing
 
-There are many different ways to contribute to React Router's development. If you're interested, check out [our contributing guidelines](CONTRIBUTING.md) to learn how you can get involved.
+There are many different ways to contribute to React Router's development. If you're interested, check out [our contributing guidelines](docs/guides/contributing.md) to learn how you can get involved.
 
 ## Packages
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -37,6 +37,7 @@
 - goldins
 - gowthamvbhat
 - GraxMonzo
+- gtu-myowin
 - haivuw
 - hernanif1
 - hongji00

--- a/docs/components/await.md
+++ b/docs/components/await.md
@@ -147,11 +147,11 @@ function Book() {
 }
 ```
 
-[useloaderdata]: ../hooks/use-loader-data
-[userouteerror]: ../hooks/use-route-error
-[defer]: ../utils/defer
-[deferred guide]: ../guides/deferred
-[useasyncvalue]: ../hooks/use-async-value
-[useasyncerror]: ../hooks/use-async-error
-[routeerrorelement]: ../route/error-element
-[loader]: ../route/loader
+[useloaderdata]: ../hooks/use-loader-data.md
+[userouteerror]: ../hooks/use-route-error.md
+[defer]: ../utils/defer.md
+[deferred guide]: ../guides/deferred.md
+[useasyncvalue]: ../hooks/use-async-value.md
+[useasyncerror]: ../hooks/use-async-error.md
+[routeerrorelement]: ../route/error-element.md
+[loader]: ../route/loader.md

--- a/docs/components/routes.md
+++ b/docs/components/routes.md
@@ -34,7 +34,7 @@ Whenever the location changes, `<Routes>` looks through all its child routes to 
 </Routes>
 ```
 
-[location]: ../hook/location
-[outlet]: ./outlet
-[use-route]: ../hooks/use-routes
-[createbrowserrouter]: ../routers/create-browser-router
+[location]: ../hooks/use-location.md
+[outlet]: ./outlet.md
+[use-route]: ../hooks/use-routes.md
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/hooks/use-matches.md
+++ b/docs/hooks/use-matches.md
@@ -99,4 +99,4 @@ function Breadcrumbs() {
 
 Now you can render `<Breadcrumbs/>` anywhere you want, probably in the root component.
 
-[createbrowserrouter]: ../routers/create-browser-router
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -144,4 +144,4 @@ For more details and expanded use cases, read the [errorElement][errorelement] d
 [workingwithformdata]: ../guides/form-data
 [useactiondata]: ../hooks/use-action-data
 [returningresponses]: ./loader#returning-responses
-[createbrowserrouter]: ../routers/create-browser-router
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -213,4 +213,4 @@ The project route doesn't have to think about errors at all. Between the loader 
 [response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [isrouteerrorresponse]: ../utils/is-route-error-response
 [json]: ../fetch/json
-[createbrowserrouter]: ../routers/create-browser-router
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -288,4 +288,4 @@ Please see the [errorElement][errorelement] documentation for more details.
 [fetcher]: ../hooks/use-fetcher
 [usesubmit]: ../hooks/use-submit
 [createroutesfromelements]: ../utils/create-routes-from-elements
-[createbrowserrouter]: ../routers/create-browser-router
+[createbrowserrouter]: ../routers/create-browser-router.md

--- a/docs/routers/create-browser-router.md
+++ b/docs/routers/create-browser-router.md
@@ -101,11 +101,11 @@ createBrowserRouter(routes, {
 
 Useful for environments like browser devtool plugins or testing to use a different window than the global `window`.
 
-[loader]: ../route/loader
-[action]: ../route/action
-[fetcher]: ../hooks/use-fetcher
-[browser-router]: ./browser-router
-[form]: ../components/form
-[route]: ../components/route
-[routes]: ../components/routes
+[loader]: ../route/loader.md
+[action]: ../route/action.md
+[fetcher]: ../hooks/use-fetcher.md
+[browser-router]: ../router-components/browser-router.md
+[form]: ../components/form.md
+[route]: ../components/route.md
+[routes]: ../components/routes.md
 [historyapi]: https://developer.mozilla.org/en-US/docs/Web/API/History

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1956,7 +1956,7 @@ That's it! Thanks for giving React Router a shot. We hope this tutorial gives yo
 
 [vite]: https://vitejs.dev/guide/
 [node]: https://nodejs.org
-[createbrowserrouter]: ../routers/create-browser-router
+[createbrowserrouter]: ../routers/create-browser-router.md
 [route]: ../route/route
 [tutorial-css]: https://gist.githubusercontent.com/ryanflorence/ba20d473ef59e1965543fa013ae4163f/raw/499707f25a5690d490c7b3d54c65c65eb895930c/react-router-6.4-tutorial-css.css
 [tutorial-data]: https://gist.githubusercontent.com/ryanflorence/1e7f5d3344c0db4a8394292c157cd305/raw/f7ff21e9ae7ffd55bfaaaf320e09c6a08a8a6611/contacts.js


### PR DESCRIPTION
The links in docs aren't working on actual github repo but they are working with `Opt+click` in vscode. I went ahead and checked for the cause and found out that it is because the links are missing `.md` extension at the end.

I only fixed some of them to see if you are accepting my PR. If you do, I will dive deeper and fix all the links in the docs. 

In `README.md`, I have linked to direct link to `our contributing guidelines` page.