### PR TITLE
fix small error in tutorial documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -111,3 +111,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- ianflynnwork

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -760,7 +760,7 @@ export function loader({ params }) {
   return getContact(params.contactId);
 }
 
-export default function Edit() {
+export default function EditContact() {
   const contact = useLoaderData();
 
   return (


### PR DESCRIPTION
the Edit function is imported in the next step by a different name (Edit -> EditContact).