### PR TITLE
fix: reset actionData state on redirection from an action

### DIFF
--- a/.changeset/short-hats-peel.md
+++ b/.changeset/short-hats-peel.md
@@ -2,4 +2,4 @@
 "@remix-run/router": patch
 ---
 
-reset action data after redirection trigger by action
+fix: reset `actionData` after successful action redirect (#9334)

--- a/.changeset/short-hats-peel.md
+++ b/.changeset/short-hats-peel.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+reset action data after redirection trigger by action

--- a/contributors.yml
+++ b/contributors.yml
@@ -54,6 +54,7 @@
 - jmargeta
 - johnpangalos
 - jonkoops
+- jrakotoharisoa
 - kantuni
 - kddnewton
 - kentcdodds
@@ -113,4 +114,3 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
-- jrakotoharisoa

--- a/contributors.yml
+++ b/contributors.yml
@@ -113,3 +113,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- jrakotoharisoa

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2706,49 +2706,79 @@ describe("a router", () => {
       expect(t.router.state.actionData).toBeNull();
     });
 
-    it("removes action data after action redirect (return)", async () => {
+    it("removes action data after action redirect (w/o loaders to run)", async () => {
       let t = setup({
         routes: [
           {
-            path: "/",
-            id: "root",
-            loader: true,
-            hasErrorBoundary: true,
-            children: [
-              {
-                index: true,
-                id: "child",
-                action: true,
-              },
-              {
-                path: "/other",
-                id: "other",
-                loader: true,
-                action: true,
-              },
-            ],
+            index: true,
+            id: "index",
+            action: true,
+          },
+          {
+            path: "/other",
+            id: "other",
           },
         ],
       });
-      let A = await t.navigate("/?index", {
+      let A = await t.navigate("/", {
         formMethod: "post",
         formData: createFormData({ gosh: "" }),
       });
-      await A.actions.child.resolve({ error: "invalid" });
-      await A.loaders.root.resolve("ROOT LOADER");
+      await A.actions.index.resolve({ error: "invalid" });
       expect(t.router.state.actionData).toEqual({
-        child: { error: "invalid" },
+        index: { error: "invalid" },
       });
 
-      let B = await t.navigate("/?index", {
+      let B = await t.navigate("/", {
         formMethod: "post",
         formData: createFormData({ gosh: "dang" }),
       });
-      let C = await B.actions.child.redirectReturn("/other");
-      await C.loaders.root.resolve("ROOT LOADER");
-      await C.loaders.other.resolve("OTHER LOADER");
+      await B.actions.index.redirectReturn("/other");
 
       expect(t.router.state.actionData).toBeNull();
+    });
+
+    it("removes action data after action redirect (w/ loaders to run)", async () => {
+      let t = setup({
+        routes: [
+          {
+            index: true,
+            id: "index",
+            action: true,
+          },
+          {
+            path: "/other",
+            id: "other",
+            loader: true,
+          },
+        ],
+      });
+      let A = await t.navigate("/", {
+        formMethod: "post",
+        formData: createFormData({ gosh: "" }),
+      });
+      await A.actions.index.resolve({ error: "invalid" });
+      expect(t.router.state.actionData).toEqual({
+        index: { error: "invalid" },
+      });
+
+      let B = await t.navigate("/", {
+        formMethod: "post",
+        formData: createFormData({ gosh: "dang" }),
+      });
+
+      let C = await B.actions.index.redirectReturn("/other");
+      expect(t.router.state.actionData).toEqual({
+        index: { error: "invalid" },
+      });
+      expect(t.router.state.loaderData).toEqual({});
+
+      await C.loaders.other.resolve("OTHER");
+
+      expect(t.router.state.actionData).toBeNull();
+      expect(t.router.state.loaderData).toEqual({
+        other: "OTHER",
+      });
     });
 
     it("uses the proper action for index routes", async () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2706,6 +2706,51 @@ describe("a router", () => {
       expect(t.router.state.actionData).toBeNull();
     });
 
+    it("removes action data after action redirect (return)", async () => {
+      let t = setup({
+        routes: [
+          {
+            path: "/",
+            id: "root",
+            loader: true,
+            hasErrorBoundary: true,
+            children: [
+              {
+                index: true,
+                id: "child",
+                action: true,
+              },
+              {
+                path: "/other",
+                id: "other",
+                loader: true,
+                action: true,
+              },
+            ],
+          },
+        ],
+      });
+      let A = await t.navigate("/?index", {
+        formMethod: "post",
+        formData: createFormData({ gosh: "" }),
+      });
+      await A.actions.child.resolve({ error: "invalid" });
+      await A.loaders.root.resolve("ROOT LOADER");
+      expect(t.router.state.actionData).toEqual({
+        child: { error: "invalid" },
+      });
+
+      let B = await t.navigate("/?index", {
+        formMethod: "post",
+        formData: createFormData({ gosh: "dang" }),
+      });
+      let C = await B.actions.child.redirectReturn("/other");
+      await C.loaders.root.resolve("ROOT LOADER");
+      await C.loaders.other.resolve("OTHER LOADER");
+
+      expect(t.router.state.actionData).toBeNull();
+    });
+
     it("uses the proper action for index routes", async () => {
       let t = setup({
         routes: [

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -660,16 +660,15 @@ export function createRouter(init: RouterInit): Router {
     // - We have committed actionData in the store
     // - The current navigation was a submission
     // - We're past the submitting state and into the loading state
-    // - This should not be susceptible to false positives for
-    //   loading/submissionRedirect since there would not be actionData in the
-    //   state since the prior action would have returned a redirect response
-    //   and short circuited
+    // - The location we're landing at is different from the submission
+    //   location, indicating we redirected from the action (avoids false
+    //   positives for loading/submissionRedirect when actionData returned
+    //   on a prior submiission)
     let isActionReload =
       state.actionData != null &&
       state.navigation.formMethod != null &&
       state.navigation.state === "loading" &&
-      state.navigation.formAction?.split("?")[0] ===
-        state.navigation.location.pathname;
+      state.navigation.formAction?.split("?")[0] === location.pathname;
 
     // Always preserve any existing loaderData from re-used routes
     let newLoaderData = newState.loaderData

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -667,7 +667,9 @@ export function createRouter(init: RouterInit): Router {
     let isActionReload =
       state.actionData != null &&
       state.navigation.formMethod != null &&
-      state.navigation.state === "loading";
+      state.navigation.state === "loading" &&
+      state.navigation.formAction?.split("?")[0] ===
+        state.navigation.location.pathname;
 
     // Always preserve any existing loaderData from re-used routes
     let newLoaderData = newState.loaderData

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -660,10 +660,10 @@ export function createRouter(init: RouterInit): Router {
     // - We have committed actionData in the store
     // - The current navigation was a submission
     // - We're past the submitting state and into the loading state
-    // - The location we're landing at is different from the submission
+    // - The location we've finished loading is different from the submission
     //   location, indicating we redirected from the action (avoids false
     //   positives for loading/submissionRedirect when actionData returned
-    //   on a prior submiission)
+    //   on a prior submission)
     let isActionReload =
       state.actionData != null &&
       state.navigation.formMethod != null &&


### PR DESCRIPTION
This pull request is a fix for issue #9333 

It removes the action data after a redirect from action.