### PR TITLE
RouteObject with `index=true` should not accept children.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -36,6 +36,7 @@
 - goldins
 - gowthamvbhat
 - GraxMonzo
+- GuptaSiddhant
 - haivuw
 - hernanif1
 - hongji00

--- a/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
+++ b/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
@@ -216,6 +216,6 @@ describe("creating routes from JSX", () => {
           </Route>
         </Route>
       );
-    }).toThrow("An index route cannot have children routes.");
+    }).toThrow("An index route must not have child routes.");
   });
 });

--- a/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
+++ b/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
@@ -196,4 +196,26 @@ describe("creating routes from JSX", () => {
       ]
     `);
   });
+
+  it("throws when the index route has children", () => {
+    expect(() => {
+      createRoutesFromChildren(
+        <Route errorElement={<h1>💥</h1>} path="/">
+          <Route
+            // @ts-expect-error
+            index
+            loader={async () => {}}
+            shouldRevalidate={() => true}
+            element={<h1>home</h1>}
+          >
+            <Route
+              path="users"
+              action={async () => {}}
+              element={<h1>users index</h1>}
+            />
+          </Route>
+        </Route>
+      );
+    }).toThrow("An index route cannot have children routes.");
+  });
 });

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -585,7 +585,7 @@ export function createRoutesFromChildren(
     };
 
     if (element.props.children) {
-      invariant(!route.index, "An index route cannot have children routes.");
+      invariant(!route.index, "An index route must not have child routes.");
       route.children = createRoutesFromChildren(
         element.props.children,
         treePath

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -584,7 +584,8 @@ export function createRoutesFromChildren(
       handle: element.props.handle,
     };
 
-    if (element.props.children && !route.index) {
+    if (element.props.children) {
+      invariant(!route.index, "An index route cannot have children routes.");
       route.children = createRoutesFromChildren(
         element.props.children,
         treePath

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -584,7 +584,7 @@ export function createRoutesFromChildren(
       handle: element.props.handle,
     };
 
-    if (element.props.children) {
+    if (element.props.children && !route.index) {
       route.children = createRoutesFromChildren(
         element.props.children,
         treePath

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -619,7 +619,7 @@ export function enhanceManualRouteObjects(
     if (routeClone.hasErrorBoundary == null) {
       routeClone.hasErrorBoundary = routeClone.errorElement != null;
     }
-    if (routeClone.children) {
+    if (!routeClone.index && routeClone.children) {
       routeClone.children = enhanceManualRouteObjects(routeClone.children);
     }
     return routeClone;

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -13,16 +13,14 @@ import type { Action as NavigationType } from "@remix-run/router";
 
 // Create react-specific types from the agnostic types in @remix-run/router to
 // export from react-router
-export interface RouteObject extends AgnosticRouteObject {
-  children?: RouteObject[];
+export type RouteObject = Omit<AgnosticRouteObject, "index" | "children"> & {
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
-}
+} & ({ index?: false; children?: RouteObject[] } | { index: true });
 
-export interface DataRouteObject extends RouteObject {
-  children?: DataRouteObject[];
+export type DataRouteObject = Omit<RouteObject, "index" | "children"> & {
   id: string;
-}
+} & ({ index?: false; children?: DataRouteObject[] } | { index: true });
 
 export interface RouteMatch<
   ParamKey extends string = string,


### PR DESCRIPTION
RouteObject type should accept either index or children but not both, since an index route cannot has children.