### PR TITLE
[v5] Inline `mini-create-react-context` dependency

### DIFF
--- a/packages/react-router/modules/createContext.js
+++ b/packages/react-router/modules/createContext.js
@@ -1,0 +1,8 @@
+// MIT License
+// Copyright (c) 2019-present StringEpsilon <StringEpsilon@gmail.com>
+// Copyright (c) 2017-2019 James Kyle <me@thejameskyle.com>
+// https://github.com/StringEpsilon/mini-create-react-context
+import React from "react";
+import createReactContext from "./miniCreateReactContext";
+
+export default React.createContext || createReactContext;

--- a/packages/react-router/modules/createNamedContext.js
+++ b/packages/react-router/modules/createNamedContext.js
@@ -1,5 +1,5 @@
 // TODO: Replace with React.createContext once we can assume React 16+
-import createContext from "mini-create-react-context";
+import createContext from "./createContext";
 
 const createNamedContext = name => {
   const context = createContext();

--- a/packages/react-router/modules/miniCreateReactContext.js
+++ b/packages/react-router/modules/miniCreateReactContext.js
@@ -1,0 +1,175 @@
+// MIT License
+// Copyright (c) 2019-present StringEpsilon <StringEpsilon@gmail.com>
+// Copyright (c) 2017-2019 James Kyle <me@thejameskyle.com>
+// https://github.com/StringEpsilon/mini-create-react-context
+import React from "react";
+import PropTypes from "prop-types";
+import warning from "tiny-warning";
+
+const MAX_SIGNED_31_BIT_INT = 1073741823;
+
+const commonjsGlobal =
+  typeof globalThis !== "undefined" // 'global proper'
+    ? // eslint-disable-next-line no-undef
+      globalThis
+    : typeof window !== "undefined"
+    ? window // Browser
+    : typeof global !== "undefined"
+    ? global // node.js
+    : {};
+
+function getUniqueId() {
+  let key = "__global_unique_id__";
+  return (commonjsGlobal[key] = (commonjsGlobal[key] || 0) + 1);
+}
+
+// Inlined Object.is polyfill.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+function objectIs(x, y) {
+  if (x === y) {
+    return x !== 0 || 1 / x === 1 / y;
+  } else {
+    // eslint-disable-next-line no-self-compare
+    return x !== x && y !== y;
+  }
+}
+
+function createEventEmitter(value) {
+  let handlers = [];
+  return {
+    on(handler) {
+      handlers.push(handler);
+    },
+
+    off(handler) {
+      handlers = handlers.filter(h => h !== handler);
+    },
+
+    get() {
+      return value;
+    },
+
+    set(newValue, changedBits) {
+      value = newValue;
+      handlers.forEach(handler => handler(value, changedBits));
+    }
+  };
+}
+
+function onlyChild(children) {
+  return Array.isArray(children) ? children[0] : children;
+}
+
+export default function createReactContext(defaultValue, calculateChangedBits) {
+  const contextProp = "__create-react-context-" + getUniqueId() + "__";
+
+  class Provider extends React.Component {
+    emitter = createEventEmitter(this.props.value);
+
+    static childContextTypes = {
+      [contextProp]: PropTypes.object.isRequired
+    };
+
+    getChildContext() {
+      return {
+        [contextProp]: this.emitter
+      };
+    }
+
+    componentWillReceiveProps(nextProps) {
+      if (this.props.value !== nextProps.value) {
+        let oldValue = this.props.value;
+        let newValue = nextProps.value;
+        let changedBits;
+
+        if (objectIs(oldValue, newValue)) {
+          changedBits = 0; // No change
+        } else {
+          changedBits =
+            typeof calculateChangedBits === "function"
+              ? calculateChangedBits(oldValue, newValue)
+              : MAX_SIGNED_31_BIT_INT;
+          if (process.env.NODE_ENV !== "production") {
+            warning(
+              (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
+              "calculateChangedBits: Expected the return value to be a " +
+                "31-bit integer. Instead received: " +
+                changedBits
+            );
+          }
+
+          changedBits |= 0;
+
+          if (changedBits !== 0) {
+            this.emitter.set(nextProps.value, changedBits);
+          }
+        }
+      }
+    }
+
+    render() {
+      return this.props.children;
+    }
+  }
+
+  class Consumer extends React.Component {
+    static contextTypes = {
+      [contextProp]: PropTypes.object
+    };
+
+    observedBits;
+
+    state = {
+      value: this.getValue()
+    };
+
+    componentWillReceiveProps(nextProps) {
+      let { observedBits } = nextProps;
+      this.observedBits =
+        observedBits === undefined || observedBits === null
+          ? MAX_SIGNED_31_BIT_INT // Subscribe to all changes by default
+          : observedBits;
+    }
+
+    componentDidMount() {
+      if (this.context[contextProp]) {
+        this.context[contextProp].on(this.onUpdate);
+      }
+      let { observedBits } = this.props;
+      this.observedBits =
+        observedBits === undefined || observedBits === null
+          ? MAX_SIGNED_31_BIT_INT // Subscribe to all changes by default
+          : observedBits;
+    }
+
+    componentWillUnmount() {
+      if (this.context[contextProp]) {
+        this.context[contextProp].off(this.onUpdate);
+      }
+    }
+
+    getValue() {
+      if (this.context[contextProp]) {
+        return this.context[contextProp].get();
+      } else {
+        return defaultValue;
+      }
+    }
+
+    onUpdate = (newValue, changedBits) => {
+      const observedBits = this.observedBits | 0;
+      if ((observedBits & changedBits) !== 0) {
+        this.setState({ value: this.getValue() });
+      }
+    };
+
+    render() {
+      return onlyChild(this.props.children)(this.state.value);
+    }
+  }
+
+  return {
+    Provider,
+    Consumer
+  };
+}

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -47,7 +47,6 @@
     "history": "^4.9.0",
     "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",
-    "mini-create-react-context": "^0.4.0",
     "path-to-regexp": "^1.7.0",
     "prop-types": "^15.6.2",
     "react-is": "^16.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.4.5", "@babel/runtime@^7.8.4":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
   integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
@@ -7101,14 +7101,6 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-mini-create-react-context@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz#df60501c83151db69e28eac0ef08b4002efab040"
-  integrity sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    tiny-warning "^1.0.3"
-
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -9963,7 +9955,7 @@ tiny-invariant@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==
 
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+tiny-warning@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
This PR inlines the `mini-create-react-context` dependency, a polyfill for older versions of React that is no longer maintained. This should have no meaningful impact, but it will remove a needless peer dependency version warning for users on React 18.

It could potentially (slightly) increase the bundle size for legacy users where the dependency is already bundled, but it shouldn't be significant enough to ease the concern for users on React 18+ IMO.