### PR TITLE
fix: update invalid url for use-search-params

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -5,6 +5,7 @@
 - alexlbr
 - AmRo045
 - andreiduca
+- aroyan
 - avipatel97
 - awreese
 - aymanemadidi

--- a/docs/hooks/use-search-params-rn.md
+++ b/docs/hooks/use-search-params-rn.md
@@ -67,5 +67,5 @@ function App() {
 
 [functional-updates]: https://reactjs.org/docs/hooks-reference.html#functional-updates
 [searchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams
-[usesearchparams]: ./use-search-params.md
+[usesearchparams]: ./use-search-params
 [usestate]: https://reactjs.org/docs/hooks-reference.html#usestate


### PR DESCRIPTION
remove `.md` extension on `use-search-params` endpoint

There is some error with the url on [useSearchParams (RN)](https://reactrouter.com/en/main/hooks/use-search-params-rn) that point to [useSearchParams](https://reactrouter.com/en/main/hooks/use-search-params.md) instead [useSearchParams](https://reactrouter.com/en/main/hooks/use-search-params)

Here's the current behavior 

https://user-images.githubusercontent.com/43630681/193406038-7a8b4e67-6ab0-4424-84e0-ee363ebd3d2f.mp4

