### PR TITLE
(fix) fix wrong var name usage in abstractions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -21,6 +21,7 @@
 - chensokheng
 - chrisngobanh
 - christopherchudzicki
+- christowiz
 - coryhouse
 - cvbuelow
 - dauletbaev

--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -174,12 +174,12 @@ function fetchProject(id) {
     headers: { Authorization: `Bearer ${token}` },
   });
 
-  if (res.status === 404) {
+  if (response.status === 404) {
     throw new Response("Not Found", { status: 404 });
   }
 
   // the fetch failed
-  if (!res.ok) {
+  if (!response.ok) {
     throw new Error("Could not fetch project");
   }
 }


### PR DESCRIPTION
The name of the constant in the abstractions section is named `response` but the following references use `res`