### PR TITLE
update picking-a-router confusing typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -27,6 +27,7 @@
 - dauletbaev
 - david-crespo
 - dokeet
+- Drishtantr
 - edwin177
 - ekaansharora
 - elanis

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -6,7 +6,7 @@ new: true
 
 # Picking a Router
 
-While your app will only use a single router, several routers are available depending on the environment you're app is running in. This document should help you figure out which one to use.
+While your app will only use a single router, several routers are available depending on the environment your app is running in. This document should help you figure out which one to use.
 
 ## Using v6.4 Data APIs
 


### PR DESCRIPTION
While going through the documentation, I came across a confusing grammatical error in https://reactrouter.com/en/main/routers/picking-a-router. Opening a PR to fix a simple typo in picking-a-router.

