### PR TITLE
docs: fix highlighted lines on tutorials page

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abdallah-nour
 - abhi-kr-2100
+- adamdotjs
 - Ajayff4
 - alany411
 - alexlbr

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -519,7 +519,7 @@ const router = createBrowserRouter([
 
 👉 **Access and render the data**
 
-```jsx filename=src/routes/root.jsx lines=[4,11,19-39]
+```jsx filename=src/routes/root.jsx lines=[4,11,19-40]
 import {
   Outlet,
   Link,


### PR DESCRIPTION
The "Access and render the data" section on the tutorial page is highlighting one line short in the code preview. This PR corrects this to highlight the full snippet.