### PR TITLE
Fix missing url in use-route-loader-data.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -108,6 +108,7 @@
 - SkayuX
 - souzasmatheus
 - srmagura
+- stasundr
 - tanayv
 - theostavrides
 - thisiskartik

--- a/docs/hooks/use-route-loader-data.md
+++ b/docs/hooks/use-route-loader-data.md
@@ -45,3 +45,5 @@ const user = useRouteLoaderData("root");
 ```
 
 The only data available is the routes that are currently rendered. If you ask for data from a route that is not currently rendered, the hook will return `undefined`.
+
+[pickingarouter]: ../routers/picking-a-router


### PR DESCRIPTION
Tiny fix in docs for missing url for picking a router in `use-route-loader-data.md`