### PR TITLE
fix: add router UMD build for unpkg

### DIFF
--- a/.changeset/weak-lizards-occur.md
+++ b/.changeset/weak-lizards-occur.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Add UMD build for @remix-run/router

--- a/packages/react-router-dom-v5-compat/rollup.config.js
+++ b/packages/react-router-dom-v5-compat/rollup.config.js
@@ -86,7 +86,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router DOM v5 Compat", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
           "react-router-dom": "ReactRouterDOM",
@@ -128,7 +128,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router DOM v5 Compat", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
           "react-router-dom": "ReactRouterDOM",

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -148,7 +148,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router DOM", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
         },
@@ -183,7 +183,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router DOM", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
         },

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -26,13 +26,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
       },
-      external: [
-        "history",
-        "react",
-        "react-dom",
-        "react-router",
-        "@remix-run/router",
-      ],
+      external: ["react", "react-dom", "react-router", "@remix-run/router"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({
@@ -73,7 +67,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
       },
-      external: ["history", "react", "react-router", "@remix-run/router"],
+      external: ["react", "react-router", "@remix-run/router"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({
@@ -101,7 +95,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
       },
-      external: ["history", "react", "react-router", "@remix-run/router"],
+      external: ["react", "react-router", "@remix-run/router"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({
@@ -147,14 +141,13 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
         globals: {
-          history: "HistoryLibrary",
           "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
         },
         name: "ReactRouterDOM",
       },
-      external: ["history", "react", "react-router", "@remix-run/router"],
+      external: ["react", "react-router", "@remix-run/router"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({
@@ -182,14 +175,13 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
         globals: {
-          history: "HistoryLibrary",
           "@remix-run/router": "RemixRouter",
           react: "React",
           "react-router": "ReactRouter",
         },
         name: "ReactRouterDOM",
       },
-      external: ["history", "react", "react-router", "@remix-run/router"],
+      external: ["react", "react-router", "@remix-run/router"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({
@@ -240,7 +232,6 @@ module.exports = function rollup() {
       ],
       external: [
         "url",
-        "history",
         "react",
         "react-dom/server",
         "react-router-dom",
@@ -284,7 +275,6 @@ module.exports = function rollup() {
       ],
       external: [
         "url",
-        "history",
         "react",
         "react-dom/server",
         "react-router-dom",

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -140,7 +140,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
         },
         name: "ReactRouter",
@@ -174,7 +174,7 @@ module.exports = function rollup() {
         banner: createBanner("React Router", version),
         globals: {
           history: "HistoryLibrary",
-          "@remix-run/router": "Router",
+          "@remix-run/router": "RemixRouter",
           react: "React",
         },
         name: "ReactRouter",

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -26,7 +26,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router", version),
       },
-      external: ["history", "@remix-run/router", "react"],
+      external: ["@remix-run/router", "react"],
       plugins: [
         extensions({ extensions: [".tsx", ".ts"] }),
         babel({
@@ -60,7 +60,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router", version),
       },
-      external: ["history", "@remix-run/router", "react"],
+      external: ["@remix-run/router", "react"],
       plugins: [
         extensions({ extensions: [".tsx", ".ts"] }),
         babel({
@@ -93,7 +93,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router", version),
       },
-      external: ["history", "@remix-run/router", "react"],
+      external: ["@remix-run/router", "react"],
       plugins: [
         extensions({ extensions: [".tsx", ".ts"] }),
         babel({
@@ -139,13 +139,12 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router", version),
         globals: {
-          history: "HistoryLibrary",
           "@remix-run/router": "RemixRouter",
           react: "React",
         },
         name: "ReactRouter",
       },
-      external: ["history", "@remix-run/router", "react"],
+      external: ["@remix-run/router", "react"],
       plugins: [
         extensions({ extensions: [".tsx", ".ts"] }),
         babel({
@@ -173,13 +172,12 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router", version),
         globals: {
-          history: "HistoryLibrary",
           "@remix-run/router": "RemixRouter",
           react: "React",
         },
         name: "ReactRouter",
       },
-      external: ["history", "@remix-run/router", "react"],
+      external: ["@remix-run/router", "react"],
       plugins: [
         extensions({ extensions: [".tsx", ".ts"] }),
         babel({

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,6 +16,7 @@
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
   "main": "./dist/router.cjs.js",
+  "unpkg": "./dist/router.umd.min.js",
   "module": "./dist/router.js",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Adds a UMD build for `@remix-run/router` since that's needed for unpkg/UMD usage of `react-router`/`react-router-dom` 

Closes #9240