### PR TITLE
docs: add fetch polyfill disclaimer to testing section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - alexlbr
 - AmRo045
 - andreiduca
+- arnassavickas
 - aroyan
 - avipatel97
 - awreese

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -66,6 +66,14 @@ If you're not interested in the data APIs, you can continue to use [`<BrowserRou
 
 Testing components that use React Router APIs is easiest with [`createMemoryRouter`][creatememoryrouter] or [`<MemoryRouter>`][memoryrouter] instead of the routers you use in your app that require DOM history APIs.
 
+Some of the React Router APIs internally use `fetch`, which is only supported starting from Node.js v18. If your project uses v17 or lower, you should add a `fetch` polyfill manually. One way to do that, is to install [`whatwg-fetch`](https://www.npmjs.com/package/whatwg-fetch) and add it to your `jest.config.js` file like so:
+```js
+module.exports = {
+  setupFiles: ['whatwg-fetch'],
+  // ...rest of the config
+}
+```
+
 ## React Native
 
 You will use [`<NativeRouter>`][nativerouter] from React Native projects.


### PR DESCRIPTION
When migrating from `<MemoryRouter>` to `createMemoryRouter`, some of my project's tests started to fail due to `fetch` not being polyfilled in the `jest` environment.

The error itself is really unclear, so IMO, at least docs should inform about this requirement.

Please let me know if better wording or suggestion should be used here.