### PR TITLE
fixed createURL() for Firefox

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abdallah-nour
 - abhi-kr-2100
+- AchThomas
 - Ajayff4
 - alany411
 - alexlbr

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2844,8 +2844,13 @@ function getTargetMatch(
 }
 
 function createURL(location: Location | string): URL {
+  // window.location.origin is "null" (the literal string value) in Firefox under certain conditions
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=878297
+  // this breaks the app when a production build is served from the local file system
   let base =
-    typeof window !== "undefined" && typeof window.location !== "undefined"
+    typeof window !== "undefined" &&
+    typeof window.location !== "undefined" &&
+    window.location.origin !== "null"
       ? window.location.origin
       : "unknown://unknown";
   let href = typeof location === "string" ? location : createHref(location);


### PR DESCRIPTION
`window.location.origin` is `"null"` (the literal string value) in Firefox under certain conditions: https://bugzilla.mozilla.org/show_bug.cgi?id=878297 

This leads to a broken app in Firefox when you build for production and try to use it from the local file system in an HTML file.

I added an additional check in createURL() in router.ts to respect that case.