### PR TITLE
Fix re-export type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -27,6 +27,7 @@
 - dauletbaev
 - david-crespo
 - dokeet
+- Drishtantr
 - edwin177
 - ekaansharora
 - elanis

--- a/contributors.yml
+++ b/contributors.yml
@@ -73,6 +73,7 @@
 - loun4
 - lqze
 - lukerSpringTree
+- Manc
 - marc2332
 - markivancho
 - marvinruder

--- a/contributors.yml
+++ b/contributors.yml
@@ -108,6 +108,7 @@
 - SkayuX
 - souzasmatheus
 - srmagura
+- stasundr
 - tanayv
 - theostavrides
 - thisiskartik

--- a/contributors.yml
+++ b/contributors.yml
@@ -6,6 +6,7 @@
 - alexlbr
 - AmRo045
 - andreiduca
+- arnassavickas
 - aroyan
 - avipatel97
 - awreese

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - abdallah-nour
 - abhi-kr-2100
+- adamdotjs
 - Ajayff4
 - alany411
 - alexlbr

--- a/docs/hooks/use-route-loader-data.md
+++ b/docs/hooks/use-route-loader-data.md
@@ -45,3 +45,5 @@ const user = useRouteLoaderData("root");
 ```
 
 The only data available is the routes that are currently rendered. If you ask for data from a route that is not currently rendered, the hook will return `undefined`.
+
+[pickingarouter]: ../routers/picking-a-router

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -66,6 +66,14 @@ If you're not interested in the data APIs, you can continue to use [`<BrowserRou
 
 Testing components that use React Router APIs is easiest with [`createMemoryRouter`][creatememoryrouter] or [`<MemoryRouter>`][memoryrouter] instead of the routers you use in your app that require DOM history APIs.
 
+Some of the React Router APIs internally use `fetch`, which is only supported starting from Node.js v18. If your project uses v17 or lower, you should add a `fetch` polyfill manually. One way to do that, is to install [`whatwg-fetch`](https://www.npmjs.com/package/whatwg-fetch) and add it to your `jest.config.js` file like so:
+```js
+module.exports = {
+  setupFiles: ['whatwg-fetch'],
+  // ...rest of the config
+}
+```
+
 ## React Native
 
 You will use [`<NativeRouter>`][nativerouter] from React Native projects.

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -6,7 +6,7 @@ new: true
 
 # Picking a Router
 
-While your app will only use a single router, several routers are available depending on the environment you're app is running in. This document should help you figure out which one to use.
+While your app will only use a single router, several routers are available depending on the environment your app is running in. This document should help you figure out which one to use.
 
 ## Using v6.4 Data APIs
 

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -67,11 +67,12 @@ If you're not interested in the data APIs, you can continue to use [`<BrowserRou
 Testing components that use React Router APIs is easiest with [`createMemoryRouter`][creatememoryrouter] or [`<MemoryRouter>`][memoryrouter] instead of the routers you use in your app that require DOM history APIs.
 
 Some of the React Router APIs internally use `fetch`, which is only supported starting from Node.js v18. If your project uses v17 or lower, you should add a `fetch` polyfill manually. One way to do that, is to install [`whatwg-fetch`](https://www.npmjs.com/package/whatwg-fetch) and add it to your `jest.config.js` file like so:
+
 ```js
 module.exports = {
-  setupFiles: ['whatwg-fetch'],
+  setupFiles: ["whatwg-fetch"],
   // ...rest of the config
-}
+};
 ```
 
 ## React Native

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -519,7 +519,7 @@ const router = createBrowserRouter([
 
 👉 **Access and render the data**
 
-```jsx filename=src/routes/root.jsx lines=[4,11,19-39]
+```jsx filename=src/routes/root.jsx lines=[4,11,19-40]
 import {
   Outlet,
   Link,

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -5,7 +5,7 @@ order: 2
 
 # Tutorial
 
-Welcome to the tutorial! We'll be building a small, but feature-rich app that let's you keep track of your contacts. We expect it to take between 30-60m if you're following along.
+Welcome to the tutorial! We'll be building a small, but feature-rich app that lets you keep track of your contacts. We expect it to take between 30-60m if you're following along.
 
 <img class="tutorial" src="/_docs/tutorial/15.webp" />
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -68,6 +68,7 @@ export type {
   ParamKeyValuePair,
   SubmitOptions,
   URLSearchParamsInit,
+  RemixRouter,
 };
 export { createSearchParams };
 


### PR DESCRIPTION
What version are you using?
- `"react-router-dom": "6.4.2"`
- `typescript: 4.8.4`
- `pnpm@7.13.4`

<details>
<summary>tsconfig</summary>

`base.json:`
```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Default",
  "compilerOptions": {
    "composite": false,
    "declaration": true,
    "declarationMap": true,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "inlineSources": false,
    "isolatedModules": true,
    "moduleResolution": "node",
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "preserveWatchOutput": true,
    "skipLibCheck": true,
    "strict": true,
    "noFallthroughCasesInSwitch": true
  },
  "exclude": ["node_modules"]
}
```
`react-app.json:`
```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Create React App",
  "extends": "./base.json",
  "compilerOptions": {
    "allowSyntheticDefaultImports": true,
    "noEmit": true,
    "lib": ["dom", "dom.iterable", "esnext"],
    "target": "ES2017",
    "module": "ESNext",
    "jsx": "react-jsx"
  },
  "include": ["src", "tests"],
  "exclude": ["node_modules"]
}
```
</details>

`router.ts:`
```ts
import {createBrowserRouter} from 'react-router-dom'

import App from './App'

const router = createBrowserRouter([
  {
    path: '/',
    element: <App />,
  },
])

export default router
```

VSCode shows error:
<img width="915" alt="Screenshot 2022-10-15 at 19 47 59" src="https://user-images.githubusercontent.com/7345847/195998313-eba72cfa-52f8-4e32-ba6c-bfa1b94c0cae.png">

> The inferred type of 'router' cannot be named without a reference to '.pnpm/@remix-run+router@1.0.2/node_modules/@remix-run/router'. This is likely not portable. A type annotation is necessary.ts(2742)

### Fix this error
by patching the exports to the `react-router-dom` package:
<img width="1463" alt="Screenshot 2022-10-15 at 20 04 20" src="https://user-images.githubusercontent.com/7345847/195999001-6e45d2bd-ef44-49d5-8634-e1da7062e0aa.png">
