### PR TITLE
Fix re-exports RemixRouter type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -123,3 +123,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- evgeniy28

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -68,6 +68,7 @@ export type {
   ParamKeyValuePair,
   SubmitOptions,
   URLSearchParamsInit,
+  RemixRouter,
 };
 export { createSearchParams };
 


### PR DESCRIPTION
What version are you using?
- `"react-router-dom": "6.4.2"`
- `typescript: 4.8.4`
- `pnpm@7.13.4`

<details>
<summary>tsconfig</summary>

`base.json:`
```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Default",
  "compilerOptions": {
    "composite": false,
    "declaration": true,
    "declarationMap": true,
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "inlineSources": false,
    "isolatedModules": true,
    "moduleResolution": "node",
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "preserveWatchOutput": true,
    "skipLibCheck": true,
    "strict": true,
    "noFallthroughCasesInSwitch": true
  },
  "exclude": ["node_modules"]
}
```
`react-app.json:`
```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Create React App",
  "extends": "./base.json",
  "compilerOptions": {
    "allowSyntheticDefaultImports": true,
    "noEmit": true,
    "lib": ["dom", "dom.iterable", "esnext"],
    "target": "ES2017",
    "module": "ESNext",
    "jsx": "react-jsx"
  },
  "include": ["src", "tests"],
  "exclude": ["node_modules"]
}
```
</details>

`router.ts:`
```ts
import {createBrowserRouter} from 'react-router-dom'

import App from './App'

const router = createBrowserRouter([
  {
    path: '/',
    element: <App />,
  },
])

export default router
```

VSCode shows error:
<img width="915" alt="Screenshot 2022-10-15 at 19 47 59" src="https://user-images.githubusercontent.com/7345847/195998313-eba72cfa-52f8-4e32-ba6c-bfa1b94c0cae.png">

> The inferred type of 'router' cannot be named without a reference to '.pnpm/@remix-run+router@1.0.2/node_modules/@remix-run/router'. This is likely not portable. A type annotation is necessary.ts(2742)

### Fix this error
by patching the exports to the `react-router-dom` package:
<img width="1463" alt="Screenshot 2022-10-15 at 20 04 20" src="https://user-images.githubusercontent.com/7345847/195999001-6e45d2bd-ef44-49d5-8634-e1da7062e0aa.png">
