### PR TITLE
chore(react-router): fix `useMatch`'s description

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -125,3 +125,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- m-shojaei

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -115,7 +115,7 @@ export function useNavigationType(): NavigationType {
 }
 
 /**
- * Returns true if the URL for the given "to" value matches the current URL.
+ * Returns a PathMatch object if the given pattern matches the current URL.
  * This is useful for components that need to know "active" state, e.g.
  * <NavLink>.
  *


### PR DESCRIPTION
Fixing `useMatch` description as the current one does not reflect the hook's signature