### PR TITLE
Fixed typo in the route/loader.md doc

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,3 +128,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- maruffahmed

--- a/docs/route/loader.md
+++ b/docs/route/loader.md
@@ -89,7 +89,7 @@ Note that the APIs here are not React Router specific, but rather standard web o
 
 While you can return anything you want from a loader and get access to it from [`useLoaderData`][useloaderdata], you can also return a web [Response][response].
 
-This might not seem immediately useful, but consider `fetch`. Since the return value of of `fetch` is a Response, and loaders understand responses, many loaders can return a simple fetch!
+This might not seem immediately useful, but consider `fetch`. Since the return value of `fetch` is a Response, and loaders understand responses, many loaders can return a simple fetch!
 
 ```tsx
 // an HTTP/REST API


### PR DESCRIPTION
There was a typo at the `docs/route/loader.md` doc. One of the `of` word appears twice in a row. So I am considering deleting one of them.

from :
> Since the return value of of `fetch` is a Response...

To :
> Since the return value of `fetch` is a Response...