### PR TITLE
fix: make url-encoding history-aware

### DIFF
--- a/.changeset/ninety-countries-cheat.md
+++ b/.changeset/ninety-countries-cheat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+make url-encoding history-aware

--- a/packages/react-router-dom/__tests__/special-characters-test.tsx
+++ b/packages/react-router-dom/__tests__/special-characters-test.tsx
@@ -9,24 +9,21 @@ import {
   waitFor,
   screen,
 } from "@testing-library/react";
-import {
-  createHashRouter,
-  createMemoryRouter,
-  HashRouter,
-  Location,
-  MemoryRouter,
-  Params,
-  useNavigate,
-} from "react-router-dom";
+import type { Location, Params } from "react-router-dom";
 import {
   BrowserRouter,
+  HashRouter,
+  MemoryRouter,
   Link,
   Routes,
   Route,
   RouterProvider,
   createBrowserRouter,
+  createHashRouter,
+  createMemoryRouter,
   createRoutesFromElements,
   useLocation,
+  useNavigate,
   useParams,
 } from "react-router-dom";
 
@@ -742,6 +739,7 @@ describe("special character tests", () => {
       it("does not encode characters in MemoryRouter (navigate)", () => {
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }
@@ -774,6 +772,7 @@ describe("special character tests", () => {
       it("does not encode characters in createMemoryRouter (navigate)", () => {
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }
@@ -823,6 +822,7 @@ describe("special character tests", () => {
 
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }
@@ -862,6 +862,7 @@ describe("special character tests", () => {
 
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }
@@ -917,6 +918,7 @@ describe("special character tests", () => {
 
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }
@@ -958,6 +960,7 @@ describe("special character tests", () => {
 
         function Start() {
           let navigate = useNavigate();
+          // eslint-disable-next-line react-hooks/exhaustive-deps
           React.useEffect(() => navigate("/with space"), []);
           return null;
         }

--- a/packages/react-router-dom/__tests__/special-characters-test.tsx
+++ b/packages/react-router-dom/__tests__/special-characters-test.tsx
@@ -9,7 +9,15 @@ import {
   waitFor,
   screen,
 } from "@testing-library/react";
-import type { Location, Params } from "react-router-dom";
+import {
+  createHashRouter,
+  createMemoryRouter,
+  HashRouter,
+  Location,
+  MemoryRouter,
+  Params,
+  useNavigate,
+} from "react-router-dom";
 import {
   BrowserRouter,
   Link,
@@ -707,6 +715,268 @@ describe("special character tests", () => {
           }
         );
       }
+    });
+  });
+
+  describe("encodes characters based on history implementation", () => {
+    function ShowPath() {
+      let { pathname, search, hash } = useLocation();
+      return <pre>{JSON.stringify({ pathname, search, hash })}</pre>;
+    }
+
+    describe("memory routers", () => {
+      it("does not encode characters in MemoryRouter", () => {
+        let ctx = render(
+          <MemoryRouter initialEntries={["/with space"]}>
+            <Routes>
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("does not encode characters in MemoryRouter (navigate)", () => {
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+        let ctx = render(
+          <MemoryRouter>
+            <Routes>
+              <Route path="/" element={<Start />} />
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </MemoryRouter>
+        );
+
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("does not encode characters in createMemoryRouter", () => {
+        let router = createMemoryRouter(
+          [{ path: "/with space", element: <ShowPath /> }],
+          { initialEntries: ["/with space"] }
+        );
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("does not encode characters in createMemoryRouter (navigate)", () => {
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+        let router = createMemoryRouter([
+          { path: "/", element: <Start /> },
+          { path: "/with space", element: <ShowPath /> },
+        ]);
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+    });
+
+    describe("browser routers", () => {
+      let testWindow: Window;
+
+      beforeEach(() => {
+        // Need to use our own custom DOM in order to get a working history
+        const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+          url: "https://remix.run/",
+        });
+        testWindow = dom.window as unknown as Window;
+        testWindow.history.pushState({}, "", "/");
+      });
+
+      it("encodes characters in BrowserRouter", () => {
+        testWindow.history.replaceState(null, "", "/with space");
+
+        let ctx = render(
+          <BrowserRouter window={testWindow}>
+            <Routes>
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </BrowserRouter>
+        );
+
+        expect(testWindow.location.pathname).toBe("/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in BrowserRouter (navigate)", () => {
+        testWindow.history.replaceState(null, "", "/");
+
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+
+        let ctx = render(
+          <BrowserRouter window={testWindow}>
+            <Routes>
+              <Route path="/" element={<Start />} />
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </BrowserRouter>
+        );
+
+        expect(testWindow.location.pathname).toBe("/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in createBrowserRouter", () => {
+        testWindow.history.replaceState(null, "", "/with space");
+
+        let router = createBrowserRouter(
+          [{ path: "/with space", element: <ShowPath /> }],
+          { window: testWindow }
+        );
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(testWindow.location.pathname).toBe("/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in createBrowserRouter (navigate)", () => {
+        testWindow.history.replaceState(null, "", "/with space");
+
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+
+        let router = createBrowserRouter(
+          [
+            { path: "/", element: <Start /> },
+            { path: "/with space", element: <ShowPath /> },
+          ],
+          { window: testWindow }
+        );
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(testWindow.location.pathname).toBe("/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+    });
+
+    describe("hash routers", () => {
+      let testWindow: Window;
+
+      beforeEach(() => {
+        // Need to use our own custom DOM in order to get a working history
+        const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+          url: "https://remix.run/",
+        });
+        testWindow = dom.window as unknown as Window;
+        testWindow.history.pushState({}, "", "/");
+      });
+
+      it("encodes characters in HashRouter", () => {
+        testWindow.history.replaceState(null, "", "/#/with space");
+
+        let ctx = render(
+          <HashRouter window={testWindow}>
+            <Routes>
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </HashRouter>
+        );
+
+        expect(testWindow.location.pathname).toBe("/");
+        expect(testWindow.location.hash).toBe("#/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in HashRouter (navigate)", () => {
+        testWindow.history.replaceState(null, "", "/");
+
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+
+        let ctx = render(
+          <HashRouter window={testWindow}>
+            <Routes>
+              <Route path="/" element={<Start />} />
+              <Route path="/with space" element={<ShowPath />} />
+            </Routes>
+          </HashRouter>
+        );
+
+        expect(testWindow.location.pathname).toBe("/");
+        expect(testWindow.location.hash).toBe("#/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in createHashRouter", () => {
+        testWindow.history.replaceState(null, "", "/#/with space");
+
+        let router = createHashRouter(
+          [{ path: "/with space", element: <ShowPath /> }],
+          { window: testWindow }
+        );
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(testWindow.location.pathname).toBe("/");
+        expect(testWindow.location.hash).toBe("#/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
+
+      it("encodes characters in createHashRouter (navigate)", () => {
+        testWindow.history.replaceState(null, "", "/");
+
+        function Start() {
+          let navigate = useNavigate();
+          React.useEffect(() => navigate("/with space"), []);
+          return null;
+        }
+
+        let router = createHashRouter(
+          [
+            { path: "/", element: <Start /> },
+            { path: "/with space", element: <ShowPath /> },
+          ],
+          { window: testWindow }
+        );
+        let ctx = render(<RouterProvider router={router} />);
+
+        expect(testWindow.location.pathname).toBe("/");
+        expect(testWindow.location.hash).toBe("#/with%20space");
+        expect(ctx.container.innerHTML).toMatchInlineSnapshot(
+          `"<pre>{\\"pathname\\":\\"/with%20space\\",\\"search\\":\\"\\",\\"hash\\":\\"\\"}</pre>"`
+        );
+      });
     });
   });
 });

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -126,6 +126,15 @@ export interface History {
   createHref(to: To): string;
 
   /**
+   * Encode a location the same way window.history would do (no-op for memory
+   * history) so we ensure our PUSH/REPLAC e navigations for data routers
+   * behave the same as POP
+   *
+   * @param location The incoming location from router.navigate()
+   */
+  encodeLocation(location: Location): Location;
+
+  /**
    * Pushes a new location onto the history stack, increasing its length by one.
    * If there were any entries in the stack after the current one, they are
    * lost.
@@ -258,6 +267,9 @@ export function createMemoryHistory(
     },
     createHref(to) {
       return typeof to === "string" ? to : createPath(to);
+    },
+    encodeLocation(location) {
+      return location;
     },
     push(to, state) {
       action = Action.Push;
@@ -527,6 +539,15 @@ export function parsePath(path: string): Partial<Path> {
   return parsedPath;
 }
 
+export function createURL(location: Location | string): URL {
+  let base =
+    typeof window !== "undefined" && typeof window.location !== "undefined"
+      ? window.location.origin
+      : "unknown://unknown";
+  let href = typeof location === "string" ? location : createPath(location);
+  return new URL(href, base);
+}
+
 export interface UrlHistory extends History {}
 
 export type UrlHistoryOptions = {
@@ -609,6 +630,16 @@ function getUrlBasedHistory(
     },
     createHref(to) {
       return createHref(window, to);
+    },
+    encodeLocation(location) {
+      // Encode a Location the same way window.location would
+      let url = createURL(createPath(location));
+      return {
+        ...location,
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+      };
     },
     push,
     replace,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1,12 +1,10 @@
-import { pathExists } from "fs-extra";
-import type { History, Location, Path, To } from "./history";
+import type { History, Location, To } from "./history";
 import {
   Action as HistoryAction,
   createLocation,
   createPath,
   createURL,
   parsePath,
-  safelyDecodeURI,
 } from "./history";
 import type {
   DataResult,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2910,6 +2910,11 @@ function findRedirect(results: DataResult[]): RedirectResult | undefined {
   }
 }
 
+function stripHashFromPath(path: To) {
+  let parsedPath = typeof path === "string" ? parsePath(path) : path;
+  return createPath({ ...parsedPath, hash: "" });
+}
+
 function isHashChangeOnly(a: Location, b: Location): boolean {
   return (
     a.pathname === b.pathname && a.search === b.search && a.hash !== b.hash
@@ -3046,10 +3051,5 @@ function getTargetMatch(
   // pathless layout routes)
   let pathMatches = getPathContributingMatches(matches);
   return pathMatches[pathMatches.length - 1];
-}
-
-function stripHashFromPath(path: To) {
-  let parsedPath = typeof path === "string" ? parsePath(path) : path;
-  return createPath({ ...parsedPath, hash: "" });
 }
 //#endregion

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -331,9 +331,12 @@ export function matchRoutes<
   for (let i = 0; matches == null && i < branches.length; ++i) {
     matches = matchRouteBranch<string, RouteObjectType>(
       branches[i],
-      // incoming pathnames are always encoded from either window.location or
-      // from route.navigate, but we want to match against the unencoded paths
-      // in the route definitions
+      // Incoming pathnames are generally encoded from either window.location
+      // or from router.navigate, but we want to match against the unencoded
+      // paths in the route definitions.  Memory router locations won't be
+      // encoded here but there also shouldn't be anything to decode so this
+      // should be a safe operation.  This avoids needing matchRoutes to be
+      // history-aware.
       safelyDecodeURI(pathname)
     );
   }


### PR DESCRIPTION
Forgot about this callout in the special character encoding PR: https://github.com/remix-run/react-router/pull/9477#discussion_r998722415

We do not want to automatically encode incoming `router.navigate()` locations when using memory routers, so we introduce a `history.encodeLocation` method so encoding can be history aware.

Decoding proves to a be a bit trickier, since we decode in `matchRoutes` which is not history-aware, but since memory locations should never be encoded in the first place, I think it's safe to decode all the time in there, since `decodeURI('/path') === '/path'`
