### PR TITLE
fix: fix initialEntries type in createMemoryRouter

### DIFF
--- a/.changeset/odd-kids-buy.md
+++ b/.changeset/odd-kids-buy.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+fix initialEntries type in createMemoryRouter

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -17,6 +17,7 @@ import type {
   Router as RemixRouter,
   ShouldRevalidateFunction,
   To,
+  InitialEntry,
 } from "@remix-run/router";
 import {
   AbortedDeferredError,
@@ -203,7 +204,7 @@ export function createMemoryRouter(
   opts?: {
     basename?: string;
     hydrationData?: HydrationState;
-    initialEntries?: string[];
+    initialEntries?: InitialEntry[];
     initialIndex?: number;
   }
 ): RemixRouter {


### PR DESCRIPTION
Closes #9470 