### PR TITLE
Fix the tutorial link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -130,3 +130,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- dmitrytarassov

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,3 +1,3 @@
 # React Router v6 Tutorial
 
-To complete this tutorial, we recommend following along with our guide in our [Getting Started documentation](https://github.com/remix-run/react-router/blob/main/docs/getting-started/tutorial.md).
+To complete this tutorial, we recommend following along with our guide in our [Getting Started documentation](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md).


### PR DESCRIPTION
The link in this [page](https://github.com/remix-run/react-router/tree/main/tutorial) is broken