### PR TITLE
Substitute params from current route params

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -137,3 +137,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- xepozz

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -390,6 +390,36 @@ describe("<Navigate>", () => {
       `);
     });
 
+    it("handles substituted navigation param from current route params", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/layout1/dest"]}>
+            <Routes>
+              <Route path="layout1">
+                <Route path=":param">
+                  {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                  <Route
+                    index
+                    element={
+                      <Navigate to="/layout2/:param" autoSubstitute />
+                    }
+                  />
+                </Route>
+              </Route>
+              <Route path="layout2">
+                <Route path=":param">
+                  <Route path="dest" element={<h1>Destination</h1>} />
+                </Route>
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`null`);
+    });
+
     it("preserves search params and hash", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -15,7 +15,7 @@ import {
   invariant,
   parsePath,
   stripBasename,
-  warning,
+  warning, generatePath,
 } from "@remix-run/router";
 import { useSyncExternalStore as useSyncExternalStoreShim } from "./use-sync-external-store-shim";
 
@@ -41,7 +41,7 @@ import {
   useNavigate,
   useOutlet,
   useRoutes,
-  _renderMatches,
+  _renderMatches, useParams,
 } from "./hooks";
 
 export interface RouterProviderProps {
@@ -161,6 +161,7 @@ export interface NavigateProps {
   replace?: boolean;
   state?: any;
   relative?: RelativeRoutingType;
+  autoSubstitute?: boolean;
 }
 
 /**
@@ -177,6 +178,7 @@ export function Navigate({
   replace,
   state,
   relative,
+  autoSubstitute,
 }: NavigateProps): null {
   invariant(
     useInRouterContext(),
@@ -194,6 +196,7 @@ export function Navigate({
 
   let dataRouterState = React.useContext(DataRouterStateContext);
   let navigate = useNavigate();
+  let params = useParams();
 
   React.useEffect(() => {
     // Avoid kicking off multiple navigations if we're in the middle of a
@@ -201,6 +204,9 @@ export function Navigate({
     // a submitting/loading state
     if (dataRouterState && dataRouterState.navigation.state !== "idle") {
       return;
+    }
+    if (autoSubstitute && typeof to === 'string') {
+      to = generatePath(to, params);
     }
     navigate(to, { replace, state, relative });
   });


### PR DESCRIPTION
Thanks to the functionality users can write their `proxy` routes like the following:
current:
`/path/:param1/subpath/:param2`

navigate to:
`/newpath/:param1/newsubpath/:param2`

It also helps to find routes because you may find the route definition just by text `/user/:id` instead of preparing `/user/${id}` for the search.

My main reason of the functionality is to make proxies like in the test.
I want to cut off the history by proxying to the app from outside. 
The following code
```jsx
<Route path="proxy/to/:somewhere" element={<Navigate replace autoSubstitute to=":somewhere" />} />
```
will satisfy me.

I'm open to discuss the new parameter or move it into `useNavigate` if you want.
Thanks!