### PR TITLE
Fix broken links in the deferred data guide

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -18,6 +18,7 @@
 - brockross
 - brophdawg11
 - btav
+- bvangraafeiland
 - CanRau
 - chaance
 - chasinhues

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -205,6 +205,6 @@ So just keep this in mind: **Deferred is 100% only about the initial load of a r
 
 [link]: ../components/link
 [usefetcher]: ../hooks/use-fetcher
-[defer response]: ../fetch/defer
+[defer response]: ../utils/defer
 [await]: ../components/await
-[useasyncvalue]: ../hooks/use-async-data
+[useasyncvalue]: ../hooks/use-async-value


### PR DESCRIPTION
The `defer` and `useAsyncValue` links presumably linked to old urls. I believe these are the correct locations.