### PR TITLE
`useElementScrollRestoration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
       "packages/react-router-native",
       "packages/router"
     ],
-    "nohoist": [
-      "**/react-native",
-      "**/react-native/**"
-    ]
+    "nohoist": ["**/react-native", "**/react-native/**"]
   },
   "scripts": {
     "build": "rollup -c",
@@ -32,9 +29,7 @@
     "watch": "rollup -c -w"
   },
   "jest": {
-    "projects": [
-      "<rootDir>/packages/*"
-    ]
+    "projects": ["<rootDir>/packages/*"]
   },
   "resolutions": {
     "@types/react": "^18.0.0",
@@ -116,7 +111,7 @@
       "none": "14.5 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "10 kB"
+      "none": "10.5 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
       "none": "16 kB"

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1046,7 +1046,7 @@ function useElementScrollRestoration({
   // window has scrollY but normal elements have scrollTop
   const getScrollY = () => {
     const el = getScrollElement();
-    return el ? el.scrollY || el.scrollTop : undefined;
+    return "scrollY" in el ? el.scrollY : el.scrollTop;
   };
 
   // Trigger manual scroll restoration while we're active


### PR DESCRIPTION
First pass based on https://github.com/remix-run/react-router/discussions/9495. @ryanflorence will have feedback and I'm sure it'll change.

`useScrollRestoration` (and `<ScrollRestoration />`, which relies on it) only allows scroll restoration at the `window` level. This does not work if the scrolling container is something other than the full page, e.g., a 2x2 grid layout where the bottom right cell is the scrolling content pane. This change preserves the current API and behavior of `useScrollRestoration` while adding a new hook `useElementScrollRestoration`, which allows the caller to specify the ID of the scrolling container to use instead of `window`.