### PR TITLE
fix: support basename in static routers

### DIFF
--- a/.changeset/funny-oranges-arrive.md
+++ b/.changeset/funny-oranges-arrive.md
@@ -1,0 +1,6 @@
+---
+"react-router-dom": patch
+"@remix-run/router": patch
+---
+
+Support `basename` in static data routers

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "34.5 kB"
+      "none": "35 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12.5 kB"

--- a/packages/react-router-dom/__tests__/data-static-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-static-router-test.tsx
@@ -13,7 +13,6 @@ import {
   unstable_createStaticRouter as createStaticRouter,
   unstable_StaticRouterProvider as StaticRouterProvider,
 } from "react-router-dom/server";
-import { getPositionOfLineAndCharacter } from "typescript";
 
 beforeEach(() => {
   jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -195,7 +194,6 @@ describe("A <StaticRouterProvider>", () => {
       })
     )) as StaticHandlerContext;
 
-    debugger;
     let html = ReactDOMServer.renderToStaticMarkup(
       <React.StrictMode>
         <StaticRouterProvider

--- a/packages/react-router-dom/__tests__/data-static-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-static-router-test.tsx
@@ -163,7 +163,7 @@ describe("A <StaticRouterProvider>", () => {
     ]);
   });
 
-  it.only("renders an initialized router with a basename", async () => {
+  it("renders an initialized router with a basename", async () => {
     let location: ReturnType<typeof useLocation>;
 
     function GetLocation() {

--- a/packages/react-router-dom/__tests__/static-link-test.tsx
+++ b/packages/react-router-dom/__tests__/static-link-test.tsx
@@ -17,6 +17,21 @@ describe("A <Link> in a <StaticRouter>", () => {
 
       expect(renderer.root.findByType("a").props.href).toEqual("/mjackson");
     });
+
+    it("uses the right href with a basename", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <StaticRouter location="/base" basename="/base">
+            <Link to="mjackson" />
+          </StaticRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "/base/mjackson"
+      );
+    });
   });
 
   describe("with an object", () => {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -64,7 +64,6 @@ export function StaticRouter({
 }
 
 export interface StaticRouterProviderProps {
-  basename?: string;
   context: StaticHandlerContext;
   router: RemixRouter;
   hydrate?: boolean;
@@ -76,7 +75,6 @@ export interface StaticRouterProviderProps {
  * on the server where there is no stateful UI.
  */
 export function unstable_StaticRouterProvider({
-  basename,
   context,
   router,
   hydrate = true,
@@ -91,7 +89,7 @@ export function unstable_StaticRouterProvider({
     router,
     navigator: getStatelessNavigator(),
     static: true,
-    basename: basename || "/",
+    basename: context.basename || "/",
   };
 
   let hydrateScript = "";
@@ -191,7 +189,7 @@ export function unstable_createStaticRouter(
 
   return {
     get basename() {
-      return "/";
+      return context.basename;
     },
     get state() {
       return {
@@ -231,6 +229,7 @@ export function unstable_createStaticRouter(
       throw msg("revalidate");
     },
     createHref() {
+      // Not needed since we use navigator.createHref internally
       throw msg("createHref");
     },
     getFetcher() {


### PR DESCRIPTION
Adds support for `basename` to static data routers.  We accept it up front in `createStaticHandler`, and then persist it through `createStaticRouter`/`StaticRouterPRovider`

Sample usage:

```jsx
let { query } = createStaticHandler(routes, { basename: '/base '});
let context = await query(request);
let router = createStaticRouter(routes, context);

return ReactDOMServer.renderToString(
  <StaticRouterProvider router={router} context={context} />
);
```