### PR TITLE
fix: properly serialize/deserialize ErrorResponse instances

### DIFF
--- a/.changeset/blue-cycles-check.md
+++ b/.changeset/blue-cycles-check.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Properly serialize/deserialize ErrorResponse instances when using built-in hydration

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "none": "14.5 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "10 kB"
+      "none": "10.5 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
       "none": "16 kB"

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -23,6 +23,7 @@ import {
   Outlet,
   createBrowserRouter,
   createHashRouter,
+  isRouteErrorResponse,
   useLoaderData,
   useActionData,
   useRouteError,
@@ -260,6 +261,40 @@ function testDomRouter(
               idle
             </div>
           </div>
+        </div>"
+      `);
+    });
+
+    it("deserializes ErrorResponse instances from the window", async () => {
+      window.__staticRouterHydrationData = {
+        loaderData: {},
+        actionData: null,
+        errors: {
+          "0": {
+            status: 404,
+            statusText: "Not Found",
+            internal: false,
+            data: { not: "found" },
+            __type: "RouteErrorResponse",
+          },
+        },
+      };
+      let { container } = render(
+        <TestDataRouter window={getWindow("/")}>
+          <Route path="/" element={<h1>Nope</h1>} errorElement={<Boundary />} />
+        </TestDataRouter>
+      );
+
+      function Boundary() {
+        let error = useRouteError();
+        return isRouteErrorResponse(error) ? <h1>Yes!</h1> : <h2>No :(</h2>;
+      }
+
+      expect(getHtml(container)).toMatchInlineSnapshot(`
+        "<div>
+          <h1>
+            Yes!
+          </h1>
         </div>"
       `);
     });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -14,7 +14,6 @@ import {
   createPath,
   useHref,
   useLocation,
-  useMatch,
   useMatches,
   useNavigate,
   useNavigation,
@@ -42,7 +41,7 @@ import {
   createHashHistory,
   invariant,
   joinPaths,
-  matchPath,
+  ErrorResponse,
 } from "@remix-run/router";
 
 import type {
@@ -205,7 +204,7 @@ export function createBrowserRouter(
   return createRouter({
     basename: opts?.basename,
     history: createBrowserHistory({ window: opts?.window }),
-    hydrationData: opts?.hydrationData || window?.__staticRouterHydrationData,
+    hydrationData: opts?.hydrationData || parseHydrationData(),
     routes: enhanceManualRouteObjects(routes),
   }).initialize();
 }
@@ -221,10 +220,45 @@ export function createHashRouter(
   return createRouter({
     basename: opts?.basename,
     history: createHashHistory({ window: opts?.window }),
-    hydrationData: opts?.hydrationData || window?.__staticRouterHydrationData,
+    hydrationData: opts?.hydrationData || parseHydrationData(),
     routes: enhanceManualRouteObjects(routes),
   }).initialize();
 }
+
+function parseHydrationData(): HydrationState | undefined {
+  let state = window?.__staticRouterHydrationData;
+  if (state && state.errors) {
+    state = {
+      ...state,
+      errors: deserializeErrors(state.errors),
+    };
+  }
+  return state;
+}
+
+function deserializeErrors(
+  errors: RemixRouter["state"]["errors"]
+): RemixRouter["state"]["errors"] {
+  if (!errors) return null;
+  let entries = Object.entries(errors);
+  let serialized: RemixRouter["state"]["errors"] = {};
+  for (let [key, val] of entries) {
+    // Hey you!  If you change this, please change the corresponding logic in
+    // serializeErrors in react-router-dom/server.tsx :)
+    if (val && val.__type === "RouteErrorResponse") {
+      serialized[key] = new ErrorResponse(
+        val.status,
+        val.statusText,
+        val.data,
+        val.internal === true
+      );
+    } else {
+      serialized[key] = val;
+    }
+  }
+  return serialized;
+}
+
 //#endregion
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -9,6 +9,7 @@ import {
   IDLE_NAVIGATION,
   Action,
   invariant,
+  isRouteErrorResponse,
   UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
 } from "@remix-run/router";
 import type { Location, RouteObject, To } from "react-router-dom";
@@ -100,7 +101,7 @@ export function unstable_StaticRouterProvider({
     let data = {
       loaderData: context.loaderData,
       actionData: context.actionData,
-      errors: context.errors,
+      errors: serializeErrors(context.errors),
     };
     // Use JSON.parse here instead of embedding a raw JS object here to speed
     // up parsing on the client.  Dual-stringify is needed to ensure all quotes
@@ -137,6 +138,24 @@ export function unstable_StaticRouterProvider({
       ) : null}
     </>
   );
+}
+
+function serializeErrors(
+  errors: StaticHandlerContext["errors"]
+): StaticHandlerContext["errors"] {
+  if (!errors) return null;
+  let entries = Object.entries(errors);
+  let serialized: StaticHandlerContext["errors"] = {};
+  for (let [key, val] of entries) {
+    // Hey you!  If you change this, please change the corresponding logic in
+    // deserializeErrors in react-router-dom/index.tsx :)
+    if (isRouteErrorResponse(val)) {
+      serialized[key] = { ...val, __type: "RouteErrorResponse" };
+    } else {
+      serialized[key] = val;
+    }
+  }
+  return serialized;
 }
 
 function getStatelessNavigator() {


### PR DESCRIPTION
Handles serialization/deserialization of `ErrorResponse` objects as mentioned in #9537