### PR TITLE
doc: Update StackBlitz link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -69,6 +69,7 @@
 - kantuni
 - kddnewton
 - kentcdodds
+- kiliman
 - kkirsche
 - koojaa
 - KostiantynPopovych

--- a/examples/notes/README.md
+++ b/examples/notes/README.md
@@ -16,4 +16,4 @@ This example demonstrates some of the basic features of Data Router, including:
 
 Open this example on [StackBlitz](https://stackblitz.com):
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/remix-run/react-router/tree/remixing/examples/notes?file=src/main.tsx)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/remix-run/react-router/tree/dev/examples/notes?file=src/main.tsx)


### PR DESCRIPTION
The link referenced the old *remixing* branch before the data features were merged into *dev*.

Fixes https://github.com/remix-run/react-router/discussions/9594