### PR TITLE
docs: Fix link in `shouldRevalidate` docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -64,6 +64,7 @@
 - JaffParker
 - JakubDrozd
 - janpaepke
+- jasonpaulos
 - jimniels
 - jmargeta
 - johnpangalos

--- a/docs/route/should-revalidate.md
+++ b/docs/route/should-revalidate.md
@@ -75,6 +75,7 @@ interface ShouldRevalidateFunction {
 [action]: ./action
 [form]: ../components/form
 [fetcher]: ../hooks/use-fetcher
+[usesubmit]: ../hooks/use-submit
 [loader]: ./loader
 [useloaderdata]: ../hooks/use-loader-data
 [params]: ./route#dynamic-segments


### PR DESCRIPTION
This PR fixes the link to `useSubmit` that's currently broken on the page https://reactrouter.com/en/main/route/should-revalidate.