### PR TITLE
docs(guide/deferred): Fixed code highlights in details element

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -32,6 +32,7 @@
 - danielberndt
 - dauletbaev
 - david-crespo
+- DigitalNaut
 - dmitrytarassov
 - dokeet
 - Drishtantr

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -112,7 +112,7 @@ export default function PackageRoute() {
 
 If you're not jazzed about bringing back render props, you can use a hook, but you'll have to break things out into another component:
 
-```jsx lines=[2, 7-13, 24]
+```jsx lines=[11, 16, 23-31]
 export default function PackageRoute() {
   const data = useLoaderData();
 

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -112,7 +112,7 @@ export default function PackageRoute() {
 
 If you're not jazzed about bringing back render props, you can use a hook, but you'll have to break things out into another component:
 
-```jsx lines=[21]
+```jsx lines=[2, 7-13, 24]
 export default function PackageRoute() {
   const data = useLoaderData();
 


### PR DESCRIPTION
"useAsyncValue" hook alternative example code was missing its highlights.

I tried my best to keep it consistent with the other examples but please review!