### PR TITLE
docs(examples/auth): specify `location` in `navigate` call

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -143,3 +143,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+-Vishvsalvi

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -11,7 +11,7 @@ Be sure to pay attention to the following features:
 
 - The use of the `useNavigate()` hook and the `<Navigate>` component for navigating both imperatively after the login form is submitted and declaratively when a non-authenticated user visits a particular route
 - The use of `location.state` to preserve the previous location so you can send the user there after they authenticate
-- The use of `navigate("...", { replace: true })` to replace the `/login` route in the history stack so the user doesn't return to the login page when clicking the back button after logging in
+- The use of `navigate("location_after_successful login", { replace: true })` to replace the `/login` route in the history stack so the user doesn't return to the login page when clicking the back button after logging in
 
 ## Preview
 


### PR DESCRIPTION
Made more clear with more specific example of the location instead of three dots.