### PR TITLE
fix: Can not extend RouteObject

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -136,3 +136,4 @@
 - xcsnowcity
 - yuleicul
 - m-shojaei
+- lilonghe

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -24,7 +24,6 @@ export interface IndexRouteObject {
   shouldRevalidate?: AgnosticIndexRouteObject["shouldRevalidate"];
   handle?: AgnosticIndexRouteObject["handle"];
   index: true;
-  children?: undefined;
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
 }


### PR DESCRIPTION
`children?: undefined;`, It makes no sense and  prevents us from extend `RouteObject`

like this commit: [https://github.com/remix-run/react-router/issues/9427#issuecomment-1321100691](https://github.com/remix-run/react-router/issues/9427#issuecomment-1321100691)

<img width="363" alt="Screenshot 2022-11-22 at 15 03 58" src="https://user-images.githubusercontent.com/12867278/203247204-f4e81aee-5797-4cc1-aec8-ed4105e94f05.png">

example code:
```
interface TestA {
    path: string;
    children?: undefined;
}

interface TestB {
    path: string;
    children?: TestC[];
}

type TestC = TestA | TestB;

type Customer = TestC & {
    authority?: string;
    children?: Customer[]
}

let data: Customer[] = [
    {
        path: '/',
        authority: '123',
        children: [
            {
                path: '/',
                authority: 'admin' // The expected type comes from property 'children' which is declared here on type 'Customer'
            }
        ]
    }
]
```