### PR TITLE
refactor(react-router): simplify types

### DIFF
--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -222,37 +222,41 @@ export function Outlet(props: OutletProps): React.ReactElement | null {
   return useOutlet(props.context);
 }
 
-export interface PathRouteProps {
-  caseSensitive?: NonIndexRouteObject["caseSensitive"];
-  path?: NonIndexRouteObject["path"];
-  id?: NonIndexRouteObject["id"];
-  loader?: NonIndexRouteObject["loader"];
-  action?: NonIndexRouteObject["action"];
-  hasErrorBoundary?: NonIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: NonIndexRouteObject["shouldRevalidate"];
-  handle?: NonIndexRouteObject["handle"];
-  index?: false;
+export type PathRouteProps = Pick<
+  NonIndexRouteObject,
+  | "action"
+  | "caseSensitive"
+  | "handle"
+  | "hasErrorBoundary"
+  | "id"
+  | "loader"
+  | "path"
+  | "shouldRevalidate"
+> & {
+  index?: false; // this is also the same as in `NonIndexRouteObject`
   children?: React.ReactNode;
-  element?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-}
+  element?: React.ReactNode | null; // this is also the same as in `NonIndexRouteObject`
+  errorElement?: React.ReactNode | null; // this is also the same as in `NonIndexRouteObject`
+};
 
 export interface LayoutRouteProps extends PathRouteProps {}
 
-export interface IndexRouteProps {
-  caseSensitive?: IndexRouteObject["caseSensitive"];
-  path?: IndexRouteObject["path"];
-  id?: IndexRouteObject["id"];
-  loader?: IndexRouteObject["loader"];
-  action?: IndexRouteObject["action"];
-  hasErrorBoundary?: IndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: IndexRouteObject["shouldRevalidate"];
-  handle?: IndexRouteObject["handle"];
-  index: true;
-  children?: undefined;
-  element?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-}
+export type IndexRouteProps = Pick<
+  IndexRouteObject,
+  | "action"
+  | "caseSensitive"
+  | "handle"
+  | "hasErrorBoundary"
+  | "id"
+  | "loader"
+  | "path"
+  | "shouldRevalidate"
+> & {
+  index: true; // this is also the same as in `IndexRouteObject`
+  children?: undefined; // this is also the same as in `IndexRouteObject`
+  element?: React.ReactNode | null; // this is also the same as in `IndexRouteObject`
+  errorElement?: React.ReactNode | null; // this is also the same as in `IndexRouteObject`
+};
 
 export type RouteProps = PathRouteProps | LayoutRouteProps | IndexRouteProps;
 

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -14,35 +14,39 @@ import type { Action as NavigationType } from "@remix-run/router";
 
 // Create react-specific types from the agnostic types in @remix-run/router to
 // export from react-router
-export interface IndexRouteObject {
-  caseSensitive?: AgnosticIndexRouteObject["caseSensitive"];
-  path?: AgnosticIndexRouteObject["path"];
-  id?: AgnosticIndexRouteObject["id"];
-  loader?: AgnosticIndexRouteObject["loader"];
-  action?: AgnosticIndexRouteObject["action"];
-  hasErrorBoundary?: AgnosticIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: AgnosticIndexRouteObject["shouldRevalidate"];
-  handle?: AgnosticIndexRouteObject["handle"];
-  index: true;
-  children?: undefined;
+export type IndexRouteObject = Pick<
+  AgnosticIndexRouteObject,
+  | "action"
+  | "caseSensitive"
+  | "handle"
+  | "hasErrorBoundary"
+  | "id"
+  | "loader"
+  | "path"
+  | "shouldRevalidate"
+> & {
+  index: true; // this is also the same as in `AgnosticIndexRouteObject`
+  children?: undefined; // this is also the same as in `AgnosticIndexRouteObject`
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
-}
+};
 
-export interface NonIndexRouteObject {
-  caseSensitive?: AgnosticNonIndexRouteObject["caseSensitive"];
-  path?: AgnosticNonIndexRouteObject["path"];
-  id?: AgnosticNonIndexRouteObject["id"];
-  loader?: AgnosticNonIndexRouteObject["loader"];
-  action?: AgnosticNonIndexRouteObject["action"];
-  hasErrorBoundary?: AgnosticNonIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: AgnosticNonIndexRouteObject["shouldRevalidate"];
-  handle?: AgnosticNonIndexRouteObject["handle"];
-  index?: false;
+export type NonIndexRouteObject = Pick<
+  AgnosticNonIndexRouteObject,
+  | "action"
+  | "caseSensitive"
+  | "handle"
+  | "hasErrorBoundary"
+  | "id"
+  | "loader"
+  | "path"
+  | "shouldRevalidate"
+> & {
+  index?: false; // this is also the same as in `AgnosticNonIndexRouteObject`
   children?: RouteObject[];
   element?: React.ReactNode | null;
   errorElement?: React.ReactNode | null;
-}
+};
 
 export type RouteObject = IndexRouteObject | NonIndexRouteObject;
 
@@ -105,14 +109,12 @@ export interface NavigateOptions {
  * to avoid "tearing" that may occur in a suspense-enabled app if the action
  * and/or location were to be read directly from the history instance.
  */
-export interface Navigator {
-  createHref: History["createHref"];
+export type Navigator = Pick<History, "createHref" | "go"> &
   // Optional for backwards-compat with Router/HistoryRouter usage (edge case)
-  encodeLocation?: History["encodeLocation"];
-  go: History["go"];
-  push(to: To, state?: any, opts?: NavigateOptions): void;
-  replace(to: To, state?: any, opts?: NavigateOptions): void;
-}
+  Partial<Pick<History, "encodeLocation">> & {
+    push(to: To, state?: any, opts?: NavigateOptions): void;
+    replace(to: To, state?: any, opts?: NavigateOptions): void;
+  };
 
 interface NavigationContextObject {
   basename: string;


### PR DESCRIPTION
I could have gone with `Omit`, which would be less code, but I like the explicitness of `Pick` more in these cases