### PR TITLE
docs(routers/create-hash-router): fix highlighting 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -47,6 +47,7 @@
 - gianlucca
 - gijo-varghese
 - goldins
+- goodrone
 - gowthamvbhat
 - GraxMonzo
 - GuptaSiddhant

--- a/docs/routers/create-hash-router.md
+++ b/docs/routers/create-hash-router.md
@@ -11,7 +11,7 @@ This router is useful if you are unable to configure your web server to direct a
 
 Other than that, it is functionally the same as [`createBrowserRouter`][createbrowserrouter].
 
-```tsx lines=[3,7,11]
+```tsx lines=[4,11]
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {


### PR DESCRIPTION
Currently the highlighting on https://reactrouter.com/en/dev/routers/create-hash-router does not make sense to me:

![image](https://user-images.githubusercontent.com/1621335/204092623-b75caf38-3ed7-4001-8c2b-e81f93d2cbc4.png)

I think that it would be better to highlight line 4 instead of 3 and 7.

I wasn't able to figure out how to build the docs portal to verify my changes.

I hope my contribution would be helpful.  Thank you for considering it.