### PR TITLE
fix: update url links on templates and JS docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,8 +16,8 @@ body:
         you ask a question, here are some resources to get help first:
 
         - Read the docs: https://reactrouter.com
-        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/getting-started/faq
-        - Explore examples: https://reactrouter.com/docs/en/v6/examples/basic
+        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/main/start/faq
+        - Explore examples: https://reactrouter.com/docs/en/main/start/examples
         - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/tagged/react-router
         - Ask in chat: https://discord.gg/6RyV8n8yyM
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,8 +16,8 @@ body:
         you ask a question, here are some resources to get help first:
 
         - Read the docs: https://reactrouter.com
-        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/v6/getting-started/faq
-        - Explore examples: https://reactrouter.com/docs/en/v6/examples/basic
+        - Check out the list of frequently asked questions: https://reactrouter.com/docs/en/main/start/faq
+        - Explore examples: https://reactrouter.com/docs/en/main/start/examples
         - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/tagged/react-router
         - Ask in chat: https://discord.gg/6RyV8n8yyM
   - type: textarea

--- a/contributors.yml
+++ b/contributors.yml
@@ -41,6 +41,7 @@
 - elanis
 - elylucas
 - emzoumpo
+- engpetermwangi
 - FilipJirsak
 - frontsideair
 - fz6m

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -120,7 +120,7 @@ export interface MemoryRouterProps {
 /**
  * A <Router> that stores all entries in memory.
  *
- * @see https://reactrouter.com/docs/en/v6/routers/memory-router
+ * @see https://reactrouter.com/docs/en/main/router-components/memory-router
  */
 export function MemoryRouter({
   basename,
@@ -170,7 +170,7 @@ export interface NavigateProps {
  * able to use hooks. In functional components, we recommend you use the
  * `useNavigate` hook instead.
  *
- * @see https://reactrouter.com/docs/en/v6/components/navigate
+ * @see https://reactrouter.com/docs/en/main/components/navigate
  */
 export function Navigate({
   to,
@@ -215,7 +215,7 @@ export interface OutletProps {
 /**
  * Renders the child route's element, if there is one.
  *
- * @see https://reactrouter.com/docs/en/v6/components/outlet
+ * @see https://reactrouter.com/docs/en/main/components/outlet
  */
 export function Outlet(props: OutletProps): React.ReactElement | null {
   return useOutlet(props.context);
@@ -258,7 +258,7 @@ export type RouteProps = PathRouteProps | LayoutRouteProps | IndexRouteProps;
 /**
  * Declares an element that should be rendered at a certain URL path.
  *
- * @see https://reactrouter.com/docs/en/v6/components/route
+ * @see https://reactrouter.com/docs/en/main/components/route
  */
 export function Route(_props: RouteProps): React.ReactElement | null {
   invariant(
@@ -284,7 +284,7 @@ export interface RouterProps {
  * router that is more specific to your environment such as a <BrowserRouter>
  * in web browsers or a <StaticRouter> for server rendering.
  *
- * @see https://reactrouter.com/docs/en/v6/routers/router
+ * @see https://reactrouter.com/docs/en/main/router-components/router
  */
 export function Router({
   basename: basenameProp = "/",
@@ -366,7 +366,7 @@ export interface RoutesProps {
  * A container for a nested tree of <Route> elements that renders the branch
  * that best matches the current location.
  *
- * @see https://reactrouter.com/docs/en/v6/components/routes
+ * @see https://reactrouter.com/docs/en/main/components/routes
  */
 export function Routes({
   children,
@@ -536,7 +536,7 @@ function ResolveAwait({
  * either a `<Route>` element or an array of them. Used internally by
  * `<Routes>` to create a route config from its children.
  *
- * @see https://reactrouter.com/docs/en/v6/utils/create-routes-from-children
+ * @see https://reactrouter.com/docs/en/main/utils/create-routes-from-children
  */
 export function createRoutesFromChildren(
   children: React.ReactNode,

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -45,7 +45,7 @@ import {
  * Returns the full href for the given "to" value. This is useful for building
  * custom links that are also accessible and preserve right-click behavior.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-href
+ * @see https://reactrouter.com/docs/en/main/hooks/use-href
  */
 export function useHref(
   to: To,
@@ -78,7 +78,7 @@ export function useHref(
 /**
  * Returns true if this component is a descendant of a <Router>.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-in-router-context
+ * @see https://reactrouter.com/docs/en/main/hooks/use-in-router-context
  */
 export function useInRouterContext(): boolean {
   return React.useContext(LocationContext) != null;
@@ -92,7 +92,7 @@ export function useInRouterContext(): boolean {
  * "routing" in your app, and we'd like to know what your use case is. We may
  * be able to provide something higher-level to better suit your needs.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-location
+ * @see https://reactrouter.com/docs/en/main/hooks/use-location
  */
 export function useLocation(): Location {
   invariant(
@@ -109,7 +109,7 @@ export function useLocation(): Location {
  * Returns the current navigation action which describes how the router came to
  * the current location, either by a pop, push, or replace on the history stack.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-navigation-type
+ * @see https://reactrouter.com/docs/en/main/hooks/use-navigation-type
  */
 export function useNavigationType(): NavigationType {
   return React.useContext(LocationContext).navigationType;
@@ -120,7 +120,7 @@ export function useNavigationType(): NavigationType {
  * This is useful for components that need to know "active" state, e.g.
  * <NavLink>.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-match
+ * @see https://reactrouter.com/docs/en/main/hooks/use-match
  */
 export function useMatch<
   ParamKey extends ParamParseKey<Path>,
@@ -152,7 +152,7 @@ export interface NavigateFunction {
  * Returns an imperative method for changing the location. Used by <Link>s, but
  * may also be used by other elements to change the location.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-navigate
+ * @see https://reactrouter.com/docs/en/main/hooks/use-navigate
  */
 export function useNavigate(): NavigateFunction {
   invariant(
@@ -225,7 +225,7 @@ const OutletContext = React.createContext<unknown>(null);
 /**
  * Returns the context (if provided) for the child route at this level of the route
  * hierarchy.
- * @see https://reactrouter.com/docs/en/v6/hooks/use-outlet-context
+ * @see https://reactrouter.com/docs/en/main/hooks/use-outlet-context
  */
 export function useOutletContext<Context = unknown>(): Context {
   return React.useContext(OutletContext) as Context;
@@ -235,7 +235,7 @@ export function useOutletContext<Context = unknown>(): Context {
  * Returns the element for the child route at this level of the route
  * hierarchy. Used internally by <Outlet> to render child routes.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-outlet
+ * @see https://reactrouter.com/docs/en/main/hooks/use-outlet
  */
 export function useOutlet(context?: unknown): React.ReactElement | null {
   let outlet = React.useContext(RouteContext).outlet;
@@ -251,7 +251,7 @@ export function useOutlet(context?: unknown): React.ReactElement | null {
  * Returns an object of key/value pairs of the dynamic params from the current
  * URL that were matched by the route path.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-params
+ * @see https://reactrouter.com/docs/en/main/hooks/use-params
  */
 export function useParams<
   ParamsOrKey extends string | Record<string, string | undefined> = string
@@ -266,7 +266,7 @@ export function useParams<
 /**
  * Resolves the pathname of the given `to` value against the current location.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-resolved-path
+ * @see https://reactrouter.com/docs/en/main/hooks/use-resolved-path
  */
 export function useResolvedPath(
   to: To,
@@ -297,7 +297,7 @@ export function useResolvedPath(
  * elements in the tree must render an <Outlet> to render their child route's
  * element.
  *
- * @see https://reactrouter.com/docs/en/v6/hooks/use-routes
+ * @see https://reactrouter.com/docs/en/main/hooks/use-routes
  */
 export function useRoutes(
   routes: RouteObject[],

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -306,7 +306,7 @@ export function convertRoutesToDataRoutes(
 /**
  * Matches the given routes to a location and returns the match data.
  *
- * @see https://reactrouter.com/docs/en/v6/utils/match-routes
+ * @see https://reactrouter.com/docs/en/main/utils/match-routes
  */
 export function matchRoutes<
   RouteObjectType extends AgnosticRouteObject = AgnosticRouteObject
@@ -528,7 +528,7 @@ function matchRouteBranch<
 /**
  * Returns a path with params interpolated.
  *
- * @see https://reactrouter.com/docs/en/v6/utils/generate-path
+ * @see https://reactrouter.com/docs/en/main/utils/generate-path
  */
 export function generatePath<Path extends string>(
   path: Path,
@@ -606,7 +606,7 @@ type Mutable<T> = {
  * Performs pattern matching on a URL pathname and returns information about
  * the match.
  *
- * @see https://reactrouter.com/docs/en/v6/utils/match-path
+ * @see https://reactrouter.com/docs/en/main/utils/match-path
  */
 export function matchPath<
   ParamKey extends ParamParseKey<Path>,
@@ -805,7 +805,7 @@ export function warning(cond: any, message: string): void {
 /**
  * Returns a resolved path object relative to the given pathname.
  *
- * @see https://reactrouter.com/docs/en/v6/utils/resolve-path
+ * @see https://reactrouter.com/docs/en/main/utils/resolve-path
  */
 export function resolvePath(to: To, fromPathname = "/"): Path {
   let {


### PR DESCRIPTION
**Previous behavior**
* Links on the issue and feature request templates errored with a `404`
* Links on the JS docs on certain components, hooks and utils errored with a `404`

**New behavior**
* Updated links to up-to-date ones, mainly a change from `v6` to `main` as provided in https://reactrouter.com/en/main