### PR TITLE
feat: optional params and static segments

### DIFF
--- a/.changeset/new-taxis-stare.md
+++ b/.changeset/new-taxis-stare.md
@@ -1,0 +1,34 @@
+---
+"react-router": minor
+"@remix-run/router": minor
+---
+
+Allows optional routes and optional static segments
+
+**Optional params examples**
+
+`:lang?/about` will get expanded matched with
+
+```
+/:lang/about
+/about
+```
+
+`/multistep/:widget1?/widget2?/widget3?`
+Will get expanded matched with:
+
+```
+/multistep
+/multistep/:widget1
+/multistep/:widget1/:widget2
+/multistep/:widget1/:widget2/:widget3
+```
+
+**optional static segment example**
+
+`/fr?/about` will get expanded and matched with:
+
+```
+/about
+/fr/about
+```

--- a/contributors.yml
+++ b/contributors.yml
@@ -76,6 +76,7 @@
 - KostiantynPopovych
 - KutnerUri
 - latin-1
+- lordofthecactus
 - liuhanqu
 - loun4
 - lqze

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "35 kB"
+      "none": "35.5 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12.5 kB"

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -338,6 +338,12 @@ describe("path matchine with optional segments", () => {
 
     expect(pickPathsAndParams(routes, "/nested")).toEqual(null);
     expect(pickPathsAndParams(routes, "/nested/one")).toEqual(null);
+    expect(pickPathsAndParams(routes, "/nested/two")).toEqual([
+      {
+        path: "/nested/one?/two/three?",
+        params: {},
+      },
+    ]);
     expect(pickPathsAndParams(routes, "/nested/one/two")).toEqual([
       {
         path: "/nested/one?/two/three?",
@@ -414,6 +420,12 @@ describe("path matching with optional dynamic segments", () => {
 
     expect(pickPathsAndParams(routes, "/nested")).toEqual(null);
     expect(pickPathsAndParams(routes, "/nested/foo")).toEqual(null);
+    expect(pickPathsAndParams(routes, "/nested/two")).toEqual([
+      {
+        path: "/nested/:one?/two/:three?",
+        params: {},
+      },
+    ]);
     expect(pickPathsAndParams(routes, "/nested/foo/two")).toEqual([
       {
         path: "/nested/:one?/two/:three?",

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -277,6 +277,82 @@ describe("path matching with splats", () => {
   });
 });
 
+describe("path matchine with optional segments", () => {
+  test("optional static segment at the start of the path", () => {
+    let routes = [
+      {
+        path: "/en?/abc",
+      },
+    ];
+
+    expect(pickPathsAndParams(routes, "/")).toEqual(null);
+    expect(pickPathsAndParams(routes, "/abc")).toEqual([
+      {
+        path: "/en?/abc",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/en/abc")).toEqual([
+      {
+        path: "/en?/abc",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/en/abc/bar")).toEqual(null);
+  });
+
+  test("optional static segment at the end of the path", () => {
+    let routes = [
+      {
+        path: "/nested/one?/two?",
+      },
+    ];
+
+    expect(pickPathsAndParams(routes, "/nested")).toEqual([
+      {
+        path: "/nested/one?/two?",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/nested/one")).toEqual([
+      {
+        path: "/nested/one?/two?",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/nested/one/two")).toEqual([
+      {
+        path: "/nested/one?/two?",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/nested/one/two/baz")).toEqual(null);
+  });
+
+  test("intercalated optional static segments", () => {
+    let routes = [
+      {
+        path: "/nested/one?/two/three?",
+      },
+    ];
+
+    expect(pickPathsAndParams(routes, "/nested")).toEqual(null);
+    expect(pickPathsAndParams(routes, "/nested/one")).toEqual(null);
+    expect(pickPathsAndParams(routes, "/nested/one/two")).toEqual([
+      {
+        path: "/nested/one?/two/three?",
+        params: {},
+      },
+    ]);
+    expect(pickPathsAndParams(routes, "/nested/one/two/three")).toEqual([
+      {
+        path: "/nested/one?/two/three?",
+        params: {},
+      },
+    ]);
+  });
+});
+
 describe("path matching with optional dynamic segments", () => {
   test("optional params at the start of the path", () => {
     let routes = [

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -419,7 +419,7 @@ function flattenRoutes<
     let segments = path.split("/");
     let optionalParams: string[] = [];
     segments.forEach((segment) => {
-      let match = segment.match(/^:([^?]+)\?$/);
+      let match = segment.match(/^:?([^?]+)\?$/);
       if (match) {
         optionalParams.push(match[1]);
       }
@@ -431,7 +431,7 @@ function flattenRoutes<
         let newMeta = routesMeta.map((m) => ({ ...m }));
 
         for (let j = optionalParams.length - 1; j >= 0; j--) {
-          let re = new RegExp(`(\\/:${optionalParams[j]})\\?`);
+          let re = new RegExp(`(\\/:?${optionalParams[j]})\\?`);
           let replacement = j < i ? "$1" : "";
           newPath = newPath.replace(re, replacement);
           newMeta[newMeta.length - 1].relativePath = newMeta[


### PR DESCRIPTION
Closes: https://github.com/remix-run/react-router/discussions/9550

Allows optional params and optional static segments

### Optional params examples
`:lang?/about` will get expanded matched with

```
/:lang/about
/about
```

`/multistep/:widget1?/widget2?/widget3?`
Will get expanded matched with:
```
/multistep
/multistep/:widget1
/multistep/:widget1/:widget2
/multistep/:widget1/:widget2/:widget3
```

### Same with static segments

`/fr?/about` will get expanded and matched with:

```
/about
/fr/about
```

### Context
Code was added at the point of `flattenRoutes`

### Feedback required
Should we allow intercalated situations? currently:
`/one/:two?/three/four?` gets matched with:
```
/one/:two/three
/one/:two/three/:four
```
