### PR TITLE
Respect replace behavior on external redirects

### DIFF
--- a/.changeset/itchy-phones-rush.md
+++ b/.changeset/itchy-phones-rush.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Respect `replace` behavior on external redirects

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1604,7 +1604,11 @@ export function createRouter(init: RouterInit): Router {
       typeof window !== "undefined" &&
       typeof window.location !== "undefined"
     ) {
-      window.location.replace(redirect.location);
+      if (replace) {
+        window.location.replace(redirect.location);
+      } else {
+        window.location.assign(redirect.location);
+      }
       return;
     }
 


### PR DESCRIPTION
Fixes a bug in `6.4.4-pre.1` where redirects were always replacing and causing incorrect back button behavior

* Start at `/`
* Click to `/a`
* Click to `/b`
  * `/b` `loader` returns `redirect('https://google.com')`
* Land on Google
* Back button should return you to `/a`

Using `<Link to="/b" replace>` above would cause the back button to go back to `/`