### PR TITLE
docs(route/action): Add missing`request` parameter

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -2,6 +2,7 @@
 - abhi-kr-2100
 - AchThomas
 - adamdotjs
+- afzalsayed96
 - Ajayff4
 - alany411
 - alexlbr

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -113,7 +113,7 @@ You can `throw` in your action to break out of the current call stack (stop runn
 
 ```tsx [10]
 <Route
-  action={async ({ params }) => {
+  action={async ({ params, request }) => {
     const res = await fetch(
       `/api/properties/${params.id}`,
       {


### PR DESCRIPTION
Adds missing `request` parameter in [action docs](https://reactrouter.com/en/main/route/action)