### PR TITLE
Fix loader request method (#9660)

### DIFF
--- a/.changeset/pretty-kiwis-study.md
+++ b/.changeset/pretty-kiwis-study.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix requests sent to revalidating loaders so they reflect a GET request

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -952,6 +952,9 @@ export function createRouter(init: RouterInit): Router {
         ...opts.submission,
       };
       loadingNavigation = navigation;
+
+      // Create a GET request for the loaders
+      request = createRequest(request.url, request.signal);
     }
 
     // Call loaders
@@ -2202,7 +2205,9 @@ export function unstable_createStaticHandler(
       };
     }
 
-    let context = await loadRouteData(request, matches);
+    // Create a GET request for the loaders
+    let loaderRequest = createRequest(request.url, request.signal);
+    let context = await loadRouteData(loaderRequest, matches);
 
     return {
       ...context,


### PR DESCRIPTION
Cherry-picked https://github.com/remix-run/react-router/pull/9660 over for the `@remix-run/router@1.0.5` hotfix.  We're updating how we create `Request`/`URL` to fix https://github.com/remix-run/remix/issues/4740 so it made sense to get this fix in as well since they touch some of the same code.
