### PR TITLE
fix: explode optional segments for relative paths in nested routes

### DIFF
--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -378,7 +378,8 @@ function flattenRoutes<
     relativePath?: string
   ) => {
     let meta: RouteMeta<RouteObjectType> = {
-      relativePath: relativePath ?? (route.path || ""),
+      relativePath:
+        relativePath === undefined ? route.path || "" : relativePath,
       caseSensitive: route.caseSensitive === true,
       childrenIndex: index,
       route,

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -378,7 +378,7 @@ function flattenRoutes<
     relativePath?: string
   ) => {
     let meta: RouteMeta<RouteObjectType> = {
-      relativePath: relativePath || route.path || "",
+      relativePath: relativePath ?? (route.path || ""),
       caseSensitive: route.caseSensitive === true,
       childrenIndex: index,
       route,
@@ -507,6 +507,13 @@ let explodeOptionalSegments = function* (path: string) {
     if (dynamicHashes.has(hash)) continue;
 
     dynamicHashes.add(hash);
+
+    // for absolute paths, ensure `/` instead of empty segment
+    if (path.startsWith("/") && exploded === "") {
+      yield "/";
+      continue;
+    }
+
     yield exploded;
   }
 };

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -487,7 +487,8 @@ let _explodeOptionalSegments = (path: string): string[] => {
  * - `/one/three/:five` (because `/one/three/:four` has priority)
  * - `/one/:two/three/:five` (because `/one/:two/three/:four` has priority)
  */
-let explodeOptionalSegments = function* (path: string) {
+let explodeOptionalSegments = (path: string) => {
+  let result: string[] = [];
   // Compute hash for dynamic path segments
   // /one/:two/three/:four -> /one/:/three/:
   let dynamicHash = (subpath: string) =>
@@ -510,12 +511,13 @@ let explodeOptionalSegments = function* (path: string) {
 
     // for absolute paths, ensure `/` instead of empty segment
     if (path.startsWith("/") && exploded === "") {
-      yield "/";
+      result.push("/");
       continue;
     }
 
-    yield exploded;
+    result.push(exploded);
   }
+  return result;
 };
 
 function rankRouteBranches(branches: RouteBranch[]): void {


### PR DESCRIPTION
#9650 added support for matching routes with optional path segments, but did not work for nested routes.
This PR fixes that.

It also refactors the approach to explicitly "explode" a path with optional path segments into the equivalent set of valid combinations of paths without optional segments (see `explodeOptionalSegments` jsdoc for an example). The paths are "exploded" prior to creating the route metadata, which means that when the route metadata gets initialized its already correct. Previously, we needed to surgically modify route metadata for a branch (which we were only handling correctly for unnested routes).