### PR TITLE
Remove instanceof Response checks in favor of isResponse

### DIFF
--- a/.changeset/curvy-hairs-deliver.md
+++ b/.changeset/curvy-hairs-deliver.md
@@ -2,4 +2,4 @@
 "@remix-run/router": patch
 ---
 
-Remove `instaanceof Response` checks in favor of duck typing
+Remove `instanceof Response` checks in favor of `isResponse`

--- a/.changeset/curvy-hairs-deliver.md
+++ b/.changeset/curvy-hairs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Remove `instaanceof Response` checks in favor of duck typing

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1988,7 +1988,7 @@ export function unstable_createStaticHandler(
     }
 
     let result = await queryImpl(request, location, matches);
-    if (result instanceof Response) {
+    if (isResponse(result)) {
       return result;
     }
 
@@ -2046,7 +2046,7 @@ export function unstable_createStaticHandler(
     }
 
     let result = await queryImpl(request, location, matches, match);
-    if (result instanceof Response) {
+    if (isResponse(result)) {
       return result;
     }
 
@@ -2087,7 +2087,7 @@ export function unstable_createStaticHandler(
       }
 
       let result = await loadRouteData(request, matches, routeMatch);
-      return result instanceof Response
+      return isResponse(result)
         ? result
         : {
             ...result,
@@ -2616,7 +2616,7 @@ async function callLoaderOrAction(
     request.signal.removeEventListener("abort", onReject);
   }
 
-  if (result instanceof Response) {
+  if (isResponse(result)) {
     let status = result.status;
 
     // Process redirects
@@ -3052,8 +3052,18 @@ function isRedirectResult(result?: DataResult): result is RedirectResult {
   return (result && result.type) === ResultType.redirect;
 }
 
+function isResponse(value: any): value is Response {
+  return (
+    value != null &&
+    typeof value.status === "number" &&
+    typeof value.statusText === "string" &&
+    typeof value.headers === "object" &&
+    typeof value.body !== "undefined"
+  );
+}
+
 function isRedirectResponse(result: any): result is Response {
-  if (!(result instanceof Response)) {
+  if (!isResponse(result)) {
     return false;
   }
 
@@ -3065,7 +3075,7 @@ function isRedirectResponse(result: any): result is Response {
 function isQueryRouteResponse(obj: any): obj is QueryRouteResponse {
   return (
     obj &&
-    obj.response instanceof Response &&
+    isResponse(obj.response) &&
     (obj.type === ResultType.data || ResultType.error)
   );
 }


### PR DESCRIPTION
When using `@remix-run/router` for server-side data fetching, we seem to get different `Response` instances from a `return fetch(...)` in a `loader`/`action`.  ~~I'm not entirely sure _why_ yet since we polyfill all `fetch`/`Request`/`Response` globals, but the `instanceof Response` checks were failing.  Copied the same `isResponse` method used in Remix and replaced all checks with that.~~

I think the underlying cause here is that our `loader` is built via ESM and uses the ESM version of the fetch polyfills, but `@remix-run/server-runtime` + `@remix-run/router` are runningin node and therefore using the CJS versions of the fetch polyfills.  Hence the `instanceof` failing.

Closes https://github.com/remix-run/remix/issues/4741