### PR TITLE
Add requestContext to staticHandler query/queryRoute

### DIFF
--- a/.changeset/afraid-snakes-cough.md
+++ b/.changeset/afraid-snakes-cough.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Add `requestContext` support to static handler `query`/`queryRoute`

--- a/.changeset/afraid-snakes-cough.md
+++ b/.changeset/afraid-snakes-cough.md
@@ -3,3 +3,5 @@
 ---
 
 Add `requestContext` support to static handler `query`/`queryRoute`
+
+- Note that the unstable API of `queryRoute(path, routeId)` has been changed to `queryRoute(path, { routeId, requestContext })`

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10955,17 +10955,17 @@ describe("a router", () => {
         ]);
 
         await query(createRequest("/child"), { requestContext });
-        expect(arg(rootStub).requestContext.sessionId).toBe("12345");
-        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+        expect(arg(rootStub).context.sessionId).toBe("12345");
+        expect(arg(childStub).context.sessionId).toBe("12345");
 
         actionStub.mockClear();
         rootStub.mockClear();
         childStub.mockClear();
 
         await query(createSubmitRequest("/child"), { requestContext });
-        expect(arg(actionStub).requestContext.sessionId).toBe("12345");
-        expect(arg(rootStub).requestContext.sessionId).toBe("12345");
-        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+        expect(arg(actionStub).context.sessionId).toBe("12345");
+        expect(arg(rootStub).context.sessionId).toBe("12345");
+        expect(arg(childStub).context.sessionId).toBe("12345");
       });
 
       describe("statusCode", () => {
@@ -11935,13 +11935,13 @@ describe("a router", () => {
           routeId: "child",
           requestContext,
         });
-        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+        expect(arg(childStub).context.sessionId).toBe("12345");
 
         await queryRoute(createSubmitRequest("/child"), {
           routeId: "child",
           requestContext,
         });
-        expect(arg(actionStub).requestContext.sessionId).toBe("12345");
+        expect(arg(actionStub).context.sessionId).toBe("12345");
       });
 
       describe("Errors with Status Codes", () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10932,6 +10932,42 @@ describe("a router", () => {
         expect(childLoaderRequest.url).toBe("http://localhost/child");
       });
 
+      it("should support a requestContext passed to loaders and actions", async () => {
+        let requestContext = { sessionId: "12345" };
+        let rootStub = jest.fn(() => "ROOT");
+        let childStub = jest.fn(() => "CHILD");
+        let actionStub = jest.fn(() => "CHILD ACTION");
+        let arg = (s) => s.mock.calls[0][0];
+        let { query } = createStaticHandler([
+          {
+            id: "root",
+            path: "/",
+            loader: rootStub,
+            children: [
+              {
+                id: "child",
+                path: "child",
+                action: actionStub,
+                loader: childStub,
+              },
+            ],
+          },
+        ]);
+
+        await query(createRequest("/child"), { requestContext });
+        expect(arg(rootStub).requestContext.sessionId).toBe("12345");
+        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+
+        actionStub.mockClear();
+        rootStub.mockClear();
+        childStub.mockClear();
+
+        await query(createSubmitRequest("/child"), { requestContext });
+        expect(arg(actionStub).requestContext.sessionId).toBe("12345");
+        expect(arg(rootStub).requestContext.sessionId).toBe("12345");
+        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+      });
+
       describe("statusCode", () => {
         it("should expose a 200 status code by default", async () => {
           let { query } = createStaticHandler([
@@ -11254,7 +11290,7 @@ describe("a router", () => {
                 isError ? Promise.reject(data) : Promise.resolve(data),
             },
           ]);
-          return handler.queryRoute(req, routeId);
+          return handler.queryRoute(req, { routeId });
         }
 
         return {
@@ -11307,7 +11343,9 @@ describe("a router", () => {
         data = await queryRoute(createRequest("/parent?index"));
         expect(data).toBe("PARENT INDEX LOADER");
 
-        data = await queryRoute(createRequest("/parent/child"), "child");
+        data = await queryRoute(createRequest("/parent/child"), {
+          routeId: "child",
+        });
         expect(data).toBe("CHILD LOADER");
       });
 
@@ -11324,19 +11362,27 @@ describe("a router", () => {
         let data;
 
         // Layout route
-        data = await queryRoute(createRequest("/parent"), "parent");
+        data = await queryRoute(createRequest("/parent"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT LOADER");
 
         // Index route
-        data = await queryRoute(createRequest("/parent"), "parentIndex");
+        data = await queryRoute(createRequest("/parent"), {
+          routeId: "parentIndex",
+        });
         expect(data).toBe("PARENT INDEX LOADER");
 
         // Parent in nested route
-        data = await queryRoute(createRequest("/parent/child"), "parent");
+        data = await queryRoute(createRequest("/parent/child"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT LOADER");
 
         // Child in nested route
-        data = await queryRoute(createRequest("/parent/child"), "child");
+        data = await queryRoute(createRequest("/parent/child"), {
+          routeId: "child",
+        });
         expect(data).toBe("CHILD LOADER");
 
         // Non-undefined falsey values should count
@@ -11464,19 +11510,27 @@ describe("a router", () => {
         let data;
 
         // Layout route
-        data = await queryRoute(createRequest("/base/parent"), "parent");
+        data = await queryRoute(createRequest("/base/parent"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT LOADER");
 
         // Index route
-        data = await queryRoute(createRequest("/base/parent"), "parentIndex");
+        data = await queryRoute(createRequest("/base/parent"), {
+          routeId: "parentIndex",
+        });
         expect(data).toBe("PARENT INDEX LOADER");
 
         // Parent in nested route
-        data = await queryRoute(createRequest("/base/parent/child"), "parent");
+        data = await queryRoute(createRequest("/base/parent/child"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT LOADER");
 
         // Child in nested route
-        data = await queryRoute(createRequest("/base/parent/child"), "child");
+        data = await queryRoute(createRequest("/base/parent/child"), {
+          routeId: "child",
+        });
         expect(data).toBe("CHILD LOADER");
 
         // Non-undefined falsey values should count
@@ -11494,19 +11548,27 @@ describe("a router", () => {
         let data;
 
         // Layout route
-        data = await queryRoute(createSubmitRequest("/parent"), "parent");
+        data = await queryRoute(createSubmitRequest("/parent"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT ACTION");
 
         // Index route
-        data = await queryRoute(createSubmitRequest("/parent"), "parentIndex");
+        data = await queryRoute(createSubmitRequest("/parent"), {
+          routeId: "parentIndex",
+        });
         expect(data).toBe("PARENT INDEX ACTION");
 
         // Parent in nested route
-        data = await queryRoute(createSubmitRequest("/parent/child"), "parent");
+        data = await queryRoute(createSubmitRequest("/parent/child"), {
+          routeId: "parent",
+        });
         expect(data).toBe("PARENT ACTION");
 
         // Child in nested route
-        data = await queryRoute(createSubmitRequest("/parent/child"), "child");
+        data = await queryRoute(createSubmitRequest("/parent/child"), {
+          routeId: "child",
+        });
         expect(data).toBe("CHILD ACTION");
 
         // Non-undefined falsey values should count
@@ -11525,19 +11587,19 @@ describe("a router", () => {
 
         data = await queryRoute(
           createSubmitRequest("/parent", { method: "PUT" }),
-          "parent"
+          { routeId: "parent" }
         );
         expect(data).toBe("PARENT ACTION");
 
         data = await queryRoute(
           createSubmitRequest("/parent", { method: "PATCH" }),
-          "parent"
+          { routeId: "parent" }
         );
         expect(data).toBe("PARENT ACTION");
 
         data = await queryRoute(
           createSubmitRequest("/parent", { method: "DELETE" }),
-          "parent"
+          { routeId: "parent" }
         );
         expect(data).toBe("PARENT ACTION");
       });
@@ -11697,10 +11759,9 @@ describe("a router", () => {
             ],
           },
         ]);
-        let response = await queryRoute(
-          createRequest("/parent/child"),
-          "child"
-        );
+        let response = await queryRoute(createRequest("/parent/child"), {
+          routeId: "child",
+        });
         expect(response instanceof Response).toBe(true);
         expect((response as Response).status).toBe(302);
         expect((response as Response).headers.get("Location")).toBe("/parent");
@@ -11724,10 +11785,9 @@ describe("a router", () => {
             ],
           },
         ]);
-        let response = await queryRoute(
-          createSubmitRequest("/parent/child"),
-          "child"
-        );
+        let response = await queryRoute(createSubmitRequest("/parent/child"), {
+          routeId: "child",
+        });
         expect(response instanceof Response).toBe(true);
         expect((response as Response).status).toBe(302);
         expect((response as Response).headers.get("Location")).toBe("/parent");
@@ -11749,7 +11809,9 @@ describe("a router", () => {
               loader: () => redirect(url),
             },
           ]);
-          let response = await handler.queryRoute(createRequest("/"), "root");
+          let response = await handler.queryRoute(createRequest("/"), {
+            routeId: "root",
+          });
           expect(response instanceof Response).toBe(true);
           expect((response as Response).status).toBe(302);
           expect((response as Response).headers.get("Location")).toBe(url);
@@ -11766,7 +11828,7 @@ describe("a router", () => {
           },
         ]);
         let request = createRequest("/");
-        let data = await queryRoute(request, "root");
+        let data = await queryRoute(request, { routeId: "root" });
         expect(data instanceof Response).toBe(true);
         expect(await data.json()).toEqual({ key: "value" });
       });
@@ -11781,7 +11843,7 @@ describe("a router", () => {
           },
         ]);
         let request = createSubmitRequest("/");
-        let data = await queryRoute(request, "root");
+        let data = await queryRoute(request, { routeId: "root" });
         expect(data instanceof Response).toBe(true);
         expect(await data.json()).toEqual({ key: "value" });
       });
@@ -11801,7 +11863,7 @@ describe("a router", () => {
         });
         let e;
         try {
-          let statePromise = queryRoute(request, "root");
+          let statePromise = queryRoute(request, { routeId: "root" });
           controller.abort();
           // This should resolve even though we never resolved the loader
           await statePromise;
@@ -11826,7 +11888,7 @@ describe("a router", () => {
         });
         let e;
         try {
-          let statePromise = queryRoute(request, "root");
+          let statePromise = queryRoute(request, { routeId: "root" });
           controller.abort();
           // This should resolve even though we never resolved the loader
           await statePromise;
@@ -11841,13 +11903,45 @@ describe("a router", () => {
         let request = createRequest("/", { signal: undefined });
         let e;
         try {
-          await queryRoute(request, "index");
+          await queryRoute(request, { routeId: "index" });
         } catch (_e) {
           e = _e;
         }
         expect(e).toMatchInlineSnapshot(
           `[Error: query()/queryRoute() requests must contain an AbortController signal]`
         );
+      });
+
+      it("should support a requestContext passed to loaders and actions", async () => {
+        let requestContext = { sessionId: "12345" };
+        let childStub = jest.fn(() => "CHILD");
+        let actionStub = jest.fn(() => "CHILD ACTION");
+        let arg = (s) => s.mock.calls[0][0];
+        let { queryRoute } = createStaticHandler([
+          {
+            path: "/",
+            children: [
+              {
+                id: "child",
+                path: "child",
+                action: actionStub,
+                loader: childStub,
+              },
+            ],
+          },
+        ]);
+
+        await queryRoute(createRequest("/child"), {
+          routeId: "child",
+          requestContext,
+        });
+        expect(arg(childStub).requestContext.sessionId).toBe("12345");
+
+        await queryRoute(createSubmitRequest("/child"), {
+          routeId: "child",
+          requestContext,
+        });
+        expect(arg(actionStub).requestContext.sessionId).toBe("12345");
       });
 
       describe("Errors with Status Codes", () => {
@@ -11887,7 +11981,7 @@ describe("a router", () => {
 
         it("should handle not found routeIds with a 403 Response", async () => {
           try {
-            await queryRoute(createRequest("/"), "junk");
+            await queryRoute(createRequest("/"), { routeId: "junk" });
             expect(false).toBe(true);
           } catch (data) {
             expect(isRouteErrorResponse(data)).toBe(true);
@@ -11899,7 +11993,7 @@ describe("a router", () => {
           }
 
           try {
-            await queryRoute(createSubmitRequest("/"), "junk");
+            await queryRoute(createSubmitRequest("/"), { routeId: "junk" });
             expect(false).toBe(true);
           } catch (data) {
             expect(isRouteErrorResponse(data)).toBe(true);
@@ -11913,7 +12007,7 @@ describe("a router", () => {
 
         it("should handle missing loaders with a 400 Response", async () => {
           try {
-            await queryRoute(createRequest("/"), "root");
+            await queryRoute(createRequest("/"), { routeId: "root" });
             expect(false).toBe(true);
           } catch (data) {
             expect(isRouteErrorResponse(data)).toBe(true);
@@ -11930,7 +12024,7 @@ describe("a router", () => {
 
         it("should handle missing actions with a 405 Response", async () => {
           try {
-            await queryRoute(createSubmitRequest("/"), "root");
+            await queryRoute(createSubmitRequest("/"), { routeId: "root" });
             expect(false).toBe(true);
           } catch (data) {
             expect(isRouteErrorResponse(data)).toBe(true);
@@ -11947,7 +12041,9 @@ describe("a router", () => {
 
         it("should handle unsupported methods with a 405 Response", async () => {
           try {
-            await queryRoute(createRequest("/", { method: "OPTIONS" }), "root");
+            await queryRoute(createRequest("/", { method: "OPTIONS" }), {
+              routeId: "root",
+            });
             expect(false).toBe(true);
           } catch (data) {
             expect(isRouteErrorResponse(data)).toBe(true);

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -318,11 +318,11 @@ export interface StaticHandler {
   dataRoutes: AgnosticDataRouteObject[];
   query(
     request: Request,
-    opts?: { requestContext?: any }
+    opts?: { requestContext?: unknown }
   ): Promise<StaticHandlerContext | Response>;
   queryRoute(
     request: Request,
-    opts?: { routeId?: string; requestContext?: any }
+    opts?: { routeId?: string; requestContext?: unknown }
   ): Promise<any>;
 }
 
@@ -1950,7 +1950,7 @@ export function unstable_createStaticHandler(
    */
   async function query(
     request: Request,
-    { requestContext }: { requestContext?: any } = {}
+    { requestContext }: { requestContext?: unknown } = {}
   ): Promise<StaticHandlerContext | Response> {
     let url = new URL(request.url);
     let method = request.method.toLowerCase();
@@ -2027,7 +2027,10 @@ export function unstable_createStaticHandler(
    */
   async function queryRoute(
     request: Request,
-    { routeId, requestContext }: { requestContext?: any; routeId?: string } = {}
+    {
+      routeId,
+      requestContext,
+    }: { requestContext?: unknown; routeId?: string } = {}
   ): Promise<any> {
     let url = new URL(request.url);
     let method = request.method.toLowerCase();
@@ -2084,7 +2087,7 @@ export function unstable_createStaticHandler(
     request: Request,
     location: Location,
     matches: AgnosticDataRouteMatch[],
-    requestContext: any,
+    requestContext: unknown,
     routeMatch?: AgnosticDataRouteMatch
   ): Promise<Omit<StaticHandlerContext, "location" | "basename"> | Response> {
     invariant(
@@ -2140,7 +2143,7 @@ export function unstable_createStaticHandler(
     request: Request,
     matches: AgnosticDataRouteMatch[],
     actionMatch: AgnosticDataRouteMatch,
-    requestContext: any,
+    requestContext: unknown,
     isRouteRequest: boolean
   ): Promise<Omit<StaticHandlerContext, "location" | "basename"> | Response> {
     let result: DataResult;
@@ -2260,7 +2263,7 @@ export function unstable_createStaticHandler(
   async function loadRouteData(
     request: Request,
     matches: AgnosticDataRouteMatch[],
-    requestContext: any,
+    requestContext: unknown,
     routeMatch?: AgnosticDataRouteMatch,
     pendingActionError?: RouteData
   ): Promise<
@@ -2614,7 +2617,7 @@ async function callLoaderOrAction(
   basename = "/",
   isStaticRequest: boolean = false,
   isRouteRequest: boolean = false,
-  requestContext: any = undefined
+  requestContext?: unknown
 ): Promise<DataResult> {
   let resultType;
   let result;
@@ -2633,7 +2636,7 @@ async function callLoaderOrAction(
     );
 
     result = await Promise.race([
-      handler({ request, params: match.params, requestContext }),
+      handler({ request, params: match.params, context: requestContext }),
       abortPromise,
     ]);
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -88,7 +88,7 @@ export interface Submission {
 interface DataFunctionArgs {
   request: Request;
   params: Params;
-  requestContext?: any;
+  context?: any;
 }
 
 /**

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -88,6 +88,7 @@ export interface Submission {
 interface DataFunctionArgs {
   request: Request;
   params: Params;
+  requestContext?: any;
 }
 
 /**


### PR DESCRIPTION
Support a `requestContext` in the static handler similar to `getLoadContext` in Remix


Route loaders/actions accept a `context` for SSR uses only as of now:

```js
let routes = [{
  path: '/',
  async loader({ request, params, context }) {
    let profile = await getUserProfile(context.user);
    return json({ profile });
  }
}
```

This is provided via the `query`/`queryRoute` methods on the server.  Went with `requestContext` since it's request-specific on the server and because we already return a static handler "context" from `query`.

```js
// entry-server.js
let requestContext = { user: getUser(req); }
let { query, queryRoute } = createStaticHandler(routes);
let context = query('/', { requestContext });
// or
let response = queryRoute('/', { routeId: 'root', requestContext });
```


Closes https://github.com/remix-run/remix/issues/4733 (perf)