### PR TITLE
Fix: action function throws an error, asking for something to return

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -152,3 +152,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- pavsoldatov

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -605,7 +605,8 @@ import {
 import { getContacts, createContact } from "../contacts";
 
 export async function action() {
-  await createContact();
+  const contact = await createContact();
+  return { contact }
 }
 
 /* other code */


### PR DESCRIPTION
The `action` function on line 607, as it is, is throwing the following error:
_You defined an action for route "0" but didn't return anything from your `action` function. Please return a value or `null`._ 

Returning a `contact` (as does the similar `loader` function) seems to solve the issue.