### PR TITLE
Fix error boundary tracking for multiple errors bubbling to the same boundary

### DIFF
--- a/.changeset/violet-rules-rest.md
+++ b/.changeset/violet-rules-rest.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix error boundary tracking for multiple errors bubbling to the same boundary

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2848,9 +2848,14 @@ function processRouteLoaderData(
         error = Object.values(pendingError)[0];
         pendingError = undefined;
       }
-      errors = Object.assign(errors || {}, {
-        [boundaryMatch.route.id]: error,
-      });
+
+      errors = errors || {};
+
+      // Prefer higher error values if lower errors bubble to the same boundary
+      if (errors[boundaryMatch.route.id] == null) {
+        errors[boundaryMatch.route.id] = error;
+      }
+
       // Once we find our first (highest) error, we set the status code and
       // prevent deeper status codes from overriding
       if (!foundError) {


### PR DESCRIPTION
Pointed to `main` just for now, need to check on timing of the next minor or if this should go as a patch

Closes https://github.com/remix-run/remix/issues/4791