### PR TITLE
Fix loader request on document POST requests

### DIFF
--- a/.changeset/kind-dodos-shop.md
+++ b/.changeset/kind-dodos-shop.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Persist method/headers on loader requests after SSR document action request

--- a/.changeset/kind-dodos-shop.md
+++ b/.changeset/kind-dodos-shop.md
@@ -2,4 +2,4 @@
 "@remix-run/router": patch
 ---
 
-Persist method/headers on loader requests after SSR document action request
+Persist `headers` on `loader` `request`'s after SSR document `action` request

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10935,7 +10935,13 @@ describe("a router", () => {
             ],
           },
         ]);
-        await query(createSubmitRequest("/child"));
+        await query(
+          createSubmitRequest("/child", {
+            headers: {
+              test: "value",
+            },
+          })
+        );
 
         // @ts-expect-error
         let actionRequest = actionStub.mock.calls[0][0]?.request;
@@ -10950,10 +10956,12 @@ describe("a router", () => {
         let rootLoaderRequest = rootLoaderStub.mock.calls[0][0]?.request;
         // @ts-expect-error
         let childLoaderRequest = childLoaderStub.mock.calls[0][0]?.request;
-        expect(rootLoaderRequest.method).toBe("GET");
+        expect(rootLoaderRequest.method).toBe("POST");
         expect(rootLoaderRequest.url).toBe("http://localhost/child");
-        expect(childLoaderRequest.method).toBe("GET");
+        expect(rootLoaderRequest.headers.get("test")).toBe("value");
+        expect(childLoaderRequest.method).toBe("POST");
         expect(childLoaderRequest.url).toBe("http://localhost/child");
+        expect(childLoaderRequest.headers.get("test")).toBe("value");
       });
 
       it("should support a requestContext passed to loaders and actions", async () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10956,11 +10956,11 @@ describe("a router", () => {
         let rootLoaderRequest = rootLoaderStub.mock.calls[0][0]?.request;
         // @ts-expect-error
         let childLoaderRequest = childLoaderStub.mock.calls[0][0]?.request;
-        expect(rootLoaderRequest.method).toBe("POST");
+        expect(rootLoaderRequest.method).toBe("GET");
         expect(rootLoaderRequest.url).toBe("http://localhost/child");
         expect(rootLoaderRequest.headers.get("test")).toBe("value");
         expect(await rootLoaderRequest.text()).toBe("");
-        expect(childLoaderRequest.method).toBe("POST");
+        expect(childLoaderRequest.method).toBe("GET");
         expect(childLoaderRequest.url).toBe("http://localhost/child");
         expect(childLoaderRequest.headers.get("test")).toBe("value");
         // Can't re-read body here since it's the same request as the root

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10959,9 +10959,11 @@ describe("a router", () => {
         expect(rootLoaderRequest.method).toBe("POST");
         expect(rootLoaderRequest.url).toBe("http://localhost/child");
         expect(rootLoaderRequest.headers.get("test")).toBe("value");
+        expect(await rootLoaderRequest.text()).toBe("");
         expect(childLoaderRequest.method).toBe("POST");
         expect(childLoaderRequest.url).toBe("http://localhost/child");
         expect(childLoaderRequest.headers.get("test")).toBe("value");
+        // Can't re-read body here since it's the same request as the root
       });
 
       it("should support a requestContext passed to loaders and actions", async () => {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2256,11 +2256,9 @@ export function unstable_createStaticHandler(
       };
     }
 
-    // Create a request for the loaders
+    // Create a GET request for the loaders
     let loaderRequest = new Request(request.url, {
-      body: null,
       headers: request.headers,
-      method: request.method,
       redirect: request.redirect,
       signal: request.signal,
     });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2256,8 +2256,14 @@ export function unstable_createStaticHandler(
       };
     }
 
-    // Create a GET request for the loaders
-    let loaderRequest = new Request(request.url, { signal: request.signal });
+    // Create a request for the loaders
+    let loaderRequest = new Request(request.url, {
+      body: null,
+      headers: request.headers,
+      method: request.method,
+      redirect: request.redirect,
+      signal: request.signal,
+    });
     let context = await loadRouteData(loaderRequest, matches, requestContext);
 
     return {


### PR DESCRIPTION
Follow up to #9660 to ensure we proxy the `request.headers` from the action request.  For document requests during SSR we also persist the method since it's a single `POST` `request`, unlike during CSR when the revalidations are separate GET requests.  This matches Remix behavior in 1.7.6 but going to confirm.

Remix PR: https://github.com/remix-run/remix/pull/4829