### PR TITLE
docs(route/route): Add missing `handle` prop

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -67,6 +67,7 @@
 - IsaiStormBlesed
 - Isammoc
 - ivanjeremic
+- ivanjonas
 - jacob-ebey
 - JaffParker
 - JakubDrozd

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -276,6 +276,10 @@ When a route throws an exception while rendering, in a `loader` or in an `action
 
 Please see the [errorElement][errorelement] documentation for more details.
 
+## `handle`
+
+Any application-specific data. Please see the [useMatches][useMatches] documentation for details and examples.
+
 [outlet]: ./outlet
 [remix]: https://remix.run
 [indexroute]: ../start/concepts#index-routes
@@ -289,3 +293,4 @@ Please see the [errorElement][errorelement] documentation for more details.
 [usesubmit]: ../hooks/use-submit
 [createroutesfromelements]: ../utils/create-routes-from-elements
 [createbrowserrouter]: ../routers/create-browser-router
+[useMatches]: ../hooks/use-matches


### PR DESCRIPTION
Adds missing `handle` prop in <Route> documentation with a link to already-existing documentation at docs/hooks/use-matches.md.

Resolves #9724