### PR TITLE
fix bug with nested optional segments

### DIFF
--- a/.changeset/slow-drinks-cheer.md
+++ b/.changeset/slow-drinks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix issue with deeply nested optional segments

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -329,7 +329,6 @@ export function matchRoutes<
 
   let branches = flattenRoutes(routes);
   rankRouteBranches(branches);
-  console.log(branches.map((b) => ({ path: b.path, score: b.score })));
 
   let matches = null;
   for (let i = 0; matches == null && i < branches.length; ++i) {


### PR DESCRIPTION
Found an issue with >2 optional nested segments due to the ordering in which we recombined the exploded paths.

The setup causing this was:

```jsx
<Route path="dashboard">
  <Route path=":widget1?"> 
    <Route path=":widget2?">
      <Route path=":widget3?">
```

When we had 2 levels of nesting (which we have tests for) everythings fine.  But once you get a third level and we get another level of recursion, we were incorrectly combining the results such that child routes interspersed prior to parent routes and we got `/dashboard/:widget2` coming _before_ `/dashboard/:widget1`