### PR TITLE
Add missing "RouterProvider" and "Router" import in tutorial.md

### DIFF
--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1908,8 +1908,10 @@ And for our final trick, many folks prefer to configure their routes with JSX. Y
 
 ```jsx
 import {
-  createRoutesFromElements,
-  createBrowserRouter,
+    createBrowserRouter,
+    RouterProvider,
+    createRoutesFromElements,
+    Route,
 } from "react-router-dom";
 
 const router = createBrowserRouter(


### PR DESCRIPTION
I follow step by step tutorial and on the last step I receive syntax error. 

We also need to import "RouterProvider" and "Router" to main.jsx

Its my first pull request, so sorry, if something wrong.