### PR TITLE
Fix shouldRevalidate on fetcher action redirect

### DIFF
--- a/.changeset/swift-bottles-cheat.md
+++ b/.changeset/swift-bottles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix fetcher shouldRevalidate

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2068,15 +2068,10 @@ describe("a router", () => {
           "currentParams": Object {},
           "currentUrl": "http://localhost/",
           "defaultShouldRevalidate": true,
-          "formAction": "/fetch",
-          "formData": FormData {},
-          "formEncType": "application/x-www-form-urlencoded",
-          "formMethod": "post",
           "nextParams": Object {},
           "nextUrl": "http://localhost/",
         }
       `);
-      expect(Object.fromEntries(arg.formData)).toEqual({ key: "value" });
 
       router.dispose();
     });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1416,7 +1416,6 @@ export function createRouter(init: RouterInit): Router {
       updateState({ fetchers: new Map(state.fetchers) });
 
       return startRedirectNavigation(state, actionResult, {
-        submission,
         isFetchActionRedirect: true,
       });
     }
@@ -1512,7 +1511,7 @@ export function createRouter(init: RouterInit): Router {
 
     let redirect = findRedirect(results);
     if (redirect) {
-      return startRedirectNavigation(state, redirect, { submission });
+      return startRedirectNavigation(state, redirect);
     }
 
     // Process and commit output from loaders


### PR DESCRIPTION
Fixes a misunderstanding in #9777.  Went back and checked Remix and it does not keep the submission around on fetch action redirects