### PR TITLE
test(useNavigate): navigate with an defined and empty query string

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -74,6 +74,7 @@
 - JakubDrozd
 - janpaepke
 - jasonpaulos
+- JesusTheHun
 - jimniels
 - jmargeta
 - johnpangalos

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -164,6 +164,63 @@ describe("useNavigate", () => {
     `);
   });
 
+  it("navigates to the new location with empty query string when no query string is provided", () => {
+    function Home() {
+      let location = useLocation();
+      let navigate = useNavigate();
+
+      return (
+        <>
+          <p>{location.pathname + location.search}</p>
+          <button onClick={() => navigate("/home")}>click me</button>
+        </>
+      );
+    }
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(
+        <MemoryRouter initialEntries={["/home?key=value"]}>
+          <Routes>
+            <Route path="home" element={<Home />} />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      Array [
+        <p>
+          /home?key=value
+        </p>,
+        <button
+          onClick={[Function]}
+        >
+          click me
+        </button>,
+      ]
+    `);
+
+    let button = renderer.root.findByType("button");
+
+    TestRenderer.act(() => {
+      button.props.onClick();
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      Array [
+        <p>
+          /home
+        </p>,
+        <button
+          onClick={[Function]}
+        >
+          click me
+        </button>,
+      ]
+    `);
+  });
+
   it("throws on invalid destination path objects", () => {
     function Home() {
       let navigate = useNavigate();


### PR DESCRIPTION
I was tracking down a bug and to make sure it wasn't a bug in `react-router` I looked for tests of `useNavigate`.
I saw there is no test of `useNavigate` that expects `navigate` to clear the query string.

That's it. This PR just add a single test.