### PR TITLE
Fix React SRR useLayoutEffect console.error when using CompatRouter

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -20,6 +20,7 @@
 - bobziroll
 - BrianT1414
 - brockross
+- brookslybrand
 - brophdawg11
 - btav
 - bvangraafeiland

--- a/packages/react-router-dom-v5-compat/__tests__/compat-router-test.tsx
+++ b/packages/react-router-dom-v5-compat/__tests__/compat-router-test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment node
+ */
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+import { act } from "react-dom/test-utils";
+import { CompatRouter, Routes } from "../index";
+
+// Have to mock react-router-dom to have a comparable API to v5, otherwise it will
+// be using v6's API and fail
+jest.mock("react-router-dom", () => ({
+  useHistory: () => ({ location: "/" }),
+}));
+
+describe("CompatRouter", () => {
+  it("should not warn about useLayoutEffect when server side rendering", () => {
+    const consoleErrorSpy = jest.spyOn(console, "error");
+
+    act(() => {
+      ReactDOMServer.renderToStaticMarkup(
+        <CompatRouter>
+          <Routes />
+        </CompatRouter>
+      );
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -23,6 +23,17 @@ export function CompatRoute(props: any) {
   );
 }
 
+// Copied with 💜 from https://github.com/bvaughn/react-resizable-panels/blob/main/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
+const canUseEffectHooks = !!(
+  typeof window !== "undefined" &&
+  typeof window.document !== "undefined" &&
+  typeof window.document.createElement !== "undefined"
+);
+
+const useIsomorphicLayoutEffect = canUseEffectHooks
+  ? React.useLayoutEffect
+  : () => {};
+
 export function CompatRouter({ children }: { children: React.ReactNode }) {
   let history = useHistory();
   let [state, setState] = React.useState(() => ({
@@ -30,7 +41,7 @@ export function CompatRouter({ children }: { children: React.ReactNode }) {
     action: history.action,
   }));
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     history.listen((location: Location, action: Action) =>
       setState({ location, action })
     );


### PR DESCRIPTION
Currently when using `react-router-dom-v5-compat`'s `CompatRouter` with SSR, you get this fun React warning in your console:

![Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.](https://user-images.githubusercontent.com/12396812/210826274-14e619e3-9b15-4adc-9a04-dfec1c789c67.png)

This is something my team has ignored, but it's pretty obnoxious. Additionally, [even Ryan](https://twitter.com/ryanflorence/status/1610499820502011911) believes this warning is unnecessary.

This PR simply adds a fix [previous React core team member Bri implemented](https://github.com/bvaughn/react-resizable-panels/blob/main/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts), as well as a test to verify that warning does not show up in a jest node environment

