### PR TITLE
History Blocking: Fix loop rendering and usePrompt

### DIFF
--- a/.changeset/light-phones-impress.md
+++ b/.changeset/light-phones-impress.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Added support for history blocking APIs

--- a/.changeset/light-phones-impress.md
+++ b/.changeset/light-phones-impress.md
@@ -2,4 +2,4 @@
 "@remix-run/router": minor
 ---
 
-Added support for history blocking APIs
+Added support for navigation blocking APIs

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules/
 
 .eslintcache
 /.env
+/NOTES.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -56,3 +56,12 @@ Experimental releases and hot-fixes do not need to be branched off of `dev`. Exp
 - Update version numbers and create a release tag: `yarn run version:experimental`
 - Push to GitHub: `git push origin --follow-tags`
 - Create a new release for the tag on GitHub to trigger the CI workflow that will publish the release to npm
+
+## Local Development
+
+### Iterating on changes locally
+
+- You can run one of the examples in `./examples`, or create a new one.
+- In the example, you will need to install it's dependencies with `yarn`
+- For an iterative development loop, in an example you can run `USE_SOURCE=true yarn dev`.
+- with `USE_SOURCE=true` enabled, you should be able to make changes to `packages` and immediatly observe your change in the example.

--- a/contributors.yml
+++ b/contributors.yml
@@ -36,6 +36,7 @@
 - danielberndt
 - dauletbaev
 - david-crespo
+- develra
 - DigitalNaut
 - dmitrytarassov
 - dokeet

--- a/examples/data-router/src/main.tsx
+++ b/examples/data-router/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>

--- a/examples/data-router/src/routes.tsx
+++ b/examples/data-router/src/routes.tsx
@@ -40,6 +40,11 @@ export function Layout() {
   let fetcherInProgress = fetchers.some((f) =>
     ["loading", "submitting"].includes(f.state)
   );
+  let [usePromptEnabled, setUsePromptEnabled] = React.useState(false);
+  usePrompt(
+    usePromptEnabled ? "Are you *really* sure you want to leave?" : null,
+    { beforeUnload: true }
+  );
   return (
     <>
       <nav>
@@ -58,6 +63,14 @@ export function Layout() {
         <Link to="/404">404 Link</Link>
         &nbsp;&nbsp;
         <button onClick={() => revalidate()}>Revalidate</button>
+        <label>
+          <input
+            type="checkbox"
+            checked={usePromptEnabled}
+            onChange={(e) => setUsePromptEnabled(e.target.checked)}
+          />
+          usePrompt
+        </label>
       </nav>
       <div style={{ position: "fixed", top: 0, right: 0 }}>
         {navigation.state !== "idle" && <p>Navigation in progress...</p>}
@@ -96,25 +109,20 @@ export function Home() {
   let data = useLoaderData() as HomeLoaderData;
   let [shouldBlockNavigation, setShouldBlockNavigation] = React.useState(false);
 
-  let blocker = useBlocker(shouldBlockNavigation ? true : null);
-  //   usePrompt(
-  //     shouldBlockNavigation ? "Are you *really* sure you want to leave?" : null,
-  //     { beforeUnload: true }
-  //   );
-
+  let blocker = useBlocker(shouldBlockNavigation ? true : false);
   return (
     <>
       <h2>Home</h2>
       <p>Last loaded at: {data.date}</p>
+      <label>
+        <input
+          type="checkbox"
+          checked={shouldBlockNavigation}
+          onChange={(e) => setShouldBlockNavigation(e.target.checked)}
+        />
+        useBlocker
+      </label>
       <div>
-        <label>
-          <input
-            type="checkbox"
-            checked={shouldBlockNavigation}
-            onChange={(e) => setShouldBlockNavigation(e.target.checked)}
-          />
-          Block navigation
-        </label>
         {blocker.state === "blocked" ? (
           <div>
             <p>Navigation is blocked.</p>

--- a/examples/data-router/src/routes.tsx
+++ b/examples/data-router/src/routes.tsx
@@ -18,6 +18,7 @@ import {
   json,
   useActionData,
   useBlocker,
+  usePrompt,
 } from "react-router-dom";
 
 import type { Todos } from "./todos";
@@ -94,7 +95,13 @@ export async function homeLoader(): Promise<HomeLoaderData> {
 export function Home() {
   let data = useLoaderData() as HomeLoaderData;
   let [shouldBlockNavigation, setShouldBlockNavigation] = React.useState(false);
-  let blocker = useBlocker(shouldBlockNavigation);
+
+  let blocker = useBlocker(shouldBlockNavigation ? true : null);
+  //   usePrompt(
+  //     shouldBlockNavigation ? "Are you *really* sure you want to leave?" : null,
+  //     { beforeUnload: true }
+  //   );
+
   return (
     <>
       <h2>Home</h2>

--- a/examples/data-router/src/routes.tsx
+++ b/examples/data-router/src/routes.tsx
@@ -17,6 +17,7 @@ import {
   useRouteError,
   json,
   useActionData,
+  useBlocker,
 } from "react-router-dom";
 
 import type { Todos } from "./todos";
@@ -92,10 +93,31 @@ export async function homeLoader(): Promise<HomeLoaderData> {
 
 export function Home() {
   let data = useLoaderData() as HomeLoaderData;
+  let [shouldBlockNavigation, setShouldBlockNavigation] = React.useState(false);
+  let blocker = useBlocker(shouldBlockNavigation);
   return (
     <>
       <h2>Home</h2>
       <p>Last loaded at: {data.date}</p>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={shouldBlockNavigation}
+            onChange={(e) => setShouldBlockNavigation(e.target.checked)}
+          />
+          Block navigation
+        </label>
+        {blocker.state === "blocked" ? (
+          <div>
+            <p>Navigation is blocked.</p>
+            <button onClick={blocker.proceed}>Proceed</button>
+            <button onClick={blocker.reset}>Reset</button>
+          </div>
+        ) : blocker.state === "proceeding" ? (
+          <p>Proceeding...</p>
+        ) : null}
+      </div>
     </>
   );
 }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1031,17 +1031,22 @@ export function usePrompt(
   message: string | null | false,
   opts?: { beforeUnload: boolean }
 ) {
+  //   let { beforeUnload } = opts ?? {};
   let blocker = useBlocker(
     React.useCallback(() => {
       let shouldPrompt = !!message;
+      let unstable_skipStateUpdateOnPopNavigation = true;
       if (!shouldPrompt) {
         return {
           shouldBlock: () => false,
-          unstable_skipStateUpdateOnPopNavigation: true,
+          unstable_skipStateUpdateOnPopNavigation,
         };
       }
       let shouldBlock = () => !window.confirm(message as string);
-      return { shouldBlock, unstable_skipStateUpdateOnPopNavigation: true };
+      return {
+        shouldBlock,
+        unstable_skipStateUpdateOnPopNavigation,
+      };
     }, [message])
   );
 
@@ -1054,13 +1059,11 @@ export function usePrompt(
   }, [blocker]);
 
   // leaving the domain
-  //   let { beforeUnload } = opts || {};
   //   React.useEffect(() => {
   //     if (!beforeUnload) return;
   //     let handleBeforeUnload = (evt: BeforeUnloadEvent) => {
-  //       if (blocker.fn()) {
-  //         evt.preventDefault();
-  //         evt.returnValue = message;
+  //       let { shouldBlock } = blocker.fn();
+  //       if (shouldBlock()) {
   //         return (evt.returnValue = message);
   //       }
   //     };

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -978,15 +978,15 @@ export function useFormAction(
   return createPath(path);
 }
 
-export type ShouldBlockFunction = () => {
-  shouldBlock: boolean;
-  force?: boolean;
+export type BlockerFunction = () => {
+  shouldBlock(): boolean;
+  unstable_skipStateUpdateOnPopNavigation?: boolean;
 };
 
 let blockerId = 0;
 
 export function useBlocker(
-  shouldBlock: boolean | (() => boolean) | ShouldBlockFunction
+  shouldBlock: boolean | (() => boolean) | BlockerFunction
 ) {
   let [blockerKey] = React.useState(() => String(++blockerId));
   let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
@@ -996,18 +996,23 @@ export function useBlocker(
     })
   );
 
-  let fn: ShouldBlockFunction = React.useCallback(() => {
+  let fn: BlockerFunction = React.useCallback(() => {
     if (typeof shouldBlock === "function") {
       let result = shouldBlock();
       if (result && typeof result === "object") {
+        let { shouldBlock } = result;
         return {
-          shouldBlock: !!result.shouldBlock,
-          force: !!result.force,
+          shouldBlock:
+            typeof shouldBlock === "function"
+              ? shouldBlock
+              : () => !!shouldBlock,
+          unstable_skipStateUpdateOnPopNavigation:
+            !!result.unstable_skipStateUpdateOnPopNavigation,
         };
       }
-      return { shouldBlock: !!result };
+      return { shouldBlock: () => !!result };
     } else {
-      return { shouldBlock: !!shouldBlock };
+      return { shouldBlock: () => !!shouldBlock };
     }
   }, [shouldBlock]);
 
@@ -1020,6 +1025,50 @@ export function useBlocker(
   }, [blockerKey, fn, router]);
 
   return blocker;
+}
+
+export function usePrompt(
+  message: string | null | false,
+  opts?: { beforeUnload: boolean }
+) {
+  let blocker = useBlocker(
+    React.useCallback(() => {
+      let shouldPrompt = !!message;
+      if (!shouldPrompt) {
+        return {
+          shouldBlock: () => false,
+          unstable_skipStateUpdateOnPopNavigation: true,
+        };
+      }
+      let shouldBlock = () => !window.confirm(message as string);
+      return { shouldBlock, unstable_skipStateUpdateOnPopNavigation: true };
+    }, [message])
+  );
+
+  let prevState = React.useRef(blocker.state);
+  React.useEffect(() => {
+    if (blocker.state === "blocked") {
+      blocker.reset();
+    }
+    prevState.current = blocker.state;
+  }, [blocker]);
+
+  // leaving the domain
+  //   let { beforeUnload } = opts || {};
+  //   React.useEffect(() => {
+  //     if (!beforeUnload) return;
+  //     let handleBeforeUnload = (evt: BeforeUnloadEvent) => {
+  //       if (blocker.fn()) {
+  //         evt.preventDefault();
+  //         evt.returnValue = message;
+  //         return (evt.returnValue = message);
+  //       }
+  //     };
+  //     window.addEventListener("beforeunload", handleBeforeUnload);
+  //     return () => {
+  //       window.removeEventListener("beforeunload", handleBeforeUnload);
+  //     };
+  //   }, [blocker, message, beforeUnload]);
 }
 
 function createFetcherForm(fetcherKey: string, routeId: string) {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -13,7 +13,6 @@ import {
   invariant,
   isRouteErrorResponse,
   UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
-  getInitialBlocker,
 } from "@remix-run/router";
 import type {
   DataRouteObject,
@@ -304,17 +303,13 @@ export function createStaticRouter(
       throw msg("dispose");
     },
     getBlocker() {
-      return getInitialBlocker(() => {
-        throw msg("getBlocker");
-      });
+      throw msg("getBlocker");
     },
     deleteBlocker() {
       throw msg("deleteBlocker");
     },
     createBlocker() {
-      return getInitialBlocker(() => {
-        throw msg("createBlocker");
-      });
+      throw msg("createBlocker");
     },
     setBlockerState() {
       throw msg("setBlockerState");

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -9,6 +9,7 @@ import type {
 import {
   IDLE_FETCHER,
   IDLE_NAVIGATION,
+  UNBLOCKED_BLOCKER,
   Action,
   invariant,
   isRouteErrorResponse,
@@ -301,6 +302,21 @@ export function createStaticRouter(
     },
     dispose() {
       throw msg("dispose");
+    },
+    getBlocker() {
+      return UNBLOCKED_BLOCKER;
+    },
+    deleteBlocker() {
+      throw msg("deleteBlocker");
+    },
+    createBlocker() {
+      throw msg("createBlocker");
+    },
+    setBlockerFunction() {
+      throw msg("setBlockerFunction");
+    },
+    setBlockerState() {
+      throw msg("setBlockerState");
     },
     _internalFetchControllers: new Map(),
     _internalActiveDeferreds: new Map(),

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -9,11 +9,11 @@ import type {
 import {
   IDLE_FETCHER,
   IDLE_NAVIGATION,
-  UNBLOCKED_BLOCKER,
   Action,
   invariant,
   isRouteErrorResponse,
   UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
+  getInitialBlocker,
 } from "@remix-run/router";
 import type {
   DataRouteObject,
@@ -304,16 +304,17 @@ export function createStaticRouter(
       throw msg("dispose");
     },
     getBlocker() {
-      return UNBLOCKED_BLOCKER;
+      return getInitialBlocker(() => {
+        throw msg("getBlocker");
+      });
     },
     deleteBlocker() {
       throw msg("deleteBlocker");
     },
     createBlocker() {
-      throw msg("createBlocker");
-    },
-    setBlockerFunction() {
-      throw msg("setBlockerFunction");
+      return getInitialBlocker(() => {
+        throw msg("createBlocker");
+      });
     },
     setBlockerState() {
       throw msg("setBlockerState");

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -267,6 +267,7 @@ export function createStaticRouter(
         preventScrollReset: false,
         revalidation: "idle" as RevalidationState,
         fetchers: new Map(),
+        blockers: new Map(),
       };
     },
     get routes() {

--- a/packages/router/__tests__/TestSequences/GoBack.ts
+++ b/packages/router/__tests__/TestSequences/GoBack.ts
@@ -31,6 +31,7 @@ export default async function GoBack(history: History) {
   });
   expect(spy).toHaveBeenCalledWith({
     action: "POP",
+    delta: expect.any(Number),
     location: {
       hash: "",
       key: expect.any(String),

--- a/packages/router/__tests__/TestSequences/GoForward.ts
+++ b/packages/router/__tests__/TestSequences/GoForward.ts
@@ -31,6 +31,7 @@ export default async function GoForward(history: History) {
   });
   expect(spy).toHaveBeenCalledWith({
     action: "POP",
+    delta: expect.any(Number),
     location: {
       hash: "",
       key: expect.any(String),
@@ -58,6 +59,7 @@ export default async function GoForward(history: History) {
   });
   expect(spy).toHaveBeenCalledWith({
     action: "POP",
+    delta: expect.any(Number),
     location: {
       hash: "",
       key: expect.any(String),

--- a/packages/router/__tests__/blocking-test.ts
+++ b/packages/router/__tests__/blocking-test.ts
@@ -13,7 +13,9 @@ describe("blocking", () => {
     });
     router.initialize();
 
-    let fn = () => true;
+    let fn = () => ({
+      shouldBlock: true,
+    });
     router.createBlocker("KEY", fn);
     let blocker = router.getBlocker("KEY");
     expect(blocker).toEqual({
@@ -34,7 +36,7 @@ describe("blocking", () => {
     });
     router.initialize();
 
-    router.createBlocker("KEY", () => true);
+    router.createBlocker("KEY", () => ({ shouldBlock: true }));
     router.deleteBlocker("KEY");
     let blocker = router.getBlocker("KEY");
     expect(blocker).toBeUndefined();
@@ -56,13 +58,15 @@ describe("blocking", () => {
 
     describe("blocker returns false", () => {
       it("sets blocker state to 'unblocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => false);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: false,
+        }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("navigates", async () => {
-        router.createBlocker("KEY", () => false);
+        router.createBlocker("KEY", () => ({ shouldBlock: false }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe("/about");
       });
@@ -70,13 +74,15 @@ describe("blocking", () => {
 
     describe("blocker returns true", () => {
       it("set blocker state to 'blocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => true);
+        router.createBlocker("KEY", () => ({ shouldBlock: true }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -86,7 +92,9 @@ describe("blocking", () => {
 
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
 
@@ -95,7 +103,9 @@ describe("blocking", () => {
       });
 
       it("proceeds with blocked navigation", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -108,7 +118,9 @@ describe("blocking", () => {
 
     describe("resets from blocked state", () => {
       it("sets blocker state to 'unblocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
 
@@ -117,7 +129,9 @@ describe("blocking", () => {
       });
 
       it("does not navigate", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -145,13 +159,15 @@ describe("blocking", () => {
 
     describe("blocker returns false", () => {
       it("sets blocker state to 'unblocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => false);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: false,
+        }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("navigates", async () => {
-        router.createBlocker("KEY", () => false);
+        router.createBlocker("KEY", () => ({ shouldBlock: false }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe("/about");
       });
@@ -159,13 +175,15 @@ describe("blocking", () => {
 
     describe("blocker returns true", () => {
       it("set blocker state to 'blocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => true);
+        router.createBlocker("KEY", () => ({ shouldBlock: true }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -175,7 +193,9 @@ describe("blocking", () => {
 
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
 
@@ -184,7 +204,9 @@ describe("blocking", () => {
       });
 
       it("proceeds with blocked navigation", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -197,7 +219,9 @@ describe("blocking", () => {
 
     describe("resets from blocked state", () => {
       it("sets blocker state to 'unblocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
 
@@ -206,7 +230,9 @@ describe("blocking", () => {
       });
 
       it("does not navigate", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -239,13 +265,15 @@ describe("blocking", () => {
 
     describe("blocker returns false", () => {
       it("set blocker state to unblocked", async () => {
-        let blocker = router.createBlocker("KEY", () => false);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: false,
+        }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("should navigate", async () => {
-        router.createBlocker("KEY", () => false);
+        router.createBlocker("KEY", () => ({ shouldBlock: false }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toEqual(
           initialEntries[initialIndex - 1]
@@ -255,13 +283,15 @@ describe("blocking", () => {
 
     describe("blocker returns true", () => {
       it("set blocker state", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => true);
+        router.createBlocker("KEY", () => ({ shouldBlock: true }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -271,7 +301,9 @@ describe("blocking", () => {
 
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
 
@@ -280,7 +312,9 @@ describe("blocking", () => {
       });
 
       it("proceeds with blocked navigation", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -297,7 +331,9 @@ describe("blocking", () => {
       it.todo("patches the history stack");
 
       it("sets blocker state to 'unblocked'", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
 
@@ -306,7 +342,9 @@ describe("blocking", () => {
       });
 
       it("does not navigate", async () => {
-        let blocker = router.createBlocker("KEY", () => true);
+        let blocker = router.createBlocker("KEY", () => ({
+          shouldBlock: true,
+        }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]

--- a/packages/router/__tests__/blocking-test.ts
+++ b/packages/router/__tests__/blocking-test.ts
@@ -1,3 +1,6 @@
+/* eslint-disable jest/no-focused-tests */
+/* eslint-disable jest/no-done-callback */
+/* eslint-disable jest/no-disabled-tests */
 import type { Router } from "../index";
 import { createMemoryHistory, createRouter } from "../index";
 
@@ -91,14 +94,17 @@ describe("blocking", () => {
     });
 
     describe("proceeds from blocked state", () => {
-      it("sets blocker state to 'proceeding'", async () => {
+      it("sets blocker state to 'proceeding'", async (done) => {
         let blocker = router.createBlocker("KEY", () => ({
           shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
 
-        await blocker.proceed?.();
+        blocker.proceed?.().then(() => {
+          expect(blocker.state).toEqual("unblocked");
+          done();
+        });
         expect(blocker.state).toEqual("proceeding");
       });
 
@@ -111,7 +117,7 @@ describe("blocking", () => {
           initialEntries[initialIndex]
         );
 
-        blocker.proceed?.();
+        await blocker.proceed?.();
         expect(router.state.location.pathname).toEqual("/about");
       });
     });
@@ -192,14 +198,17 @@ describe("blocking", () => {
     });
 
     describe("proceeds from blocked state", () => {
-      it("sets blocker state to 'proceeding'", async () => {
+      it("sets blocker state to 'proceeding'", async (done) => {
         let blocker = router.createBlocker("KEY", () => ({
           shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
 
-        await blocker.proceed?.();
+        blocker.proceed?.().then(() => {
+          expect(blocker.state).toEqual("unblocked");
+          done();
+        });
         expect(blocker.state).toEqual("proceeding");
       });
 
@@ -212,7 +221,7 @@ describe("blocking", () => {
           initialEntries[initialIndex]
         );
 
-        blocker.proceed?.();
+        await blocker.proceed?.();
         expect(router.state.location.pathname).toEqual("/about");
       });
     });
@@ -300,14 +309,17 @@ describe("blocking", () => {
     });
 
     describe("proceeds from blocked state", () => {
-      it("sets blocker state to 'proceeding'", async () => {
+      it("sets blocker state to 'proceeding'", async (done) => {
         let blocker = router.createBlocker("KEY", () => ({
           shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
 
-        await blocker.proceed?.();
+        blocker.proceed?.().then(() => {
+          expect(blocker.state).toEqual("unblocked");
+          done();
+        });
         expect(blocker.state).toEqual("proceeding");
       });
 

--- a/packages/router/__tests__/blocking-test.ts
+++ b/packages/router/__tests__/blocking-test.ts
@@ -1,0 +1,322 @@
+import type { Router } from "../index";
+import { createMemoryHistory, createRouter } from "../index";
+
+describe("blocking", () => {
+  let router: Router;
+  it("creates a blocker", () => {
+    router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+      }),
+      routes: [{ path: "/" }, { path: "/about" }],
+    });
+    router.initialize();
+
+    let fn = () => true;
+    router.createBlocker("KEY", fn);
+    let blocker = router.getBlocker("KEY");
+    expect(blocker).toEqual({
+      fn,
+      state: "unblocked",
+      proceed: undefined,
+      reset: undefined,
+    });
+  });
+
+  it("deletes a blocker", () => {
+    router = createRouter({
+      history: createMemoryHistory({
+        initialEntries: ["/"],
+        initialIndex: 0,
+      }),
+      routes: [{ path: "/" }, { path: "/about" }],
+    });
+    router.initialize();
+
+    router.createBlocker("KEY", () => true);
+    router.deleteBlocker("KEY");
+    let blocker = router.getBlocker("KEY");
+    expect(blocker).toBeUndefined();
+  });
+
+  describe("on history push", () => {
+    let initialEntries = ["/", "/about"];
+    let initialIndex = 0;
+    beforeEach(() => {
+      router = createRouter({
+        history: createMemoryHistory({
+          initialEntries,
+          initialIndex,
+        }),
+        routes: [{ path: "/" }, { path: "/about" }],
+      });
+      router.initialize();
+    });
+
+    describe("blocker returns false", () => {
+      it("sets blocker state to 'unblocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => false);
+        await router.navigate("/about");
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("navigates", async () => {
+        router.createBlocker("KEY", () => false);
+        await router.navigate("/about");
+        expect(router.state.location.pathname).toBe("/about");
+      });
+    });
+
+    describe("blocker returns true", () => {
+      it("set blocker state to 'blocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(blocker.state).toEqual("blocked");
+      });
+
+      it("does not navigate", async () => {
+        router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+      });
+    });
+
+    describe("proceeds from blocked state", () => {
+      it("sets blocker state to 'proceeding'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(blocker.state).toEqual("blocked");
+
+        await blocker.proceed?.();
+        expect(blocker.state).toEqual("proceeding");
+      });
+
+      it("proceeds with blocked navigation", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        blocker.proceed?.();
+        expect(router.state.location.pathname).toEqual("/about");
+      });
+    });
+
+    describe("resets from blocked state", () => {
+      it("sets blocker state to 'unblocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(blocker.state).toEqual("blocked");
+
+        blocker.reset?.();
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("does not navigate", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about");
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        blocker.reset?.();
+        expect(router.state.location.pathname).toEqual("/");
+      });
+    });
+  });
+
+  describe("on history replace", () => {
+    let initialEntries = ["/", "/about"];
+    let initialIndex = 0;
+    beforeEach(() => {
+      router = createRouter({
+        history: createMemoryHistory({
+          initialEntries,
+          initialIndex,
+        }),
+        routes: [{ path: "/" }, { path: "/about" }],
+      });
+      router.initialize();
+    });
+
+    describe("blocker returns false", () => {
+      it("sets blocker state to 'unblocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => false);
+        await router.navigate("/about", { replace: true });
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("navigates", async () => {
+        router.createBlocker("KEY", () => false);
+        await router.navigate("/about", { replace: true });
+        expect(router.state.location.pathname).toBe("/about");
+      });
+    });
+
+    describe("blocker returns true", () => {
+      it("set blocker state to 'blocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(blocker.state).toEqual("blocked");
+      });
+
+      it("does not navigate", async () => {
+        router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+      });
+    });
+
+    describe("proceeds from blocked state", () => {
+      it("sets blocker state to 'proceeding'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(blocker.state).toEqual("blocked");
+
+        await blocker.proceed?.();
+        expect(blocker.state).toEqual("proceeding");
+      });
+
+      it("proceeds with blocked navigation", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        blocker.proceed?.();
+        expect(router.state.location.pathname).toEqual("/about");
+      });
+    });
+
+    describe("resets from blocked state", () => {
+      it("sets blocker state to 'unblocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(blocker.state).toEqual("blocked");
+
+        blocker.reset?.();
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("does not navigate", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate("/about", { replace: true });
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        blocker.reset?.();
+        expect(router.state.location.pathname).toEqual("/");
+      });
+    });
+  });
+
+  describe("on history pop", () => {
+    let initialEntries = ["/", "/about", "/contact", "/help"];
+    let initialIndex = 1;
+    beforeEach(() => {
+      router = createRouter({
+        history: createMemoryHistory({
+          initialEntries,
+          initialIndex,
+        }),
+        routes: [
+          { path: "/" },
+          { path: "/about" },
+          { path: "/contact" },
+          { path: "/help" },
+        ],
+      });
+      router.initialize();
+    });
+
+    describe("blocker returns false", () => {
+      it("set blocker state to unblocked", async () => {
+        let blocker = router.createBlocker("KEY", () => false);
+        await router.navigate(-1);
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("should navigate", async () => {
+        router.createBlocker("KEY", () => false);
+        await router.navigate(-1);
+        expect(router.state.location.pathname).toEqual(
+          initialEntries[initialIndex - 1]
+        );
+      });
+    });
+
+    describe("blocker returns true", () => {
+      it("set blocker state", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(blocker.state).toEqual("blocked");
+      });
+
+      it("does not navigate", async () => {
+        router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+      });
+    });
+
+    describe("proceeds from blocked state", () => {
+      it("sets blocker state to 'proceeding'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(blocker.state).toEqual("blocked");
+
+        await blocker.proceed?.();
+        expect(blocker.state).toEqual("proceeding");
+      });
+
+      it("proceeds with blocked navigation", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        await blocker.proceed?.();
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex - 1]
+        );
+      });
+    });
+
+    describe("resets from blocked state", () => {
+      it.todo("patches the history stack");
+
+      it("sets blocker state to 'unblocked'", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(blocker.state).toEqual("blocked");
+
+        blocker.reset?.();
+        expect(blocker.state).toEqual("unblocked");
+      });
+
+      it("does not navigate", async () => {
+        let blocker = router.createBlocker("KEY", () => true);
+        await router.navigate(-1);
+        expect(router.state.location.pathname).toBe(
+          initialEntries[initialIndex]
+        );
+
+        blocker.reset?.();
+        expect(router.state.location.pathname).toEqual(
+          initialEntries[initialIndex]
+        );
+      });
+    });
+  });
+});

--- a/packages/router/__tests__/blocking-test.ts
+++ b/packages/router/__tests__/blocking-test.ts
@@ -14,7 +14,7 @@ describe("blocking", () => {
     router.initialize();
 
     let fn = () => ({
-      shouldBlock: true,
+      shouldBlock: () => true,
     });
     router.createBlocker("KEY", fn);
     let blocker = router.getBlocker("KEY");
@@ -36,7 +36,7 @@ describe("blocking", () => {
     });
     router.initialize();
 
-    router.createBlocker("KEY", () => ({ shouldBlock: true }));
+    router.createBlocker("KEY", () => ({ shouldBlock: () => true }));
     router.deleteBlocker("KEY");
     let blocker = router.getBlocker("KEY");
     expect(blocker).toBeUndefined();
@@ -59,14 +59,14 @@ describe("blocking", () => {
     describe("blocker returns false", () => {
       it("sets blocker state to 'unblocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: false,
+          shouldBlock: () => false,
         }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("navigates", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: false }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => false }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe("/about");
       });
@@ -75,14 +75,14 @@ describe("blocking", () => {
     describe("blocker returns true", () => {
       it("set blocker state to 'blocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: true }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => true }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -93,7 +93,7 @@ describe("blocking", () => {
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
@@ -104,7 +104,7 @@ describe("blocking", () => {
 
       it("proceeds with blocked navigation", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
@@ -119,7 +119,7 @@ describe("blocking", () => {
     describe("resets from blocked state", () => {
       it("sets blocker state to 'unblocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(blocker.state).toEqual("blocked");
@@ -130,7 +130,7 @@ describe("blocking", () => {
 
       it("does not navigate", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about");
         expect(router.state.location.pathname).toBe(
@@ -160,14 +160,14 @@ describe("blocking", () => {
     describe("blocker returns false", () => {
       it("sets blocker state to 'unblocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: false,
+          shouldBlock: () => false,
         }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("navigates", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: false }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => false }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe("/about");
       });
@@ -176,14 +176,14 @@ describe("blocking", () => {
     describe("blocker returns true", () => {
       it("set blocker state to 'blocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: true }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => true }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -194,7 +194,7 @@ describe("blocking", () => {
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
@@ -205,7 +205,7 @@ describe("blocking", () => {
 
       it("proceeds with blocked navigation", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
@@ -220,7 +220,7 @@ describe("blocking", () => {
     describe("resets from blocked state", () => {
       it("sets blocker state to 'unblocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(blocker.state).toEqual("blocked");
@@ -231,7 +231,7 @@ describe("blocking", () => {
 
       it("does not navigate", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate("/about", { replace: true });
         expect(router.state.location.pathname).toBe(
@@ -266,14 +266,14 @@ describe("blocking", () => {
     describe("blocker returns false", () => {
       it("set blocker state to unblocked", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: false,
+          shouldBlock: () => false,
         }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("unblocked");
       });
 
       it("should navigate", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: false }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => false }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toEqual(
           initialEntries[initialIndex - 1]
@@ -284,14 +284,14 @@ describe("blocking", () => {
     describe("blocker returns true", () => {
       it("set blocker state", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
       });
 
       it("does not navigate", async () => {
-        router.createBlocker("KEY", () => ({ shouldBlock: true }));
+        router.createBlocker("KEY", () => ({ shouldBlock: () => true }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(
           initialEntries[initialIndex]
@@ -302,7 +302,7 @@ describe("blocking", () => {
     describe("proceeds from blocked state", () => {
       it("sets blocker state to 'proceeding'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
@@ -313,7 +313,7 @@ describe("blocking", () => {
 
       it("proceeds with blocked navigation", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(
@@ -332,7 +332,7 @@ describe("blocking", () => {
 
       it("sets blocker state to 'unblocked'", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(blocker.state).toEqual("blocked");
@@ -343,7 +343,7 @@ describe("blocking", () => {
 
       it("does not navigate", async () => {
         let blocker = router.createBlocker("KEY", () => ({
-          shouldBlock: true,
+          shouldBlock: () => true,
         }));
         await router.navigate(-1);
         expect(router.state.location.pathname).toBe(

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -983,6 +983,7 @@ describe("a router", () => {
         restoreScrollPosition: false,
         revalidation: "idle",
         fetchers: new Map(),
+        blockers: new Map(),
       });
     });
 

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -82,7 +82,7 @@ export interface Update {
    */
   location: Location;
 
-  delta?: number;
+  delta: number;
 }
 
 /**
@@ -171,12 +171,6 @@ export interface History {
    * @returns unlisten - A function that may be used to stop listening
    */
   listen(listener: Listener): () => void;
-}
-
-interface Events<F> {
-  length: number;
-  push(fn: F): () => void;
-  call(arg: any): void;
 }
 
 type HistoryState = {
@@ -291,7 +285,7 @@ export function createMemoryHistory(
       index += 1;
       entries.splice(index, entries.length, nextLocation);
       if (v5Compat && listener) {
-        listener({ action, location: nextLocation });
+        listener({ action, location: nextLocation, delta: 1 });
       }
     },
     replace(to, state) {
@@ -299,7 +293,7 @@ export function createMemoryHistory(
       let nextLocation = createMemoryLocation(to, state);
       entries[index] = nextLocation;
       if (v5Compat && listener) {
-        listener({ action, location: nextLocation });
+        listener({ action, location: nextLocation, delta: 0 });
       }
     },
     go(delta) {
@@ -308,7 +302,7 @@ export function createMemoryHistory(
       let nextLocation = entries[nextIndex];
       index = nextIndex;
       if (listener) {
-        listener({ action, location: nextLocation });
+        listener({ action, location: nextLocation, delta });
       }
     },
     listen(fn: Listener) {
@@ -664,7 +658,7 @@ function getUrlBasedHistory(
     }
 
     if (v5Compat && listener) {
-      listener({ action, location: history.location });
+      listener({ action, location: history.location, delta: 1 });
     }
   }
 
@@ -679,7 +673,7 @@ function getUrlBasedHistory(
     globalHistory.replaceState(historyState, "", url);
 
     if (v5Compat && listener) {
-      listener({ action, location: history.location });
+      listener({ action, location: history.location, delta: 0 });
     }
   }
 

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -91,6 +91,17 @@ export interface Listener {
 }
 
 /**
+ * A change to the current location that was blocked. May be retried
+ * after obtaining user confirmation.
+ */
+export interface Transition extends Update {
+  /**
+   * Retries the update to the current location.
+   */
+  retry(): void;
+}
+
+/**
  * Describes a location that is the destination of some navigation, either via
  * `history.push` or `history.replace`. May be either a URL or the pieces of a
  * URL path.
@@ -171,6 +182,12 @@ export interface History {
   listen(listener: Listener): () => void;
 }
 
+interface Events<F> {
+  length: number;
+  push(fn: F): () => void;
+  call(arg: any): void;
+}
+
 type HistoryState = {
   usr: any;
   key?: string;
@@ -227,7 +244,7 @@ export function createMemoryHistory(
     initialIndex == null ? entries.length - 1 : initialIndex
   );
   let action = Action.Pop;
-  let listener: Listener | null = null;
+  let listeners = createEvents<Listener>();
 
   function clampIndex(n: number): number {
     return Math.min(Math.max(n, 0), entries.length - 1);
@@ -281,30 +298,25 @@ export function createMemoryHistory(
       let nextLocation = createMemoryLocation(to, state);
       index += 1;
       entries.splice(index, entries.length, nextLocation);
-      if (v5Compat && listener) {
-        listener({ action, location: nextLocation });
+      if (v5Compat) {
+        listeners.call({ action, location: nextLocation });
       }
     },
     replace(to, state) {
       action = Action.Replace;
       let nextLocation = createMemoryLocation(to, state);
       entries[index] = nextLocation;
-      if (v5Compat && listener) {
-        listener({ action, location: nextLocation });
+      if (v5Compat) {
+        listeners.call({ action, location: nextLocation });
       }
     },
     go(delta) {
       action = Action.Pop;
       index = clampIndex(index + delta);
-      if (listener) {
-        listener({ action, location: getCurrentLocation() });
-      }
+      listeners.call({ action, location: getCurrentLocation() });
     },
-    listen(fn: Listener) {
-      listener = fn;
-      return () => {
-        listener = null;
-      };
+    listen(fn) {
+      return listeners.push(fn);
     },
   };
 
@@ -478,6 +490,24 @@ function warning(cond: any, message: string) {
   }
 }
 
+function createEvents<F extends Function>(): Events<F> {
+  let handlers: F[] = [];
+  return {
+    get length() {
+      return handlers.length;
+    },
+    push(fn: F) {
+      handlers.push(fn);
+      return function () {
+        handlers = handlers.filter((handler) => handler !== fn);
+      };
+    },
+    call(arg) {
+      handlers.forEach((fn) => fn && fn(arg));
+    },
+  };
+}
+
 function createKey() {
   return Math.random().toString(36).substr(2, 8);
 }
@@ -592,13 +622,11 @@ function getUrlBasedHistory(
   let { window = document.defaultView!, v5Compat = false } = options;
   let globalHistory = window.history;
   let action = Action.Pop;
-  let listener: Listener | null = null;
+  let listeners = createEvents<Listener>();
 
   function handlePop() {
     action = Action.Pop;
-    if (listener) {
-      listener({ action, location: history.location });
-    }
+    listeners.call({ action, location: history.location });
   }
 
   function push(to: To, state?: any) {
@@ -618,8 +646,8 @@ function getUrlBasedHistory(
       window.location.assign(url);
     }
 
-    if (v5Compat && listener) {
-      listener({ action, location: history.location });
+    if (v5Compat) {
+      listeners.call({ action, location: history.location });
     }
   }
 
@@ -632,8 +660,8 @@ function getUrlBasedHistory(
     let url = history.createHref(location);
     globalHistory.replaceState(historyState, "", url);
 
-    if (v5Compat && listener) {
-      listener({ action, location: history.location });
+    if (v5Compat) {
+      listeners.call({ action, location: history.location });
     }
   }
 
@@ -645,15 +673,11 @@ function getUrlBasedHistory(
       return getLocation(window, globalHistory);
     },
     listen(fn: Listener) {
-      if (listener) {
-        throw new Error("A history only accepts one active listener");
-      }
       window.addEventListener(PopStateEventType, handlePop);
-      listener = fn;
-
+      let removeListener = listeners.push(fn);
       return () => {
         window.removeEventListener(PopStateEventType, handlePop);
-        listener = null;
+        removeListener();
       };
     },
     createHref(to) {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -637,6 +637,13 @@ export const IDLE_FETCHER: FetcherStates["Idle"] = {
   formData: undefined,
 };
 
+export const UNBLOCKED_BLOCKER: Blocker & { state: "unblocked" } = {
+  state: "unblocked",
+  fn: () => false,
+  proceed: undefined,
+  reset: undefined,
+};
+
 const isBrowser =
   typeof window !== "undefined" &&
   typeof window.document !== "undefined" &&

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -916,6 +916,10 @@ export function createRouter(init: RouterInit): Router {
   }
 
   function createBlocker(key: string, fn: ShouldBlockFunction) {
+    if (state.blockers.has(key)) {
+      return state.blockers.get(key)!;
+    }
+
     let blocker: Blocker = {
       state: "unblocked",
       proceed: undefined,
@@ -923,7 +927,6 @@ export function createRouter(init: RouterInit): Router {
       fn,
     };
     state.blockers.set(key, blocker);
-    updateState({ blockers: state.blockers });
     return blocker;
   }
 
@@ -947,7 +950,6 @@ export function createRouter(init: RouterInit): Router {
 
   function deleteBlocker(key: string) {
     state.blockers.delete(key);
-    updateState({ blockers: state.blockers });
   }
 
   function setBlockerState(
@@ -956,7 +958,10 @@ export function createRouter(init: RouterInit): Router {
     opts?: SetBlockerOpts
   ) {
     let blocker = state.blockers.get(key);
-    if (!blocker) return;
+    if (!blocker) {
+      return;
+    }
+
     invariant(
       nextState === "proceeding" ||
         nextState === "blocked" ||
@@ -984,7 +989,8 @@ export function createRouter(init: RouterInit): Router {
       blocker.reset = undefined;
     }
 
-    updateState({ blockers: state.blockers });
+    state.blockers.set(key, blocker);
+    updateState({ blockers: new Map(state.blockers) });
     return blocker;
   }
 

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -794,30 +794,42 @@ export function createRouter(init: RouterInit): Router {
     unlistenHistory = init.history.listen(
       ({ action: historyAction, location, delta }) => {
         for (let [key, blocker] of state.blockers) {
+          let {
+            shouldBlock,
+            unstable_skipStateUpdateOnPopNavigation: skipStateUpdate,
+          } = blocker.fn();
+
           // So this is a bit tricky to follow if navigation is blocked, so
           // let's try to walk through what's happening line-by-line:
           //
-          // If a POP navigation occurs while a navigation is blocked, we do
-          // nothing until the user either proceeds or resets. History will
-          // update our delta so that we can patch up the stack once navigation
-          // is unblocked.
+          // If a POP navigation occurs while a navigation is blocked, one of
+          // two things is happening:
+          //  1. Navigation was blocked and our URL is out-of-sync with our
+          //     router state. In this case we go back by the delta. This
+          //     triggers our listener again and then...
+          //  2. Navigation state is still blocked, so we update our little
+          //     state tracker and bail. The navigation blocker state is now
+          //     blocked until the user proceeds or resets.
           if (blocker.state === "blocked") {
+            if (blocked.get(key)) {
+              blocked.delete(key);
+            } else {
+              blocked.set(key, true);
+              init.history.go(delta);
+            }
             return;
           }
 
           // If we are in an unblocked state, it's either because:
           //  1. Navigation was never blocked
-          //  2. Navigation was blocked but we never updated the router state.
+          //  2. Navigation was blocked but we haven't yet updated the router
+          //     state.
+          //
           //     When a blocker is registered with a prompt (window.confirm) we
           //     never actually update the blocker state in response to POP
           //     navigations -- we either immediately navigate when the user
           //     accepts or revert the URL if they don't.
           if (blocker.state === "unblocked") {
-            let {
-              shouldBlock,
-              unstable_skipStateUpdateOnPopNavigation: skipStateUpdate,
-            } = blocker.fn();
-
             // If we've already blocked this navigation attempt but our router
             // state was never updated, we do nothing until the user either
             // proceeds or resets. We don't need to evaluate our shouldBlock
@@ -941,6 +953,14 @@ export function createRouter(init: RouterInit): Router {
         )
       : state.loaderData;
 
+    let blockers = state.blockers;
+    for (let [key, blocker] of blockers) {
+      blocker.state = "unblocked";
+      blocker.proceed = undefined;
+      blocker.reset = undefined;
+      state.blockers.set(key, blocker);
+    }
+
     updateState({
       ...newState, // matches, errors, fetchers go through as-is
       actionData,
@@ -955,6 +975,7 @@ export function createRouter(init: RouterInit): Router {
         ? false
         : getSavedScrollPosition(location, newState.matches || state.matches),
       preventScrollReset: pendingPreventScrollReset,
+      blockers: new Map(state.blockers),
     });
 
     if (isUninterruptedRevalidation) {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -778,17 +778,19 @@ export function createRouter(init: RouterInit): Router {
     unlistenHistory = init.history.listen(
       ({ action: historyAction, location, delta }) => {
         for (let [key, blocker] of state.blockers) {
-          if (blocker.state !== "proceeding" && blocker.fn()) {
+          if (blocker.state === "blocked") {
+            return;
+          }
+
+          if (blocker.state === "unblocked" && blocker.fn()) {
+            init.history.go(delta);
             setBlockerState(key, "blocked", {
-              onProceed() {
-                return navigate(location, {
-                  replace: historyAction === HistoryAction.Replace,
-                });
+              async onProceed() {
+                init.history.go(delta * -1);
               },
               onReset() {
-                if (delta !== 0) {
-                  init.history.go(delta);
-                }
+                // noop, we've already blocked and setting state back to
+                // 'unblocked' in `setBlockerState`
               },
             });
             return;

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -874,7 +874,7 @@ export function warning(cond: any, message: string): void {
     if (typeof console !== "undefined") console.warn(message);
 
     try {
-      // Welcome to debugging React Router!
+      // Welcome to debugging @remix-run/router!
       //
       // This error is thrown as a convenience so you can more easily
       // find the source for a warning that appears in the console by


### PR DESCRIPTION
Note: This should target https://github.com/remix-run/react-router/pull/9709 - but the implementation changed drastically after https://github.com/remix-run/react-router/pull/9709/commits/3545cdcc45b08b5ee5f61b37161811ce133be051 - I reviewed the changes and pulled in the bits that still work well with the previous implementation.

This PR includes two major fixes for History Blocking that I needed to be able to continue with our React Router migration. Feel free to take them whole-sale or just pick out the pieces you like. I will say the usePrompt logic took me 4/5 days of iterating and thinking hard about the various scenarios. I tried to comment the code well, but let me know if you have any additional questions. 

Here is the behavior usePrompt ended up with - I think it's the best I could do with my approach. To reiterate the issues for what happens if you close a previous prompt with a new back-button click:

Chrome: closes the prompt and triggers the 'shouldBlock' conditional case (window.confirm is false) BUT if it triggers another navigation that event gets dropped on the floor as there is a navigation from the back-button pending.

Safari: closes the prompt and triggers the 'shouldBlock' conditional case (same as chrome), BUT if it triggers another navigation that event gets queued and handled in addition to the navigation event from the back-button.

Firefox: stacks the prompts on top of each other and keeps previous prompts suspended. As the user clicks 'OK' or 'Cancel, the correct response is queued and then all prompts resolve when the final one closes, all navigation triggered seem to happen.

FWIW I think Chrome is the most 'buggy' implementation as it calls a function and drops it on the floor with no error or warning. Both Safari and Firefox have reasonable implementations IMO.

| prompt state | Chrome | Firefox | Safari | 
| ------------------- | ----------- | ---------- | --------- |
| single prompt accepted | works as expected | works as expected |works as expected |
| single prompt rejected | works as expected | works as expected | works as expected | 
| multi prompt accepted | will cancel instead| works as expected if user clicks OK on all prompts, else cancel | URL is wrong until user clicks OK and then navigates to the right place |
| multi prompt rejected | works as expected | works as expected | works as expected |

Please pull this and play around with it. AFAICT everything is working as it should, but I could easily have missed something. I think if we do end up taking this whole-sale, it would make sense to mark usePrompt and useBlocker as unstable for the first release to work out an kinks. 

Lemme know if you have any questions - I'm both here and on Discord,
Develra