### PR TITLE
Add missing `await` in errorElement example code in docs

### DIFF
--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -64,7 +64,7 @@ Here's a "not found" case in a [loader][loader]:
     if (res.status === 404) {
       throw new Response("Not Found", { status: 404 });
     }
-    const home = res.json();
+    const home = await res.json();
     const descriptionHtml = parseMarkdown(
       data.descriptionMarkdown
     );


### PR DESCRIPTION
Assuming `home` isn't meant to be a Promise