### PR TITLE
Improved absolute redirect url detection in actions/loaders

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -89,6 +89,7 @@
 - latin-1
 - lequangdongg
 - liuhanqu
+- lkwr
 - lopezac
 - lordofthecactus
 - loun4

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -10673,6 +10673,8 @@ describe("a router", () => {
           "https://remix.run/blog",
           "//remix.run/blog",
           "app://whatever",
+          "mailto:hello@remix.run",
+          "web+remix:whatever",
         ];
 
         for (let url of urls) {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2683,8 +2683,7 @@ async function callLoaderOrAction(
         "Redirects returned/thrown from loaders/actions must have a Location header"
       );
 
-      let isAbsolute =
-        /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
+      let isAbsolute = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(location);
 
       // Support relative routing in internal redirects
       if (!isAbsolute) {


### PR DESCRIPTION
This solves the issue remix-run/remix#5002.

With this change, we are able to redirect to URI's like `mailto:mail@example.com` before this change it was not possible because it was interpreted as a relative path.

The regex comes from https://stackoverflow.com/a/31991870 and should match all common absolute URLs and URIs including string starting with `//`.

I tested it with in my own project and it worked like a charm!