### PR TITLE
docs: link directly to v4 of `history` package from v5 docs

### DIFF
--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -1,6 +1,6 @@
 # history
 
-The term "history" and "`history` object" in this documentation refers to [the `history` package](https://github.com/remix-run/history), which is one of only 2 major dependencies of React Router (besides React itself), and which provides several different implementations for managing session history in JavaScript in various environments.
+The term "history" and "`history` object" in this documentation refers to [the `history` package]([https://github.com/remix-run/history](https://github.com/remix-run/history/tree/v4)), which is one of only 2 major dependencies of React Router (besides React itself), and which provides several different implementations for managing session history in JavaScript in various environments.
 
 The following terms are also used:
 


### PR DESCRIPTION
Since v5 of RR is using `history` package version 4, I think it can be best to link directly to that branch for users to easily navigate.
Although this is written in the README of the `history` package, I think people might be confused in finding it :)

Thanks!