### PR TITLE
docs(components/await): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -33,6 +33,7 @@
 - codeape2
 - coryhouse
 - cvbuelow
+- damianstasik
 - danielberndt
 - dauletbaev
 - david-crespo

--- a/docs/components/await.md
+++ b/docs/components/await.md
@@ -140,7 +140,6 @@ function Book() {
         >
           <Reviews />
         </Await>
-        />
       </React.Suspense>
     </div>
   );


### PR DESCRIPTION
This PR fixes a small typo in the last example.