### PR TITLE
docs(start/tutorial): fix links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -162,3 +162,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- fyzhu

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -139,10 +139,10 @@ export default function Root() {
         <nav>
           <ul>
             <li>
-              <a href={`contacts/1`}>Your Name</a>
+              <a href={`/contacts/1`}>Your Name</a>
             </li>
             <li>
-              <a href={`contacts/2`}>Your Friend</a>
+              <a href={`/contacts/2`}>Your Friend</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
If we use `<a>` tag, we need to add a slash, ortherwise we got /contacts/contacts/2

<img width="613" alt="image" src="https://user-images.githubusercontent.com/5175751/211746394-509dcef7-d804-47e2-907d-1026d5b3fed6.png">
