### PR TITLE
Fix scroll restoration when redirecting in an action

### DIFF
--- a/.changeset/kind-seals-know.md
+++ b/.changeset/kind-seals-know.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix scroll reset if a submission redirects

--- a/.changeset/quiet-crabs-jump.md
+++ b/.changeset/quiet-crabs-jump.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Add `preventScrollReset` prop to `<Form>`

--- a/.changeset/quiet-crabs-jump.md
+++ b/.changeset/quiet-crabs-jump.md
@@ -1,5 +1,5 @@
 ---
-"react-router-dom": patch
+"react-router-dom": minor
 ---
 
 Add `preventScrollReset` prop to `<Form>`

--- a/.changeset/scroll-restoration-action-redirect.md
+++ b/.changeset/scroll-restoration-action-redirect.md
@@ -1,5 +1,0 @@
----
-"@remix-run/router": patch
----
-
-Fix scroll restoration when redirecting in an action

--- a/.changeset/scroll-restoration-action-redirect.md
+++ b/.changeset/scroll-restoration-action-redirect.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix scroll restoration when redirecting in an action

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "38.5 kB"
+      "none": "39 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "12.5 kB"

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -138,6 +138,12 @@ export interface SubmitOptions {
    * hierarchy and want to instead route based on /-delimited URL segments
    */
   relative?: RelativeRoutingType;
+
+  /**
+   * In browser-based environments, prevent resetting scroll after this
+   * navigation when using the <ScrollRestoration> component
+   */
+  preventScrollReset?: boolean;
 }
 
 export function getFormSubmissionInfo(

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -594,6 +594,12 @@ export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   relative?: RelativeRoutingType;
 
   /**
+   * Prevent the scroll position from resetting to the top of the viewport on
+   * completion of the navigation when using the <ScrollRestoration> component
+   */
+  preventScrollReset?: boolean;
+
+  /**
    * A function to call when the form is submitted. If you call
    * `event.preventDefault()` then this form will not do anything.
    */
@@ -640,6 +646,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       fetcherKey,
       routeId,
       relative,
+      preventScrollReset,
       ...props
     },
     forwardedRef
@@ -664,6 +671,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
         method: submitMethod,
         replace,
         relative,
+        preventScrollReset,
       });
     };
 
@@ -906,6 +914,7 @@ function useSubmitImpl(fetcherKey?: string, routeId?: string): SubmitFunction {
       let href = url.pathname + url.search;
       let opts = {
         replace: options.replace,
+        preventScrollReset: options.preventScrollReset,
         formData,
         formMethod: method as FormMethod,
         formEncType: encType as FormEncType,
@@ -1000,8 +1009,9 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
   Form: ReturnType<typeof createFetcherForm>;
   submit: (
     target: SubmitTarget,
-    // Fetchers cannot replace because they are not navigation events
-    options?: Omit<SubmitOptions, "replace">
+    // Fetchers cannot replace/preventScrollReset because they are not
+    // navigation events
+    options?: Omit<SubmitOptions, "replace" | "preventScrollReset">
   ) => void;
   load: (href: string) => void;
 };

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1165,7 +1165,7 @@ function useScrollRestoration({
         }
       }
 
-      // Opt out of scroll reset if this link requested it
+      // Don't reset if this navigation opted out
       if (preventScrollReset === true) {
         return;
       }

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6414,232 +6414,423 @@ describe("a router", () => {
       },
     ];
 
-    it("restores scroll on initial load (w/o hydrationData)", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/no-loader"],
+    describe("scroll restoration", () => {
+      it("restores scroll on initial load (w/o hydrationData)", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/no-loader"],
+        });
+
+        expect(t.router.state.restoreScrollPosition).toBe(null);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        // Assume initial location had a saved position
+        let positions = { default: 50 };
+        t.router.enableScrollRestoration(positions, () => 0);
+        expect(t.router.state.restoreScrollPosition).toBe(50);
       });
 
-      expect(t.router.state.restoreScrollPosition).toBe(null);
-      expect(t.router.state.preventScrollReset).toBe(false);
+      it("restores scroll on initial load (w/ hydrationData)", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/"],
+          hydrationData: {
+            loaderData: {
+              index: "INDEX",
+            },
+          },
+        });
 
-      // Assume initial location had a saved position
-      let positions = { default: 50 };
-      t.router.enableScrollRestoration(positions, () => 0);
-      expect(t.router.state.restoreScrollPosition).toBe(50);
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        // Assume initial location had a saved position
+        let positions = { default: 50 };
+        t.router.enableScrollRestoration(positions, () => 0);
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+      });
+
+      it("restores scroll on navigations", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/"],
+          hydrationData: {
+            loaderData: {
+              index: "INDEX_DATA",
+            },
+          },
+        });
+
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        let positions = {};
+
+        // Simulate scrolling to 100 on /
+        let activeScrollPosition = 100;
+        t.router.enableScrollRestoration(positions, () => activeScrollPosition);
+
+        // No restoration on first click to /tasks
+        let nav1 = await t.navigate("/tasks");
+        await nav1.loaders.tasks.resolve("TASKS");
+        expect(t.router.state.restoreScrollPosition).toBe(null);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        // Simulate scrolling down on /tasks
+        activeScrollPosition = 200;
+
+        // Restore on pop back to /
+        let nav2 = await t.navigate(-1);
+        expect(t.router.state.restoreScrollPosition).toBe(null);
+        await nav2.loaders.index.resolve("INDEX");
+        expect(t.router.state.restoreScrollPosition).toBe(100);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        // Restore on pop forward to /tasks
+        let nav3 = await t.navigate(1);
+        await nav3.loaders.tasks.resolve("TASKS");
+        expect(t.router.state.restoreScrollPosition).toBe(200);
+        expect(t.router.state.preventScrollReset).toBe(false);
+      });
+
+      it("restores scroll using custom key", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/"],
+          hydrationData: {
+            loaderData: {
+              index: "INDEX_DATA",
+            },
+          },
+        });
+
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+        expect(t.router.state.preventScrollReset).toBe(false);
+
+        let positions = { "/tasks": 100 };
+        let activeScrollPosition = 0;
+        t.router.enableScrollRestoration(
+          positions,
+          () => activeScrollPosition,
+          (l) => l.pathname
+        );
+
+        let nav1 = await t.navigate("/tasks");
+        await nav1.loaders.tasks.resolve("TASKS");
+        expect(t.router.state.restoreScrollPosition).toBe(100);
+        expect(t.router.state.preventScrollReset).toBe(false);
+      });
+
+      it("restores scroll on GET submissions", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/tasks"],
+          hydrationData: {
+            loaderData: {
+              tasks: "TASKS",
+            },
+          },
+        });
+
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+        expect(t.router.state.preventScrollReset).toBe(false);
+        // We were previously on tasks at 100
+        let positions = { "/tasks": 100 };
+        // But we've scrolled up to 50 to submit.  We'll save this overtop of
+        // the 100 when we start this submission navigation and then restore to
+        // 50 below
+        let activeScrollPosition = 50;
+        t.router.enableScrollRestoration(
+          positions,
+          () => activeScrollPosition,
+          (l) => l.pathname
+        );
+
+        let nav1 = await t.navigate("/tasks", {
+          formMethod: "get",
+          formData: createFormData({ key: "value" }),
+        });
+        await nav1.loaders.tasks.resolve("TASKS2");
+        expect(t.router.state.restoreScrollPosition).toBe(50);
+        expect(t.router.state.preventScrollReset).toBe(false);
+      });
+
+      it("restores scroll on POST submissions", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          initialEntries: ["/tasks"],
+          hydrationData: {
+            loaderData: {
+              index: "INDEX_DATA",
+            },
+          },
+        });
+
+        expect(t.router.state.restoreScrollPosition).toBe(false);
+        expect(t.router.state.preventScrollReset).toBe(false);
+        // We were previously on tasks at 100
+        let positions = { "/tasks": 100 };
+        // But we've scrolled up to 50 to submit.  We'll save this overtop of
+        // the 100 when we start this submission navigation and then restore to
+        // 50 below
+        let activeScrollPosition = 50;
+        t.router.enableScrollRestoration(
+          positions,
+          () => activeScrollPosition,
+          (l) => l.pathname
+        );
+
+        let nav1 = await t.navigate("/tasks", {
+          formMethod: "post",
+          formData: createFormData({}),
+        });
+        const nav2 = await nav1.actions.tasks.redirectReturn("/tasks");
+        await nav2.loaders.tasks.resolve("TASKS");
+        expect(t.router.state.restoreScrollPosition).toBe(50);
+        expect(t.router.state.preventScrollReset).toBe(false);
+      });
     });
 
-    it("restores scroll on initial load (w/ hydrationData)", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX",
-          },
-        },
+    describe("scroll reset", () => {
+      describe("default behavior", () => {
+        it("resets on navigations", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks");
+          await nav1.loaders.tasks.resolve("TASKS");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(false);
+        });
+
+        it("resets on navigations that redirect", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks");
+          let nav2 = await nav1.loaders.tasks.redirectReturn("/");
+          await nav2.loaders.index.resolve("INDEX_DATA 2");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(false);
+        });
+
+        it("does not reset on submission navigations", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", {
+            formMethod: "post",
+            formData: createFormData({}),
+          });
+          await nav1.actions.tasks.resolve("ACTION");
+          await nav1.loaders.tasks.resolve("TASKS");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(true);
+        });
+
+        it("resets on submission navigations that redirect", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", {
+            formMethod: "post",
+            formData: createFormData({}),
+          });
+          let nav2 = await nav1.actions.tasks.redirectReturn("/");
+          await nav2.loaders.index.resolve("INDEX_DATA2");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(false);
+        });
       });
 
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
+      describe("user-specified flag preventScrollReset flag", () => {
+        it("prevents scroll reset on navigations", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
 
-      // Assume initial location had a saved position
-      let positions = { default: 50 };
-      t.router.enableScrollRestoration(positions, () => 0);
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-    });
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
 
-    it("restores scroll on navigations", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", { preventScrollReset: true });
+          await nav1.loaders.tasks.resolve("TASKS");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(true);
+        });
+
+        it("prevents scroll reset on navigations that redirect", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", { preventScrollReset: true });
+          let nav2 = await nav1.loaders.tasks.redirectReturn("/");
+          await nav2.loaders.index.resolve("INDEX_DATA 2");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(true);
+        });
+
+        it("prevents scroll reset on submission navigations", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", {
+            formMethod: "post",
+            formData: createFormData({}),
+            preventScrollReset: true,
+          });
+          await nav1.actions.tasks.resolve("ACTION");
+          await nav1.loaders.tasks.resolve("TASKS");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(true);
+        });
+
+        it("prevents scroll reset on submission navigations that redirect", async () => {
+          let t = setup({
+            routes: SCROLL_ROUTES,
+            initialEntries: ["/"],
+            hydrationData: {
+              loaderData: {
+                index: "INDEX_DATA",
+              },
+            },
+          });
+
+          expect(t.router.state.restoreScrollPosition).toBe(false);
+          expect(t.router.state.preventScrollReset).toBe(false);
+
+          let positions = {};
+          let activeScrollPosition = 0;
+          t.router.enableScrollRestoration(
+            positions,
+            () => activeScrollPosition
+          );
+
+          let nav1 = await t.navigate("/tasks", {
+            formMethod: "post",
+            formData: createFormData({}),
+            preventScrollReset: true,
+          });
+          let nav2 = await nav1.actions.tasks.redirectReturn("/");
+          await nav2.loaders.index.resolve("INDEX_DATA2");
+          expect(t.router.state.restoreScrollPosition).toBe(null);
+          expect(t.router.state.preventScrollReset).toBe(true);
+        });
       });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      let positions = {};
-
-      // Simulate scrolling to 100 on /
-      let activeScrollPosition = 100;
-      t.router.enableScrollRestoration(positions, () => activeScrollPosition);
-
-      // No restoration on first click to /tasks
-      let nav1 = await t.navigate("/tasks");
-      await nav1.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(null);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      // Simulate scrolling down on /tasks
-      activeScrollPosition = 200;
-
-      // Restore on pop back to /
-      let nav2 = await t.navigate(-1);
-      expect(t.router.state.restoreScrollPosition).toBe(null);
-      await nav2.loaders.index.resolve("INDEX");
-      expect(t.router.state.restoreScrollPosition).toBe(100);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      // Restore on pop forward to /tasks
-      let nav3 = await t.navigate(1);
-      await nav3.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(200);
-      expect(t.router.state.preventScrollReset).toBe(false);
-    });
-
-    it("restores scroll using custom key", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
-      });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      let positions = { "/tasks": 100 };
-      let activeScrollPosition = 0;
-      t.router.enableScrollRestoration(
-        positions,
-        () => activeScrollPosition,
-        (l) => l.pathname
-      );
-
-      let nav1 = await t.navigate("/tasks");
-      await nav1.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(100);
-      expect(t.router.state.preventScrollReset).toBe(false);
-    });
-
-    it("restores scroll on submissions that redirect to the same location", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/tasks"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
-      });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-      // We were previously on tasks at 100
-      let positions = { "/tasks": 100 };
-      // But we've scrolled up to 50 to submit.  We'll save this overtop of
-      // the 100 when we start this submission navigation and then restore to
-      // 50 below
-      let activeScrollPosition = 50;
-      t.router.enableScrollRestoration(
-        positions,
-        () => activeScrollPosition,
-        (l) => l.pathname
-      );
-
-      let nav1 = await t.navigate("/tasks", {
-        formMethod: "post",
-        formData: createFormData({}),
-      });
-      const nav2 = await nav1.actions.tasks.redirectReturn("/tasks");
-      await nav2.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(50);
-      expect(t.router.state.preventScrollReset).toBe(false);
-    });
-
-    it("restores scroll on submissions that redirect to new locations", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/tasks"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
-      });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-      let positions = { "/": 50, "/tasks": 100 };
-      let activeScrollPosition = 0;
-      t.router.enableScrollRestoration(
-        positions,
-        () => activeScrollPosition,
-        (l) => l.pathname
-      );
-
-      let nav1 = await t.navigate("/tasks", {
-        formMethod: "post",
-        formData: createFormData({}),
-      });
-      const nav2 = await nav1.actions.tasks.redirectReturn("/");
-      await nav2.loaders.index.resolve("INDEX");
-      expect(t.router.state.restoreScrollPosition).toBe(50);
-      expect(t.router.state.preventScrollReset).toBe(false);
-    });
-    
-    it("does not restore scroll on submissions", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
-      });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      let positions = { "/tasks": 100 };
-      let activeScrollPosition = 0;
-      t.router.enableScrollRestoration(
-        positions,
-        () => activeScrollPosition,
-        (l) => l.pathname
-      );
-
-      let nav1 = await t.navigate("/tasks", {
-        formMethod: "post",
-        formData: createFormData({}),
-      });
-      await nav1.actions.tasks.resolve("ACTION");
-      await nav1.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-    });
-
-    it("does not reset scroll", async () => {
-      let t = setup({
-        routes: SCROLL_ROUTES,
-        initialEntries: ["/"],
-        hydrationData: {
-          loaderData: {
-            index: "INDEX_DATA",
-          },
-        },
-      });
-
-      expect(t.router.state.restoreScrollPosition).toBe(false);
-      expect(t.router.state.preventScrollReset).toBe(false);
-
-      let positions = {};
-      let activeScrollPosition = 0;
-      t.router.enableScrollRestoration(positions, () => activeScrollPosition);
-
-      let nav1 = await t.navigate("/tasks", { preventScrollReset: true });
-      await nav1.loaders.tasks.resolve("TASKS");
-      expect(t.router.state.restoreScrollPosition).toBe(null);
-      expect(t.router.state.preventScrollReset).toBe(true);
     });
   });
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6520,6 +6520,72 @@ describe("a router", () => {
       expect(t.router.state.preventScrollReset).toBe(false);
     });
 
+    it("restores scroll on submissions that redirect to the same location", async () => {
+      let t = setup({
+        routes: SCROLL_ROUTES,
+        initialEntries: ["/tasks"],
+        hydrationData: {
+          loaderData: {
+            index: "INDEX_DATA",
+          },
+        },
+      });
+
+      expect(t.router.state.restoreScrollPosition).toBe(false);
+      expect(t.router.state.preventScrollReset).toBe(false);
+      // We were previously on tasks at 100
+      let positions = { "/tasks": 100 };
+      // But we've scrolled up to 50 to submit.  We'll save this overtop of
+      // the 100 when we start this submission navigation and then restore to
+      // 50 below
+      let activeScrollPosition = 50;
+      t.router.enableScrollRestoration(
+        positions,
+        () => activeScrollPosition,
+        (l) => l.pathname
+      );
+
+      let nav1 = await t.navigate("/tasks", {
+        formMethod: "post",
+        formData: createFormData({}),
+      });
+      const nav2 = await nav1.actions.tasks.redirectReturn("/tasks");
+      await nav2.loaders.tasks.resolve("TASKS");
+      expect(t.router.state.restoreScrollPosition).toBe(50);
+      expect(t.router.state.preventScrollReset).toBe(false);
+    });
+
+    it("restores scroll on submissions that redirect to new locations", async () => {
+      let t = setup({
+        routes: SCROLL_ROUTES,
+        initialEntries: ["/tasks"],
+        hydrationData: {
+          loaderData: {
+            index: "INDEX_DATA",
+          },
+        },
+      });
+
+      expect(t.router.state.restoreScrollPosition).toBe(false);
+      expect(t.router.state.preventScrollReset).toBe(false);
+      let positions = { "/": 50, "/tasks": 100 };
+      let activeScrollPosition = 0;
+      t.router.enableScrollRestoration(
+        positions,
+        () => activeScrollPosition,
+        (l) => l.pathname
+      );
+
+      let nav1 = await t.navigate("/tasks", {
+        formMethod: "post",
+        formData: createFormData({}),
+      });
+      const nav2 = await nav1.actions.tasks.redirectReturn("/");
+      await nav2.loaders.index.resolve("INDEX");
+      expect(t.router.state.restoreScrollPosition).toBe(50);
+      expect(t.router.state.preventScrollReset).toBe(false);
+    });
+    
     it("does not restore scroll on submissions", async () => {
       let t = setup({
         routes: SCROLL_ROUTES,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -771,6 +771,12 @@ export function createRouter(init: RouterInit): Router {
         )
       : state.loaderData;
 
+    // Don't restore on submission navigations unless they redirect
+    let restoreScrollPosition =
+      state.navigation.formData && location.state?._isRedirect !== true
+        ? false
+        : getSavedScrollPosition(location, newState.matches || state.matches);
+
     updateState({
       ...newState, // matches, errors, fetchers go through as-is
       actionData,
@@ -780,10 +786,7 @@ export function createRouter(init: RouterInit): Router {
       initialized: true,
       navigation: IDLE_NAVIGATION,
       revalidation: "idle",
-      // Don't restore on submission navigations
-      restoreScrollPosition: state.navigation.formData
-        ? false
-        : getSavedScrollPosition(location, newState.matches || state.matches),
+      restoreScrollPosition,
       preventScrollReset: pendingPreventScrollReset,
     });
 


### PR DESCRIPTION
Closes #9577 

This also introduces `<Form preventScrollReset>` and fixes an underlying bug where we were preventing _restore_ on submissions when we should be preventing _reset_ 😬 .  We _always_ restore if we have a previous known position (which we never do by default because we use `location.key`).

New semantics:

```jsx
// 1. Default behavior

// Resets scroll
<Link />
<Form />
<Form method="get" />
<Form method="post" /> /* action redirects */

// Does not reset scroll
<Form method="post" /> /* action does not redirect */


// 2. Override default

// does not reset scroll
<Link preventScrollReset />
<Form preventScrollReset />
<Form preventScrollReset method="get" />
<Form preventScrollReset method="post" /> /* action redirects */
<Form preventScrollReset method="post" /> /* action does not redirect */
```

