### PR TITLE
docs: add keyword "await" before function call "getContact(params.con…

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -164,3 +164,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- evgeniyworkbel

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -699,7 +699,8 @@ import { Form, useLoaderData } from "react-router-dom";
 import { getContact } from "../contacts";
 
 export async function loader({ params }) {
-  return getContact(params.contactId);
+  const contact = await getContact(params.contactId);
+  return contact;
 }
 
 export default function Contact() {


### PR DESCRIPTION
I noticed that author forgot to specify "await" in code example in the subsection "Add a loader to the contact page and access data with useLoaderData" of section "URL Params in Loaders"