### PR TITLE
Support OPTIONS requests in staticHandler.queryRoute

### DIFF
--- a/.changeset/real-panthers-hear.md
+++ b/.changeset/real-panthers-hear.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Support `OPTIONS` requests in `staticHandler.queryRoute`

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -12518,6 +12518,14 @@ describe("a router", () => {
         expect(data).toBe("PARENT LOADER");
       });
 
+      it("should support OPTIONS requests", async () => {
+        let { queryRoute } = createStaticHandler(SSR_ROUTES);
+        let data = await queryRoute(
+          createRequest("/parent", { method: "OPTIONS" })
+        );
+        expect(data).toBe("PARENT LOADER");
+      });
+
       it("should support singular route load navigations (primitives)", async () => {
         let { queryRoute } = createStaticHandler(SSR_ROUTES);
         let data;
@@ -13276,7 +13284,7 @@ describe("a router", () => {
 
         it("should handle unsupported methods with a 405 Response", async () => {
           try {
-            await queryRoute(createRequest("/", { method: "OPTIONS" }), {
+            await queryRoute(createRequest("/", { method: "TRACE" }), {
               routeId: "root",
             });
             expect(false).toBe(true);
@@ -13284,7 +13292,7 @@ describe("a router", () => {
             expect(isRouteErrorResponse(data)).toBe(true);
             expect(data.status).toBe(405);
             expect(data.error).toEqual(
-              new Error('Invalid request method "OPTIONS"')
+              new Error('Invalid request method "TRACE"')
             );
             expect(data.internal).toBe(true);
           }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2421,7 +2421,7 @@ export function createStaticHandler(
     let matches = matchRoutes(dataRoutes, location, basename);
 
     // SSR supports HEAD requests while SPA doesn't
-    if (!isValidMethod(method) && method !== "head") {
+    if (!isValidMethod(method) && method !== "head" && method !== "options") {
       throw getInternalRouterError(405, { method });
     } else if (!matches) {
       throw getInternalRouterError(404, { pathname: location.pathname });


### PR DESCRIPTION
Fixes a regression in Remix 1.10.0 for CORS requests.  Remix used to reject `OPTIONS` on data requests but allow them on resource requests.  Since we don't distinguish these in `createStaticHandler.queryRoute`, this PR allows `OPTIONS` requests for any usage of `queryRoute`

Closes: https://github.com/remix-run/remix/issues/5093