### PR TITLE
Link to the tutorial on https://reactrouter.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 React Router is a lightweight, fully-featured routing library for the [React](https://reactjs.org) JavaScript library. React Router runs everywhere that React runs; on the web, on the server (using node.js), and on React Native.
 
-If you're new to React Router, we recommend you start with [the tutorial](/docs/start/tutorial.md).
+If you're new to React Router, we recommend you start with [the tutorial](https://reactrouter.com/en/main/start/tutorial).
 
 If you're migrating to v6 from v5 (or v4, which is the same as v5), check out [the migration guide](/docs/upgrading/v5.md). If you're migrating from Reach Router, check out [the migration guide for Reach Router](/docs/upgrading/reach.md). If you need to find the code for v5, [it is on the `v5` branch](https://github.com/remix-run/react-router/tree/v5).
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -78,6 +78,7 @@
 - JakubDrozd
 - janpaepke
 - jasonpaulos
+- jdufresne
 - JesusTheHun
 - jimniels
 - jmargeta

--- a/packages/react-router-dom/README.md
+++ b/packages/react-router-dom/README.md
@@ -2,4 +2,4 @@
 
 The `react-router-dom` package contains bindings for using [React
 Router](https://github.com/remix-run/react-router) in web applications.
-Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md) for more information on how to get started with React Router.
+Please see [the Getting Started guide](https://reactrouter.com/en/main/start/tutorial) for more information on how to get started with React Router.

--- a/packages/react-router-native/README.md
+++ b/packages/react-router-native/README.md
@@ -3,4 +3,4 @@
 The `react-router-native` package contains bindings for using [React
 Router](https://github.com/remix-run/react-router) in [React
 Native](https://facebook.github.io/react-native/) applications.
-Please see [the Getting Started guide](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md) for more information on how to get started with React Router.
+Please see [the Getting Started guide](https://reactrouter.com/en/main/start/tutorial) for more information on how to get started with React Router.

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -1,3 +1,3 @@
 # React Router v6 Tutorial
 
-To complete this tutorial, we recommend following along with our guide in our [Getting Started documentation](https://github.com/remix-run/react-router/blob/main/docs/start/tutorial.md).
+To complete this tutorial, we recommend following along with our guide in our [Getting Started documentation](https://reactrouter.com/en/main/start/tutorial).


### PR DESCRIPTION
The raw MarkDown is less styled and has broken image files. The documents are intended to be read on https://reactrouter.com/ so link there to be more friendly to newcomers.

Fixes #9607