### PR TITLE
Remove instanceof check from isRouteErrorResponse

### DIFF
--- a/.changeset/silver-snails-destroy.md
+++ b/.changeset/silver-snails-destroy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Remove instanceof check from isRouteErrorResponse to avoid bundling issues on the server

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1395,8 +1395,14 @@ export class ErrorResponse {
 
 /**
  * Check if the given error is an ErrorResponse generated from a 4xx/5xx
- * Response throw from an action/loader
+ * Response thrown from an action/loader
  */
-export function isRouteErrorResponse(e: any): e is ErrorResponse {
-  return e instanceof ErrorResponse;
+export function isRouteErrorResponse(error: any): error is ErrorResponse {
+  return (
+    error != null &&
+    typeof error.status === "number" &&
+    typeof error.statusText === "string" &&
+    typeof error.internal === "boolean" &&
+    "data" in error
+  );
 }


### PR DESCRIPTION
I thought we had removed all of these but looks like we missed one.  Can't use `instanceof` on non-primitives because depending on how server code is bundles/executed we can end up with an ESM and CJS instance of the class and these checks fail across the boundary.

Closes https://github.com/remix-run/blues-stack/issues/145