### PR TITLE
Add unstable_usePrompt

### DIFF
--- a/.changeset/spicy-nails-compete.md
+++ b/.changeset/spicy-nails-compete.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Add `unstable_usePrompt`

--- a/package.json
+++ b/package.json
@@ -118,10 +118,10 @@
       "none": "15 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "11 kB"
+      "none": "11.5 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "16.5 kB"
+      "none": "17 kB"
     }
   }
 }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1231,13 +1231,10 @@ function usePrompt({ when, message }: { when: boolean; message: string }) {
 
   React.useEffect(() => {
     if (blocker.state === "blocked") {
-      console.log("calling window.confirm");
       let proceed = window.confirm(message);
       if (proceed) {
-        console.log("calling setTimeout before proceed");
         setTimeout(blocker.proceed, 0);
       } else {
-        console.log("resetting");
         blocker.reset();
       }
     }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -18,6 +18,7 @@ import {
   useNavigate,
   useNavigation,
   useResolvedPath,
+  unstable_useBlocker as useBlocker,
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_NavigationContext as NavigationContext,
@@ -1210,6 +1211,41 @@ export function useBeforeUnload(
     };
   }, [callback, capture]);
 }
+
+/**
+ * Wrapper around useBlocker to show a window.confirm prompt to users instead
+ * of building a custom UI with useBlocker.
+ *
+ * Warning: This has *a lot of rough edges* and behaves very differently (and
+ * very incorrectly in some cases) across browsers if user click addition
+ * back/forward navigations while the confirm is open.  Use at your own risk.
+ */
+function usePrompt({ when, message }: { when: boolean; message: string }) {
+  let blocker = useBlocker(when);
+
+  React.useEffect(() => {
+    if (blocker.state === "blocked" && !when) {
+      blocker.reset();
+    }
+  }, [blocker, when]);
+
+  React.useEffect(() => {
+    if (blocker.state === "blocked") {
+      console.log("calling window.confirm");
+      let proceed = window.confirm(message);
+      if (proceed) {
+        console.log("calling setTimeout before proceed");
+        setTimeout(blocker.proceed, 0);
+      } else {
+        console.log("resetting");
+        blocker.reset();
+      }
+    }
+  }, [blocker, message]);
+}
+
+export { usePrompt as unstable_usePrompt };
+
 //#endregion
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add an unstable version of `usePrompt`.  Behavior gets _very_ weird (and in some cases very wrong across browsers) if users click additional back/forward navigations while a prompt is open and there's nothing we can do about it, but this provides a simpler path than building a custom `useBlocker` modal/inline-prompt.