### PR TITLE
Change useScrollRestoration to use pagehide event

### DIFF
--- a/.changeset/small-squids-wash.md
+++ b/.changeset/small-squids-wash.md
@@ -2,4 +2,4 @@
 "react-router-dom": patch
 ---
 
-Modified to use pagehide instead of beforeunload to work in the environment of safari on ios
+Use `pagehide` instead of `beforeunload` for `<ScrollRestoration>`. This has better cross-browser support, specifically on Mobile Safari.

--- a/.changeset/small-squids-wash.md
+++ b/.changeset/small-squids-wash.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Modified to use pagehide instead of beforeunload to work in the environment of safari on ios

--- a/contributors.yml
+++ b/contributors.yml
@@ -166,3 +166,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- jakkku

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1143,8 +1143,8 @@ function useScrollRestoration({
     };
   }, []);
 
-  // Save positions on unload
-  useBeforeUnload(
+  // Save positions on pagehide
+  usePageHide(
     React.useCallback(() => {
       if (navigation.state === "idle") {
         let key = (getKey ? getKey(location, matches) : null) || location.key;
@@ -1237,6 +1237,28 @@ export function useBeforeUnload(
     window.addEventListener("beforeunload", callback, opts);
     return () => {
       window.removeEventListener("beforeunload", callback, opts);
+    };
+  }, [callback, capture]);
+}
+
+/**
+ * Setup a callback to be fired on the window's `pagehide` event. This is
+ * useful for saving some data to `window.localStorage` just before the page
+ * refreshes.  This event is better supported than beforeunload across browsers.
+ *
+ * Note: The `callback` argument should be a function created with
+ * `React.useCallback()`.
+ */
+function usePageHide(
+  callback: (event: PageTransitionEvent) => any,
+  options?: { capture?: boolean }
+): void {
+  let { capture } = options || {};
+  React.useEffect(() => {
+    let opts = capture != null ? { capture } : undefined;
+    window.addEventListener("pagehide", callback, opts);
+    return () => {
+      window.removeEventListener("pagehide", callback, opts);
     };
   }, [callback, capture]);
 }


### PR DESCRIPTION
`pagehide` seems to be a better cross-browser way of detecting the unload of a page.  And in the case of scroll restoration there's no need to ever prompt the user so `pagehide` seems a better option anyway.

From https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes:

> If you're specifically trying to detect page unload events, the pagehide event is the best option.

<img width="790" alt="Screenshot 2023-01-19 at 2 07 50 PM" src="https://user-images.githubusercontent.com/1609022/213537294-16d0afc2-c019-472f-92e2-87bce6cfb742.png">


<img width="781" alt="Screenshot 2023-01-19 at 2 06 59 PM" src="https://user-images.githubusercontent.com/1609022/213537191-f5867a12-222b-476e-b264-a35631593827.png">


Closes #9463 