### PR TITLE
chore: set yarn classic as packageManager

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -169,3 +169,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- piecyk

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@remix-run/react-router",
   "private": true,
+  "packageManager": "yarn@1.22.19",
   "workspaces": {
     "packages": [
       "packages/react-router",


### PR DESCRIPTION
By adding "packageManager" field, we show which package manager is expected to be used, also Corepack can pick it automatically. 