### PR TITLE
docs(Browser-router.md): Update for React 18.0

### DIFF
--- a/docs/router-components/browser-router.md
+++ b/docs/router-components/browser-router.md
@@ -27,14 +27,15 @@ A `<BrowserRouter>` stores the current location in the browser's address bar usi
 
 ```tsx
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import {createRoot} from 'react-dom/client';
 import { BrowserRouter } from "react-router-dom";
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+
+root.render(
   <BrowserRouter>
     {/* The rest of your app goes here */}
-  </BrowserRouter>,
-  root
+  </BrowserRouter>
 );
 ```
 


### PR DESCRIPTION
React V18 synthax correction (cause I had the following error in my Chrome console : "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot"). I hope this will helps.