### PR TITLE
fix: Only show dev errors to devs 

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -463,18 +463,28 @@ function DefaultErrorElement() {
   let lightgrey = "rgba(200,200,200, 0.5)";
   let preStyles = { padding: "0.5rem", backgroundColor: lightgrey };
   let codeStyles = { padding: "2px 4px", backgroundColor: lightgrey };
+
+  let devInfo = null;
+  if (__DEV__) {
+    devInfo = (
+      <>
+        <p>💿 Hey developer 👋</p>
+        <p>
+          You can provide a way better UX than this when your app throws errors
+          by providing your own&nbsp;
+          <code style={codeStyles}>errorElement</code> props on&nbsp;
+          <code style={codeStyles}>&lt;Route&gt;</code>
+        </p>
+      </>
+    );
+  }
+
   return (
     <>
-      <h2>Unhandled Thrown Error!</h2>
+      <h2>Unhandled Error Thrown!</h2>
       <h3 style={{ fontStyle: "italic" }}>{message}</h3>
       {stack ? <pre style={preStyles}>{stack}</pre> : null}
-      <p>💿 Hey developer 👋</p>
-      <p>
-        You can provide a way better UX than this when your app throws errors by
-        providing your own&nbsp;
-        <code style={codeStyles}>errorElement</code> props on&nbsp;
-        <code style={codeStyles}>&lt;Route&gt;</code>
-      </p>
+      {devInfo}
     </>
   );
 }


### PR DESCRIPTION
Fixes #9542 

This changes the default error element to only show a developer-specific message in development builds. I think this is a good middle ground, but maybe we want to show a completely different element in production? I'm totally open to changes here, so hopefully this is a good starting point.