### PR TITLE
Update auth example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -64,6 +64,7 @@
 - GuptaSiddhant
 - haivuw
 - hernanif1
+- HNicolas
 - hongji00
 - hsbtr
 - hyesungoh

--- a/examples/auth/src/App.tsx
+++ b/examples/auth/src/App.tsx
@@ -128,10 +128,9 @@ function AuthStatus() {
 }
 
 function RequireAuth({ children }: { children: JSX.Element }) {
-  let auth = useAuth();
   let location = useLocation();
 
-  if (!auth.user) {
+  if (!fakeAuthProvider.isAuthenticated) {
     // Redirect them to the /login page, but save the current location they were
     // trying to go to when they were redirected. This allows us to send them
     // along to that page after they login, which is a nicer user experience


### PR DESCRIPTION
Use the `fakeAuthProvider.isAuthenticated` property instead of `auth.user` state in the `RequireAuth` component.
After a user sign in, `user.state` is not always updated just after the redirection to a protected route which lead to another redirection to the login page.