### PR TITLE
Added better detection for absolute urls in link component

### DIFF
--- a/.changeset/afraid-scissors-rhyme.md
+++ b/.changeset/afraid-scissors-rhyme.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Improved absolute url detection in `Link` component (now also supports `mailto:` urls)

--- a/packages/react-router-dom/__tests__/link-href-test.tsx
+++ b/packages/react-router-dom/__tests__/link-href-test.tsx
@@ -128,6 +128,50 @@ describe("<Link> href", () => {
 
       expect(renderer.root.findByType("a").props.href).toEqual("//remix.run");
     });
+
+    test('<Link to="mailto:remix@example.com"> is treated as external link', () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox/messages"]}>
+            <Routes>
+              <Route path="inbox">
+                <Route
+                  path="messages"
+                  element={<Link to="mailto:remix@example.com" />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "mailto:remix@example.com"
+      );
+    });
+
+    test('<Link to="web+remix://somepath"> is treated as external link', () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/inbox/messages"]}>
+            <Routes>
+              <Route path="inbox">
+                <Route
+                  path="messages"
+                  element={<Link to="web+remix://somepath" />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.root.findByType("a").props.href).toEqual(
+        "web+remix://somepath"
+      );
+    });
   });
 
   describe("in a dynamic route", () => {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -420,8 +420,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   ) {
     // `location` is the unaltered href we will render in the <a> tag for absolute URLs
     let location = typeof to === "string" ? to : createPath(to);
-    let isAbsolute =
-      /^[a-z+]+:\/\//i.test(location) || location.startsWith("//");
+    let isAbsolute = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(location);
 
     // Location to use in the click handler
     let navigationLocation = location;


### PR DESCRIPTION
This merge request improves the detection of absolute URLs in the `<Link to=".." />` component.

### Before this merge request:

`<Link to="mailto:remix@example.com" />` will not solve to the correct url because its detected as a relative url.

### After this merge request:

`<Link to="mailto:remix@example.com" />` will solve to the correct url and opens the mail app depending on the browser.

This uses the same regex as in #9829