### PR TITLE
docs(guides/deferred): add FAQ about using `Response` objects with `defer`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -99,6 +99,7 @@
 - koojaa
 - KostiantynPopovych
 - KutnerUri
+- landisdesign
 - latin-1
 - lequangdongg
 - liuhanqu

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -207,6 +207,38 @@ When you decide you'd like to try the trade-offs of `defer`, we don't want you t
 
 So just keep this in mind: **Deferred is 100% only about the initial load of a route and its params.**
 
+### Why don't Response objects returned by the loader work anymore?
+
+When you use `defer`, you're telling React Router to load the page immediately, without the deferred data. The page is already loaded before the Response object is returned.
+
+If you want your page to redirect based upon your deferred data, you'll need to return something to tell the page itself to do the redirect:
+
+```jsx lines=[6-12, 14-16]
+// Let's assume getPackageLocation returns { status: 401 } if the user's session on the server logged out.
+
+function PackageLocation() {
+  const packageLocation = useAsyncValue();
+
+  const navigate = useNavigate();
+  const isLoggedOut = packageLocation.status === 401;
+  useLayoutEffect(() => {
+    if (isLoggedOut) {
+      navigate('/login');
+    }
+  }, [navigate, isLoggedOut]);
+
+  return isLoggedOut
+    ? 'Rerouting...'
+    : (
+      <p>
+        Your package is at {packageLocation.latitude} lat and{" "}
+        {packageLocation.longitude} long.
+      </p>
+    );
+}
+
+```
+
 [link]: ../components/link
 [usefetcher]: ../hooks/use-fetcher
 [defer response]: ../utils/defer

--- a/docs/guides/deferred.md
+++ b/docs/guides/deferred.md
@@ -209,34 +209,39 @@ So just keep this in mind: **Deferred is 100% only about the initial load of a r
 
 ### Why don't Response objects returned by the loader work anymore?
 
-When you use `defer`, you're telling React Router to load the page immediately, without the deferred data. The page is already loaded before the Response object is returned.
+When you use `defer`, you're telling React Router to load the page immediately, without the deferred data. The page is already loaded before the `Response` object is returned so responses are not automatically processed in the same way as if you had done `return fetch(url)`.
 
-If you want your page to redirect based upon your deferred data, you'll need to return something to tell the page itself to do the redirect:
+Therefore, you will need to handle your own `Response` processing and resolve your deferred Promise with data, not a `Response` instance.
 
-```jsx lines=[6-12, 14-16]
-// Let's assume getPackageLocation returns { status: 401 } if the user's session on the server logged out.
+```jsx
+async function loader({ request, params }) {
+  return defer({
+    // Broken! Resolves with a Response
+    // broken: fetch(url),
 
-function PackageLocation() {
-  const packageLocation = useAsyncValue();
-
-  const navigate = useNavigate();
-  const isLoggedOut = packageLocation.status === 401;
-  useLayoutEffect(() => {
-    if (isLoggedOut) {
-      navigate('/login');
-    }
-  }, [navigate, isLoggedOut]);
-
-  return isLoggedOut
-    ? 'Rerouting...'
-    : (
-      <p>
-        Your package is at {packageLocation.latitude} lat and{" "}
-        {packageLocation.longitude} long.
-      </p>
-    );
+    // Fixed! Resolves with the response data
+    data: fetch(url).then((res) => res.json()),
+  });
 }
+```
 
+Or consider the scenario where our deferred data could return a redirect `Response`. You can detect the redirect and send the status code and location back as data, and then you could perform a client-side redirect in your component via `useEffect` and `useNavigate`.
+
+```jsx
+async function loader({ request, params }) {
+  let data = fetch(url).then((res) => {
+    if (res.status == 301) {
+      return {
+        isRedirect: true,
+        status: res.status,
+        location: res.headers.get("Location"),
+      };
+    }
+    return res.json();
+  });
+
+  return defer({ data });
+}
 ```
 
 [link]: ../components/link


### PR DESCRIPTION
After explaining how React Router uses response objects to replicate web standard behavior, it can be confusing why this suddenly stops working just by adding "defer" to the loader's return value. Thinking it through yields the answer (deferred data isn't handled by the response returning the HTML), but it seems like it would reduce the friction to add a little explanation.