### PR TITLE
fix(router): fix `replaceState` compatibility with `jsdom`

### DIFF
--- a/.changeset/cool-chicken-invite.md
+++ b/.changeset/cool-chicken-invite.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Provide a URL to replaceState for compatibility with jsdom

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -603,7 +603,7 @@ function getUrlBasedHistory(
   // case we should log a warning as it will result in bugs.
   if (index == null) {
     index = 0;
-    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "");
+    globalHistory.replaceState({ ...globalHistory.state, idx: index }, "", window.location.href);
   }
 
   function getIndex(): number {


### PR DESCRIPTION
Workaround upstream jsdom bug:
https://github.com/jsdom/jsdom/issues/3504

The third argument to replaceState is optional, but provide it anyway for improved compatibility with all environments.

The call to replaceState was introduced in
bb7590ac85feb0cb039a5aeac2e2874c117207c9.