### PR TITLE
docs(start/tutorial): fix EditContact component typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -128,6 +128,7 @@
 - morleytatro
 - ms10596
 - noisypigeon
+- ned-park
 - omar-moquete
 - p13i
 - parched

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1298,7 +1298,7 @@ import {
   useNavigate,
 } from "react-router-dom";
 
-export default function Edit() {
+export default function EditContact() {
   const contact = useLoaderData();
   const navigate = useNavigate();
 


### PR DESCRIPTION
Changed to match the name used throughout the rest of the tutorial