### PR TITLE
docs(hooks/use-matches): Fix crumb route

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -176,3 +176,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- rubeonline

--- a/docs/hooks/use-matches.md
+++ b/docs/hooks/use-matches.md
@@ -56,7 +56,7 @@ The proverbial use case here is adding breadcrumbs to a parent layout that uses 
       // here we use "crumb" and return some elements,
       // this is what we'll render in the breadcrumbs
       // for this route
-      crumb: () => <Link to="/message">Messages</Link>,
+      crumb: () => <Link to="/messages">Messages</Link>,
     }}
   >
     <Route


### PR DESCRIPTION
Route of the crumb should be /messages instead of /message