### PR TITLE
docs(hooks/use-submit): Fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -119,6 +119,7 @@
 - marvinruder
 - maxpou
 - mcansh
+- MeatSim
 - MenouerBetty
 - mfijas
 - MichaelDeBoey

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -5,7 +5,7 @@ new: true
 
 # `useSubmit`
 
-The imperative version of `<Form>` that let's you, the programmer, submit a form instead of the user.
+The imperative version of `<Form>` that lets you, the programmer, submit a form instead of the user.
 
 <docs-warning>This feature only works if using a data router, see [Picking a Router][pickingarouter]</docs-warning>
 


### PR DESCRIPTION
Change "let's" (contraction of "let us") to "lets" (singular of "let")