### PR TITLE
docs(start/tutorial) fix: highlighting for changing `<form>` to `<Form>`

### DIFF
--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -594,7 +594,7 @@ We'll create new contacts by exporting an `action` in our root route, wiring it 
 
 👉 **Create the action and change `<form>` to `<Form>`**
 
-```jsx filename=src/routes/root.jsx lines=[5,7,9-11,22-25]
+```jsx filename=src/routes/root.jsx lines=[5,7,9-11,24-26]
 import {
   Outlet,
   Link,

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -594,7 +594,7 @@ We'll create new contacts by exporting an `action` in our root route, wiring it 
 
 👉 **Create the action and change `<form>` to `<Form>`**
 
-```jsx filename=src/routes/root.jsx lines=[5,7,9-11,24-26]
+```jsx filename=src/routes/root.jsx lines=[5,7,9-12,24-26]
 import {
   Outlet,
   Link,


### PR DESCRIPTION
Fixes the current highlighting which covers some things that don't change and is missing the </Form> which does:
![image](https://user-images.githubusercontent.com/87483870/216114907-0de56fb9-7d3f-4f7a-aad5-79986379fc0b.png)
