### PR TITLE
ci: use current branch when gathering PRs for stable releases

### DIFF
--- a/.github/workflows/release-comments.yml
+++ b/.github/workflows/release-comments.yml
@@ -6,7 +6,10 @@ on:
       ref:
         required: true
         type: string
-      packageVersionToFollow:
+      package_version_to_follow:
+        required: true
+        type: string
+      release_branch:
         required: true
         type: string
 
@@ -38,5 +41,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           VERSION: ${{ inputs.ref }}
           DEFAULT_BRANCH: "main"
-          NIGHTLY_BRANCH: "dev"
-          PACKAGE_VERSION_TO_FOLLOW: ${{ inputs.packageVersionToFollow }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          PACKAGE_VERSION_TO_FOLLOW: ${{ inputs.package_version_to_follow }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'remix-run/react-router'
     runs-on: ubuntu-latest
     outputs:
-      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+      published_packages: ${{ steps.changesets.outputs.published_packages }}
       published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: 🛑 Cancel Previous Runs
@@ -58,13 +58,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN_SO_OTHER_ACTIONS_RUN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  findPackage:
+  find_package_version:
     name: 🦋 Find Package
     needs: [release]
     runs-on: ubuntu-latest
     if: github.repository == 'remix-run/react-router' && needs.release.outputs.published == 'true'
     outputs:
-      package: ${{ steps.findPackage.outputs.package }}
+      package_version: ${{ steps.find_package_version.outputs.package_version }}
     steps:
       - name: 🛑 Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -78,19 +78,20 @@ jobs:
           node-version: 16
           cache: "npm"
 
-      - id: findPackage
+      - id: find_package_version
         run: |
-          package=$(node ./scripts/release/find-release-from-changeset.js)
-          echo "package=${package}" >> $GITHUB_OUTPUT
+          package_version=$(node ./scripts/release/find-release-from-changeset.js)
+          echo "package_version=${package_version}" >> $GITHUB_OUTPUT
         env:
-          packageVersionToFollow: "react-router"
-          publishedPackages: ${{ needs.release.outputs.publishedPackages }}
+          package_version_to_follow: "react-router"
+          published_packages: ${{ needs.release.outputs.published_packages }}
 
   comment:
     name: 📝 Comment on related issues and pull requests
-    if: github.repository == 'remix-run/react-router' && needs.findPackage.outputs.package != ''
-    needs: [release, findPackage]
+    if: github.repository == 'remix-run/react-router' && needs.find_package_version.outputs.packageVersion != ''
+    needs: [release, find_package_version]
     uses: ./.github/workflows/release-comments.yml
     with:
-      ref: refs/tags/${{ needs.findPackage.outputs.package }}
-      packageVersionToFollow: "react-router"
+      ref: refs/tags/remix@${{ needs.find_package_version.outputs.packageVersion }}
+      package_version_to_follow: "react-router"
+      release_branch: ${{ github.ref_name }}

--- a/scripts/release/comment.ts
+++ b/scripts/release/comment.ts
@@ -5,6 +5,7 @@ import {
   PR_FILES_STARTS_WITH,
   IS_STABLE_RELEASE,
   AWAITING_RELEASE_LABEL,
+  DRY_RUN,
 } from "./constants";
 import {
   closeIssue,
@@ -41,19 +42,21 @@ async function commentOnIssuesAndPrsAboutRelease() {
   for (let pr of merged) {
     console.log(`commenting on pr ${getGitHubUrl("pull", pr.number)}`);
 
-    promises.push(
-      commentOnPullRequest({
-        owner: OWNER,
-        repo: REPO,
-        pr: pr.number,
-        version: VERSION,
-      })
-    );
+    if (!DRY_RUN) {
+      promises.push(
+        commentOnPullRequest({
+          owner: OWNER,
+          repo: REPO,
+          pr: pr.number,
+          version: VERSION,
+        })
+      );
+    }
 
     let prLabels = pr.labels.map((label) => label.name);
     let prIsAwaitingRelease = prLabels.includes(AWAITING_RELEASE_LABEL);
 
-    if (IS_STABLE_RELEASE && prIsAwaitingRelease) {
+    if (IS_STABLE_RELEASE && prIsAwaitingRelease && !DRY_RUN) {
       promises.push(
         removeLabel({ owner: OWNER, repo: REPO, issue: pr.number })
       );
@@ -75,20 +78,24 @@ async function commentOnIssuesAndPrsAboutRelease() {
       let issueUrl = getGitHubUrl("issue", issue.number);
       console.log(`commenting on issue ${issueUrl}`);
 
-      promises.push(
-        commentOnIssue({
-          owner: OWNER,
-          repo: REPO,
-          issue: issue.number,
-          version: VERSION,
-        })
-      );
+      if (!DRY_RUN) {
+        promises.push(
+          commentOnIssue({
+            owner: OWNER,
+            repo: REPO,
+            issue: issue.number,
+            version: VERSION,
+          })
+        );
+      }
 
       if (IS_STABLE_RELEASE) {
         console.log(`closing issue ${issueUrl}`);
-        promises.push(
-          closeIssue({ owner: OWNER, repo: REPO, issue: issue.number })
-        );
+        if (!DRY_RUN) {
+          promises.push(
+            closeIssue({ owner: OWNER, repo: REPO, issue: issue.number })
+          );
+        }
       }
     }
   }

--- a/scripts/release/constants.ts
+++ b/scripts/release/constants.ts
@@ -3,8 +3,8 @@ import { cleanupRef, cleanupTagName, isNightly, isStable } from "./utils";
 if (!process.env.DEFAULT_BRANCH) {
   throw new Error("DEFAULT_BRANCH is required");
 }
-if (!process.env.NIGHTLY_BRANCH) {
-  throw new Error("NIGHTLY_BRANCH is required");
+if (!process.env.RELEASE_BRANCH) {
+  throw new Error("RELEASE_BRANCH is required");
 }
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("GITHUB_TOKEN is required");
@@ -28,8 +28,9 @@ export const VERSION = cleanupTagName(cleanupRef(process.env.VERSION));
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 export const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
 export const DEFAULT_BRANCH = process.env.DEFAULT_BRANCH;
-export const NIGHTLY_BRANCH = process.env.NIGHTLY_BRANCH;
+export const RELEASE_BRANCH = process.env.RELEASE_BRANCH;
 export const PR_FILES_STARTS_WITH = ["packages/"];
 export const IS_NIGHTLY_RELEASE = isNightly(VERSION);
 export const AWAITING_RELEASE_LABEL = "awaiting release";
 export const IS_STABLE_RELEASE = isStable(VERSION);
+export const DRY_RUN = process.env.DRY_RUN === "true";

--- a/scripts/release/find-release-from-changeset.js
+++ b/scripts/release/find-release-from-changeset.js
@@ -27,12 +27,11 @@ function findReleaseFromChangeset(publishedPackages, packageVersionToFollow) {
     );
   }
 
-  let result = `${found.name}@${found.version}`;
-  console.log(result);
-  return result;
+  console.log(found.version);
+  return found.version;
 }
 
 findReleaseFromChangeset(
-  process.env.publishedPackages,
-  process.env.packageVersionToFollow
+  process.env.published_packages,
+  process.env.package_version_to_follow
 );

--- a/scripts/release/github.ts
+++ b/scripts/release/github.ts
@@ -3,7 +3,7 @@ import * as semver from "semver";
 
 import {
   PR_FILES_STARTS_WITH,
-  NIGHTLY_BRANCH,
+  RELEASE_BRANCH,
   DEFAULT_BRANCH,
   PACKAGE_VERSION_TO_FOLLOW,
   AWAITING_RELEASE_LABEL,
@@ -54,15 +54,15 @@ export async function prsMergedSinceLastTag({
   let prs: Awaited<ReturnType<typeof getMergedPRsBetweenTags>> = [];
 
   // if both the current and previous tags are prereleases
-  // we can just get the PRs for the "dev" branch
-  // but if one of them is stable, we should wind up all of them from both the main and dev branches
+  // we can just get the PRs for the `release` branch
+  // but if one of them is stable, we should wind up all of them from both the main and `release` branches
   if (currentTag.isPrerelease && previousTag.isPrerelease) {
     prs = await getMergedPRsBetweenTags(
       owner,
       repo,
       previousTag,
       currentTag,
-      NIGHTLY_BRANCH
+      RELEASE_BRANCH
     );
   } else {
     let [nightly, stable] = await Promise.all([
@@ -71,7 +71,7 @@ export async function prsMergedSinceLastTag({
         repo,
         previousTag,
         currentTag,
-        NIGHTLY_BRANCH
+        RELEASE_BRANCH
       ),
       getMergedPRsBetweenTags(
         owner,


### PR DESCRIPTION
sync with remix https://github.com/remix-run/remix/pull/5342

Signed-off-by: Logan McAnsh <logan@mcan.sh>