### PR TITLE
Skip scrollIntoView for hash if preventScrollReset===true

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -147,6 +147,7 @@
 - shihanng
 - shivamsinghchahar
 - SimenB
+- sjdemartini
 - SkayuX
 - souzasmatheus
 - srmagura

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1203,6 +1203,11 @@ function useScrollRestoration({
         return;
       }
 
+      // don't reset or try to scroll to a hash if this navigation opted out
+      if (preventScrollReset === true) {
+        return;
+      }
+
       // try to scroll to the hash
       if (location.hash) {
         let el = document.getElementById(location.hash.slice(1));
@@ -1210,11 +1215,6 @@ function useScrollRestoration({
           el.scrollIntoView();
           return;
         }
-      }
-
-      // Don't reset if this navigation opted out
-      if (preventScrollReset === true) {
-        return;
       }
 
       // otherwise go to the top on new locations


### PR DESCRIPTION
As is, `useScrollRestoration` *always* scrolls to a hash when navigating to a page where that hash element can be found, regardless of the `preventScrollReset` value. This means that it's impossible to use `useScrollRestoration`/`<ScrollRestoration />` and control the scrolling behavior when using `navigate` or `Link`s that point to hashes, without this change. Apps are forced to have the app immediately jump to the hash element with no workaround.

With this small adjustment, the scroll-to-hash behavior will not occur if `preventScrollReset===true`, in the same way as scroll-to-top does not (for non-hash links).

A primary use-case for this is when an app wants control over the scroll behavior for a specific action. For instance, someone clicks a button that should link to a given hash element, so we want to update the router state history (using `navigate` or `Link`), but want to smooth-scroll to that element ourselves and don't want `ScrollRestoration` to immediately jump. (Or don't want the scroll position to change at all in response to the `Link`/`navigate` change, but do want the URL to be updated.) It seems appropriate that `preventScrollReset` should behave this way for hash links, since the prop currently has no effect but intuitively can allow for the same level of user-control here as it does for non-hash links.

---

I couldn't find any tests for `useScrollRestoration`, but if there are some that I missed where it makes sense to add a new test case for this scenario, please let me know. Thank you!