### PR TITLE
fix(router): "hard" redirect to different paths on the same origin if redirect location does not contain basename

### DIFF
--- a/.changeset/wet-dogs-check.md
+++ b/.changeset/wet-dogs-check.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Correctly perform a "hard" redirect for same-origin absolute URLs outside of the router basename

--- a/contributors.yml
+++ b/contributors.yml
@@ -9,6 +9,7 @@
 - alany411
 - alexlbr
 - AmRo045
+- amsal
 - andreiduca
 - arnassavickas
 - aroyan

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "41.6 kB"
+      "none": "41.7 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13 kB"

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1915,12 +1915,16 @@ export function createRouter(init: RouterInit): Router {
 
     // Check if this an absolute external redirect that goes to a new origin
     if (
-      ABSOLUTE_URL_REGEX.test(redirect.location) &&
+      (ABSOLUTE_URL_REGEX.test(redirect.location) || (init.basename !== undefined && init.basename !== "/")) &&
       isBrowser &&
       typeof window?.location !== "undefined"
     ) {
       let newOrigin = init.history.createURL(redirect.location).origin;
-      if (window.location.origin !== newOrigin) {
+
+      // Only the last trailing slash is replaced
+      const BASENAME_URL_REGEX = new RegExp("^" + init.basename?.replace(/\/$/, '') + "([/|?.*|?.#]|$)", 'i');
+
+      if (window.location.origin !== newOrigin || !BASENAME_URL_REGEX.test(redirect.location)) {
         if (replace) {
           window.location.replace(redirect.location);
         } else {


### PR DESCRIPTION
Fix for #10052 

Checks whether the redirect location contains the basename (if set) and redirect as an external url if the basename is not present in the redirect location.

Also related: #9859