### PR TITLE
fix(defer): respect headers and status

### DIFF
--- a/.changeset/nasty-carrots-breathe.md
+++ b/.changeset/nasty-carrots-breathe.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Remix document response now respects headers and status code set in defer()

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -12350,6 +12350,10 @@ describe("a router", () => {
                 "x-custom": "yes",
               }),
             },
+            statusCode: 201,
+            loaderHeaders: {
+              deferred: new Headers({ "x-custom": "yes" }),
+            }
           });
         });
 

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3183,7 +3183,12 @@ async function callLoaderOrAction(
   }
 
   if (result instanceof DeferredData) {
-    return { type: ResultType.deferred, deferredData: result };
+    return {
+      type: ResultType.deferred,
+      deferredData: result,
+      statusCode: result.init?.status,
+      headers: result.init?.headers && new Headers(result.init.headers),
+    };
   }
 
   return { type: ResultType.data, data: result };


### PR DESCRIPTION
Fixes the following issue:

When a Remix document request involves a loader which defer()s with specific response headers and/or status code, those are not at all respected.

Fixes issue: https://github.com/remix-run/remix/issues/5345