### PR TITLE
docs: Fix link to Outlet component

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -178,3 +178,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- 0xEddie

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -327,7 +327,6 @@ Please see the [errorElement][errorelement] documentation for more details.
 
 Any application-specific data. Please see the [useMatches][usematches] documentation for details and examples.
 
-[outlet]: ./outlet
 [remix]: https://remix.run
 [indexroute]: ../start/concepts#index-routes
 [outlet]: ../components/outlet


### PR DESCRIPTION
When Outlet was moved to the components section (out of route section), the old link was never deleted in `route.md`.