### PR TITLE
Fixed typo in doc

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -179,3 +179,4 @@
 - xavier-lc
 - xcsnowcity
 - yuleicul
+- DiegoAWS

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1141,7 +1141,7 @@ touch src/routes/destroy.jsx
 
 ```jsx filename=src/routes/destroy.jsx
 import { redirect } from "react-router-dom";
-import { deleteContact } from "../contacts";
+import { deleteContact } from "../contact";
 
 export async function action({ params }) {
   await deleteContact(params.contactId);


### PR DESCRIPTION
The file for helper functions is named `contact.js` not contact`s`.js 

`import { deleteContact } from "../contacts";` should be 
`import { deleteContact } from "../contact";`