### PR TITLE
Wrap LocationContext in useMemo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -42,6 +42,7 @@
 - dauletbaev
 - david-crespo
 - DigitalNaut
+- dmarkow
 - dmitrytarassov
 - dokeet
 - Drishtantr

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -330,7 +330,7 @@ export function Router({
     key = "default",
   } = locationProp;
 
-  let location = React.useMemo(() => {
+  let locationContext = React.useMemo(() => {
     let trailingPathname = stripBasename(pathname, basename);
 
     if (trailingPathname == null) {
@@ -338,31 +338,31 @@ export function Router({
     }
 
     return {
-      pathname: trailingPathname,
-      search,
-      hash,
-      state,
-      key,
+      location: {
+        pathname: trailingPathname,
+        search,
+        hash,
+        state,
+        key,
+      },
+      navigationType,
     };
-  }, [basename, pathname, search, hash, state, key]);
+  }, [basename, pathname, search, hash, state, key, navigationType]);
 
   warning(
-    location != null,
+    locationContext != null,
     `<Router basename="${basename}"> is not able to match the URL ` +
       `"${pathname}${search}${hash}" because it does not start with the ` +
       `basename, so the <Router> won't render anything.`
   );
 
-  if (location == null) {
+  if (locationContext == null) {
     return null;
   }
 
   return (
     <NavigationContext.Provider value={navigationContext}>
-      <LocationContext.Provider
-        children={children}
-        value={{ location, navigationType }}
-      />
+      <LocationContext.Provider children={children} value={locationContext} />
     </NavigationContext.Provider>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/3672. `LocationContext` was using a new object every render, even if `location` and `navigationType` were the same. [React's own docs recommend against this](https://reactjs.org/docs/context.html#caveats).

This update wraps the location context in a `useMemo` just like [navigationContext](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/components.tsx#L315-L319).

I know "is this really hurting performance?" comes up often on this type of issue. For us the answer was definitely yes. We had a large data grid (5,000+ cells on the screen) where each cell needed the value of `useLocation` and clicking in a cell caused a fetcher to run. Even when we wrapped the cells in `React.memo()`, running the fetcher still caused every cell to re-render due to the context change. This did cause some noticeable lag on the page.

I've been running this patch in production since last summer with no issues.