### PR TITLE
docs(tutorial): Fix logic loader data in edit route

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -179,3 +179,4 @@
 - xcsnowcity
 - yuleicul
 - zheng-chuang
+- nnhjs

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -756,7 +756,7 @@ Nothing we haven't seen before, feel free to copy/paste:
 import { Form, useLoaderData } from "react-router-dom";
 
 export default function EditContact() {
-  const contact = useLoaderData();
+  const { contact } = useLoaderData();
 
   return (
     <Form method="post" id="contact-form">
@@ -1299,7 +1299,7 @@ import {
 } from "react-router-dom";
 
 export default function EditContact() {
-  const contact = useLoaderData();
+  const { contact } = useLoaderData();
   const navigate = useNavigate();
 
   return (


### PR DESCRIPTION
In this tutorial, within route `/contact/:contactId/edit ` 
  - We forgot destructuring  contact data before render it on UI. 

Before fix: 
<img width="1628" alt="before-fix" src="https://user-images.githubusercontent.com/52577080/220858245-308a1bd4-e6bc-424b-98f5-605e9457fee1.png">

After fixed: 
<img width="1630" alt="after-fixed" src="https://user-images.githubusercontent.com/52577080/220858293-118416cf-2307-4312-b6bc-61f4f4ff2741.png">
