### PR TITLE
Add support to number in Link to prop

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -185,3 +185,4 @@
 - xcsnowcity
 - yionr
 - yuleicul
+- zyzo

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -392,7 +392,7 @@ export interface LinkProps
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  to: To;
+  to: To | number;
 }
 
 const isBrowser =


### PR DESCRIPTION
The code seems to already support this but typing is not. `<Link to={-1} />` would be great to implement back button