### PR TITLE
fix: treat absolute/same-origin/different-basename <Link to> values as external

### DIFF
--- a/.changeset/big-olives-doubt.md
+++ b/.changeset/big-olives-doubt.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Treat absolute/same-origin/different-basename <Link to> values as external

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       "none": "15 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "11.5 kB"
+      "none": "11.6 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
       "none": "17.5 kB"

--- a/packages/react-router-dom/__tests__/link-click-test.tsx
+++ b/packages/react-router-dom/__tests__/link-click-test.tsx
@@ -138,7 +138,6 @@ describe("A <Link> click", () => {
           <div>
             <h1>Home</h1>
             <Link
-              reloadDocument
               to="https://remix.run"
               onClick={(e) => {
                 handlerCalled = true;
@@ -157,6 +156,78 @@ describe("A <Link> click", () => {
             <Routes>
               <Route path="home" element={<Home />} />
               <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      act(() => {
+        click(node.querySelector("a"));
+      });
+
+      expect(handlerCalled).toBe(true);
+      expect(defaultPrevented).toBe(false);
+    });
+  });
+
+  describe("when a same-origin/different-basename absolute URL is specified", () => {
+    it.only("does not prevent default", () => {
+      function Home() {
+        return (
+          <div>
+            <h1>Home</h1>
+            <Link to="http://localhost/not/base">About</Link>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOM.createRoot(node).render(
+          <MemoryRouter initialEntries={["/base/home"]} basename="/base">
+            <Routes>
+              <Route path="home" element={<Home />} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      let anchor = node.querySelector("a");
+      expect(anchor).not.toBeNull();
+
+      let event: MouseEvent;
+      act(() => {
+        event = click(anchor);
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("calls provided listener", () => {
+      let handlerCalled;
+      let defaultPrevented;
+
+      function Home() {
+        return (
+          <div>
+            <h1>Home</h1>
+            <Link
+              to="http://localhost/not/base"
+              onClick={(e) => {
+                handlerCalled = true;
+                defaultPrevented = e.defaultPrevented;
+              }}
+            >
+              About
+            </Link>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOM.createRoot(node).render(
+          <MemoryRouter initialEntries={["/base/home"]} basename="/base">
+            <Routes>
+              <Route path="home" element={<Home />} />
             </Routes>
           </MemoryRouter>
         );

--- a/packages/react-router-dom/__tests__/link-click-test.tsx
+++ b/packages/react-router-dom/__tests__/link-click-test.tsx
@@ -171,7 +171,7 @@ describe("A <Link> click", () => {
   });
 
   describe("when a same-origin/different-basename absolute URL is specified", () => {
-    it.only("does not prevent default", () => {
+    it("does not prevent default", () => {
       function Home() {
         return (
           <div>

--- a/packages/react-router-dom/__tests__/link-push-test.tsx
+++ b/packages/react-router-dom/__tests__/link-push-test.tsx
@@ -283,4 +283,47 @@ describe("Link push and replace", () => {
       `);
     });
   });
+
+  describe("to an absolute same-origin/same-basename URL, when it is clicked", () => {
+    it("performs a push", () => {
+      function Home() {
+        return (
+          <div>
+            <h1>Home</h1>
+            <Link to="http://localhost/base/about">About</Link>
+          </div>
+        );
+      }
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/base/home"]} basename="/base">
+            <Routes>
+              <Route path="home" element={<Home />} />
+              <Route path="about" element={<ShowNavigationType />} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      let anchor = renderer.root.findByType("a");
+
+      TestRenderer.act(() => {
+        anchor.props.onClick(
+          new MouseEvent("click", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <p>
+          PUSH
+        </p>
+      `);
+    });
+  });
 });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -42,6 +42,7 @@ import {
   createHashHistory,
   UNSAFE_invariant as invariant,
   joinPaths,
+  stripBasename,
   ErrorResponse,
 } from "@remix-run/router";
 
@@ -420,6 +421,8 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     },
     ref
   ) {
+    let { basename } = React.useContext(NavigationContext);
+
     // Rendered into <a href> for absolute URLs
     let absoluteHref;
     let isExternal = false;
@@ -434,7 +437,10 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         let targetUrl = to.startsWith("//")
           ? new URL(currentUrl.protocol + to)
           : new URL(to);
-        if (targetUrl.origin === currentUrl.origin) {
+        let isSameBasename =
+          stripBasename(targetUrl.pathname, basename) != null;
+
+        if (targetUrl.origin === currentUrl.origin && isSameBasename) {
           // Strip the protocol/origin for same-origin absolute URLs
           to = targetUrl.pathname + targetUrl.search + targetUrl.hash;
         } else {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -428,7 +428,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     let isExternal = false;
 
     if (typeof to === "string" && ABSOLUTE_URL_REGEX.test(to)) {
-      debugger;
       // Render the absolute href server- and client-side
       absoluteHref = to;
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -428,6 +428,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     let isExternal = false;
 
     if (typeof to === "string" && ABSOLUTE_URL_REGEX.test(to)) {
+      debugger;
       // Render the absolute href server- and client-side
       absoluteHref = to;
 
@@ -437,12 +438,11 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
         let targetUrl = to.startsWith("//")
           ? new URL(currentUrl.protocol + to)
           : new URL(to);
-        let isSameBasename =
-          stripBasename(targetUrl.pathname, basename) != null;
+        let path = stripBasename(targetUrl.pathname, basename);
 
-        if (targetUrl.origin === currentUrl.origin && isSameBasename) {
-          // Strip the protocol/origin for same-origin absolute URLs
-          to = targetUrl.pathname + targetUrl.search + targetUrl.hash;
+        if (targetUrl.origin === currentUrl.origin && path != null) {
+          // Strip the protocol/origin/basename for same-origin absolute URLs
+          to = path + targetUrl.search + targetUrl.hash;
         } else {
           isExternal = true;
         }


### PR DESCRIPTION
Closes #10052 