### PR TITLE
Specifiy that layouts require an <Outlet> to work

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -78,6 +78,7 @@
 - Isammoc
 - ivanjeremic
 - ivanjonas
+- JackPriceBurns
 - jacob-ebey
 - JaffParker
 - jakkku

--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -664,6 +664,8 @@ And the resulting element tree rendered will be:
 </PageLayout>
 ```
 
+Do not forget to add an `<Outlet>` to your layout where you would like the children to be rendered. Using `{children}` will not work as expected.
+
 The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
 
 <docs-error>You can do it like this, but we recommend using a layout route</docs-error>

--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -664,7 +664,9 @@ And the resulting element tree rendered will be:
 </PageLayout>
 ```
 
-Do not forget to add an `<Outlet>` to your layout where you would like the children to be rendered. Using `{children}` will not work as expected.
+<docs-warning>
+Don't forget to add an `<Outlet>` to your layout where you would like child route elements to be rendered. Using `children` will not work as expected.
+</docs-warning>
 
 The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
 


### PR DESCRIPTION
When I tried to create a layout, I was thoroughly confused because the lines above say it will be rendered like this:
```jsx
<PageLayout>
  <Privacy />
</PageLayout>
```

So I assumed that inside PageLayout, I could just render the children with `{children}` and that's where `<Privacy />` would go. To my surprise, nothing showed up, and the documentation felt confusing. I found the answer on [stack overflow](https://stackoverflow.com/questions/69982197/page-layout-broken-in-react-router-v6), but felt a little note here would helpful to anyone brand new to using React router.