### PR TITLE
docs(start/tutorial): fix EditContact loaded data

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -8,6 +8,7 @@
 - Ajayff4
 - akamfoad
 - alany411
+- alberto
 - alexlbr
 - AmRo045
 - amsal

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -757,7 +757,7 @@ Nothing we haven't seen before, feel free to copy/paste:
 import { Form, useLoaderData } from "react-router-dom";
 
 export default function EditContact() {
-  const contact = useLoaderData();
+  const { contact } = useLoaderData();
 
   return (
     <Form method="post" id="contact-form">


### PR DESCRIPTION
When editing any contact the form is always empty. It's because the loader wraps the contact in an object, so it has to be destructured in the component call to be loaded properly.