### PR TITLE
docs(routers/create-memory-router): fix typos

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -158,6 +158,7 @@
 - sanketshah19
 - senseibarni
 - sergiodxa
+- sgalhs
 - shamsup
 - shihanng
 - shivamsinghchahar

--- a/docs/routers/create-memory-router.md
+++ b/docs/routers/create-memory-router.md
@@ -5,7 +5,7 @@ new: true
 
 # `createMemoryRouter`
 
-Instead of using the browser's history a memory router manages its own history stack in memory. It's primarily useful for testing and component development tools like Storybook, but can also be used for running React Router in any non-browser environment.
+Instead of using the browser's history, a memory router manages its own history stack in memory. It's primarily useful for testing and component development tools like Storybook, but can also be used for running React Router in any non-browser environment.
 
 ```jsx lines=[2-3,24-27]
 import {

--- a/docs/routers/create-memory-router.md
+++ b/docs/routers/create-memory-router.md
@@ -5,7 +5,7 @@ new: true
 
 # `createMemoryRouter`
 
-Instead of using the browsers history a memory router manages it's own history stack in memory. It's primarily useful for testing and component development tools like Storybook, but can also be used for running React Router in any non-browser environment.
+Instead of using the browser's history a memory router manages its own history stack in memory. It's primarily useful for testing and component development tools like Storybook, but can also be used for running React Router in any non-browser environment.
 
 ```jsx lines=[2-3,24-27]
 import {


### PR DESCRIPTION
Found a couple of typos in create-memory-router.md file. Fixed them as best as I could.