### PR TITLE
Introduce useNavLink hook

### DIFF
--- a/.changeset/red-spies-stare.md
+++ b/.changeset/red-spies-stare.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+Introduce useNavLink hook


### PR DESCRIPTION
👋 

I've run into a use-case where I need the `isActive` logic of react-router `NavLink` but do not want to render a `Link` itself. Exporting a `useNavLink` hook solves this. Wondering if the maintainers would be interested in adding this as a feature in the library iteself.