### PR TITLE
Patch patch cause the spec is weird

### DIFF
--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3492,7 +3492,10 @@ function createClientSideRequest(
 
   if (submission && isMutationMethod(submission.formMethod)) {
     let { formMethod, formEncType, formData } = submission;
-    init.method = formMethod;
+    // Didn't think we needed this but it turns out unlike other methods, patch
+    // won't be properly normalized to uppercase and results in a 405 error.
+    // See: https://fetch.spec.whatwg.org/#concept-method
+    init.method = formMethod.toUpperCase();
     init.body =
       formEncType === "application/x-www-form-urlencoded"
         ? convertFormDataToSearchParams(formData)


### PR DESCRIPTION
Adding a `toUpperCase()` back that was removed in https://github.com/remix-run/react-router/pull/10207 cause the spec is weird and doesn't uppercase `patch`: https://fetch.spec.whatwg.org/#concept-method