### PR TITLE
docs(start/concepts): fix warning

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -200,3 +200,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- kno-raziel

--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -664,9 +664,7 @@ And the resulting element tree rendered will be:
 </PageLayout>
 ```
 
-<docs-warning>
-Don't forget to add an `<Outlet>` to your layout where you would like child route elements to be rendered. Using `children` will not work as expected.
-</docs-warning>
+<docs-warning>Don't forget to add an `<Outlet>` to your layout where you would like child route elements to be rendered. Using `{children}` will not work as expected.</docs-warning>
 
 The `PageLayout` route is admittedly weird. We call it a [layout route](#layout-route) because it doesn't participate in the matching at all (though its children do). It only exists to make wrapping multiple child routes in the same layout simpler. If we didn't allow this then you'd have to handle layouts in two different ways: sometimes your routes do it for you, sometimes you do it manually with lots of layout component repetition throughout your app:
 


### PR DESCRIPTION
The <Outlet> is being treated as markup by the mdx, and is being rendered as a tag on the page resulting in :

```html
<docs-warning>
Don't forget to add an `
<outlet>` 
to your layout where you would like child route elements to be rendered. Using `children` will not work as expected.
</outlet>
</docs-warning>
```

instead of
```html
<docs-warning>
Don't forget to add an <code>`<outlet>`</code> to your layout where you would like child route elements to be rendered. Using <code>`{children}`</code> will not work as expected.
</docs-warning>
```

![image](https://user-images.githubusercontent.com/8211946/225778278-196fbbe2-d86f-4ee5-9e2e-4c468d156663.png)
