### PR TITLE
fix: don't include fetcher submission on navigation in fetch action redirect

### DIFF
--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -8702,8 +8702,18 @@ describe("a router", () => {
         expect(A.fetcher.state).toBe("submitting");
         let AR = await A.actions.foo.redirect("/bar");
         expect(A.fetcher.state).toBe("loading");
-        expect(t.router.state.navigation.state).toBe("loading");
-        expect(t.router.state.navigation.location?.pathname).toBe("/bar");
+        expect(t.router.state.navigation).toMatchObject({
+          state: "loading",
+          location: {
+            pathname: "/bar",
+          },
+          // Fetcher action redirect should not proxy the fetcher submission
+          // onto the loading navigation
+          formAction: undefined,
+          formData: undefined,
+          formEncType: undefined,
+          formMethod: undefined,
+        });
         await AR.loaders.root.resolve("ROOT*");
         await AR.loaders.bar.resolve("stuff");
         expect(A.fetcher).toEqual({


### PR DESCRIPTION
Follow up to #10208 to ensure we only hand the submission to `shouldRevalidate` but we don't put it on the loading `navigation`