### PR TITLE
fix(examples/data-router): use the right properties

### DIFF
--- a/examples/data-router/package-lock.json
+++ b/examples/data-router/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-replace": "5.0.2",
-        "@types/node": "18.11.18",
+        "@types/node": "^18.11.18",
         "@types/react": "18.0.27",
         "@types/react-dom": "18.0.10",
         "@vitejs/plugin-react": "3.0.1",
@@ -461,8 +461,9 @@
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",

--- a/examples/data-router/package.json
+++ b/examples/data-router/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "5.0.2",
-    "@types/node": "18.11.18",
+    "@types/node": "^18.11.18",
     "@types/react": "18.0.27",
     "@types/react-dom": "18.0.10",
     "@vitejs/plugin-react": "3.0.1",

--- a/examples/data-router/src/app.tsx
+++ b/examples/data-router/src/app.tsx
@@ -29,31 +29,31 @@ import "./index.css";
 let router = createBrowserRouter([
   {
     path: "/",
-    Component: Layout,
+    element: <Layout/>,
     children: [
       {
         index: true,
         loader: homeLoader,
-        Component: Home,
+        element: <Home/>,
       },
       {
         path: "todos",
         action: todosAction,
         loader: todosLoader,
-        Component: TodosList,
-        ErrorBoundary: TodosBoundary,
+        element: <TodosList/>,
+        errorElement: <TodosBoundary/>,
         children: [
           {
             path: ":id",
             loader: todoLoader,
-            Component: Todo,
+            element: <Todo/>,
           },
         ],
       },
       {
         path: "deferred",
         loader: deferredLoader,
-        Component: DeferredPage,
+        element: <DeferredPage />,
       },
     ],
   },

--- a/examples/data-router/src/main.tsx
+++ b/examples/data-router/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>


### PR DESCRIPTION
The example didn't run. For some reason, the wrong properties were used. Replaced and everything worked