### PR TITLE
Match location.state type to code

### DIFF
--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -11,7 +11,7 @@ title: useLocation
 declare function useLocation(): Location;
 
 interface Location extends Path {
-  state: unknown;
+  state: any;
   key: Key;
 }
 ```


### PR DESCRIPTION
Fixes #10241

We use `any` now. This doc needs updating.