### PR TITLE
docs(start/concepts): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -201,3 +201,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- lpaube

--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -135,7 +135,7 @@ history.listen(({ location, action }) => {
 });
 ```
 
-Apps don't need to set up their own history objects--that's job of `<Router>`. It sets up one of these objects, subscribe to changes in the [history stack](#history-stack), and finally updates its state when the [URL](#url) changes. This causes the app to re-render and the correct UI to display. The only thing it needs to put on state is a `location`, everything else works from that single object.
+Apps don't need to set up their own history objects--that's the job of `<Router>`. It sets up one of these objects, subscribe to changes in the [history stack](#history-stack), and finally updates its state when the [URL](#url) changes. This causes the app to re-render and the correct UI to display. The only thing it needs to put on state is a `location`, everything else works from that single object.
 
 ### Locations
 


### PR DESCRIPTION
Added the missing word "the" in the documentation.