### PR TITLE
docs(readme): Change links to full path

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -202,3 +202,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- ericschn

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -2,9 +2,9 @@
 
 The `react-router` package is the heart of [React Router](https://github.com/remix-run/react-router) and provides all
 the core functionality for both
-[`react-router-dom`](/packages/react-router-dom)
+[`react-router-dom`](https://github.com/remix-run/react-router/tree/main/packages/react-router-dom)
 and
-[`react-router-native`](/packages/react-router-native).
+[`react-router-native`](https://github.com/remix-run/react-router/tree/main/packages/react-router-native).
 
 If you're using React Router, you should never `import` anything directly from
 the `react-router` package, but you should have everything you need in either


### PR DESCRIPTION
These links work on github, but don't work correctly on https://www.npmjs.com/package/react-router