### PR TITLE
docs(create-browser-router.md): correct link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -91,6 +91,7 @@
 - jasonpaulos
 - jdufresne
 - jenseng
+- JeraldVin
 - JesusTheHun
 - jimniels
 - jmargeta

--- a/docs/routers/create-browser-router.md
+++ b/docs/routers/create-browser-router.md
@@ -121,7 +121,7 @@ Useful for environments like browser devtool plugins or testing to use a differe
 [fetcher]: ../hooks/use-fetcher
 [browser-router]: ./browser-router
 [form]: ../components/form
-[route]: ../components/route
+[route]: ../route/route
 [routes]: ../components/routes
 [historyapi]: https://developer.mozilla.org/en-US/docs/Web/API/History
 [api-development-strategy]: ../guides/api-development-strategy.md


### PR DESCRIPTION
Changed the link to Route object instead of Route APIs

The link is used here:
`
routes
An array of [Route][route] objects with nested routes on the children property.
`