### PR TITLE
docs(use-navigate.md): restore hint for `replace`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -167,6 +167,7 @@
 - ryanflorence
 - ryanhiebert
 - sanketshah19
+- scarf005
 - senseibarni
 - sergiodxa
 - sgalhs

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -47,4 +47,6 @@ The `navigate` function has two signatures:
 - Either pass a `To` value (same type as `<Link to>`) with an optional second `{ replace, state }` arg or
 - Pass the delta you want to go in the history stack. For example, `navigate(-1)` is equivalent to hitting the back button.
 
+If using `replace: true`, the navigation will replace the current entry in the history stack instead of adding a new one.
+
 [redirect]: ../fetch/redirect


### PR DESCRIPTION
restored the line since despite #8991 got merged into main, 854f4a41780089ad114fecef1a25111830f5cc0b was nowhere to be seen in commit history.