### PR TITLE
Add behavior: instant to scroll restoration calls

### DIFF
--- a/.changeset/happy-seahorses-bake.md
+++ b/.changeset/happy-seahorses-bake.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Explicitly use "instant" scroll behavior in useScrollRestoration / ScrollRestoration

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1216,7 +1216,7 @@ function useScrollRestoration({
 
       // been here before, scroll to it
       if (typeof restoreScrollPosition === "number") {
-        window.scrollTo(0, restoreScrollPosition);
+        window.scrollTo({ left: 0, top: restoreScrollPosition, behavior: 'instant' });
         return;
       }
 
@@ -1235,7 +1235,7 @@ function useScrollRestoration({
       }
 
       // otherwise go to the top on new locations
-      window.scrollTo(0, 0);
+      window.scrollTo({ left: 0, top: 0, behavior: 'instant' });
     }, [location, restoreScrollPosition, preventScrollReset]);
   }
 }


### PR DESCRIPTION
This explicitly sets the scroll behaviour to "instant" so that CSS (`scroll-behavior: smooth` on the `html` tag) does not affect the call (the current behaviour jumps around when switching page in a non-intuitive way).

This could be made configurable, but I can't think of any reason why somebody would _want_ it to use smooth scrolling.

Worth noting that this version of the `scrollTo` API is not supported by IE. I'm not sure if this project is still trying to support IE ([seems not](https://github.com/remix-run/react-router/commit/f6df0697e1b2064a2b3a12e8b39577326fdd945b)), but if so, it will be necessary to do some [feature detection](https://stackoverflow.com/a/55221484/1180785) to fall-back to the old API.

I've marked the changeset as "minor" since this is effectively a new feature (but maybe you would consider it a bugfix?)

I didn't add or amend any unit tests as this functionality does not currently appear to be tested?