### PR TITLE
Stabilize useNavigate/useSubmit/fetcher.submit for data routers

### DIFF
--- a/.changeset/fetcher-basename-copy.md
+++ b/.changeset/fetcher-basename-copy.md
@@ -1,0 +1,6 @@
+---
+"react-router-dom": minor
+"@remix-run/router": minor
+---
+
+Support relative routing and `basename` in `useFetcher`. Note that this introduces a new `future.v7_prependBasename` flag to the `@remix-run/router`, so if you are writing code using the router directly you may need to enable this flag to opt-into this change.

--- a/.changeset/fetcher-basename-copy.md
+++ b/.changeset/fetcher-basename-copy.md
@@ -1,6 +1,0 @@
----
-"react-router-dom": minor
-"@remix-run/router": minor
----
-
-Support relative routing and `basename` in `useFetcher`. Note that this introduces a new `future.v7_prependBasename` flag to the `@remix-run/router`, so if you are writing code using the router directly you may need to enable this flag to opt-into this change.

--- a/.changeset/fetcher-basename.md
+++ b/.changeset/fetcher-basename.md
@@ -1,0 +1,13 @@
+---
+"react-router-dom": minor
+"@remix-run/router": minor
+---
+
+- Enable relative routing in the `@remix-run/router` when providing a source route ID from which the path is relative to:
+
+  - Example: `router.navigate("../path", { fromRouteId: "some-route" })`.
+  - This also applies to `router.fetch` which already receives a source route ID
+
+- Introduce a new `@remix-run/router` `future.v7_prependBasename` flag to enable `basename` prefixing to all paths coming into `router.navigate` and `router.fetch`.
+  - Previously the `basename` was prepended in the React Router layer, but now that relative routing is being handled by the router we need prepend the `basename` _after_ resolving any relative paths
+  - This also enables `basename` support in `useFetcher` as well

--- a/.changeset/stable-navigate-submit.md
+++ b/.changeset/stable-navigate-submit.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+When using a `RouterProvider`, `useNavigate`/`useSubmit`/`fetcher.submit` are now stable across location changes, since we can handle relative routing via the `@remix-run/router` instance and get rid of our dependence on `useLocation()`. When using `BrowserRouter`, these hooks remain unstable across location changes because they still rely on `useLocation()`.

--- a/package.json
+++ b/package.json
@@ -105,19 +105,19 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "44.1 kB"
+      "none": "45 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.1 kB"
+      "none": "13.3 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "15.3 kB"
+      "none": "15.6 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "11.6 kB"
+      "none": "11.8 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "17.5 kB"
+      "none": "17.7 kB"
     }
   }
 }

--- a/packages/react-router-dom-v5-compat/index.ts
+++ b/packages/react-router-dom-v5-compat/index.ts
@@ -172,12 +172,12 @@ export {
   unstable_usePrompt,
   useRevalidator,
   useRouteError,
-  useRouteId,
   useRouteLoaderData,
   useSubmit,
   UNSAFE_DataRouterContext,
   UNSAFE_DataRouterStateContext,
   UNSAFE_useScrollRestoration,
+  UNSAFE_useRouteId,
 } from "./react-router-dom";
 
 export type { StaticRouterProps } from "./lib/components";

--- a/packages/react-router-dom-v5-compat/index.ts
+++ b/packages/react-router-dom-v5-compat/index.ts
@@ -172,6 +172,7 @@ export {
   unstable_usePrompt,
   useRevalidator,
   useRouteError,
+  useRouteId,
   useRouteLoaderData,
   useSubmit,
   UNSAFE_DataRouterContext,

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -2695,6 +2695,39 @@ function testDomRouter(
             "/foo/bar?index&a=1#hash"
           );
         });
+
+        // eslint-disable-next-line jest/expect-expect
+        it('does not put ?index param in final URL for <Form method="get"', async () => {
+          let testWindow = getWindow("/form");
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="form">
+                  <Route
+                    index={true}
+                    element={
+                      <Form>
+                        <button type="submit" name="name" value="value">
+                          Submit
+                        </button>
+                      </Form>
+                    }
+                  />
+                </Route>
+              </Route>
+            ),
+            {
+              window: testWindow,
+            }
+          );
+          render(<RouterProvider router={router} />);
+
+          assertLocation(testWindow, "/form", "");
+
+          fireEvent.click(screen.getByText("Submit"));
+          await new Promise((r) => setTimeout(r, 0));
+          assertLocation(testWindow, "/form", "?name=value");
+        });
       });
 
       describe("dynamic routes", () => {

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -3458,6 +3458,7 @@ function testDomRouter(
 
         async function clickAndAssert(btnText: string, expectedOutput: string) {
           fireEvent.click(screen.getByText(btnText));
+          await new Promise((r) => setTimeout(r, 1));
           await waitFor(() => screen.getByText(new RegExp(expectedOutput)));
           expect(getHtml(container.querySelector("#output")!)).toContain(
             expectedOutput

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -4467,6 +4467,230 @@ function testDomRouter(
         expect(html).toContain("render count:3");
         expect(html).toContain("fetcher count:1");
       });
+
+      describe("with a basename", () => {
+        it("prepends the basename to fetcher.load paths", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/" element={<Comp />}>
+                <Route path="fetch" loader={() => "FETCH"} />
+              </Route>
+            ),
+            {
+              basename: "/base",
+              window: getWindow("/base"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          function Comp() {
+            let fetcher = useFetcher();
+            return (
+              <>
+                <p>{`data:${fetcher.data}`}</p>
+                <button onClick={() => fetcher.load("/fetch")}>load</button>
+              </>
+            );
+          }
+
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:undefined
+              </p>
+              <button>
+                load
+              </button>
+            </div>"
+          `);
+
+          fireEvent.click(screen.getByText("load"));
+          await waitFor(() => screen.getByText(/FETCH/));
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:FETCH
+              </p>
+              <button>
+                load
+              </button>
+            </div>"
+          `);
+        });
+
+        it('prepends the basename to fetcher.submit({ method: "get" }) paths', async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/" element={<Comp />}>
+                <Route path="fetch" loader={() => "FETCH"} />
+              </Route>
+            ),
+            {
+              basename: "/base",
+              window: getWindow("/base"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          function Comp() {
+            let fetcher = useFetcher();
+            return (
+              <>
+                <p>{`data:${fetcher.data}`}</p>
+                <button
+                  onClick={() =>
+                    fetcher.submit({}, { method: "get", action: "/fetch" })
+                  }
+                >
+                  load
+                </button>
+              </>
+            );
+          }
+
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:undefined
+              </p>
+              <button>
+                load
+              </button>
+            </div>"
+          `);
+
+          fireEvent.click(screen.getByText("load"));
+          await waitFor(() => screen.getByText(/FETCH/));
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:FETCH
+              </p>
+              <button>
+                load
+              </button>
+            </div>"
+          `);
+        });
+
+        it('prepends the basename to fetcher.submit({ method: "post" }) paths', async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/" element={<Comp />}>
+                <Route path="fetch" action={() => "FETCH"} />
+              </Route>
+            ),
+            {
+              basename: "/base",
+              window: getWindow("/base"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          function Comp() {
+            let fetcher = useFetcher();
+            return (
+              <>
+                <p>{`data:${fetcher.data}`}</p>
+                <button
+                  onClick={() =>
+                    fetcher.submit({}, { method: "post", action: "/fetch" })
+                  }
+                >
+                  submit
+                </button>
+              </>
+            );
+          }
+
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:undefined
+              </p>
+              <button>
+                submit
+              </button>
+            </div>"
+          `);
+
+          fireEvent.click(screen.getByText("submit"));
+          await waitFor(() => screen.getByText(/FETCH/));
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:FETCH
+              </p>
+              <button>
+                submit
+              </button>
+            </div>"
+          `);
+        });
+        it("prepends the basename to fetcher.Form paths", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/" element={<Comp />}>
+                <Route path="fetch" action={() => "FETCH"} />
+              </Route>
+            ),
+            {
+              basename: "/base",
+              window: getWindow("/base"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          function Comp() {
+            let fetcher = useFetcher();
+            return (
+              <>
+                <p>{`data:${fetcher.data}`}</p>
+                <fetcher.Form method="post" action="/fetch">
+                  <button type="submit">submit</button>
+                </fetcher.Form>
+              </>
+            );
+          }
+
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:undefined
+              </p>
+              <form
+                action="/base/fetch"
+                method="post"
+              >
+                <button
+                  type="submit"
+                >
+                  submit
+                </button>
+              </form>
+            </div>"
+          `);
+
+          fireEvent.click(screen.getByText("submit"));
+          await waitFor(() => screen.getByText(/FETCH/));
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:FETCH
+              </p>
+              <form
+                action="/base/fetch"
+                method="post"
+              >
+                <button
+                  type="submit"
+                >
+                  submit
+                </button>
+              </form>
+            </div>"
+          `);
+        });
       });
     });
 

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -4439,7 +4439,8 @@ function testDomRouter(
                       Click
                     </button>
                     <p>
-                      {count}-{fetcherCount.current}
+                      {`render count:${count}`}
+                      {`fetcher count:${fetcherCount.current}`}
                     </p>
                   </>
                 );
@@ -4453,38 +4454,19 @@ function testDomRouter(
 
         let { container } = render(<RouterProvider router={router} />);
 
-        expect(getHtml(container)).toMatchInlineSnapshot(`
-          "<div>
-            <button>
-              Click
-            </button>
-            <p>
-              0
-              -
-              0
-            </p>
-          </div>"
-        `);
+        let html = getHtml(container);
+        expect(html).toContain("render count:0");
+        expect(html).toContain("fetcher count:0");
 
         fireEvent.click(screen.getByText("Click"));
         fireEvent.click(screen.getByText("Click"));
         fireEvent.click(screen.getByText("Click"));
-        fireEvent.click(screen.getByText("Click"));
-        fireEvent.click(screen.getByText("Click"));
-        await waitFor(() => screen.getByText(/5-1/));
+        await waitFor(() => screen.getByText(/render count:3/));
 
-        expect(getHtml(container)).toMatchInlineSnapshot(`
-          "<div>
-            <button>
-              Click
-            </button>
-            <p>
-              5
-              -
-              1
-            </p>
-          </div>"
-        `);
+        html = getHtml(container);
+        expect(html).toContain("render count:3");
+        expect(html).toContain("fetcher count:1");
+      });
       });
     });
 

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -215,7 +215,8 @@ export function getFormSubmissionInfo(
       // When grabbing the action from the element, it will have had the basename
       // prefixed to ensure non-JS scenarios work, so strip it since we'll
       // re-prefix in the router
-      let attr = target.getAttribute("action") || form.getAttribute("action");
+      let attr =
+        target.getAttribute("formaction") || form.getAttribute("action");
       action = attr ? stripBasename(attr, basename) : null;
     }
 

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -119,9 +119,6 @@ export interface SubmitOptions {
   /**
    * The action URL path used to submit the form. Overrides `<form action>`.
    * Defaults to the path of the current route.
-   *
-   * Note: It is assumed the path is already resolved. If you need to resolve a
-   * relative path, use `useFormAction`.
    */
   action?: string;
 

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -1,5 +1,8 @@
-import type { FormEncType, HTMLFormMethod } from "@remix-run/router";
-import type { RelativeRoutingType } from "react-router";
+import type {
+  FormEncType,
+  HTMLFormMethod,
+  RelativeRoutingType,
+} from "@remix-run/router";
 
 export const defaultMethod: HTMLFormMethod = "get";
 const defaultEncType: FormEncType = "application/x-www-form-urlencoded";

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -18,13 +18,13 @@ import {
   useNavigate,
   useNavigation,
   useResolvedPath,
-  useRouteId,
   unstable_useBlocker as useBlocker,
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_NavigationContext as NavigationContext,
   UNSAFE_RouteContext as RouteContext,
   UNSAFE_mapRouteProperties as mapRouteProperties,
+  UNSAFE_useRouteId as useRouteId,
 } from "react-router";
 import type {
   BrowserHistory,
@@ -169,7 +169,6 @@ export {
   useResolvedPath,
   useRevalidator,
   useRouteError,
-  useRouteId,
   useRouteLoaderData,
   useRoutes,
 } from "react-router";
@@ -194,6 +193,7 @@ export {
   UNSAFE_NavigationContext,
   UNSAFE_LocationContext,
   UNSAFE_RouteContext,
+  UNSAFE_useRouteId,
 } from "react-router";
 //#endregion
 
@@ -1003,7 +1003,8 @@ function useSubmitImpl(
   );
 }
 
-// TODO: Deprecate entirely in favor of router.resolvePath()?
+// v7: Eventually we should deprecate this entirely in favor of using the
+// router method directly?
 export function useFormAction(
   action?: string,
   { relative }: { relative?: RelativeRoutingType } = {}

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1022,10 +1022,10 @@ export function useFormAction(
   }
 
   if ((!action || action === ".") && match.route.index) {
-    path.search = path.search
-      ? path.search.replace(/^\?/, "?index&")
-      : "?index";
-  }
+      path.search = path.search
+        ? path.search.replace(/^\?/, "?index&")
+        : "?index";
+    }
 
   // If we're operating within a basename, prepend it to the pathname prior
   // to creating the form action.  If this is a root navigation, then just use

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -169,6 +169,7 @@ export {
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
+  useRouterNavigate,
   useRoutes,
 } from "react-router";
 

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -6,6 +6,7 @@ import type {
   StaticHandlerContext,
   CreateStaticHandlerOptions as RouterCreateStaticHandlerOptions,
   UNSAFE_RouteManifest as RouteManifest,
+  FutureConfig,
 } from "@remix-run/router";
 import {
   IDLE_BLOCKER,
@@ -224,7 +225,10 @@ export function createStaticHandler(
 
 export function createStaticRouter(
   routes: RouteObject[],
-  context: StaticHandlerContext
+  context: StaticHandlerContext,
+  opts?: {
+    future?: Partial<FutureConfig>;
+  }
 ): RemixRouter {
   let manifest: RouteManifest = {};
   let dataRoutes = convertRoutesToDataRoutes(
@@ -289,12 +293,6 @@ export function createStaticRouter(
     },
     revalidate() {
       throw msg("revalidate");
-    },
-    resolvePath() {
-      //
-      // FIXME: TODO - Implement!
-      //
-      throw new Error("TODO - Not Implemented yet!");
     },
     createHref,
     encodeLocation,

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -290,6 +290,12 @@ export function createStaticRouter(
     revalidate() {
       throw msg("revalidate");
     },
+    resolvePath() {
+      //
+      // FIXME: TODO - Implement!
+      //
+      throw new Error("TODO - Not Implemented yet!");
+    },
     createHref,
     encodeLocation,
     getFetcher() {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -225,10 +225,7 @@ export function createStaticHandler(
 
 export function createStaticRouter(
   routes: RouteObject[],
-  context: StaticHandlerContext,
-  opts?: {
-    future?: Partial<FutureConfig>;
-  }
+  context: StaticHandlerContext
 ): RemixRouter {
   let manifest: RouteManifest = {};
   let dataRoutes = convertRoutesToDataRoutes(

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -109,6 +109,7 @@ export {
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
+  useRouterNavigate,
   useRoutes,
 } from "react-router";
 

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -108,7 +108,6 @@ export {
   useResolvedPath,
   useRevalidator,
   useRouteError,
-  useRouteId,
   useRouteLoaderData,
   useRoutes,
 } from "react-router";
@@ -133,6 +132,7 @@ export {
   UNSAFE_NavigationContext,
   UNSAFE_LocationContext,
   UNSAFE_RouteContext,
+  UNSAFE_useRouteId,
 } from "react-router";
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -108,8 +108,8 @@ export {
   useResolvedPath,
   useRevalidator,
   useRouteError,
+  useRouteId,
   useRouteLoaderData,
-  useRouterNavigate,
   useRoutes,
 } from "react-router";
 

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -3346,11 +3346,6 @@ function MemoryNavigate({
 }) {
   let dataRouterContext = React.useContext(DataRouterContext);
 
-  let basename = dataRouterContext?.basename;
-  if (basename && basename !== "/") {
-    to = to === "/" ? basename : joinPaths([basename, to]);
-  }
-
   let onClickHandler = React.useCallback(
     async (event: React.MouseEvent) => {
       event.preventDefault();
@@ -3363,9 +3358,17 @@ function MemoryNavigate({
     [dataRouterContext, to, formMethod, formData]
   );
 
+  // Only prepend the basename to the rendered href, send the non-prefixed `to`
+  // value into the router since it will prepend the basename
+  let basename = dataRouterContext?.basename;
+  let href = to;
+  if (basename && basename !== "/") {
+    href = to === "/" ? basename : joinPaths([basename, to]);
+  }
+
   return formData ? (
     <form onClick={onClickHandler} children={children} />
   ) : (
-    <a href={to} onClick={onClickHandler} children={children} />
+    <a href={href} onClick={onClickHandler} children={children} />
   );
 }

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as TestRenderer from "react-test-renderer";
+import type { RelativeRoutingType, To } from "react-router";
 import {
   MemoryRouter,
   Navigate,
@@ -8,7 +9,10 @@ import {
   Route,
   RouterProvider,
   createMemoryRouter,
+  createRoutesFromElements,
   useLocation,
+  useNavigate,
+  useRouterNavigate,
 } from "react-router";
 import { prettyDOM, render, screen, waitFor } from "@testing-library/react";
 
@@ -468,6 +472,1114 @@ describe("<Navigate>", () => {
           About
         </h1>
       </div>"
+    `);
+  });
+});
+
+function UseNavigateWrapper({
+  to,
+  relative,
+}: {
+  to: To;
+  relative: RelativeRoutingType;
+}) {
+  let navigate = useNavigate();
+  React.useEffect(() => {
+    navigate(to, { relative });
+  });
+  return null;
+}
+
+describe("useNavigate", () => {
+  describe("with an absolute href", () => {
+    it("navigates to the correct URL", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route path="home" element={<UseNavigateWrapper to="/about" />} />
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+  });
+
+  describe("with a relative href (relative=route)", () => {
+    it("navigates to the correct URL", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route
+                path="home"
+                element={<UseNavigateWrapper to="../about" />}
+              />
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from an index routes", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route path="home">
+                <Route index element={<UseNavigateWrapper to="../about" />} />
+              </Route>
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside a pathless layout route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route element={<Outlet />}>
+                <Route
+                  path="home"
+                  element={<UseNavigateWrapper to="../about" />}
+                />
+              </Route>
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route path="home">
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route
+                        index
+                        element={<UseNavigateWrapper to="../about" />}
+                      />
+                    </Route>
+                  </Route>
+                </Route>
+              </Route>
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home/page"]}>
+            <Routes>
+              <Route path="home" element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route
+                        path="page"
+                        element={<UseNavigateWrapper to="../../about" />}
+                      />
+                    </Route>
+                  </Route>
+                </Route>
+              </Route>
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles parent navigation from inside multiple pathless layout routes", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/home/page"]}>
+            <Routes>
+              <Route
+                path="home"
+                element={
+                  <>
+                    <h1>Home</h1>
+                    <Outlet />
+                  </>
+                }
+              >
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route
+                        path="page"
+                        element={
+                          <>
+                            <h2>Page</h2>
+                            <UseNavigateWrapper to=".." />
+                          </>
+                        }
+                      />
+                    </Route>
+                  </Route>
+                </Route>
+              </Route>
+              <Route path="about" element={<h1>About</h1>} />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Home
+        </h1>
+      `);
+    });
+
+    it("handles relative navigation from nested index route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/layout/thing"]}>
+            <Routes>
+              <Route path="layout">
+                <Route path=":param">
+                  {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                  <Route index element={<UseNavigateWrapper to="dest" />} />
+                  <Route path="dest" element={<h1>Destination</h1>} />
+                </Route>
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Destination
+        </h1>
+      `);
+    });
+  });
+
+  describe("with a relative href (relative=path)", () => {
+    it("navigates to the correct URL", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<h1>Contacts</h1>} />
+              <Route
+                path="contacts/:id"
+                element={<UseNavigateWrapper to=".." relative="path" />}
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from an index routes", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<h1>Contacts</h1>} />
+              <Route path="contacts/:id">
+                <Route
+                  index
+                  element={<UseNavigateWrapper to=".." relative="path" />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside a pathless layout route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<h1>Contacts</h1>} />
+              <Route element={<Outlet />}>
+                <Route
+                  path="contacts/:id"
+                  element={<UseNavigateWrapper to=".." relative="path" />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<h1>Contacts</h1>} />
+              <Route path="contacts/:id">
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route
+                        index
+                        element={<UseNavigateWrapper to=".." relative="path" />}
+                      />
+                    </Route>
+                  </Route>
+                </Route>
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<Outlet />}>
+                <Route index element={<h1>Contacts</h1>} />
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route
+                        path=":id"
+                        element={<UseNavigateWrapper to=".." relative="path" />}
+                      />
+                    </Route>
+                  </Route>
+                </Route>
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles relative navigation from nested index route", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/layout/thing"]}>
+            <Routes>
+              <Route path="layout">
+                <Route path=":param">
+                  {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                  <Route
+                    index
+                    element={<UseNavigateWrapper to="dest" relative="path" />}
+                  />
+                  <Route path="dest" element={<h1>Destination</h1>} />
+                </Route>
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Destination
+        </h1>
+      `);
+    });
+
+    it("preserves search params and hash", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/contacts/1"]}>
+            <Routes>
+              <Route path="contacts" element={<Contacts />} />
+              <Route
+                path="contacts/:id"
+                element={
+                  <UseNavigateWrapper to="..?foo=bar#hash" relative="path" />
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      function Contacts() {
+        let { search, hash } = useLocation();
+        return (
+          <>
+            <h1>Contacts</h1>
+            <p>
+              {search}
+              {hash}
+            </p>
+          </>
+        );
+      }
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <h1>
+            Contacts
+          </h1>,
+          <p>
+            ?foo=bar
+            #hash
+          </p>,
+        ]
+      `);
+    });
+  });
+
+  it("is not stable across location changes", () => {
+    let router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          Component: () => (
+            <>
+              <NavBar />
+              <Outlet />
+            </>
+          ),
+          children: [
+            {
+              path: "home",
+              element: <h1>Home</h1>,
+            },
+            {
+              path: "about",
+              element: <h1>About</h1>,
+            },
+          ],
+        },
+      ],
+      { initialEntries: ["/home"] }
+    );
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    function NavBar() {
+      let count = React.useRef(0);
+      let navigate = useNavigate();
+      console.log("rendering NavBar");
+      React.useEffect(() => {
+        count.current++;
+      }, [navigate]);
+      return <p>{count.current}</p>;
+    }
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          0
+        </p>,
+        <h1>
+          Home
+        </h1>,
+      ]
+    `);
+
+    TestRenderer.act(() => {
+      router.navigate("/about");
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          1
+        </p>,
+        <h1>
+          About
+        </h1>,
+      ]
+    `);
+
+    TestRenderer.act(() => {
+      router.navigate("/home");
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          2
+        </p>,
+        <h1>
+          Home
+        </h1>,
+      ]
+    `);
+  });
+});
+
+function UseRouterNavigateWrapper({
+  to,
+  relative,
+}: {
+  to: To;
+  relative?: RelativeRoutingType;
+}) {
+  let navigate = useRouterNavigate();
+  React.useEffect(() => {
+    navigate(to, { relative });
+  });
+  return null;
+}
+
+describe("useRouterNavigate", () => {
+  describe("with an absolute href", () => {
+    it("navigates to the correct URL", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route
+              path="home"
+              element={<UseRouterNavigateWrapper to="/about" />}
+            />
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+  });
+
+  describe("with a relative href (relative=route)", () => {
+    it("navigates to the correct URL", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route
+              path="home"
+              element={<UseRouterNavigateWrapper to="../about" />}
+            />
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from an index routes", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="home">
+              <Route
+                index
+                element={<UseRouterNavigateWrapper to="../about" />}
+              />
+            </Route>
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside a pathless layout route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route element={<Outlet />}>
+              <Route
+                path="home"
+                element={<UseRouterNavigateWrapper to="../about" />}
+              />
+            </Route>
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="home">
+              <Route element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route
+                      index
+                      element={<UseRouterNavigateWrapper to="../about" />}
+                    />
+                  </Route>
+                </Route>
+              </Route>
+            </Route>
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="home" element={<Outlet />}>
+              <Route element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route
+                      path="page"
+                      element={<UseRouterNavigateWrapper to="../../about" />}
+                    />
+                  </Route>
+                </Route>
+              </Route>
+            </Route>
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home/page"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("handles parent navigation from inside multiple pathless layout routes", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route
+              path="home"
+              element={
+                <>
+                  <h1>Home</h1>
+                  <Outlet />
+                </>
+              }
+            >
+              <Route element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route
+                      path="page"
+                      element={
+                        <>
+                          <h2>Page</h2>
+                          <UseRouterNavigateWrapper to=".." />
+                        </>
+                      }
+                    />
+                  </Route>
+                </Route>
+              </Route>
+            </Route>
+            <Route path="about" element={<h1>About</h1>} />
+          </>
+        ),
+        { initialEntries: ["/home/page"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Home
+        </h1>
+      `);
+    });
+
+    it("handles relative navigation from nested index route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="layout">
+              <Route path=":param">
+                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                <Route index element={<UseRouterNavigateWrapper to="dest" />} />
+                <Route path="dest" element={<h1>Destination</h1>} />
+              </Route>
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/layout/thing"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Destination
+        </h1>
+      `);
+    });
+  });
+
+  describe("with a relative href (relative=path)", () => {
+    it("navigates to the correct URL", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<h1>Contacts</h1>} />
+            <Route
+              path="contacts/:id"
+              element={<UseRouterNavigateWrapper to=".." relative="path" />}
+            />
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from an index routes", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<h1>Contacts</h1>} />
+            <Route path="contacts/:id">
+              <Route
+                index
+                element={<UseRouterNavigateWrapper to=".." relative="path" />}
+              />
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside a pathless layout route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<h1>Contacts</h1>} />
+            <Route element={<Outlet />}>
+              <Route
+                path="contacts/:id"
+                element={<UseRouterNavigateWrapper to=".." relative="path" />}
+              />
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<h1>Contacts</h1>} />
+            <Route path="contacts/:id">
+              <Route element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route
+                      index
+                      element={
+                        <UseRouterNavigateWrapper to=".." relative="path" />
+                      }
+                    />
+                  </Route>
+                </Route>
+              </Route>
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<Outlet />}>
+              <Route index element={<h1>Contacts</h1>} />
+              <Route element={<Outlet />}>
+                <Route element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route
+                      path=":id"
+                      element={
+                        <UseRouterNavigateWrapper to=".." relative="path" />
+                      }
+                    />
+                  </Route>
+                </Route>
+              </Route>
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Contacts
+        </h1>
+      `);
+    });
+
+    it("handles relative navigation from nested index route", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="layout">
+              <Route path=":param">
+                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                <Route
+                  index
+                  element={
+                    <UseRouterNavigateWrapper to="dest" relative="path" />
+                  }
+                />
+                <Route path="dest" element={<h1>Destination</h1>} />
+              </Route>
+            </Route>
+          </>
+        ),
+        { initialEntries: ["/layout/thing"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          Destination
+        </h1>
+      `);
+    });
+
+    it("preserves search params and hash", () => {
+      let router = createMemoryRouter(
+        createRoutesFromElements(
+          <>
+            <Route path="contacts" element={<Contacts />} />
+            <Route
+              path="contacts/:id"
+              element={
+                <UseRouterNavigateWrapper
+                  to="..?foo=bar#hash"
+                  relative="path"
+                />
+              }
+            />
+          </>
+        ),
+        { initialEntries: ["/contacts/1"] }
+      );
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      function Contacts() {
+        let { search, hash } = useLocation();
+        return (
+          <>
+            <h1>Contacts</h1>
+            <p>
+              {search}
+              {hash}
+            </p>
+          </>
+        );
+      }
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <h1>
+            Contacts
+          </h1>,
+          <p>
+            ?foo=bar
+            #hash
+          </p>,
+        ]
+      `);
+    });
+  });
+
+  it("is stable across location changes", () => {
+    let router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          Component: () => (
+            <>
+              <NavBar />
+              <Outlet />
+            </>
+          ),
+          children: [
+            {
+              path: "home",
+              element: <h1>Home</h1>,
+            },
+            {
+              path: "about",
+              element: <h1>About</h1>,
+            },
+          ],
+        },
+      ],
+      { initialEntries: ["/home"] }
+    );
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    function NavBar() {
+      let count = React.useRef(0);
+      let navigate = useRouterNavigate();
+      React.useEffect(() => {
+        count.current++;
+      }, [navigate]);
+      return <p>{count.current}</p>;
+    }
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          0
+        </p>,
+        <h1>
+          Home
+        </h1>,
+      ]
+    `);
+
+    TestRenderer.act(() => {
+      router.navigate("/about");
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          1
+        </p>,
+        <h1>
+          About
+        </h1>,
+      ]
+    `);
+
+    TestRenderer.act(() => {
+      router.navigate("/home");
+    });
+
+    expect(renderer.toJSON()).toMatchInlineSnapshot(`
+      [
+        <p>
+          1
+        </p>,
+        <h1>
+          Home
+        </h1>,
+      ]
     `);
   });
 });

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -31,6 +31,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -53,6 +54,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -75,6 +77,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -97,6 +100,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -125,6 +129,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -156,6 +161,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           About
@@ -200,6 +206,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Home
@@ -225,6 +232,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Destination
@@ -250,6 +258,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Contacts
@@ -272,6 +281,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Contacts
@@ -297,6 +307,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Contacts
@@ -328,6 +339,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Contacts
@@ -359,6 +371,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Contacts
@@ -387,6 +400,7 @@ describe("<Navigate>", () => {
         );
       });
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <h1>
           Destination
@@ -423,6 +437,7 @@ describe("<Navigate>", () => {
         );
       }
 
+      // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         [
           <h1>
@@ -472,1114 +487,6 @@ describe("<Navigate>", () => {
           About
         </h1>
       </div>"
-    `);
-  });
-});
-
-function UseNavigateWrapper({
-  to,
-  relative,
-}: {
-  to: To;
-  relative: RelativeRoutingType;
-}) {
-  let navigate = useNavigate();
-  React.useEffect(() => {
-    navigate(to, { relative });
-  });
-  return null;
-}
-
-describe("useNavigate", () => {
-  describe("with an absolute href", () => {
-    it("navigates to the correct URL", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route path="home" element={<UseNavigateWrapper to="/about" />} />
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=route)", () => {
-    it("navigates to the correct URL", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route
-                path="home"
-                element={<UseNavigateWrapper to="../about" />}
-              />
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route path="home">
-                <Route index element={<UseNavigateWrapper to="../about" />} />
-              </Route>
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route element={<Outlet />}>
-                <Route
-                  path="home"
-                  element={<UseNavigateWrapper to="../about" />}
-                />
-              </Route>
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route path="home">
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route element={<Outlet />}>
-                      <Route
-                        index
-                        element={<UseNavigateWrapper to="../about" />}
-                      />
-                    </Route>
-                  </Route>
-                </Route>
-              </Route>
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home/page"]}>
-            <Routes>
-              <Route path="home" element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route element={<Outlet />}>
-                      <Route
-                        path="page"
-                        element={<UseNavigateWrapper to="../../about" />}
-                      />
-                    </Route>
-                  </Route>
-                </Route>
-              </Route>
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles parent navigation from inside multiple pathless layout routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home/page"]}>
-            <Routes>
-              <Route
-                path="home"
-                element={
-                  <>
-                    <h1>Home</h1>
-                    <Outlet />
-                  </>
-                }
-              >
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route element={<Outlet />}>
-                      <Route
-                        path="page"
-                        element={
-                          <>
-                            <h2>Page</h2>
-                            <UseNavigateWrapper to=".." />
-                          </>
-                        }
-                      />
-                    </Route>
-                  </Route>
-                </Route>
-              </Route>
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Home
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/layout/thing"]}>
-            <Routes>
-              <Route path="layout">
-                <Route path=":param">
-                  {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                  <Route index element={<UseNavigateWrapper to="dest" />} />
-                  <Route path="dest" element={<h1>Destination</h1>} />
-                </Route>
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=path)", () => {
-    it("navigates to the correct URL", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<h1>Contacts</h1>} />
-              <Route
-                path="contacts/:id"
-                element={<UseNavigateWrapper to=".." relative="path" />}
-              />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<h1>Contacts</h1>} />
-              <Route path="contacts/:id">
-                <Route
-                  index
-                  element={<UseNavigateWrapper to=".." relative="path" />}
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<h1>Contacts</h1>} />
-              <Route element={<Outlet />}>
-                <Route
-                  path="contacts/:id"
-                  element={<UseNavigateWrapper to=".." relative="path" />}
-                />
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<h1>Contacts</h1>} />
-              <Route path="contacts/:id">
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route element={<Outlet />}>
-                      <Route
-                        index
-                        element={<UseNavigateWrapper to=".." relative="path" />}
-                      />
-                    </Route>
-                  </Route>
-                </Route>
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<Outlet />}>
-                <Route index element={<h1>Contacts</h1>} />
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route element={<Outlet />}>
-                      <Route
-                        path=":id"
-                        element={<UseNavigateWrapper to=".." relative="path" />}
-                      />
-                    </Route>
-                  </Route>
-                </Route>
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/layout/thing"]}>
-            <Routes>
-              <Route path="layout">
-                <Route path=":param">
-                  {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                  <Route
-                    index
-                    element={<UseNavigateWrapper to="dest" relative="path" />}
-                  />
-                  <Route path="dest" element={<h1>Destination</h1>} />
-                </Route>
-              </Route>
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-
-    it("preserves search params and hash", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
-              <Route path="contacts" element={<Contacts />} />
-              <Route
-                path="contacts/:id"
-                element={
-                  <UseNavigateWrapper to="..?foo=bar#hash" relative="path" />
-                }
-              />
-            </Routes>
-          </MemoryRouter>
-        );
-      });
-
-      function Contacts() {
-        let { search, hash } = useLocation();
-        return (
-          <>
-            <h1>Contacts</h1>
-            <p>
-              {search}
-              {hash}
-            </p>
-          </>
-        );
-      }
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        [
-          <h1>
-            Contacts
-          </h1>,
-          <p>
-            ?foo=bar
-            #hash
-          </p>,
-        ]
-      `);
-    });
-  });
-
-  it("is not stable across location changes", () => {
-    let router = createMemoryRouter(
-      [
-        {
-          path: "/",
-          Component: () => (
-            <>
-              <NavBar />
-              <Outlet />
-            </>
-          ),
-          children: [
-            {
-              path: "home",
-              element: <h1>Home</h1>,
-            },
-            {
-              path: "about",
-              element: <h1>About</h1>,
-            },
-          ],
-        },
-      ],
-      { initialEntries: ["/home"] }
-    );
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
-    });
-
-    function NavBar() {
-      let count = React.useRef(0);
-      let navigate = useNavigate();
-      console.log("rendering NavBar");
-      React.useEffect(() => {
-        count.current++;
-      }, [navigate]);
-      return <p>{count.current}</p>;
-    }
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          0
-        </p>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-
-    TestRenderer.act(() => {
-      router.navigate("/about");
-    });
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          1
-        </p>,
-        <h1>
-          About
-        </h1>,
-      ]
-    `);
-
-    TestRenderer.act(() => {
-      router.navigate("/home");
-    });
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          2
-        </p>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-  });
-});
-
-function UseRouterNavigateWrapper({
-  to,
-  relative,
-}: {
-  to: To;
-  relative?: RelativeRoutingType;
-}) {
-  let navigate = useRouterNavigate();
-  React.useEffect(() => {
-    navigate(to, { relative });
-  });
-  return null;
-}
-
-describe("useRouterNavigate", () => {
-  describe("with an absolute href", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={<UseRouterNavigateWrapper to="/about" />}
-            />
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=route)", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={<UseRouterNavigateWrapper to="../about" />}
-            />
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home">
-              <Route
-                index
-                element={<UseRouterNavigateWrapper to="../about" />}
-              />
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route element={<Outlet />}>
-              <Route
-                path="home"
-                element={<UseRouterNavigateWrapper to="../about" />}
-              />
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home">
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      index
-                      element={<UseRouterNavigateWrapper to="../about" />}
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home" element={<Outlet />}>
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path="page"
-                      element={<UseRouterNavigateWrapper to="../../about" />}
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home/page"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles parent navigation from inside multiple pathless layout routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={
-                <>
-                  <h1>Home</h1>
-                  <Outlet />
-                </>
-              }
-            >
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path="page"
-                      element={
-                        <>
-                          <h2>Page</h2>
-                          <UseRouterNavigateWrapper to=".." />
-                        </>
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home/page"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Home
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="layout">
-              <Route path=":param">
-                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                <Route index element={<UseRouterNavigateWrapper to="dest" />} />
-                <Route path="dest" element={<h1>Destination</h1>} />
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/layout/thing"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=path)", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route
-              path="contacts/:id"
-              element={<UseRouterNavigateWrapper to=".." relative="path" />}
-            />
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route path="contacts/:id">
-              <Route
-                index
-                element={<UseRouterNavigateWrapper to=".." relative="path" />}
-              />
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route element={<Outlet />}>
-              <Route
-                path="contacts/:id"
-                element={<UseRouterNavigateWrapper to=".." relative="path" />}
-              />
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route path="contacts/:id">
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      index
-                      element={
-                        <UseRouterNavigateWrapper to=".." relative="path" />
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<Outlet />}>
-              <Route index element={<h1>Contacts</h1>} />
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path=":id"
-                      element={
-                        <UseRouterNavigateWrapper to=".." relative="path" />
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="layout">
-              <Route path=":param">
-                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                <Route
-                  index
-                  element={
-                    <UseRouterNavigateWrapper to="dest" relative="path" />
-                  }
-                />
-                <Route path="dest" element={<h1>Destination</h1>} />
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/layout/thing"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-
-    it("preserves search params and hash", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<Contacts />} />
-            <Route
-              path="contacts/:id"
-              element={
-                <UseRouterNavigateWrapper
-                  to="..?foo=bar#hash"
-                  relative="path"
-                />
-              }
-            />
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      function Contacts() {
-        let { search, hash } = useLocation();
-        return (
-          <>
-            <h1>Contacts</h1>
-            <p>
-              {search}
-              {hash}
-            </p>
-          </>
-        );
-      }
-
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        [
-          <h1>
-            Contacts
-          </h1>,
-          <p>
-            ?foo=bar
-            #hash
-          </p>,
-        ]
-      `);
-    });
-  });
-
-  it("is stable across location changes", () => {
-    let router = createMemoryRouter(
-      [
-        {
-          path: "/",
-          Component: () => (
-            <>
-              <NavBar />
-              <Outlet />
-            </>
-          ),
-          children: [
-            {
-              path: "home",
-              element: <h1>Home</h1>,
-            },
-            {
-              path: "about",
-              element: <h1>About</h1>,
-            },
-          ],
-        },
-      ],
-      { initialEntries: ["/home"] }
-    );
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
-    });
-
-    function NavBar() {
-      let count = React.useRef(0);
-      let navigate = useRouterNavigate();
-      React.useEffect(() => {
-        count.current++;
-      }, [navigate]);
-      return <p>{count.current}</p>;
-    }
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          0
-        </p>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-
-    TestRenderer.act(() => {
-      router.navigate("/about");
-    });
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          1
-        </p>,
-        <h1>
-          About
-        </h1>,
-      ]
-    `);
-
-    TestRenderer.act(() => {
-      router.navigate("/home");
-    });
-
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <p>
-          1
-        </p>,
-        <h1>
-          Home
-        </h1>,
-      ]
     `);
   });
 });

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as TestRenderer from "react-test-renderer";
-import type { RelativeRoutingType, To } from "react-router";
 import {
   MemoryRouter,
   Navigate,
@@ -9,10 +8,7 @@ import {
   Route,
   RouterProvider,
   createMemoryRouter,
-  createRoutesFromElements,
   useLocation,
-  useNavigate,
-  useRouterNavigate,
 } from "react-router";
 import { prettyDOM, render, screen, waitFor } from "@testing-library/react";
 

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -11,7 +11,6 @@ import {
   createRoutesFromElements,
   Outlet,
   RouterProvider,
-  useRouterNavigate,
 } from "react-router";
 
 describe("useNavigate", () => {
@@ -348,109 +347,745 @@ describe("useNavigate", () => {
       `);
     });
   });
-});
 
-function UseNavigateButton({
-  to,
-  relative,
-}: {
-  to: To;
-  relative?: RelativeRoutingType;
-}) {
-  let navigate = useNavigate();
-  return <button onClick={() => navigate(to, { relative })}>Navigate</button>;
-}
+  describe("when relative navigation is handled via React Context", () => {
+    describe("with an absolute href", () => {
+      it("navigates to the correct URL", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route
+                  path="home"
+                  element={<UseNavigateButton to="/about" />}
+                />
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
 
-describe("useNavigate (mimicing <Navigate> tests)", () => {
-  describe("with an absolute href", () => {
-    it("navigates to the correct URL", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
-              <Route path="home" element={<UseNavigateButton to="/about" />} />
-              <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
-        );
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+    });
+
+    describe("with a relative href (relative=route)", () => {
+      it("navigates to the correct URL", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route
+                  path="home"
+                  element={<UseNavigateButton to="../about" />}
+                />
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
+      it("handles upward navigation from an index routes", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route path="home">
+                  <Route index element={<UseNavigateButton to="../about" />} />
+                </Route>
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
 
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside a pathless layout route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route element={<Outlet />}>
+                  <Route
+                    path="home"
+                    element={<UseNavigateButton to="../about" />}
+                  />
+                </Route>
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route path="home">
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route element={<Outlet />}>
+                        <Route
+                          index
+                          element={<UseNavigateButton to="../about" />}
+                        />
+                      </Route>
+                    </Route>
+                  </Route>
+                </Route>
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home/page"]}>
+              <Routes>
+                <Route path="home" element={<Outlet />}>
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route element={<Outlet />}>
+                        <Route
+                          path="page"
+                          element={<UseNavigateButton to="../../about" />}
+                        />
+                      </Route>
+                    </Route>
+                  </Route>
+                </Route>
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+
+      it("handles parent navigation from inside multiple pathless layout routes", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/home/page"]}>
+              <Routes>
+                <Route
+                  path="home"
+                  element={
+                    <>
+                      <h1>Home</h1>
+                      <Outlet />
+                    </>
+                  }
+                >
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route element={<Outlet />}>
+                        <Route
+                          path="page"
+                          element={
+                            <>
+                              <h2>Page</h2>
+                              <UseNavigateButton to=".." />
+                            </>
+                          }
+                        />
+                      </Route>
+                    </Route>
+                  </Route>
+                </Route>
+                <Route path="about" element={<h1>About</h1>} />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Home
+          </h1>
+        `);
+      });
+
+      it("handles relative navigation from nested index route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/layout/thing"]}>
+              <Routes>
+                <Route path="layout">
+                  <Route path=":param">
+                    {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                    <Route index element={<UseNavigateButton to="dest" />} />
+                    <Route path="dest" element={<h1>Destination</h1>} />
+                  </Route>
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Destination
+          </h1>
+        `);
+      });
     });
-  });
 
-  describe("with a relative href (relative=route)", () => {
-    it("navigates to the correct URL", () => {
+    describe("with a relative href (relative=path)", () => {
+      it("navigates to the correct URL", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<h1>Contacts</h1>} />
+                <Route
+                  path="contacts/:id"
+                  element={<UseNavigateButton to=".." relative="path" />}
+                />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from an index routes", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<h1>Contacts</h1>} />
+                <Route path="contacts/:id">
+                  <Route
+                    index
+                    element={<UseNavigateButton to=".." relative="path" />}
+                  />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside a pathless layout route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<h1>Contacts</h1>} />
+                <Route element={<Outlet />}>
+                  <Route
+                    path="contacts/:id"
+                    element={<UseNavigateButton to=".." relative="path" />}
+                  />
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<h1>Contacts</h1>} />
+                <Route path="contacts/:id">
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route element={<Outlet />}>
+                        <Route
+                          index
+                          element={
+                            <UseNavigateButton to=".." relative="path" />
+                          }
+                        />
+                      </Route>
+                    </Route>
+                  </Route>
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
+      });
+
+      it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<Outlet />}>
+                  <Route index element={<h1>Contacts</h1>} />
+                  <Route element={<Outlet />}>
+                    <Route element={<Outlet />}>
+                      <Route element={<Outlet />}>
+                        <Route
+                          path=":id"
+                          element={
+                            <UseNavigateButton to=".." relative="path" />
+                          }
+                        />
+                      </Route>
+                    </Route>
+                  </Route>
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
+      });
+
+      it("handles relative navigation from nested index route", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/layout/thing"]}>
+              <Routes>
+                <Route path="layout">
+                  <Route path=":param">
+                    {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
+                    <Route
+                      index
+                      element={<UseNavigateButton to="dest" relative="path" />}
+                    />
+                    <Route path="dest" element={<h1>Destination</h1>} />
+                  </Route>
+                </Route>
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Destination
+          </h1>
+        `);
+      });
+
+      it("preserves search params and hash", () => {
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(
+            <MemoryRouter initialEntries={["/contacts/1"]}>
+              <Routes>
+                <Route path="contacts" element={<Contacts />} />
+                <Route
+                  path="contacts/:id"
+                  element={
+                    <UseNavigateButton to="..?foo=bar#hash" relative="path" />
+                  }
+                />
+              </Routes>
+            </MemoryRouter>
+          );
+        });
+
+        function Contacts() {
+          let { search, hash } = useLocation();
+          return (
+            <>
+              <h1>Contacts</h1>
+              <p>
+                {search}
+                {hash}
+              </p>
+            </>
+          );
+        }
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          [
+            <h1>
+              Contacts
+            </h1>,
+            <p>
+              ?foo=bar
+              #hash
+            </p>,
+          ]
+        `);
+      });
+    });
+
+    it("is not stable across location changes", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(
           <MemoryRouter initialEntries={["/home"]}>
             <Routes>
               <Route
+                path="/"
+                element={
+                  <>
+                    <NavBar />
+                    <Outlet />
+                  </>
+                }
+              >
+                <Route path="home" element={<h1>Home</h1>} />
+                <Route path="about" element={<h1>About</h1>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      function NavBar() {
+        let count = React.useRef(0);
+        let navigate = useNavigate();
+        React.useEffect(() => {
+          count.current++;
+        }, [navigate]);
+        return (
+          <nav>
+            <button onClick={() => navigate("/home")}>Home</button>
+            <button onClick={() => navigate("/about")}>About</button>
+            <p>{count.current}</p>
+          </nav>
+        );
+      }
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              0
+            </p>
+          </nav>,
+          <h1>
+            Home
+          </h1>,
+        ]
+      `);
+
+      // @ts-expect-error
+      let buttons = renderer.root.findAllByType("button");
+      TestRenderer.act(() => {
+        buttons[1].props.onClick(); // link to /about
+      });
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              1
+            </p>
+          </nav>,
+          <h1>
+            About
+          </h1>,
+        ]
+      `);
+
+      // @ts-expect-error
+      buttons = renderer.root.findAllByType("button");
+      TestRenderer.act(() => {
+        buttons[0].props.onClick(); // link back to /home
+      });
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              2
+            </p>
+          </nav>,
+          <h1>
+            Home
+          </h1>,
+        ]
+      `);
+    });
+  });
+
+  describe("when relative navigation is handled via @remix-run/router", () => {
+    describe("with an absolute href", () => {
+      it("navigates to the correct URL", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
+              <Route path="home" element={<UseNavigateButton to="/about" />} />
+              <Route path="about" element={<h1>About</h1>} />
+            </>
+          ),
+          { initialEntries: ["/home"] }
+        );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+      });
+    });
+
+    describe("with a relative href (relative=route)", () => {
+      it("navigates to the correct URL", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
+              <Route
                 path="home"
                 element={<UseNavigateButton to="../about" />}
               />
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
+      it("handles upward navigation from an index routes", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="home">
                 <Route index element={<UseNavigateButton to="../about" />} />
               </Route>
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
+      it("handles upward navigation from inside a pathless layout route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route element={<Outlet />}>
                 <Route
                   path="home"
@@ -458,29 +1093,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                 />
               </Route>
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home"]}>
-            <Routes>
+      it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="home">
                 <Route element={<Outlet />}>
                   <Route element={<Outlet />}>
@@ -494,29 +1132,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                 </Route>
               </Route>
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home/page"]}>
-            <Routes>
+      it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="home" element={<Outlet />}>
                 <Route element={<Outlet />}>
                   <Route element={<Outlet />}>
@@ -530,29 +1171,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                 </Route>
               </Route>
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home/page"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles parent navigation from inside multiple pathless layout routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/home/page"]}>
-            <Routes>
+      it("handles parent navigation from inside multiple pathless layout routes", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route
                 path="home"
                 element={
@@ -579,29 +1223,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                 </Route>
               </Route>
               <Route path="about" element={<h1>About</h1>} />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/home/page"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Home
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Home
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/layout/thing"]}>
-            <Routes>
+      it("handles relative navigation from nested index route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="layout">
                 <Route path=":param">
                   {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
@@ -609,59 +1256,65 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   <Route path="dest" element={<h1>Destination</h1>} />
                 </Route>
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/layout/thing"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Destination
+          </h1>
+        `);
       });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
     });
-  });
 
-  describe("with a relative href (relative=path)", () => {
-    it("navigates to the correct URL", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+    describe("with a relative href (relative=path)", () => {
+      it("navigates to the correct URL", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<h1>Contacts</h1>} />
               <Route
                 path="contacts/:id"
                 element={<UseNavigateButton to=".." relative="path" />}
               />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+      it("handles upward navigation from an index routes", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<h1>Contacts</h1>} />
               <Route path="contacts/:id">
                 <Route
@@ -669,29 +1322,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   element={<UseNavigateButton to=".." relative="path" />}
                 />
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+      it("handles upward navigation from inside a pathless layout route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<h1>Contacts</h1>} />
               <Route element={<Outlet />}>
                 <Route
@@ -699,29 +1355,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   element={<UseNavigateButton to=".." relative="path" />}
                 />
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+      it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<h1>Contacts</h1>} />
               <Route path="contacts/:id">
                 <Route element={<Outlet />}>
@@ -735,29 +1394,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   </Route>
                 </Route>
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+      it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<Outlet />}>
                 <Route index element={<h1>Contacts</h1>} />
                 <Route element={<Outlet />}>
@@ -771,29 +1433,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   </Route>
                 </Route>
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Contacts
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/layout/thing"]}>
-            <Routes>
+      it("handles relative navigation from nested index route", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="layout">
                 <Route path=":param">
                   {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
@@ -804,29 +1469,32 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   <Route path="dest" element={<h1>Destination</h1>} />
                 </Route>
               </Route>
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/layout/thing"] }
         );
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            Destination
+          </h1>
+        `);
       });
 
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-
-    it("preserves search params and hash", () => {
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(
-          <MemoryRouter initialEntries={["/contacts/1"]}>
-            <Routes>
+      it("preserves search params and hash", () => {
+        let router = createMemoryRouter(
+          createRoutesFromElements(
+            <>
               <Route path="contacts" element={<Contacts />} />
               <Route
                 path="contacts/:id"
@@ -834,881 +1502,188 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
                   <UseNavigateButton to="..?foo=bar#hash" relative="path" />
                 }
               />
-            </Routes>
-          </MemoryRouter>
+            </>
+          ),
+          { initialEntries: ["/contacts/1"] }
         );
+
+        function Contacts() {
+          let { search, hash } = useLocation();
+          return (
+            <>
+              <h1>Contacts</h1>
+              <p>
+                {search}
+                {hash}
+              </p>
+            </>
+          );
+        }
+
+        let renderer: TestRenderer.ReactTestRenderer;
+        TestRenderer.act(() => {
+          renderer = TestRenderer.create(<RouterProvider router={router} />);
+        });
+
+        // @ts-expect-error
+        let button = renderer.root.findByType("button");
+        TestRenderer.act(() => button.props.onClick());
+
+        // @ts-expect-error
+        expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          [
+            <h1>
+              Contacts
+            </h1>,
+            <p>
+              ?foo=bar
+              #hash
+            </p>,
+          ]
+        `);
+      });
+    });
+
+    it("is stable across location changes", () => {
+      let router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            Component: () => (
+              <>
+                <NavBar />
+                <Outlet />
+              </>
+            ),
+            children: [
+              {
+                path: "home",
+                element: <h1>Home</h1>,
+              },
+              {
+                path: "about",
+                element: <h1>About</h1>,
+              },
+            ],
+          },
+        ],
+        { initialEntries: ["/home"] }
+      );
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
       });
 
-      function Contacts() {
-        let { search, hash } = useLocation();
+      function NavBar() {
+        let count = React.useRef(0);
+        let navigate = useNavigate();
+        React.useEffect(() => {
+          count.current++;
+        }, [navigate]);
         return (
-          <>
-            <h1>Contacts</h1>
-            <p>
-              {search}
-              {hash}
-            </p>
-          </>
+          <nav>
+            <button onClick={() => router.navigate("/home")}>Home</button>
+            <button onClick={() => router.navigate("/about")}>About</button>
+            <p>{count.current}</p>
+          </nav>
         );
       }
 
       // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              0
+            </p>
+          </nav>,
+          <h1>
+            Home
+          </h1>,
+        ]
+      `);
+
+      // @ts-expect-error
+      let buttons = renderer.root.findAllByType("button");
+      TestRenderer.act(() => {
+        buttons[1].props.onClick(); // link to /about
+      });
 
       // @ts-expect-error
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              1
+            </p>
+          </nav>,
           <h1>
-            Contacts
+            About
           </h1>,
-          <p>
-            ?foo=bar
-            #hash
-          </p>,
+        ]
+      `);
+
+      // @ts-expect-error
+      buttons = renderer.root.findAllByType("button");
+      TestRenderer.act(() => {
+        buttons[0].props.onClick(); // link back to /home
+      });
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        [
+          <nav>
+            <button
+              onClick={[Function]}
+            >
+              Home
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              About
+            </button>
+            <p>
+              1
+            </p>
+          </nav>,
+          <h1>
+            Home
+          </h1>,
         ]
       `);
     });
   });
-
-  it("is not stable across location changes", () => {
-    let router = createMemoryRouter(
-      [
-        {
-          path: "/",
-          Component: () => (
-            <>
-              <NavBar />
-              <Outlet />
-            </>
-          ),
-          children: [
-            {
-              path: "home",
-              element: <h1>Home</h1>,
-            },
-            {
-              path: "about",
-              element: <h1>About</h1>,
-            },
-          ],
-        },
-      ],
-      { initialEntries: ["/home"] }
-    );
-
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
-    });
-
-    function NavBar() {
-      let count = React.useRef(0);
-      let navigate = useNavigate();
-      React.useEffect(() => {
-        count.current++;
-      }, [navigate]);
-      return (
-        <nav>
-          <button onClick={() => router.navigate("/home")}>Home</button>
-          <button onClick={() => router.navigate("/about")}>About</button>
-          <p>{count.current}</p>
-        </nav>
-      );
-    }
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            0
-          </p>
-        </nav>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-
-    // @ts-expect-error
-    let buttons = renderer.root.findAllByType("button");
-    TestRenderer.act(() => {
-      buttons[1].props.onClick();
-    });
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            1
-          </p>
-        </nav>,
-        <h1>
-          About
-        </h1>,
-      ]
-    `);
-
-    // @ts-expect-error
-    buttons = renderer.root.findAllByType("button");
-    TestRenderer.act(() => {
-      buttons[0].props.onClick();
-    });
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            2
-          </p>
-        </nav>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-  });
 });
 
-function UseRouterNavigateButton({
+function UseNavigateButton({
   to,
   relative,
 }: {
   to: To;
   relative?: RelativeRoutingType;
 }) {
-  let navigate = useRouterNavigate();
+  let navigate = useNavigate();
   return <button onClick={() => navigate(to, { relative })}>Navigate</button>;
 }
-
-describe("useRouterNavigate (mimicing <Navigate> tests)", () => {
-  describe("with an absolute href", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={<UseRouterNavigateButton to="/about" />}
-            />
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=route)", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={<UseRouterNavigateButton to="../about" />}
-            />
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home">
-              <Route
-                index
-                element={<UseRouterNavigateButton to="../about" />}
-              />
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route element={<Outlet />}>
-              <Route
-                path="home"
-                element={<UseRouterNavigateButton to="../about" />}
-              />
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home">
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      index
-                      element={<UseRouterNavigateButton to="../about" />}
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="home" element={<Outlet />}>
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path="page"
-                      element={<UseRouterNavigateButton to="../../about" />}
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home/page"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          About
-        </h1>
-      `);
-    });
-
-    it("handles parent navigation from inside multiple pathless layout routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="home"
-              element={
-                <>
-                  <h1>Home</h1>
-                  <Outlet />
-                </>
-              }
-            >
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path="page"
-                      element={
-                        <>
-                          <h2>Page</h2>
-                          <UseRouterNavigateButton to=".." />
-                        </>
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="about" element={<h1>About</h1>} />
-          </>
-        ),
-        { initialEntries: ["/home/page"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Home
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="layout">
-              <Route path=":param">
-                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                <Route index element={<UseRouterNavigateButton to="dest" />} />
-                <Route path="dest" element={<h1>Destination</h1>} />
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/layout/thing"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-  });
-
-  describe("with a relative href (relative=path)", () => {
-    it("navigates to the correct URL", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route
-              path="contacts/:id"
-              element={<UseRouterNavigateButton to=".." relative="path" />}
-            />
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from an index routes", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route path="contacts/:id">
-              <Route
-                index
-                element={<UseRouterNavigateButton to=".." relative="path" />}
-              />
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside a pathless layout route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route element={<Outlet />}>
-              <Route
-                path="contacts/:id"
-                element={<UseRouterNavigateButton to=".." relative="path" />}
-              />
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<h1>Contacts</h1>} />
-            <Route path="contacts/:id">
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      index
-                      element={
-                        <UseRouterNavigateButton to=".." relative="path" />
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles upward navigation from inside multiple pathless layout routes + path route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<Outlet />}>
-              <Route index element={<h1>Contacts</h1>} />
-              <Route element={<Outlet />}>
-                <Route element={<Outlet />}>
-                  <Route element={<Outlet />}>
-                    <Route
-                      path=":id"
-                      element={
-                        <UseRouterNavigateButton to=".." relative="path" />
-                      }
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Contacts
-        </h1>
-      `);
-    });
-
-    it("handles relative navigation from nested index route", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="layout">
-              <Route path=":param">
-                {/* redirect /layout/:param/ index routes to /layout/:param/dest */}
-                <Route
-                  index
-                  element={
-                    <UseRouterNavigateButton to="dest" relative="path" />
-                  }
-                />
-                <Route path="dest" element={<h1>Destination</h1>} />
-              </Route>
-            </Route>
-          </>
-        ),
-        { initialEntries: ["/layout/thing"] }
-      );
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        <h1>
-          Destination
-        </h1>
-      `);
-    });
-
-    it("preserves search params and hash", () => {
-      let router = createMemoryRouter(
-        createRoutesFromElements(
-          <>
-            <Route path="contacts" element={<Contacts />} />
-            <Route
-              path="contacts/:id"
-              element={
-                <UseRouterNavigateButton to="..?foo=bar#hash" relative="path" />
-              }
-            />
-          </>
-        ),
-        { initialEntries: ["/contacts/1"] }
-      );
-
-      function Contacts() {
-        let { search, hash } = useLocation();
-        return (
-          <>
-            <h1>Contacts</h1>
-            <p>
-              {search}
-              {hash}
-            </p>
-          </>
-        );
-      }
-
-      let renderer: TestRenderer.ReactTestRenderer;
-      TestRenderer.act(() => {
-        renderer = TestRenderer.create(<RouterProvider router={router} />);
-      });
-
-      // @ts-expect-error
-      let button = renderer.root.findByType("button");
-      TestRenderer.act(() => button.props.onClick());
-
-      // @ts-expect-error
-      expect(renderer.toJSON()).toMatchInlineSnapshot(`
-        [
-          <h1>
-            Contacts
-          </h1>,
-          <p>
-            ?foo=bar
-            #hash
-          </p>,
-        ]
-      `);
-    });
-  });
-
-  it("is not stable across location changes", () => {
-    let router = createMemoryRouter(
-      [
-        {
-          path: "/",
-          Component: () => (
-            <>
-              <NavBar />
-              <Outlet />
-            </>
-          ),
-          children: [
-            {
-              path: "home",
-              element: <h1>Home</h1>,
-            },
-            {
-              path: "about",
-              element: <h1>About</h1>,
-            },
-          ],
-        },
-      ],
-      { initialEntries: ["/home"] }
-    );
-
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
-    });
-
-    function NavBar() {
-      let count = React.useRef(0);
-      let navigate = useRouterNavigate();
-      React.useEffect(() => {
-        count.current++;
-      }, [navigate]);
-      return (
-        <nav>
-          <button onClick={() => router.navigate("/home")}>Home</button>
-          <button onClick={() => router.navigate("/about")}>About</button>
-          <p>{count.current}</p>
-        </nav>
-      );
-    }
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            0
-          </p>
-        </nav>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-
-    // @ts-expect-error
-    let buttons = renderer.root.findAllByType("button");
-    TestRenderer.act(() => {
-      buttons[1].props.onClick();
-    });
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            1
-          </p>
-        </nav>,
-        <h1>
-          About
-        </h1>,
-      ]
-    `);
-
-    // @ts-expect-error
-    buttons = renderer.root.findAllByType("button");
-    TestRenderer.act(() => {
-      buttons[0].props.onClick();
-    });
-
-    // @ts-expect-error
-    expect(renderer.toJSON()).toMatchInlineSnapshot(`
-      [
-        <nav>
-          <button
-            onClick={[Function]}
-          >
-            Home
-          </button>
-          <button
-            onClick={[Function]}
-          >
-            About
-          </button>
-          <p>
-            1
-          </p>
-        </nav>,
-        <h1>
-          Home
-        </h1>,
-      ]
-    `);
-  });
-});

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -898,7 +898,7 @@ describe("useNavigate", () => {
           <nav>
             <button onClick={() => navigate("/home")}>Home</button>
             <button onClick={() => navigate("/about")}>About</button>
-            <p>{count.current}</p>
+            <p>{`count:${count.current}`}</p>
           </nav>
         );
       }
@@ -918,7 +918,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              0
+              count:0
             </p>
           </nav>,
           <h1>
@@ -948,7 +948,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              1
+              count:1
             </p>
           </nav>,
           <h1>
@@ -978,7 +978,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              2
+              count:2
             </p>
           </nav>,
           <h1>
@@ -1585,7 +1585,7 @@ describe("useNavigate", () => {
           <nav>
             <button onClick={() => router.navigate("/home")}>Home</button>
             <button onClick={() => router.navigate("/about")}>About</button>
-            <p>{count.current}</p>
+            <p>{`count:${count.current}`}</p>
           </nav>
         );
       }
@@ -1605,7 +1605,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              0
+              count:0
             </p>
           </nav>,
           <h1>
@@ -1635,7 +1635,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              1
+              count:1
             </p>
           </nav>,
           <h1>
@@ -1665,7 +1665,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              1
+              count:1
             </p>
           </nav>,
           <h1>

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -908,47 +908,93 @@ describe("useNavigate (mimicing <Navigate> tests)", () => {
       React.useEffect(() => {
         count.current++;
       }, [navigate]);
-      return <p>{count.current}</p>;
+      return (
+        <nav>
+          <button onClick={() => router.navigate("/home")}>Home</button>
+          <button onClick={() => router.navigate("/about")}>About</button>
+          <p>{count.current}</p>
+        </nav>
+      );
     }
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          0
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            0
+          </p>
+        </nav>,
         <h1>
           Home
         </h1>,
       ]
     `);
 
+    // @ts-expect-error
+    let buttons = renderer.root.findAllByType("button");
     TestRenderer.act(() => {
-      router.navigate("/about");
+      buttons[1].props.onClick();
     });
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          1
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            1
+          </p>
+        </nav>,
         <h1>
           About
         </h1>,
       ]
     `);
 
+    // @ts-expect-error
+    buttons = renderer.root.findAllByType("button");
     TestRenderer.act(() => {
-      router.navigate("/home");
+      buttons[0].props.onClick();
     });
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          2
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            2
+          </p>
+        </nav>,
         <h1>
           Home
         </h1>,
@@ -1535,7 +1581,7 @@ describe("useRouterNavigate (mimicing <Navigate> tests)", () => {
     });
   });
 
-  it("is stable across location changes", () => {
+  it("is not stable across location changes", () => {
     let router = createMemoryRouter(
       [
         {
@@ -1561,58 +1607,104 @@ describe("useRouterNavigate (mimicing <Navigate> tests)", () => {
       { initialEntries: ["/home"] }
     );
 
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
     function NavBar() {
       let count = React.useRef(0);
       let navigate = useRouterNavigate();
       React.useEffect(() => {
         count.current++;
       }, [navigate]);
-      return <p>{count.current}</p>;
+      return (
+        <nav>
+          <button onClick={() => router.navigate("/home")}>Home</button>
+          <button onClick={() => router.navigate("/about")}>About</button>
+          <p>{count.current}</p>
+        </nav>
+      );
     }
-
-    let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
-    });
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          0
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            0
+          </p>
+        </nav>,
         <h1>
           Home
         </h1>,
       ]
     `);
 
+    // @ts-expect-error
+    let buttons = renderer.root.findAllByType("button");
     TestRenderer.act(() => {
-      router.navigate("/about");
+      buttons[1].props.onClick();
     });
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          1
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            1
+          </p>
+        </nav>,
         <h1>
           About
         </h1>,
       ]
     `);
 
+    // @ts-expect-error
+    buttons = renderer.root.findAllByType("button");
     TestRenderer.act(() => {
-      router.navigate("/home");
+      buttons[0].props.onClick();
     });
 
     // @ts-expect-error
     expect(renderer.toJSON()).toMatchInlineSnapshot(`
       [
-        <p>
-          1
-        </p>,
+        <nav>
+          <button
+            onClick={[Function]}
+          >
+            Home
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            About
+          </button>
+          <p>
+            1
+          </p>
+        </nav>,
         <h1>
           Home
         </h1>,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -102,13 +102,13 @@ import {
   useActionData,
   useAsyncError,
   useAsyncValue,
+  useRouteId,
   useLoaderData,
   useMatches,
   useNavigation,
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
-  useRouterNavigate,
 } from "./lib/hooks";
 
 // Exported for backwards compatibility, but not being used internally anymore
@@ -205,8 +205,8 @@ export {
   useResolvedPath,
   useRevalidator,
   useRouteError,
+  useRouteId,
   useRouteLoaderData,
-  useRouterNavigate,
   useRoutes,
 };
 
@@ -256,7 +256,7 @@ export function createMemoryRouter(
   routes: RouteObject[],
   opts?: {
     basename?: string;
-    future?: FutureConfig;
+    future?: Partial<Omit<FutureConfig, "v7_prependBasename">>;
     hydrationData?: HydrationState;
     initialEntries?: InitialEntry[];
     initialIndex?: number;
@@ -264,7 +264,10 @@ export function createMemoryRouter(
 ): RemixRouter {
   return createRouter({
     basename: opts?.basename,
-    future: opts?.future,
+    future: {
+      ...opts?.future,
+      v7_prependBasename: true,
+    },
     history: createMemoryHistory({
       initialEntries: opts?.initialEntries,
       initialIndex: opts?.initialIndex,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -205,7 +205,6 @@ export {
   useResolvedPath,
   useRevalidator,
   useRouteError,
-  useRouteId,
   useRouteLoaderData,
   useRoutes,
 };
@@ -299,4 +298,5 @@ export {
   DataRouterContext as UNSAFE_DataRouterContext,
   DataRouterStateContext as UNSAFE_DataRouterStateContext,
   mapRouteProperties as UNSAFE_mapRouteProperties,
+  useRouteId as UNSAFE_useRouteId,
 };

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -17,6 +17,7 @@ import type {
   PathMatch,
   PathPattern,
   RedirectFunction,
+  RelativeRoutingType,
   Router as RemixRouter,
   ShouldRevalidateFunction,
   To,
@@ -76,7 +77,6 @@ import type {
   NonIndexRouteObject,
   RouteMatch,
   RouteObject,
-  RelativeRoutingType,
 } from "./lib/context";
 import {
   DataRouterContext,
@@ -108,6 +108,7 @@ import {
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
+  useRouterNavigate,
 } from "./lib/hooks";
 
 // Exported for backwards compatibility, but not being used internally anymore
@@ -205,6 +206,7 @@ export {
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
+  useRouterNavigate,
   useRoutes,
 };
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -8,6 +8,7 @@ import type {
   RouterState,
   To,
   LazyRouteFunction,
+  RelativeRoutingType,
 } from "@remix-run/router";
 import {
   Action as NavigationType,
@@ -27,7 +28,6 @@ import type {
   RouteObject,
   Navigator,
   NonIndexRouteObject,
-  RelativeRoutingType,
 } from "./context";
 import {
   LocationContext,

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -5,6 +5,7 @@ import type {
   AgnosticNonIndexRouteObject,
   History,
   Location,
+  RelativeRoutingType,
   Router,
   StaticHandlerContext,
   To,
@@ -87,8 +88,6 @@ export const AwaitContext = React.createContext<TrackedPromise | null>(null);
 if (__DEV__) {
   AwaitContext.displayName = "Await";
 }
-
-export type RelativeRoutingType = "route" | "path";
 
 export interface NavigateOptions {
   replace?: boolean;

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -106,7 +106,17 @@ router.fetch("key", "/page", {
 
 By default, active loaders will revalidate after any navigation or fetcher mutation. If you need to kick off a revalidation for other use-cases, you can use `router.revalidate()` to re-execute all active loaders.
 
+### Future Flags
+
+We use _Future Flags_ in the router to help us introduce breaking changes in an opt-in fashion ahead of major releases. Please check out the [blog post][future-flags-post] and [React Router Docs][api-development-strategy] for more information on this process. The currently available future flags in `@remix-run/router` are:
+
+| Flag | Description |
+| `v7_normalizeFormMethod` | Normalize `useNavigation().formMethod` to be an uppercase HTTP Method |
+| `v7_prependBasename` | Prepend the `basename` to incoming `router.navigate`/`router.fetch` paths |
+
 [react-router]: https://reactrouter.com
 [remix]: https://remix.run
 [react-router-repo]: https://github.com/remix-run/react-router
 [remix-routers-repo]: https://github.com/brophdawg11/remix-routers
+[api-development-strategy]: https://reactrouter.com/en/main/guides/api-development-strategy
+[future-flags-post]: https://remix.run/blog/future-flags

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -17,12 +17,19 @@ A Router instance can be created using `createRouter`:
 // including history listeners and kicking off the initial data fetch
 let router = createRouter({
   // Required properties
-  routes, // Routes array
-  history, // History instance
+  routes: [{
+    path: '/',
+    loader: ({ request, params }) => { /* ... */ },
+    children: [{
+      path: 'home',
+      loader: ({ request, params }) => { /* ... */ },
+    }]
+  },
+  history: createBrowserHistory(),
 
   // Optional properties
   basename, // Base path
-  mapRouteProperties, // Map function framework-agnostic routes to framework-aware routes
+  mapRouteProperties, // Map framework-agnostic routes to framework-aware routes
   future, // Future flags
   hydrationData, // Hydration data if using server-side-rendering
 }).initialize();
@@ -82,6 +89,11 @@ formData.append(key, value);
 router.navigate("/page", {
   formMethod: "post",
   formData,
+});
+
+// Relative routing from a source routeId
+router.navigate("../../somewhere", {
+  fromRouteId: "active-route-id",
 });
 ```
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -15942,6 +15942,57 @@ describe("a router", () => {
       /* eslint-enable jest/expect-expect */
     });
 
+    it("resolves relative routes when using relative:path", () => {
+      let history = createMemoryHistory({
+        initialEntries: ["/a/b/c/d/e/f"],
+      });
+      let routes = [
+        {
+          id: "a",
+          path: "/a",
+          children: [
+            {
+              id: "bc",
+              path: "b/c",
+              children: [
+                {
+                  id: "de",
+                  path: "d/e",
+                  children: [
+                    {
+                      id: "f",
+                      path: "f",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      // Navigating without relative:path
+      let router = createRouter({ routes, history }).initialize();
+      router.navigate("..");
+      expect(router.state.location.pathname).toBe("/a/b/c/d/e");
+      router.navigate("/a/b/c/d/e/f");
+
+      router.navigate("../..");
+      expect(router.state.location.pathname).toBe("/a/b/c");
+      router.navigate("/a/b/c/d/e/f");
+
+      // Navigating with relative:path
+      router.navigate("..", { relative: "path" });
+      expect(router.state.location.pathname).toBe("/a/b/c/d/e");
+      router.navigate("/a/b/c/d/e/f");
+
+      router.navigate("../..", { relative: "path" });
+      expect(router.state.location.pathname).toBe("/a/b/c/d");
+      router.navigate("/a/b/c/d/e/f");
+
+      router.dispose();
+    });
+
     it("should not append ?index to get submission navigations to self from index route", () => {
       let router = createRouter({
         routes: [

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -15669,7 +15669,6 @@ describe("a router", () => {
       });
 
       it("from a splat route", () => {
-        debugger;
         assertRoutingToSelf(
           [
             {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -15543,7 +15543,7 @@ describe("a router", () => {
     });
   });
 
-  describe.only("router.resolveRoute", () => {
+  describe.skip("router.resolveRoute", () => {
     it("static routes", () => {
       let router = createRouter({
         routes: [

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -15542,4 +15542,215 @@ describe("a router", () => {
       });
     });
   });
+
+  describe.only("router.resolveRoute", () => {
+    it("static routes", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    id: "activeRoute",
+                    path: "bar",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo/bar?a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+    });
+
+    it("layout routes", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    id: "activeRoute",
+                    path: "bar",
+                    children: [
+                      {
+                        index: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo/bar?a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+    });
+
+    it("index routes", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    path: "bar",
+                    children: [
+                      {
+                        id: "activeRoute",
+                        index: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo/bar?index&a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar?index"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar?index"
+      );
+    });
+
+    it("index routes with a path", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    id: "activeRoute",
+                    path: "bar",
+                    index: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo/bar?index&a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar?index"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar?index"
+      );
+    });
+
+    it("dynamic routes", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    id: "activeRoute",
+                    path: ":param",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo/bar?a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo/bar"
+      );
+    });
+
+    it("splat routes", () => {
+      let router = createRouter({
+        routes: [
+          {
+            path: "/",
+            children: [
+              {
+                path: "foo",
+                children: [
+                  {
+                    id: "activeRoute",
+                    path: "*",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        history: createMemoryHistory({
+          initialEntries: ["/foo/bar?a=1#hash"],
+        }),
+      });
+      expect(
+        router.resolvePath(undefined, { fromRouteId: "activeRoute" })
+      ).toBe("/foo?a=1#hash");
+      expect(router.resolvePath(".", { fromRouteId: "activeRoute" })).toBe(
+        "/foo"
+      );
+      expect(router.resolvePath("", { fromRouteId: "activeRoute" })).toBe(
+        "/foo"
+      );
+    });
+  });
 });

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -3707,6 +3707,7 @@ describe("a router", () => {
           ],
           future: {
             v7_normalizeFormMethod: true,
+            v7_prependBasename: false,
           },
         });
         let A = await t.navigate("/child", {
@@ -15746,16 +15747,13 @@ describe("a router", () => {
       });
 
       it("from an index route with a path", () => {
-        assertRoutingToParent(
-          [
-            {
-              id: "activeRoute",
-              path: "bar",
-              index: true,
-            },
-          ],
-          "/foo"
-        );
+        assertRoutingToParent([
+          {
+            id: "activeRoute",
+            path: "bar",
+            index: true,
+          },
+        ]);
       });
 
       it("from a dynamic param route", () => {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3167,9 +3167,9 @@ function normalizeNavigateOptions(
   // Flatten submission onto URLSearchParams for GET submissions
   let parsedPath = parsePath(path);
   let searchParams = convertFormDataToSearchParams(opts.formData);
-  // Since fetcher GET submissions only run a single loader (as opposed to
-  // navigation GET submissions which run all loaders), we need to preserve
-  // any incoming ?index params
+  // On GET navigation submissions we can drop the ?index param from the
+  // resulting location since all loaders will run.  But fetcher GET submissions
+  // only run a single loader so we need to preserve any incoming ?index params
   if (isFetcher && parsedPath.search && hasNakedIndexQuery(parsedPath.search)) {
     searchParams.append("index", "");
   }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3125,7 +3125,7 @@ function normalizeTo(
 // URLSearchParams so they behave identically to links with query params
 function normalizeNavigateOptions(
   normalizeFormMethod: boolean,
-  isFetcher = false,
+  isFetcher: boolean,
   path: string,
   opts?: RouterNavigateOptions
 ): {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3066,8 +3066,11 @@ function normalizeTo(
 ) {
   let contextualMatches: AgnosticDataRouteMatch[];
   let activeRouteMatch: AgnosticDataRouteMatch | undefined;
-  if (fromRouteId != null) {
-    // Grab matches up to the calling route
+  if (fromRouteId != null && relative !== "path") {
+    // Grab matches up to the calling route so our route-relative logic is
+    // relative to the correct source route.  When using relative:path,
+    // fromRouteId is ignored since that is always relative to the current
+    // location path
     contextualMatches = [];
     for (let match of matches) {
       contextualMatches.push(match);
@@ -3099,7 +3102,7 @@ function normalizeTo(
 
   // Add an ?index param for matched index routes if we don't already have one
   if (
-    (!to || to === ".") &&
+    (to == null || to === "" || to === ".") &&
     activeRouteMatch &&
     activeRouteMatch.route.index &&
     !hasNakedIndexQuery(path.search)

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1357,7 +1357,7 @@ export function createRouter(init: RouterInit): Router {
         matches,
         manifest,
         mapRouteProperties,
-        router.basename
+        basename
       );
 
       if (request.signal.aborted) {
@@ -1725,7 +1725,7 @@ export function createRouter(init: RouterInit): Router {
       requestMatches,
       manifest,
       mapRouteProperties,
-      router.basename
+      basename
     );
 
     if (fetchRequest.signal.aborted) {
@@ -1968,7 +1968,7 @@ export function createRouter(init: RouterInit): Router {
       matches,
       manifest,
       mapRouteProperties,
-      router.basename
+      basename
     );
 
     // Deferred isn't supported for fetcher loads, await everything and treat it
@@ -2185,7 +2185,7 @@ export function createRouter(init: RouterInit): Router {
           matches,
           manifest,
           mapRouteProperties,
-          router.basename
+          basename
         )
       ),
       ...fetchersToLoad.map((f) => {
@@ -2197,7 +2197,7 @@ export function createRouter(init: RouterInit): Router {
             f.matches,
             manifest,
             mapRouteProperties,
-            router.basename
+            basename
           );
         } else {
           let error: ErrorResult = {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3467,7 +3467,7 @@ async function callLoaderOrAction(
   matches: AgnosticDataRouteMatch[],
   manifest: RouteManifest,
   mapRouteProperties: MapRoutePropertiesFunction,
-  basename = "/",
+  basename: string,
   isStaticRequest: boolean = false,
   isRouteRequest: boolean = false,
   requestContext?: unknown


### PR DESCRIPTION
This work closes a handful of things:
* Stabilizes `useNavigate` across `location` changes: https://github.com/remix-run/react-router/issues/7634#issuecomment-1306650156
* Stabilizes `useSubmit` and `fetcher.submit` across location changes: https://github.com/remix-run/react-router/issues/9739
  * Forked off from https://github.com/remix-run/react-router/discussions/9737
* It does this by moving the relative routing logic into `@remix-run/router` (when using a `RouterProvider`): https://github.com/remix-run/react-router/discussions/9588
* We also get `basename` handling for fetchers with this: https://github.com/remix-run/react-router/issues/9711