### PR TITLE
Add docs section in Link/Navlink for `reloadDocument`

### DIFF
--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -151,4 +151,3 @@ The `reloadDocument` property can be used to skip client side routing and let th
 [history-replace-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
 [history-push-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
-  

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -142,12 +142,13 @@ You can access this state value while on the "new-path" route:
 let { state } = useLocation();
 ```
 
+## `reloadDocument`
+
+The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
+
 [link-native]: ./link-native
 [scrollrestoration]: ./scroll-restoration
 [history-replace-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
 [history-push-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
   
-## `reloadDocument`
-
-The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -147,3 +147,7 @@ let { state } = useLocation();
 [history-replace-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
 [history-push-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
+  
+## `reloadDocument`
+
+The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -121,3 +121,7 @@ Adding the `caseSensitive` prop changes the matching logic to make it case sensi
 When a `NavLink` is active it will automatically apply `<a aria-current="page">` to the underlying anchor tag. See [aria-current][aria-current] on MDN.
 
 [aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
+  
+## `reloadDocument`
+
+The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -120,8 +120,8 @@ Adding the `caseSensitive` prop changes the matching logic to make it case sensi
 
 When a `NavLink` is active it will automatically apply `<a aria-current="page">` to the underlying anchor tag. See [aria-current][aria-current] on MDN.
 
-[aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
-  
 ## `reloadDocument`
 
 The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
+
+[aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current


### PR DESCRIPTION
I see this is documented above, but I didn't realize it was an option until I was reading the source and saw it in the type of the props