### PR TITLE
Add better control over submission serialization 

### DIFF
--- a/.changeset/raw-payload-submission-router.md
+++ b/.changeset/raw-payload-submission-router.md
@@ -1,0 +1,52 @@
+---
+"@remix-run/router": minor
+---
+
+Add support for a new `payload` parameter for `router.navigate` and `router.fetch` submissions. This allows you to submit data to an action without requiring serialization into a `FormData` instance. This `payload` value wil be passed unaltered to your action function.
+
+```js
+router.navigate("/", { payload: { key: "value" } });
+
+function action({ request, payload }) {
+  // payload is `{ key: 'value' }`
+  // request.body is `null`
+}
+```
+
+You may also opt-into serialization of this `payload` into your `request` using the `formEncType` parameter:
+
+```js
+router.navigate("/", {
+  payload: { key: "value" },
+  formEncType: "application/json",
+});
+
+function action({ request, payload }) {
+  // payload is `{ key: 'value' }`
+  // await request.text() is '{"key":"value"}'
+}
+```
+
+```js
+router.navigate("/", {
+  payload: { key: "value" },
+  formEncType: "application/x-www-form-urlencoded",
+});
+
+function action({ request, payload }) {
+  // payload is `{ key: 'value' }`
+  // await request.formData() is a `FormData` instance with a single entry of key=value
+}
+```
+
+```js
+router.navigate("/", {
+  payload: "Plain ol' text",
+  formEncType: "text/plain",
+});
+
+function action({ request, payload }) {
+  // payload is "Plain ol' text"
+  // await request.text() is "Plain ol' text"
+}
+```

--- a/.changeset/raw-payload-submission-router.md
+++ b/.changeset/raw-payload-submission-router.md
@@ -15,38 +15,6 @@ function action({ request, payload }) {
 
 You may also opt-into serialization of this `payload` into your `request` using the `formEncType` parameter:
 
-```js
-router.navigate("/", {
-  payload: { key: "value" },
-  formEncType: "application/json",
-});
-
-function action({ request, payload }) {
-  // payload              => { key: 'value' }
-  // await request.json() => {"key":"value"}
-}
-```
-
-```js
-router.navigate("/", {
-  payload: { key: "value" },
-  formEncType: "application/x-www-form-urlencoded",
-});
-
-function action({ request, payload }) {
-  // payload                  => { key: 'value' }
-  // await request.formData() => FormData instance with a single entry of key=value
-}
-```
-
-```js
-router.navigate("/", {
-  payload: "Plain ol' text",
-  formEncType: "text/plain",
-});
-
-function action({ request, payload }) {
-  // payload              => "Plain ol' text"
-  // await request.text() => "Plain ol' text"
-}
-```
+- `formEncType: "application/x-ww-form-urlencoded"` => serializes into `request.formData()`
+- `formEncType: "application/json"` => serializes into `request.json()`
+- `formEncType: "text/plain"` => serializes into `request.text()`

--- a/.changeset/raw-payload-submission-router.md
+++ b/.changeset/raw-payload-submission-router.md
@@ -2,14 +2,14 @@
 "@remix-run/router": minor
 ---
 
-Add support for a new `payload` parameter for `router.navigate` and `router.fetch` submissions. This allows you to submit data to an action without requiring serialization into a `FormData` instance. This `payload` value wil be passed unaltered to your action function.
+Add support for a new `payload` parameter for `router.navigate`/`router.fetch` submissions. This allows you to submit data to an `action` without requiring serialization into a `FormData` instance. This `payload` value will be passed unaltered to your `action` function.
 
 ```js
 router.navigate("/", { payload: { key: "value" } });
 
 function action({ request, payload }) {
-  // payload is `{ key: 'value' }`
-  // request.body is `null`
+  // payload      => { key: 'value' }
+  // request.body => null
 }
 ```
 
@@ -22,8 +22,8 @@ router.navigate("/", {
 });
 
 function action({ request, payload }) {
-  // payload is `{ key: 'value' }`
-  // await request.text() is '{"key":"value"}'
+  // payload              => { key: 'value' }
+  // await request.json() => {"key":"value"}
 }
 ```
 
@@ -34,8 +34,8 @@ router.navigate("/", {
 });
 
 function action({ request, payload }) {
-  // payload is `{ key: 'value' }`
-  // await request.formData() is a `FormData` instance with a single entry of key=value
+  // payload                  => { key: 'value' }
+  // await request.formData() => FormData instance with a single entry of key=value
 }
 ```
 
@@ -46,7 +46,7 @@ router.navigate("/", {
 });
 
 function action({ request, payload }) {
-  // payload is "Plain ol' text"
-  // await request.text() is "Plain ol' text"
+  // payload              => "Plain ol' text"
+  // await request.text() => "Plain ol' text"
 }
 ```

--- a/.changeset/raw-payload-submission.md
+++ b/.changeset/raw-payload-submission.md
@@ -1,0 +1,31 @@
+---
+"react-router-dom": minor
+---
+
+Support submission of raw payloads through `useSubmit`/`fetcher.submit` by opting out of serialization into `request.formData` using `encType: null`. When opting-out of serialization, your data will be passed to the action in a new `payload` parameter:
+
+```jsx
+function Component() {
+  let submit = useSubmit();
+  submit({ key: "value" }, { encType: null });
+}
+
+function action({ request, payload }) {
+  // payload is `{ key: 'value' }`
+  // request.body is `null`
+}
+```
+
+Since the default behavior in `useSubmit` today is to serialize to `application/x-www-formn-urlencoded`, that will remain the behavior for `encType:undefined` in v6. But in v7, we plan to change the default behavior for `undefined` to skip serialization. In order to better prepare for this change, we encourage developers to add explicit content types to scenarios in which they are submitting raw JSON objects:
+
+```jsx
+function Component() {
+  let submit = useSubmit();
+
+  // Change this:
+  submit({ key: "value" });
+
+  // To this:
+  submit({ key: "value" }, { encType: "application/x-www-form-urlencoded" });
+}
+```

--- a/.changeset/raw-payload-submission.md
+++ b/.changeset/raw-payload-submission.md
@@ -2,7 +2,7 @@
 "react-router-dom": minor
 ---
 
-Support submission of raw payloads through `useSubmit`/`fetcher.submit` by opting out of serialization into `request.formData` using `encType: null`. When opting-out of serialization, your data will be passed to the action in a new `payload` parameter:
+- Support submission of raw payloads through `useSubmit`/`fetcher.submit` by opting out of serialization into `request.formData` using `encType: null`. When opting-out of serialization, your data will be passed to the action in a new `payload` parameter:
 
 ```jsx
 function Component() {
@@ -11,12 +11,12 @@ function Component() {
 }
 
 function action({ request, payload }) {
-  // payload is `{ key: 'value' }`
-  // request.body is `null`
+  // payload      => { key: 'value' }
+  // request.body => null
 }
 ```
 
-Since the default behavior in `useSubmit` today is to serialize to `application/x-www-formn-urlencoded`, that will remain the behavior for `encType:undefined` in v6. But in v7, we plan to change the default behavior for `undefined` to skip serialization. In order to better prepare for this change, we encourage developers to add explicit content types to scenarios in which they are submitting raw JSON objects:
+Since the default behavior in `useSubmit` today is to serialize to `application/x-www-form-urlencoded`, that will remain the behavior for `encType:undefined` in v6. But in v7, we plan to change the default behavior for `undefined` to skip serialization. In order to better prepare for this change, we encourage developers to add explicit content types to scenarios in which they are submitting raw JSON objects:
 
 ```jsx
 function Component() {
@@ -27,5 +27,43 @@ function Component() {
 
   // To this:
   submit({ key: "value" }, { encType: "application/x-www-form-urlencoded" });
+}
+```
+
+- You may now also opt-into different types of serialization of this `payload` into your `request` using the `formEncType` parameter:
+
+```js
+function Component() {
+  let submit = useSubmit();
+  submit({ key: "value" }, { encType: "application/json" });
+}
+
+function action({ request, payload }) {
+  // payload              => { key: 'value' }
+  // await request.json() => {"key":"value"}
+}
+```
+
+```js
+function Component() {
+  let submit = useSubmit();
+  submit({ key: "value" }, { encType: "application/x-www-form-urlencoded" });
+}
+
+function action({ request, payload }) {
+  // payload                  => { key: 'value' }
+  // await request.formData() => FormData instance with a single entry of key=value
+}
+```
+
+```js
+function Component() {
+  let submit = useSubmit();
+  submit("Plain ol' text", { encType: "text/plain" });
+}
+
+function action({ request, payload }) {
+  // payload              => "Plain ol' text"
+  // await request.text() => "Plain ol' text"
 }
 ```

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -38,6 +38,7 @@ function SomeComponent() {
   // build your UI with these properties
   fetcher.state;
   fetcher.formData;
+  fetcher.payload;
   fetcher.formMethod;
   fetcher.formAction;
   fetcher.data;
@@ -131,6 +132,8 @@ export function useIdleLogout() {
   }, [userIsIdle]);
 }
 ```
+
+`fetcher.submit` is a wrapper around a [`useSubmit`][use-submit] call for the fetcher instance, so it also accepts the same options as `useSubmit`.
 
 If you want to submit to an index route, use the [`?index` param][indexsearchparam].
 
@@ -231,3 +234,4 @@ fetcher.formMethod; // "post"
 [link]: ../components/link
 [form]: ../components/form
 [api-development-strategy]: ../guides/api-development-strategy
+[use-submit]: ./use-submit.md

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -203,6 +203,8 @@ function TaskCheckbox({ task }) {
 }
 ```
 
+If you opt-out of serialization using `encType:null`, then `fetcher.formData` will be `undefined` and your data will be exposed on `fetcher.payload`.
+
 ## `fetcher.formAction`
 
 Tells you the action url the form is being submitted to.
@@ -226,6 +228,10 @@ fetcher.formMethod; // "post"
 ```
 
 <docs-warning>The `fetcher.formMethod` field is lowercase without the `future.v7_normalizeFormMethod` [Future Flag][api-development-strategy]. This is being normalized to uppercase to align with the `fetch()` behavior in v7, so please upgrade your React Router v6 applications to adopt the uppercase HTTP methods.</docs-warning>
+
+## `fetcher.payload`
+
+Any POST, PUT, PATCH, or DELETE that started from a `fetcher.submit(payload, { encType: null })` will have your `payload` value represented in `fetcher.payload`.
 
 [loader]: ../route/loader
 [action]: ../route/action

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -203,7 +203,7 @@ function TaskCheckbox({ task }) {
 }
 ```
 
-If you opt-out of serialization using `encType:null`, then `fetcher.formData` will be `undefined` and your data will be exposed on `fetcher.payload`.
+If you opt-out of serialization using `encType: null`, then `fetcher.formData` will be `undefined` and your data will be exposed on `fetcher.payload`.
 
 ## `fetcher.formAction`
 

--- a/docs/hooks/use-navigation.md
+++ b/docs/hooks/use-navigation.md
@@ -91,7 +91,7 @@ let isRedirecting =
 
 Any POST, PUT, PATCH, or DELETE navigation that started from a `<Form>` or `useSubmit` will have your form's submission data attached to it. This is primarily useful to build "Optimistic UI" with the `submission.formData` [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object.
 
-If you opt-out of serialization using `encType:null`, then `navigation.formData` will be `undefined` and your data will be exposed on `navigation.payload`.
+If you opt-out of serialization using `encType: null`, then `navigation.formData` will be `undefined` and your data will be exposed on `navigation.payload`.
 
 In the case of a GET form submission, `formData` will be empty and the data will be reflected in `navigation.location.search`.
 

--- a/docs/hooks/use-navigation.md
+++ b/docs/hooks/use-navigation.md
@@ -91,11 +91,13 @@ let isRedirecting =
 
 Any POST, PUT, PATCH, or DELETE navigation that started from a `<Form>` or `useSubmit` will have your form's submission data attached to it. This is primarily useful to build "Optimistic UI" with the `submission.formData` [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object.
 
+If you opt-out of serialization using `encType:null`, then `navigation.formData` will be `undefined` and your data will be exposed on `navigation.payload`.
+
 In the case of a GET form submission, `formData` will be empty and the data will be reflected in `navigation.location.search`.
 
 ## `navigation.payload`
 
-Any POST, PUT, PATCH, or DELETE navigation that started from a `useSubmit(payload, { encType: null })` will have your `payload` value represented on the navigation.
+Any POST, PUT, PATCH, or DELETE navigation that started from a `useSubmit(payload, { encType: null })` will have your `payload` value represented in `navigation.payload`.
 
 ## `navigation.location`
 

--- a/docs/hooks/use-navigation.md
+++ b/docs/hooks/use-navigation.md
@@ -23,6 +23,7 @@ function SomeComponent() {
   navigation.state;
   navigation.location;
   navigation.formData;
+  navigation.payload;
   navigation.formAction;
   navigation.formMethod;
 }
@@ -91,6 +92,10 @@ let isRedirecting =
 Any POST, PUT, PATCH, or DELETE navigation that started from a `<Form>` or `useSubmit` will have your form's submission data attached to it. This is primarily useful to build "Optimistic UI" with the `submission.formData` [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) object.
 
 In the case of a GET form submission, `formData` will be empty and the data will be reflected in `navigation.location.search`.
+
+## `navigation.payload`
+
+Any POST, PUT, PATCH, or DELETE navigation that started from a `useSubmit(payload, { encType: null })` will have your `payload` value represented on the navigation.
 
 ## `navigation.location`
 

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -78,6 +78,48 @@ formData.append("cheese", "gouda");
 submit(formData);
 ```
 
+### Payload Serialization
+
+You may also submit raw JSON to your `action` and the default behavior will be to encode the key/values into `FormData`:
+
+```tsx
+let obj = { key: "value" };
+submit(obj); // -> request.formData()
+```
+
+You may also choose which type of serialization you'd like via the `encType` option:
+
+```tsx
+let obj = { key: "value" };
+submit(obj, encType: 'application/x-www-form-urlencoded'); // -> request.formData()
+```
+
+```tsx
+let obj = { key: "value" };
+submit(obj, { encType: "application/json" }); // -> request.json()
+```
+
+```tsx
+let text = "Plain ol' text";
+submit(obj, { encType: "text/plain" }); // -> request.text()
+```
+
+<docs-warn>In future versions of React Router, the default behavior will not serialize raw JSON payloads. If you are submitting raw JSON today it's recommended to specify an explicit `encType`.</docs-warn>
+
+### Opting out of serialization
+
+Sometimes in a client-side application, it's overkill to require serialization into `request.formData` when you have a raw JSON object in your component and want to submit it to your `action` directly. If you'd like to opt out of serialization, you can pass `encType: null` to your second options argument, and your data will be sent to your acton function verbatim as a `payload` parameter:
+
+```tsx
+let obj = { key: "value" };
+submit(obj, { encType: null });
+
+function action({ request, payload }) {
+  // payload is `obj` from your component
+  // request.body === null
+}
+```
+
 ## Submit options
 
 The second argument is a set of options that map directly to form submission attributes:

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -91,7 +91,7 @@ You may also choose which type of serialization you'd like via the `encType` opt
 
 ```tsx
 let obj = { key: "value" };
-submit(obj, encType: 'application/x-www-form-urlencoded'); // -> request.formData()
+submit(obj, { encType: 'application/x-www-form-urlencoded' }); // -> request.formData()
 ```
 
 ```tsx
@@ -108,7 +108,7 @@ submit(obj, { encType: "text/plain" }); // -> request.text()
 
 ### Opting out of serialization
 
-Sometimes in a client-side application, it's overkill to require serialization into `request.formData` when you have a raw JSON object in your component and want to submit it to your `action` directly. If you'd like to opt out of serialization, you can pass `encType: null` to your second options argument, and your data will be sent to your acton function verbatim as a `payload` parameter:
+Sometimes in a client-side application, it's overkill to require serialization into `request.formData` when you have a raw JSON object in your component and want to submit it to your `action` directly. If you'd like to opt out of serialization, you can pass `encType: null` to your second options argument, and your data will be sent to your action function verbatim as a `payload` parameter:
 
 ```tsx
 let obj = { key: "value" };

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -101,6 +101,22 @@ formData.get("lyrics");
 
 For more information on `formData` see [Working with FormData][workingwithformdata].
 
+### Opt-in serialization types
+
+Note that when using [`useSubmit`][usesubmit] you may also pass `encType: "application/json"` or `encType: "text/plain"` to instead serialize your payload into `request.json()` or `request.text()`.
+
+## `payload`
+
+A `payload` is provided to your action when you submit imperatively with [`useSubmit`][usesubmit] and provide a raw javascript value. This value might also be serialized into the request depending on the `encType`.
+
+```jsx
+function Component {
+  let submit = useSubmit();
+  submit({ key: "value" }, { encType: null });
+  // action payload is { key: 'value' }
+}
+```
+
 ## Returning Responses
 
 While you can return anything you want from an action and get access to it from [`useActionData`][useactiondata], you can also return a web [Response][response].
@@ -144,5 +160,6 @@ For more details and expanded use cases, read the [errorElement][errorelement] d
 [form]: ../components/form
 [workingwithformdata]: ../guides/form-data
 [useactiondata]: ../hooks/use-action-data
+[usesubmit]: ../hooks/use-submit
 [returningresponses]: ./loader#returning-responses
 [createbrowserrouter]: ../routers/create-browser-router

--- a/docs/route/should-revalidate.md
+++ b/docs/route/should-revalidate.md
@@ -66,6 +66,7 @@ interface ShouldRevalidateFunction {
     formAction?: Submission["formAction"];
     formEncType?: Submission["formEncType"];
     formData?: Submission["formData"];
+    payload?: Submission["payload"];
     actionResult?: DataResult;
     defaultShouldRevalidate: boolean;
   }): boolean;

--- a/package.json
+++ b/package.json
@@ -114,10 +114,10 @@
       "none": "15.6 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "11.8 kB"
+      "none": "12 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "17.7 kB"
+      "none": "17.9 kB"
     }
   }
 }

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -3132,60 +3132,61 @@ function testDomRouter(
 
       it("serializes formData on submit(object) submissions", async () => {
         let actionSpy = jest.fn();
+        let payload = { a: "1", b: "2" };
         let router = createTestRouter(
-          createRoutesFromElements(
-            <Route path="/" action={actionSpy} element={<FormPage />} />
-          ),
+          [
+            {
+              path: "/",
+              action: actionSpy,
+              Component() {
+                let submit = useSubmit();
+                return (
+                  <button onClick={() => submit(payload, { method: "post" })}>
+                    Submit
+                  </button>
+                );
+              },
+            },
+          ],
           { window: getWindow("/") }
         );
         render(<RouterProvider router={router} />);
-
-        function FormPage() {
-          let submit = useSubmit();
-          return (
-            <button
-              onClick={() => submit({ a: "1", b: "2" }, { method: "post" })}
-            >
-              Submit
-            </button>
-          );
-        }
 
         fireEvent.click(screen.getByText("Submit"));
         let formData = await actionSpy.mock.calls[0][0].request.formData();
         expect(formData.get("a")).toBe("1");
         expect(formData.get("b")).toBe("2");
-        expect(actionSpy.mock.calls[0][0].payload).toBe(undefined);
+        expect(actionSpy.mock.calls[0][0].payload).toBe(payload);
       });
 
       it("serializes formData on submit(object)/encType:application/x-www-form-urlencoded submissions", async () => {
         let actionSpy = jest.fn();
+        let payload = { a: "1", b: "2" };
         let router = createTestRouter(
-          createRoutesFromElements(
-            <Route path="/" action={actionSpy} element={<FormPage />} />
-          ),
+          [
+            {
+              path: "/",
+              action: actionSpy,
+              Component() {
+                let submit = useSubmit();
+                return (
+                  <button
+                    onClick={() =>
+                      submit(payload, {
+                        method: "post",
+                        encType: "application/x-www-form-urlencoded",
+                      })
+                    }
+                  >
+                    Submit
+                  </button>
+                );
+              },
+            },
+          ],
           { window: getWindow("/") }
         );
         render(<RouterProvider router={router} />);
-
-        function FormPage() {
-          let submit = useSubmit();
-          return (
-            <button
-              onClick={() =>
-                submit(
-                  { a: "1", b: "2" },
-                  {
-                    method: "post",
-                    encType: "application/x-www-form-urlencoded",
-                  }
-                )
-              }
-            >
-              Submit
-            </button>
-          );
-        }
 
         fireEvent.click(screen.getByText("Submit"));
         let request = actionSpy.mock.calls[0][0].request;
@@ -3195,35 +3196,37 @@ function testDomRouter(
         let formData = await request.formData();
         expect(formData.get("a")).toBe("1");
         expect(formData.get("b")).toBe("2");
-        expect(actionSpy.mock.calls[0][0].payload).toBe(undefined);
+        expect(actionSpy.mock.calls[0][0].payload).toBe(payload);
       });
 
       it("serializes JSON on submit(object)/encType:application/json submissions", async () => {
         let actionSpy = jest.fn();
+        let payload = { a: "1", b: "2" };
         let router = createTestRouter(
-          createRoutesFromElements(
-            <Route path="/" action={actionSpy} element={<FormPage />} />
-          ),
+          [
+            {
+              path: "/",
+              action: actionSpy,
+              Component() {
+                let submit = useSubmit();
+                return (
+                  <button
+                    onClick={() =>
+                      submit(payload, {
+                        method: "post",
+                        encType: "application/json",
+                      })
+                    }
+                  >
+                    Submit
+                  </button>
+                );
+              },
+            },
+          ],
           { window: getWindow("/") }
         );
         render(<RouterProvider router={router} />);
-
-        let payload = { a: "1", b: "2" };
-        function FormPage() {
-          let submit = useSubmit();
-          return (
-            <button
-              onClick={() =>
-                submit(payload, {
-                  method: "post",
-                  encType: "application/json",
-                })
-              }
-            >
-              Submit
-            </button>
-          );
-        }
 
         fireEvent.click(screen.getByText("Submit"));
         let request = actionSpy.mock.calls[0][0].request;
@@ -3234,30 +3237,32 @@ function testDomRouter(
 
       it("serializes text on submit(object)/encType:text/plain submissions", async () => {
         let actionSpy = jest.fn();
+        let payload = "look ma, no formData!";
         let router = createTestRouter(
-          createRoutesFromElements(
-            <Route path="/" action={actionSpy} element={<FormPage />} />
-          ),
+          [
+            {
+              path: "/",
+              action: actionSpy,
+              Component() {
+                let submit = useSubmit();
+                return (
+                  <button
+                    onClick={() =>
+                      submit(payload, {
+                        method: "post",
+                        encType: "text/plain",
+                      })
+                    }
+                  >
+                    Submit
+                  </button>
+                );
+              },
+            },
+          ],
           { window: getWindow("/") }
         );
         render(<RouterProvider router={router} />);
-
-        let payload = "look ma, no formData!";
-        function FormPage() {
-          let submit = useSubmit();
-          return (
-            <button
-              onClick={() =>
-                submit(payload, {
-                  method: "post",
-                  encType: "text/plain",
-                })
-              }
-            >
-              Submit
-            </button>
-          );
-        }
 
         fireEvent.click(screen.getByText("Submit"));
         let request = actionSpy.mock.calls[0][0].request;

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -9,7 +9,7 @@ import {
   prettyDOM,
 } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { ErrorResponse, IDLE_NAVIGATION, Navigation } from "@remix-run/router";
+import type { ErrorResponse } from "@remix-run/router";
 import type { RouteObject } from "react-router-dom";
 import {
   Form,

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -3156,7 +3156,7 @@ function testDomRouter(
         let formData = await actionSpy.mock.calls[0][0].request.formData();
         expect(formData.get("a")).toBe("1");
         expect(formData.get("b")).toBe("2");
-        expect(actionSpy.mock.calls[0][0].payload).toBe(payload);
+        expect(actionSpy.mock.calls[0][0].payload).toBe(undefined);
       });
 
       it("serializes formData on submit(object)/encType:application/x-www-form-urlencoded submissions", async () => {
@@ -3196,7 +3196,7 @@ function testDomRouter(
         let formData = await request.formData();
         expect(formData.get("a")).toBe("1");
         expect(formData.get("b")).toBe("2");
-        expect(actionSpy.mock.calls[0][0].payload).toBe(payload);
+        expect(actionSpy.mock.calls[0][0].payload).toBe(undefined);
       });
 
       it("serializes JSON on submit(object)/encType:application/json submissions", async () => {

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -253,10 +253,18 @@ export function getFormSubmissionInfo(
       `Cannot submit element that is not <form>, <button>, or ` +
         `<input type="submit|image">`
     );
-  } else if (options.encType === null) {
+  } else if (
+    options.encType !== undefined &&
+    options.encType !== "application/x-www-form-urlencoded" &&
+    options.encType !== "multipart/form-data"
+  ) {
+    // Any encType other than these (null, application/json, text/plain) means
+    // we will not be submitting as FormData so send the payload through.  The
+    // @remix-run/router will handle serialization of the payload upon Request
+    // creation if needed
     method = options.method || defaultMethod;
     action = options.action || null;
-    encType = null;
+    encType = options.encType;
     payload = target;
   } else {
     method = options.method || defaultMethod;
@@ -273,6 +281,8 @@ export function getFormSubmissionInfo(
           formData.append(name, value);
         }
       } else if (target != null) {
+        // To be deprecated in v7 so the default behavior of undefined matches
+        // the null behavior of no-serialization
         for (let name of Object.keys(target)) {
           // @ts-expect-error
           formData.append(name, target[name]);

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -283,6 +283,10 @@ export function getFormSubmissionInfo(
           formData.append(name, value);
         }
       } else if (target != null) {
+        // When a raw object is sent - even though we encode it into formData,
+        // we still expose it as payload so it aligns with the behavior if
+        // encType were application/json or text/plain
+        payload = target;
         // To be deprecated in v7 so the default behavior of undefined matches
         // the null behavior of no-serialization
         for (let name of Object.keys(target)) {

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -257,10 +257,13 @@ export function getFormSubmissionInfo(
     options.encType !== undefined &&
     options.encType !== "application/x-www-form-urlencoded"
   ) {
-    // Any encType other than these (null, application/json, text/plain) means
-    // we will not be submitting as FormData so send the payload through.  The
-    // @remix-run/router will handle serialization of the payload upon Request
-    // creation if needed
+    // The default behavior is to encode as application/x-www-form-urlencoded
+    // into FormData which is handled in the else block below.
+    //
+    // Any other encType value (null, application/json, text/plain) means
+    // we will not be submitting as FormData so send the payload through
+    // directly.  The @remix-run/router will handle serialization of the
+    // payload upon Request creation if needed.
     method = options.method || defaultMethod;
     action = options.action || null;
     encType = options.encType;

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -253,29 +253,41 @@ export function getFormSubmissionInfo(
       `Cannot submit element that is not <form>, <button>, or ` +
         `<input type="submit|image">`
     );
-  } else if (target instanceof FormData) {
+  } else if (
+    options.encType !== undefined &&
+    options.encType !== "application/x-www-form-urlencoded"
+  ) {
+    // Any encType other than these (null, application/json, text/plain) means
+    // we will not be submitting as FormData so send the payload through.  The
+    // @remix-run/router will handle serialization of the payload upon Request
+    // creation if needed
     method = options.method || defaultMethod;
     action = options.action || null;
-    encType = options.encType || defaultEncType;
-    formData = target;
-  } else if (target instanceof URLSearchParams) {
-    method = options.method || defaultMethod;
-    action = options.action || null;
-    encType = options.encType || defaultEncType;
-    formData = new FormData();
-    for (let [name, value] of target) {
-      formData.append(name, value);
-    }
-  } else {
-    // Anything left at this point is a raw payload and router will serialize
-    // it into the request based on the encType
-    method = options.method || defaultMethod;
-    action = options.action || null;
-    // In v7 we want to remove the defaultEncType from here so it defaults to
-    // no serialization
-    encType =
-      options.encType === null ? null : options.encType || defaultEncType;
+    encType = options.encType;
     payload = target;
+  } else {
+    method = options.method || defaultMethod;
+    action = options.action || null;
+    encType = options.encType || defaultEncType;
+
+    if (target instanceof FormData) {
+      formData = target;
+    } else {
+      formData = new FormData();
+
+      if (target instanceof URLSearchParams) {
+        for (let [name, value] of target) {
+          formData.append(name, value);
+        }
+      } else if (target != null) {
+        // To be deprecated in v7 so the default behavior of undefined matches
+        // the null behavior of no-serialization
+        for (let name of Object.keys(target)) {
+          // @ts-expect-error
+          formData.append(name, target[name]);
+        }
+      }
+    }
   }
 
   return { action, method: method.toLowerCase(), encType, formData, payload };

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -55,6 +55,7 @@ import type {
   SubmitOptions,
   ParamKeyValuePair,
   URLSearchParamsInit,
+  SubmitTarget,
 } from "./dom";
 import {
   createSearchParams,
@@ -914,15 +915,6 @@ type SetURLSearchParams = (
   navigateOpts?: NavigateOptions
 ) => void;
 
-type SubmitTarget =
-  | HTMLFormElement
-  | HTMLButtonElement
-  | HTMLInputElement
-  | FormData
-  | URLSearchParams
-  | { [name: string]: string }
-  | null;
-
 /**
  * Submits a HTML `<form>` to the server without reloading the page.
  */
@@ -971,18 +963,16 @@ function useSubmitImpl(
         );
       }
 
-      let { action, method, encType, formData } = getFormSubmissionInfo(
-        target,
-        options,
-        basename
-      );
+      let { action, method, encType, formData, payload } =
+        getFormSubmissionInfo(target, options, basename);
 
       // Base options shared between fetch() and navigate()
       let opts = {
         preventScrollReset: options.preventScrollReset,
         formData,
-        formMethod: method as HTMLFormMethod,
-        formEncType: encType as FormEncType,
+        payload,
+        formMethod: method,
+        formEncType: encType,
       };
 
       if (fetcherKey) {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6059,7 +6059,7 @@ describe("a router", () => {
       expect(request.method).toBe("POST");
       expect(request.url).toBe("http://localhost/");
       expect(request.headers.get("Content-Type")).toBe("application/json");
-      expect(JSON.parse(await request.text())).toEqual(payload);
+      expect(await request.json()).toEqual(payload);
     });
 
     it("serializes payload as application/json if specified (array)", async () => {
@@ -6085,7 +6085,7 @@ describe("a router", () => {
       expect(request.method).toBe("POST");
       expect(request.url).toBe("http://localhost/");
       expect(request.headers.get("Content-Type")).toBe("application/json");
-      expect(JSON.parse(await request.text())).toEqual(payload);
+      expect(await request.json()).toEqual(payload);
     });
 
     it("serializes payload as text/plain if specified", async () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -1910,6 +1910,61 @@ describe("a router", () => {
       router.dispose();
     });
 
+    it("includes payload on actions that return data", async () => {
+      let shouldRevalidate = jest.fn(() => true);
+
+      let history = createMemoryHistory({ initialEntries: ["/child"] });
+      let router = createRouter({
+        history,
+        routes: [
+          {
+            path: "/",
+            id: "root",
+            loader: () => "ROOT",
+            shouldRevalidate,
+            children: [
+              {
+                path: "child",
+                id: "child",
+                loader: () => "CHILD",
+                action: () => "ACTION",
+              },
+            ],
+          },
+        ],
+      });
+      router.initialize();
+
+      // Initial load - no existing data, should always call loader and should
+      // not give use ability to opt-out
+      await tick();
+      let payload = { key: "value" };
+      router.navigate("/child", {
+        formMethod: "post",
+        formEncType: null,
+        payload,
+      });
+      await tick();
+      expect(shouldRevalidate.mock.calls.length).toBe(1);
+      // @ts-expect-error
+      let arg = shouldRevalidate.mock.calls[0][0];
+      expect(arg).toMatchObject({
+        currentParams: {},
+        currentUrl: expect.URL("http://localhost/child"),
+        nextParams: {},
+        nextUrl: expect.URL("http://localhost/child"),
+        defaultShouldRevalidate: true,
+        formMethod: "post",
+        formAction: "/child",
+        formEncType: null,
+        formData: undefined,
+        payload,
+        actionResult: "ACTION",
+      });
+
+      router.dispose();
+    });
+
     it("includes submission on actions that return redirects", async () => {
       let shouldRevalidate = jest.fn(() => true);
 
@@ -6019,6 +6074,10 @@ describe("a router", () => {
         formEncType: "application/x-www-form-urlencoded",
         payload,
       });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
+        payload,
+      });
       await nav.actions.root.resolve("ACTION");
 
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
@@ -6047,6 +6106,10 @@ describe("a router", () => {
         formEncType: "application/json",
         payload,
       });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
+        payload,
+      });
       await nav.actions.root.resolve("ACTION");
 
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
@@ -6071,6 +6134,10 @@ describe("a router", () => {
       let nav = await t.navigate("/", {
         formMethod: "post",
         formEncType: "application/json",
+        payload,
+      });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
         payload,
       });
       await nav.actions.root.resolve("ACTION");
@@ -6099,6 +6166,10 @@ describe("a router", () => {
         formEncType: "text/plain",
         payload,
       });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
+        payload,
+      });
       await nav.actions.root.resolve("ACTION");
 
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
@@ -6124,6 +6195,10 @@ describe("a router", () => {
         formMethod: "post",
         payload,
       });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
+        payload,
+      });
       await nav.actions.root.resolve("ACTION");
 
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
@@ -6147,6 +6222,10 @@ describe("a router", () => {
       let nav = await t.navigate("/", {
         formMethod: "post",
         formEncType: null,
+        payload,
+      });
+      expect(t.router.state.navigation).toMatchObject({
+        formData: undefined,
         payload,
       });
       await nav.actions.root.resolve("ACTION");
@@ -10585,6 +10664,187 @@ describe("a router", () => {
           }
         `);
         expect(t.router.getFetcher(key).data).toBe(undefined);
+      });
+    });
+
+    describe("fetcher submissions", () => {
+      it("serializes payload as application/x-www-form-urlencoded", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = { a: "1" };
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          formEncType: "application/x-www-form-urlencoded",
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("http://localhost/");
+        expect(request.headers.get("Content-Type")).toBe(
+          "application/x-www-form-urlencoded;charset=UTF-8"
+        );
+        expect((await request.formData()).get("a")).toBe("1");
+      });
+
+      it("serializes payload as application/json if specified (object)", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = { a: "1" };
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          formEncType: "application/json",
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("http://localhost/");
+        expect(request.headers.get("Content-Type")).toBe("application/json");
+        expect(await request.json()).toEqual(payload);
+      });
+
+      it("serializes payload as application/json if specified (array)", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = [1, 2, 3];
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          formEncType: "application/json",
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("http://localhost/");
+        expect(request.headers.get("Content-Type")).toBe("application/json");
+        expect(await request.json()).toEqual(payload);
+      });
+
+      it("serializes payload as text/plain if specified", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = "plain text";
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          formEncType: "text/plain",
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("http://localhost/");
+        expect(request.headers.get("Content-Type")).toBe("text/plain");
+        expect(await request.text()).toEqual(payload);
+      });
+
+      it("does not serialize payload when encType=undefined", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = { a: "1" };
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.body).toBe(null);
+        expect(request.headers.get("Content-Type")).toBe(null);
+      });
+
+      it("does not serialize payload when encType=null", async () => {
+        let t = setup({
+          routes: [{ id: "root", path: "/", action: true }],
+        });
+
+        let payload = { a: "1" };
+        let F = await t.fetch("/", "key", {
+          formMethod: "post",
+          formEncType: null,
+          payload,
+        });
+        expect(t.router.state.fetchers.get("key")).toMatchObject({
+          formData: undefined,
+          payload,
+        });
+        await F.actions.root.resolve("ACTION");
+
+        expect(F.actions.root.stub).toHaveBeenCalledWith({
+          params: {},
+          request: expect.any(Request),
+          payload,
+        });
+
+        let request = F.actions.root.stub.mock.calls[0][0].request;
+        expect(request.method).toBe("POST");
+        expect(request.body).toBe(null);
+        expect(request.headers.get("Content-Type")).toBe(null);
       });
     });
   });

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2220,6 +2220,7 @@ describe("a router", () => {
           "formMethod": "post",
           "nextParams": {},
           "nextUrl": "http://localhost/",
+          "payload": undefined,
         }
       `);
       expect(Object.fromEntries(arg.formData)).toEqual({ key: "value" });
@@ -2281,6 +2282,7 @@ describe("a router", () => {
           "formMethod": "post",
           "nextParams": {},
           "nextUrl": "http://localhost/",
+          "payload": undefined,
         }
       `);
 
@@ -9746,6 +9748,7 @@ describe("a router", () => {
               "b": "three",
             },
             "nextUrl": "http://localhost/two/three",
+            "payload": undefined,
           }
         `);
 

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -432,7 +432,6 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
 type BaseSubmissionOptions = {
   formMethod?: HTMLFormMethod;
   formEncType?: FormEncType;
-  action?: ActionFunction;
 } & (
   | { formData: FormData; payload?: undefined }
   | { formData?: undefined; payload: any }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -147,7 +147,7 @@ export interface Router {
     key: string,
     routeId: string,
     href: string | null,
-    opts?: RouterNavigateOptions
+    opts?: RouterFetchOptions
   ): void;
 
   /**
@@ -418,13 +418,25 @@ export interface GetScrollPositionFunction {
 
 export type RelativeRoutingType = "route" | "path";
 
-type BaseNavigateOptions = {
-  replace?: boolean;
-  state?: any;
+type BaseNavigateOrFetchOptions = {
+  fromRouteId?: string;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  fromRouteId?: string;
 };
+
+type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
+  replace?: boolean;
+  state?: any;
+};
+
+type BaseSubmissionOptions = {
+  formMethod?: HTMLFormMethod;
+  formEncType?: FormEncType;
+  action?: ActionFunction;
+} & (
+  | { formData: FormData; payload?: undefined }
+  | { formData?: undefined; payload: any }
+);
 
 /**
  * Options for a navigate() call for a Link navigation
@@ -434,13 +446,7 @@ type LinkNavigateOptions = BaseNavigateOptions;
 /**
  * Options for a navigate() call for a Form navigation
  */
-type SubmissionNavigateOptions = BaseNavigateOptions & {
-  formMethod?: HTMLFormMethod;
-  formEncType?: FormEncType;
-} & (
-    | { formData: FormData; payload?: undefined }
-    | { formData?: undefined; payload: any }
-  );
+type SubmissionNavigateOptions = BaseNavigateOptions & BaseSubmissionOptions;
 
 /**
  * Options to pass to navigate() for either a Link or Form navigation
@@ -450,11 +456,19 @@ export type RouterNavigateOptions =
   | SubmissionNavigateOptions;
 
 /**
+ * Options for a navigate() call for a Link navigation
+ */
+type LoadFetchOptions = BaseNavigateOrFetchOptions;
+
+/**
+ * Options for a navigate() call for a Form navigation
+ */
+type SubmitFetchOptions = BaseNavigateOrFetchOptions & BaseSubmissionOptions;
+
+/**
  * Options to pass to fetch()
  */
-export type RouterFetchOptions =
-  | Omit<LinkNavigateOptions, "replace">
-  | Omit<SubmissionNavigateOptions, "replace">;
+export type RouterFetchOptions = LoadFetchOptions | SubmitFetchOptions;
 
 /**
  * Potential states for state.navigation

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -438,8 +438,8 @@ type SubmissionNavigateOptions = BaseNavigateOptions & {
   formMethod?: HTMLFormMethod;
   formEncType?: FormEncType;
 } & (
-    | { formData: FormData; payload: undefined }
-    | { formData: undefined; payload: any }
+    | { formData: FormData; payload?: undefined }
+    | { formData?: undefined; payload: any }
   );
 
 /**
@@ -485,8 +485,8 @@ export type NavigationStates = {
     formAction: string;
     formEncType: FormEncType;
   } & (
-    | { formData: FormData; payload: undefined }
-    | { formData: undefined; payload: NonNullable<unknown> | null }
+    | { formData: FormData; payload?: undefined }
+    | { formData?: undefined; payload: NonNullable<unknown> | null }
   );
 };
 
@@ -526,8 +526,8 @@ type FetcherStates<TData = any> = {
     data: TData | undefined;
     " _hasFetcherDoneAnything "?: boolean;
   } & (
-    | { formData: FormData; payload: undefined }
-    | { formData: undefined; payload: NonNullable<unknown> | null }
+    | { formData: FormData; payload?: undefined }
+    | { formData?: undefined; payload: NonNullable<unknown> | null }
   );
 };
 
@@ -1291,6 +1291,7 @@ export function createRouter(init: RouterInit): Router {
       let navigation: NavigationStates["Loading"] = {
         state: "loading",
         location,
+        ...EMPTY_SUBMISSION,
         ...opts.submission,
       };
       loadingNavigation = navigation;
@@ -1454,7 +1455,7 @@ export function createRouter(init: RouterInit): Router {
         ? submission || fetcherSubmission
         : loadingNavigation.formMethod &&
           loadingNavigation.formAction &&
-          loadingNavigation.formEncType !== undefined
+          loadingNavigation.formEncType != null
         ? {
             formMethod: loadingNavigation.formMethod,
             formAction: loadingNavigation.formAction,
@@ -1752,6 +1753,7 @@ export function createRouter(init: RouterInit): Router {
       fetchRedirectIds.add(key);
       let loadingFetcher: FetcherStates["Loading"] = {
         state: "loading",
+        ...EMPTY_SUBMISSION,
         ...submission,
         data: undefined,
         " _hasFetcherDoneAnything ": true,
@@ -1798,6 +1800,7 @@ export function createRouter(init: RouterInit): Router {
     let loadFetcher: FetcherStates["Loading"] = {
       state: "loading",
       data: actionResult.data,
+      ...EMPTY_SUBMISSION,
       ...submission,
       " _hasFetcherDoneAnything ": true,
     };
@@ -2113,7 +2116,7 @@ export function createRouter(init: RouterInit): Router {
       formMethod &&
       formAction &&
       (formData || payload) &&
-      formEncType !== undefined
+      formEncType != null
     ) {
       submission = {
         formMethod,
@@ -3162,8 +3165,11 @@ function normalizeNavigateOptions(
     };
   }
 
-  // Can't submit both
-  if (opts.formData != null && opts.payload !== undefined) {
+  // formData/payload are mutually exclusive
+  if (
+    (opts.formData == null && opts.payload === undefined) ||
+    (opts.formData != null && opts.payload !== undefined)
+  ) {
     return {
       path,
       error: getInternalRouterError(400, { type: "formData-payload" }),
@@ -3177,9 +3183,13 @@ function normalizeNavigateOptions(
     ? (rawFormMethod.toUpperCase() as V7_FormMethod)
     : (rawFormMethod.toLowerCase() as FormMethod);
   let formAction = stripHashFromPath(path);
+  let formData: FormData;
 
   // User opted-out of serialization, so just pass along the payload directly
   if (opts.payload !== undefined) {
+    // Any payload encType's besides these pass through as a normal payload and
+    // get serialized in createClientSideRequest since they are not represented
+    // via formData
     submission = {
       formMethod,
       formAction,
@@ -3189,14 +3199,9 @@ function normalizeNavigateOptions(
     };
 
     return { path, submission };
-  }
-
-  if (opts.formData == null) {
-    // But must submit one or the other
-    return {
-      path,
-      error: getInternalRouterError(400, { type: "formData-payload" }),
-    };
+  } else {
+    // We know this exists due to the mutually exclusive check above
+    formData = opts.formData!;
   }
 
   submission = {
@@ -3204,7 +3209,7 @@ function normalizeNavigateOptions(
     formAction,
     formEncType:
       (opts && opts.formEncType) || "application/x-www-form-urlencoded",
-    formData: opts.formData,
+    formData,
     payload: undefined,
   };
 
@@ -3214,7 +3219,7 @@ function normalizeNavigateOptions(
 
   // Flatten submission onto URLSearchParams for GET submissions
   let parsedPath = parsePath(path);
-  let searchParams = convertFormDataToSearchParams(opts.formData);
+  let searchParams = convertFormDataToSearchParams(formData);
   // On GET navigation submissions we can drop the ?index param from the
   // resulting location since all loaders will run.  But fetcher GET submissions
   // only run a single loader so we need to preserve any incoming ?index params
@@ -3716,23 +3721,51 @@ function createClientSideRequest(
   let url = history.createURL(stripHashFromPath(location)).toString();
   let init: RequestInit = { signal };
 
-  if (
-    submission &&
-    isMutationMethod(submission.formMethod) &&
-    submission.formData
-  ) {
-    let { formMethod, formEncType, formData } = submission;
+  if (submission && isMutationMethod(submission.formMethod)) {
+    let { formMethod, formEncType, formData, payload } = submission;
     // Didn't think we needed this but it turns out unlike other methods, patch
     // won't be properly normalized to uppercase and results in a 405 error.
     // See: https://fetch.spec.whatwg.org/#concept-method
     init.method = formMethod.toUpperCase();
-    init.body =
-      formEncType === "application/x-www-form-urlencoded"
-        ? convertFormDataToSearchParams(formData)
-        : formData;
+
+    if (formData) {
+      if (formEncType === "application/x-www-form-urlencoded") {
+        // Content-Type is inferred (https://fetch.spec.whatwg.org/#dom-request)
+        init.body = convertFormDataToSearchParams(formData);
+      } else {
+        // Content-Type is inferred (https://fetch.spec.whatwg.org/#dom-request)
+        init.body = formData;
+      }
+    } else if (payload != null) {
+      if (formEncType === "application/x-www-form-urlencoded") {
+        let payloadFormData = new FormData();
+
+        if (payload instanceof URLSearchParams) {
+          for (let [name, value] of payload) {
+            payloadFormData.append(name, value);
+          }
+        } else if (payload != null) {
+          for (let name of Object.keys(payload)) {
+            // @ts-expect-error
+            payloadFormData.append(name, payload[name]);
+          }
+        }
+
+        // Content-Type is inferred (https://fetch.spec.whatwg.org/#dom-request)
+        init.body = convertFormDataToSearchParams(payloadFormData);
+      } else if (formEncType === "application/json") {
+        init.headers = new Headers({ "Content-Type": formEncType });
+        init.body = JSON.stringify(payload);
+      } else if (formEncType === "text/plain") {
+        init.headers = new Headers({
+          "Content-Type": formEncType,
+        });
+        init.body =
+          typeof payload === "string" ? payload : JSON.stringify(payload);
+      }
+    }
   }
 
-  // Content-Type is inferred (https://fetch.spec.whatwg.org/#dom-request)
   return new Request(url, init);
 }
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -89,6 +89,8 @@ export type V7_MutationFormMethod = Exclude<V7_FormMethod, "GET">;
 export type FormEncType =
   | "application/x-www-form-urlencoded"
   | "multipart/form-data"
+  | "application/json"
+  | "text/plain"
   | null; // Opt-out of serialization
 
 /**
@@ -101,8 +103,8 @@ export type Submission = {
   formAction: string;
   formEncType: FormEncType;
 } & (
-  | { formData: FormData; payload: undefined }
-  | { formData: undefined; payload: NonNullable<unknown> | null }
+  | { formData: FormData; payload?: undefined }
+  | { formData?: undefined; payload: NonNullable<unknown> | null }
 );
 
 /**

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -88,19 +88,22 @@ export type V7_MutationFormMethod = Exclude<V7_FormMethod, "GET">;
 
 export type FormEncType =
   | "application/x-www-form-urlencoded"
-  | "multipart/form-data";
+  | "multipart/form-data"
+  | null; // Opt-out of serialization
 
 /**
  * @private
  * Internal interface to pass around for action submissions, not intended for
  * external consumption
  */
-export interface Submission {
+export type Submission = {
   formMethod: FormMethod | V7_FormMethod;
   formAction: string;
   formEncType: FormEncType;
-  formData: FormData;
-}
+} & (
+  | { formData: FormData; payload: undefined }
+  | { formData: undefined; payload: NonNullable<unknown> | null }
+);
 
 /**
  * @private
@@ -110,6 +113,7 @@ export interface Submission {
 interface DataFunctionArgs {
   request: Request;
   params: Params;
+  payload: any;
   context?: any;
 }
 
@@ -161,6 +165,7 @@ export interface ShouldRevalidateFunction {
     formAction?: Submission["formAction"];
     formEncType?: Submission["formEncType"];
     formData?: Submission["formData"];
+    payload?: any;
     actionResult?: DataResult;
     defaultShouldRevalidate: boolean;
   }): boolean;

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -115,7 +115,6 @@ export type Submission = {
 interface DataFunctionArgs {
   request: Request;
   params: Params;
-  payload: any;
   context?: any;
 }
 
@@ -127,7 +126,9 @@ export interface LoaderFunctionArgs extends DataFunctionArgs {}
 /**
  * Arguments passed to action functions
  */
-export interface ActionFunctionArgs extends DataFunctionArgs {}
+export interface ActionFunctionArgs extends DataFunctionArgs {
+  payload: any;
+}
 
 /**
  * Loaders and actions can return anything except `undefined` (`null` is a


### PR DESCRIPTION
~~Depends on #10336~~

Closes part of #10324 (does not yet handle call-site/override actions - that will be a separate PR):

* Adds support for `useSubmit()(obj, { encType: null })` to opt out of serialization for raw payloads.  These are then passed to the `action` via the `payload` parameter.  Same goes for `fetcher.submit`.
* Add support for opt-in serialization of payloads for `encType:application/json` and `encType:text/plain`

See the changesets for examples.