### PR TITLE
Update routes.md fixing broken link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -86,6 +86,7 @@
 - jacob-ebey
 - JaffParker
 - jakkku
+- jamesrwilliams
 - JakubDrozd
 - janpaepke
 - jasikpark

--- a/docs/components/routes.md
+++ b/docs/components/routes.md
@@ -34,7 +34,7 @@ Whenever the location changes, `<Routes>` looks through all its child routes to 
 </Routes>
 ```
 
-[location]: ../hook/location
+[location]: ../hooks/use-location
 [outlet]: ./outlet
 [use-route]: ../hooks/use-routes
 [createbrowserrouter]: ../routers/create-browser-router

--- a/docs/components/routes.md
+++ b/docs/components/routes.md
@@ -34,7 +34,7 @@ Whenever the location changes, `<Routes>` looks through all its child routes to 
 </Routes>
 ```
 
-[location]: ../hooks/use-location
+[location]: ../utils/location
 [outlet]: ./outlet
 [use-route]: ../hooks/use-routes
 [createbrowserrouter]: ../routers/create-browser-router


### PR DESCRIPTION
Fixes a link that currently 404s on the `<Routes>` component page.
- From: https://reactrouter.com/en/main/hook/location (404s)
- To: https://reactrouter.com/en/main/hooks/use-location