### PR TITLE
chore: update `no-response` workflow

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -22,7 +22,7 @@ jobs:
             anything from the original author after the previous notice.
           close-pr-message: >
             This PR has been automatically closed because we didn't hear
-            anything from the original author after the previous notice anymore.
+            anything from the original author after the previous notice.
           stale-issue-label: needs-response
           stale-issue-message: >
             This issue has been automatically marked stale because we haven't

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           close-issue-message: >
             This issue has been automatically closed because we didn't hear
-            anything from the original author after the previous notice anymore.
+            anything from the original author after the previous notice.
           close-pr-message: >
             This PR has been automatically closed because we didn't hear
             anything from the original author after the previous notice anymore.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -17,18 +17,25 @@ jobs:
       - name: 🥺 Handle Ghosting
         uses: actions/stale@v8
         with:
-          days-before-close: 10
           close-issue-message: >
-            This issue has been automatically closed because we haven't received a
-            response from the original author 🙈. This automation helps keep the issue
-            tracker clean from issues that aren't actionable. Please reach out if you
-            have more information for us! 🙂
+            This issue has been automatically closed because we didn't hear
+            anything from the original author after the previous notice anymore.
           close-pr-message: >
-            This PR has been automatically closed because we haven't received a
-            response from the original author 🙈. This automation helps keep the issue
-            tracker clean from PRs that aren't actionable. Please reach out if you
-            have more information for us! 🙂
-          # don't automatically mark issues/PRs as stale
-          days-before-stale: -1
+            This PR has been automatically closed because we didn't hear
+            anything from the original author after the previous notice anymore.
           stale-issue-label: needs-response
+          stale-issue-message: >
+            This issue has been automatically marked stale because we haven't
+            received a response from the original author in a while 🙈. This
+            automation helps keep the issue tracker clean from issues that are
+            not actionable. Please reach out if you have more information for us
+            or you think this issue shouldn't be closed! 🙂 If you don't do so
+            within 7 days, this issue will be automatically closed.
           stale-pr-label: needs-response
+          stale-pr-message: >
+            This PR has been automatically marked stale because we haven't
+            received a response from the original author in a while 🙈. This
+            automation helps keep the issue tracker clean from issues that are
+            not actionable. Please reach out if you have more information for us
+            or you think this issue shouldn't be closed! 🙂 If you don't do so
+            within 7 days, this PR will be automatically closed.


### PR DESCRIPTION
This will notify people before the PR/issue is actually closed as it now often happens by surprise when people are assuming everything is already fine