### PR TITLE
Improve incompatibility message re: Routes x createBrowserRouter

### DIFF
--- a/docs/components/routes.md
+++ b/docs/components/routes.md
@@ -17,7 +17,7 @@ interface RoutesProps {
 </Routes>;
 ```
 
-<docs-info>If you're using a data router like [`createBrowserRouter`][createbrowserrouter] it is uncommon to use this component as it does not participate in data loading.</docs-info>
+<docs-info>If you're using a data router like [`createBrowserRouter`][createbrowserrouter] it is uncommon to use this component as it does not participate in data loading or `errorElement` error handling. If you want to use `<Routes>`, stick to a pre-v6.4 router like `<BrowserRouter/>`.</docs-info>
 
 Whenever the location changes, `<Routes>` looks through all its child routes to find the best match and renders that branch of the UI. `<Route>` elements may be nested to indicate nested UI, which also correspond to nested URL paths. Parent routes render their child routes by rendering an [`<Outlet>`][outlet].
 


### PR DESCRIPTION
Routes are incompatible with data api routers, but the current info block doesn't get that point across well enough, making it unclear that you'll need to add an `errorElement` to each root Route at the top of a Routes

It will be even better when we can link to the data api router replacement for this form of nested routing!