### PR TITLE
Fix descendant Routes rendering alongside RouterProvider errors

### DIFF
--- a/.changeset/descendant-routes-data-errors.md
+++ b/.changeset/descendant-routes-data-errors.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix bug preventing rendering of descendant `<Routes>` when `RouterProvider` errors existed

--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
       "none": "45 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.3 kB"
+      "none": "13.4 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "15.6 kB"
+      "none": "15.7 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "11.8 kB"

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -18,12 +18,17 @@ import {
   UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
 } from "@remix-run/router";
 import { UNSAFE_mapRouteProperties as mapRouteProperties } from "react-router";
-import type { Location, RouteObject, To } from "react-router-dom";
-import { Routes } from "react-router-dom";
+import type {
+  DataRouteObject,
+  Location,
+  RouteObject,
+  To,
+} from "react-router-dom";
 import {
   createPath,
   parsePath,
   Router,
+  useRoutes,
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
 } from "react-router-dom";
@@ -127,7 +132,7 @@ export function StaticRouterProvider({
             navigationType={dataRouterContext.router.state.historyAction}
             navigator={dataRouterContext.navigator}
           >
-            <Routes />
+            <DataRoutes routes={router.routes} />
           </Router>
         </DataRouterStateContext.Provider>
       </DataRouterContext.Provider>
@@ -140,6 +145,14 @@ export function StaticRouterProvider({
       ) : null}
     </>
   );
+}
+
+function DataRoutes({
+  routes,
+}: {
+  routes: DataRouteObject[];
+}): React.ReactElement | null {
+  return useRoutes(routes);
 }
 
 function serializeErrors(

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -1806,14 +1806,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own
+            You can provide a way better UX than this when your app throws errors by providing your own 
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-
+             
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -1925,14 +1925,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own
+            You can provide a way better UX than this when your app throws errors by providing your own 
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-
+             
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -2159,14 +2159,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own
+            You can provide a way better UX than this when your app throws errors by providing your own 
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-
+             
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -2345,14 +2345,14 @@ describe("createMemoryRouter", () => {
               💿 Hey developer 👋
             </p>
             <p>
-              You can provide a way better UX than this when your app throws errors by providing your own
+              You can provide a way better UX than this when your app throws errors by providing your own 
               <code
                 style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
               >
                 ErrorBoundary
               </code>
                or
-
+               
               <code
                 style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
               >

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -1053,7 +1053,7 @@ describe("createMemoryRouter", () => {
     `);
   });
 
-  it.only("renders <Routes> alongside a data router ErrorBoundary", () => {
+  it("renders <Routes> alongside a data router ErrorBoundary", () => {
     let router = createMemoryRouter(
       [
         {
@@ -1806,14 +1806,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own 
+            You can provide a way better UX than this when your app throws errors by providing your own
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-             
+
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -1925,14 +1925,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own 
+            You can provide a way better UX than this when your app throws errors by providing your own
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-             
+
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -2159,14 +2159,14 @@ describe("createMemoryRouter", () => {
             💿 Hey developer 👋
           </p>
           <p>
-            You can provide a way better UX than this when your app throws errors by providing your own 
+            You can provide a way better UX than this when your app throws errors by providing your own
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
               ErrorBoundary
             </code>
              or
-             
+
             <code
               style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
             >
@@ -2345,14 +2345,14 @@ describe("createMemoryRouter", () => {
               💿 Hey developer 👋
             </p>
             <p>
-              You can provide a way better UX than this when your app throws errors by providing your own 
+              You can provide a way better UX than this when your app throws errors by providing your own
               <code
                 style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
               >
                 ErrorBoundary
               </code>
                or
-               
+
               <code
                 style="padding: 2px 4px; background-color: rgba(200, 200, 200, 0.5);"
               >

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -1019,11 +1019,6 @@ describe("createMemoryRouter", () => {
       ),
       {
         initialEntries: ["/deep/path/to/descendant/routes"],
-        hydrationData: {
-          loaderData: {
-            "0-0": "count=1",
-          },
-        },
       }
     );
     let { container } = render(<RouterProvider router={router} />);
@@ -1053,6 +1048,56 @@ describe("createMemoryRouter", () => {
       "<div>
         <h1>
           👋 Hello from the other side!
+        </h1>
+      </div>"
+    `);
+  });
+
+  it.only("renders <Routes> alongside a data router ErrorBoundary", () => {
+    let router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          Component() {
+            return (
+              <>
+                <Outlet />
+                <Routes>
+                  <Route index element={<h1>Descendant</h1>} />
+                </Routes>
+              </>
+            );
+          },
+          children: [
+            {
+              id: "index",
+              index: true,
+              Component: () => <h1>Child</h1>,
+              ErrorBoundary() {
+                return <p>{(useRouteError() as Error).message}</p>;
+              },
+            },
+          ],
+        },
+      ],
+      {
+        initialEntries: ["/"],
+        hydrationData: {
+          errors: {
+            index: new Error("Broken!"),
+          },
+        },
+      }
+    );
+    let { container } = render(<RouterProvider router={router} />);
+
+    expect(getHtml(container)).toMatchInlineSnapshot(`
+      "<div>
+        <p>
+          Broken!
+        </p>
+        <h1>
+          Descendant
         </h1>
       </div>"
     `);

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -116,13 +116,25 @@ export function RouterProvider({
             navigationType={router.state.historyAction}
             navigator={navigator}
           >
-            {router.state.initialized ? <Routes /> : fallbackElement}
+            {router.state.initialized ? (
+              <DataRoutes routes={router.routes} />
+            ) : (
+              fallbackElement
+            )}
           </Router>
         </DataRouterStateContext.Provider>
       </DataRouterContext.Provider>
       {null}
     </>
   );
+}
+
+function DataRoutes({
+  routes,
+}: {
+  routes: DataRouteObject[];
+}): React.ReactElement | null {
+  return useRoutes(routes);
 }
 
 export interface MemoryRouterProps {
@@ -393,15 +405,7 @@ export function Routes({
   children,
   location,
 }: RoutesProps): React.ReactElement | null {
-  let dataRouterContext = React.useContext(DataRouterContext);
-  // When in a DataRouterContext _without_ children, we use the router routes
-  // directly.  If we have children, then we're in a descendant tree and we
-  // need to use child routes.
-  let routes =
-    dataRouterContext && !children
-      ? (dataRouterContext.router.routes as DataRouteObject[])
-      : createRoutesFromChildren(children);
-  return useRoutes(routes, location);
+  return useRoutes(createRoutesFromChildren(children), location);
 }
 
 export interface AwaitResolveRenderFunction {

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -319,6 +319,7 @@ export function useRoutes(
   );
 
   let { navigator } = React.useContext(NavigationContext);
+  let dataRouterContext = React.useContext(DataRouterContext);
   let dataRouterStateContext = React.useContext(DataRouterStateContext);
   let { matches: parentMatches } = React.useContext(RouteContext);
   let routeMatch = parentMatches[parentMatches.length - 1];
@@ -432,7 +433,10 @@ export function useRoutes(
         })
       ),
     parentMatches,
-    dataRouterStateContext || undefined
+    // Only pass along the dataRouterStateContext when we're rendering from the
+    // RouterProvider layer.  If routes is different then we're rendering from
+    // a descendant <Routes> tree
+    dataRouterContext?.router.routes === routes ? dataRouterStateContext : null
   );
 
   // When a user passes in a `locationArg`, the associated routes need to
@@ -613,7 +617,7 @@ function RenderedRoute({ routeContext, match, children }: RenderedRouteProps) {
 export function _renderMatches(
   matches: RouteMatch[] | null,
   parentMatches: RouteMatch[] = [],
-  dataRouterState?: RemixRouter["state"]
+  dataRouterState: RemixRouter["state"] | null = null
 ): React.ReactElement | null {
   if (matches == null) {
     if (dataRouterState?.errors) {
@@ -635,7 +639,9 @@ export function _renderMatches(
     );
     invariant(
       errorIndex >= 0,
-      `Could not find a matching route for the current errors: ${errors}`
+      `Could not find a matching route for errors on route IDs: ${Object.keys(
+        errors
+      ).join(",")}`
     );
     renderedMatches = renderedMatches.slice(
       0,


### PR DESCRIPTION
Fix descendant `<Routes>` rendering inside a `RouterProvider` when data routes errors exist

Closes #10317 