### PR TITLE
update useState URL to current

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -163,6 +163,7 @@
 - promet99
 - pyitphyoaung
 - RobHannay
+- rimian
 - rtmann
 - rubeonline
 - ryanflorence

--- a/docs/hooks/use-search-params.md
+++ b/docs/hooks/use-search-params.md
@@ -69,5 +69,5 @@ function App() {
 [functional-updates]: https://reactjs.org/docs/hooks-reference.html#functional-updates
 [searchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams
 [usesearchparams-native]: ./use-search-params-rn
-[usestate]: https://reactjs.org/docs/hooks-reference.html#usestate
+[usestate]: https://react.dev/reference/react/useState
 [usenavigate]: ./use-navigate


### PR DESCRIPTION
The link directs to content that is out-of-date. Fixed!
