### PR TITLE
chore: Set default hash path when current path is missing hash value

### DIFF
--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -414,6 +414,9 @@ export type HashHistoryOptions = UrlHistoryOptions;
 export function createHashHistory(
   options: HashHistoryOptions = {}
 ): HashHistory {
+  if (!window.location.hash) {
+    window.location.hash = '/';
+  }
   function createHashLocation(
     window: Window,
     globalHistory: Window["history"]


### PR DESCRIPTION
This feature is available at [https://github.com/remix-run/history/blob/v4.10.0/modules/createHashHistory.js#L171-L174](https://github.com/remix-run/history/blob/v4.10.0/modules/createHashHistory.js#L171-L174) and is very convenient.