### PR TITLE
chore: If there is no hash value in the current path, set the default hash value to /.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -211,3 +211,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- zhangrenyang

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -414,6 +414,9 @@ export type HashHistoryOptions = UrlHistoryOptions;
 export function createHashHistory(
   options: HashHistoryOptions = {}
 ): HashHistory {
+  if (!window.location.hash) {
+    window.location.hash = '/';
+  }
   function createHashLocation(
     window: Window,
     globalHistory: Window["history"]


### PR DESCRIPTION
This feature was originally available here [https://github.com/remix-run/history/blob/v4.10.0/modules/createHashHistory.js#L171-L174](https://github.com/remix-run/history/blob/v4.10.0/modules/createHashHistory.js#L171-L174), and it's very useful.


https://user-images.githubusercontent.com/3096013/233759229-adc80e72-5f77-4d06-9927-6c56a7aaf2b4.mp4

![hash](https://user-images.githubusercontent.com/3096013/233759231-eb5fc2b7-0f28-4512-b3b7-f047a205a64d.gif)
