### PR TITLE
refactor(react-router): clean up `useRoutes`' `RouterProvider` detection

### DIFF
--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -41,6 +41,7 @@ import {
   useOutlet,
   useRoutes,
   _renderMatches,
+  useRoutesImpl,
 } from "./hooks";
 
 export interface RouterProviderProps {
@@ -132,7 +133,9 @@ function DataRoutes({
 }: {
   routes: DataRouteObject[];
 }): React.ReactElement | null {
-  return useRoutes(routes);
+  let state = React.useContext(DataRouterStateContext);
+  invariant(state, "No Router state available for DataRoutes");
+  return useRoutesImpl(routes, undefined, state);
 }
 
 export interface MemoryRouterProps {

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -312,6 +312,15 @@ export function useRoutes(
   routes: RouteObject[],
   locationArg?: Partial<Location> | string
 ): React.ReactElement | null {
+  return useRoutesImpl(routes, locationArg);
+}
+
+// Internal implementation with accept optional param for RouterProvider usage
+export function useRoutesImpl(
+  routes: RouteObject[],
+  locationArg?: Partial<Location> | string,
+  dataRouterState?: RemixRouter["state"]
+): React.ReactElement | null {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the
@@ -320,8 +329,6 @@ export function useRoutes(
   );
 
   let { navigator } = React.useContext(NavigationContext);
-  let dataRouterContext = React.useContext(DataRouterContext);
-  let dataRouterStateContext = React.useContext(DataRouterStateContext);
   let { matches: parentMatches } = React.useContext(RouteContext);
   let routeMatch = parentMatches[parentMatches.length - 1];
   let parentParams = routeMatch ? routeMatch.params : {};
@@ -434,10 +441,7 @@ export function useRoutes(
         })
       ),
     parentMatches,
-    // Only pass along the dataRouterStateContext when we're rendering from the
-    // RouterProvider layer.  If routes is different then we're rendering from
-    // a descendant <Routes> tree
-    dataRouterContext?.router.routes === routes ? dataRouterStateContext : null
+    dataRouterState
   );
 
   // When a user passes in a `locationArg`, the associated routes need to


### PR DESCRIPTION
Quick follow up to https://github.com/remix-run/react-router/pull/10374 to avoid relying on implicit detection of being inside a `RouterProvider` and move to an explicit param passed to a new internal `useRoutesImpl` hook.