### PR TITLE
feat(react-router): add `useSubmit`/`useFetcher` to `createMemoryRouter`

### DIFF
--- a/.changeset/memory-submit-fetcher.md
+++ b/.changeset/memory-submit-fetcher.md
@@ -1,0 +1,5 @@
+---
+"react-router": minor
+---
+
+Add `useSubmit`/`useFetcher` support to `createMemoryRouter` apps in `react-router` now that we can support non-DOM submissions

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -82,6 +82,8 @@ function SomeComponent() {
 }
 ```
 
+<docs-warn>`fetcher.Form` is only available in the DOM-based versions of React Router (`createBrowserRouter`and `createHashRouter`) but not in the memory-based versions (`createMemoryRouter`)</docs-warn>
+
 ## `fetcher.load()`
 
 Loads data from a route loader.

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -106,7 +106,9 @@ let text = "Plain ol' text";
 submit(obj, { encType: "text/plain" }); // -> request.text()
 ```
 
-<docs-warn>In future versions of React Router, the default behavior will not serialize raw JSON payloads. If you are submitting raw JSON today it's recommended to specify an explicit `encType`.</docs-warn>
+<docs-info>If you're using `createMemoryRouter`, then the `FormData` APIs of `useSubmit` aren't relevant, and all submissions are `payload` based.</docs-info>
+
+<docs-warn>In future versions of React Router DOM, the default behavior will not serialize raw JSON payloads. If you are submitting raw JSON today it's recommended to specify an explicit `encType`.</docs-warn>
 
 ### Opting out of serialization
 

--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
       "none": "45.8 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "12.9 kB"
+      "none": "14.0 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "15.3 kB"
+      "none": "16.4 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "12 kB"

--- a/packages/react-router-dom/__tests__/exports-test.tsx
+++ b/packages/react-router-dom/__tests__/exports-test.tsx
@@ -3,15 +3,21 @@ import * as ReactRouterDOM from "react-router-dom";
 
 let nonReExportedKeys = new Set(["UNSAFE_mapRouteProperties"]);
 
+let exportedButDifferent = new Set(["useFetcher", "useFetchers", "useSubmit"]);
+
 describe("react-router-dom", () => {
   for (let key in ReactRouter) {
-    if (!nonReExportedKeys.has(key)) {
-      it(`re-exports ${key} from react-router`, () => {
-        expect(ReactRouterDOM[key]).toBe(ReactRouter[key]);
-      });
-    } else {
+    if (nonReExportedKeys.has(key)) {
       it(`does not re-export ${key} from react-router`, () => {
         expect(ReactRouterDOM[key]).toBe(undefined);
+      });
+    } else if (exportedButDifferent.has(key)) {
+      it(`exports ${key} but not from react-router`, () => {
+        expect(ReactRouterDOM[key]).not.toBe(ReactRouter[key]);
+      });
+    } else {
+      it(`re-exports ${key} from react-router`, () => {
+        expect(ReactRouterDOM[key]).toBe(ReactRouter[key]);
       });
     }
   }

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -128,13 +128,14 @@ export interface SubmitOptions {
   method?: HTMLFormMethod;
 
   /**
-   * The action URL path used to submit the form. Overrides `<form action>`.
-   * Defaults to the path of the current route.
+   * The action URL path used to submit the form (or a direct action to be
+   * executed). Overrides `<form action>`. Defaults to the path of the current
+   * route.
    */
   action?: string | ActionFunction;
 
   /**
-   * The action URL used to submit the form. Overrides `<form encType>`.
+   * The encType to be used to encode the submission. Overrides `<form encType>`.
    * Defaults to "application/x-www-form-urlencoded".  Specifying `null` will
    * opt-out of serialization and will submit the data directly to your action
    * in the `payload` parameter.

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -979,7 +979,7 @@ function useSubmitImpl(
       let path =
         typeof options.action === "function" ? null : options.action || action;
       let routerAction =
-        typeof options.action === "function" ? options.action : null;
+        typeof options.action === "function" ? options.action : undefined;
 
       // Base options shared between fetch() and navigate()
       let opts = {

--- a/packages/react-router-native/__tests__/exports-test.tsx
+++ b/packages/react-router-native/__tests__/exports-test.tsx
@@ -5,13 +5,13 @@ let nonReExportedKeys = new Set(["UNSAFE_mapRouteProperties"]);
 
 describe("react-router-native", () => {
   for (let key in ReactRouter) {
-    if (!nonReExportedKeys.has(key)) {
-      it(`re-exports ${key} from react-router`, () => {
-        expect(ReactRouterNative[key]).toBe(ReactRouter[key]);
-      });
-    } else {
+    if (nonReExportedKeys.has(key)) {
       it(`does not re-export ${key} from react-router`, () => {
         expect(ReactRouterNative[key]).toBe(undefined);
+      });
+    } else {
+      it(`re-exports ${key} from react-router`, () => {
+        expect(ReactRouterNative[key]).toBe(ReactRouter[key]);
       });
     }
   }

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -27,6 +27,7 @@ export type {
   unstable_BlockerFunction,
   DataRouteMatch,
   DataRouteObject,
+  FetcherWithMethods,
   Fetcher,
   Hash,
   IndexRouteObject,
@@ -62,6 +63,8 @@ export type {
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
+  SubmitFunction,
+  SubmitOptions,
   To,
 } from "react-router";
 export {
@@ -92,6 +95,8 @@ export {
   useActionData,
   useAsyncError,
   useAsyncValue,
+  useFetcher,
+  useFetchers,
   unstable_useBlocker,
   useHref,
   useInRouterContext,
@@ -110,6 +115,7 @@ export {
   useRouteError,
   useRouteLoaderData,
   useRoutes,
+  useSubmit,
 } from "react-router";
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -85,7 +85,12 @@ import {
   NavigationContext,
   RouteContext,
 } from "./lib/context";
-import type { NavigateFunction } from "./lib/hooks";
+import type {
+  FetcherWithMethods,
+  NavigateFunction,
+  SubmitFunction,
+  SubmitOptions,
+} from "./lib/hooks";
 import {
   useBlocker,
   useHref,
@@ -102,6 +107,8 @@ import {
   useActionData,
   useAsyncError,
   useAsyncValue,
+  useFetcher,
+  useFetchers,
   useRouteId,
   useLoaderData,
   useMatches,
@@ -109,6 +116,7 @@ import {
   useRevalidator,
   useRouteError,
   useRouteLoaderData,
+  useSubmit,
 } from "./lib/hooks";
 
 // Exported for backwards compatibility, but not being used internally anymore
@@ -126,6 +134,7 @@ export type {
   DataRouteMatch,
   DataRouteObject,
   Fetcher,
+  FetcherWithMethods,
   Hash,
   IndexRouteObject,
   IndexRouteProps,
@@ -160,6 +169,8 @@ export type {
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
+  SubmitFunction,
+  SubmitOptions,
   To,
 };
 export {
@@ -190,6 +201,8 @@ export {
   useAsyncError,
   useAsyncValue,
   useBlocker as unstable_useBlocker,
+  useFetcher,
+  useFetchers,
   useHref,
   useInRouterContext,
   useLoaderData,
@@ -207,6 +220,7 @@ export {
   useRouteError,
   useRouteLoaderData,
   useRoutes,
+  useSubmit,
 };
 
 function mapRouteProperties(route: RouteObject) {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -610,6 +610,10 @@ interface HandleLoadersResult extends ShortCircuitable {
    * errors thrown from the current set of loaders
    */
   errors?: RouterState["errors"];
+  /**
+   * fetchers updates via revalidation
+   */
+  fetchers?: RouterState["fetchers"];
 }
 
 /**
@@ -1335,7 +1339,7 @@ export function createRouter(init: RouterInit): Router {
     }
 
     // Call loaders
-    let { shortCircuited, loaderData, errors } = await handleLoaders(
+    let { shortCircuited, loaderData, errors, fetchers } = await handleLoaders(
       request,
       location,
       matches,
@@ -1361,6 +1365,7 @@ export function createRouter(init: RouterInit): Router {
       ...(pendingActionData ? { actionData: pendingActionData } : {}),
       loaderData,
       errors,
+      ...(fetchers ? { fetchers } : {}),
     });
   }
 


### PR DESCRIPTION
Now that https://github.com/remix-run/react-router/discussions/10324 is handled, we can support `useSubmit` (and therefore `useFetcher`) in `react-router` since those are no longer coupled to `DOM`/`<form>`/`FormData` availability.