### PR TITLE
Add missing static propr for StaticRouterProvider

### DIFF
--- a/.changeset/soft-moons-sneeze.md
+++ b/.changeset/soft-moons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Add static prop to `StaticRouterProvider`'s internal `Router` component

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -136,7 +136,7 @@ export function StaticRouterProvider({
             location={state.location}
             navigationType={state.historyAction}
             navigator={dataRouterContext.navigator}
-            static={true}
+            static={dataRouterContext.static}
           >
             <DataRoutes routes={router.routes} state={state} />
           </Router>

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -136,6 +136,7 @@ export function StaticRouterProvider({
             location={state.location}
             navigationType={state.historyAction}
             navigator={dataRouterContext.navigator}
+            static={true}
           >
             <DataRoutes routes={router.routes} state={state} />
           </Router>


### PR DESCRIPTION
Fix SSR warnings about `useLayoutEffect` on the server since we were missing the `static` prop inside `StaticRouterProvider` (which is what `useIsomorphicLayoutEffect` relies on)