### PR TITLE
Avoid unnecessary router subscribes

### DIFF
--- a/.changeset/silent-stingrays-boil.md
+++ b/.changeset/silent-stingrays-boil.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Avoid uneccesary unsubscribe/resubscribes on router state changes

--- a/contributors.yml
+++ b/contributors.yml
@@ -9,6 +9,7 @@
 - akamfoad
 - alany411
 - alberto
+- alexandernanberg
 - alexlbr
 - AmRo045
 - amsal

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -57,20 +57,10 @@ export function RouterProvider({
   fallbackElement,
   router,
 }: RouterProviderProps): React.ReactElement {
-  let [state, setState] = React.useState(router.state);
-
   // Need to use a layout effect here so we are subscribed early enough to
   // pick up on any render-driven redirects/navigations (useEffect/<Navigate>)
-  React.useLayoutEffect(() => {
-    return router.subscribe((newState) => {
-      setState((prevState) => {
-        if (prevState !== newState) {
-          return newState;
-        }
-        return prevState;
-      });
-    });
-  }, [router]);
+  let [state, setState] = React.useState(router.state);
+  React.useLayoutEffect(() => router.subscribe(setState), [router, setState]);
 
   let navigator = React.useMemo((): Navigator => {
     return {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -63,11 +63,14 @@ export function RouterProvider({
   // pick up on any render-driven redirects/navigations (useEffect/<Navigate>)
   React.useLayoutEffect(() => {
     return router.subscribe((newState) => {
-      if (newState !== state) {
-        setState(newState);
-      }
+      setState((prevState) => {
+        if (prevState !== newState) {
+          return newState;
+        }
+        return prevState;
+      });
     });
-  }, [router, state]);
+  }, [router]);
 
   let navigator = React.useMemo((): Navigator => {
     return {


### PR DESCRIPTION
Rebased #10400 onto the `release-next` branch for inclusion in 6.11 since this fixes an issue in Remix apps on React 17.