### PR TITLE
Corrected a grammatical mistake in a sentence

### DIFF
--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -82,7 +82,7 @@ You can pass a render prop as children to customize the content of the `<NavLink
 
 ## `end`
 
-The `end` prop changes the matching logic for the `active` and `pending` states to only match to the "end" of the NavLinks's `to` path. If the URL is longer than `to`, it will no longer be considered active.
+The `end` prop changes the matching logic for the `active` and `pending` states to only match to the "end" of the NavLink's `to` path. If the URL is longer than `to`, it will no longer be considered active.
 
 Without the end prop, this link is always active because every URL matches `/`.
 


### PR DESCRIPTION
Changed "NavLinks's" to "NavLink's" to correct a grammatical mistake and improve the clarity of the sentence.

This change applies to the latest version of React Router. No potential issues or side effects are expected from this change.

Thanks for taking the time to review this pull request!
