### PR TITLE
fix(router): fix `generatePath` typings

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -60,6 +60,7 @@
 - emzoumpo
 - engpetermwangi
 - ericschn
+- exah
 - FilipJirsak
 - frontsideair
 - fyzhu

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -712,9 +712,7 @@ function matchRouteBranch<
  */
 export function generatePath<Path extends string>(
   originalPath: Path,
-  params: {
-    [key in PathParam<Path>]: string | null;
-  } = {} as any
+  params: Partial<{ [key in PathParam<Path>]: string | null }> = {}
 ): string {
   let path: string = originalPath;
   if (path.endsWith("*") && path !== "*" && !path.endsWith("/*")) {


### PR DESCRIPTION
The previous version forbids passing `undefined` values, also casting to `any` is a bad practice. 