### PR TITLE
feat: improve the Await props generics

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -215,3 +215,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- GiveMe-A-Name

--- a/docs/components/await.md
+++ b/docs/components/await.md
@@ -37,18 +37,18 @@ function Book() {
 ## Type declaration
 
 ```tsx
-declare function Await(
-  props: AwaitProps
+declare function Await<T>(
+  props: AwaitProps<T>
 ): React.ReactElement;
 
-interface AwaitProps {
-  children: React.ReactNode | AwaitResolveRenderFunction;
+interface AwaitProps<T> {
+  children: React.ReactNode | AwaitResolveRenderFunction<T>;
   errorElement?: React.ReactNode;
-  resolve: TrackedPromise | any;
+  resolve: TrackedPromise<T> | any;
 }
 
-interface AwaitResolveRenderFunction {
-  (data: Awaited<any>): React.ReactElement;
+interface AwaitResolveRenderFunction<T = any> {
+  (data: Awaited<T>): React.ReactElement;
 }
 ```
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -413,21 +413,21 @@ export function Routes({
   return useRoutes(createRoutesFromChildren(children), location);
 }
 
-export interface AwaitResolveRenderFunction {
-  (data: Awaited<any>): React.ReactNode;
+export interface AwaitResolveRenderFunction<T = any> {
+  (data: Awaited<T>): React.ReactNode;
 }
 
-export interface AwaitProps {
-  children: React.ReactNode | AwaitResolveRenderFunction;
+export interface AwaitProps<T> {
+  children: React.ReactNode | AwaitResolveRenderFunction<T>;
   errorElement?: React.ReactNode;
-  resolve: TrackedPromise | any;
+  resolve: TrackedPromise<T> | any;
 }
 
 /**
  * Component to use for rendering lazily loaded data from returning defer()
  * in a loader function
  */
-export function Await({ children, errorElement, resolve }: AwaitProps) {
+export function Await<T>({ children, errorElement, resolve }: AwaitProps<T>) {
   return (
     <AwaitErrorBoundary resolve={resolve} errorElement={errorElement}>
       <ResolveAwait>{children}</ResolveAwait>

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1220,7 +1220,7 @@ export const json: JsonFunction = (data, init = {}) => {
   });
 };
 
-export interface TrackedPromise extends Promise<any> {
+export interface TrackedPromise<T = any> extends Promise<T> {
   _tracked?: boolean;
   _data?: any;
   _error?: any;


### PR DESCRIPTION
Now, when we use Await in `ts` project, the `type` will ignore because the define of `Await`components.

For examples:
![image](https://github.com/remix-run/react-router/assets/58852732/09301631-de04-480e-be56-89ba1a0951cc)

It no good for developer developed in IDE.

we can improve the Await `Type System` by generics.

![e12d4589-fca9-44ad-a9e5-25fef2fd42bd](https://github.com/remix-run/react-router/assets/58852732/f7033efc-b13b-4c89-872e-67cb6ba27ee0)
