### PR TITLE
Ability to list entries in memory history

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -215,3 +215,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- 3alisaki

--- a/packages/router/__tests__/memory-test.ts
+++ b/packages/router/__tests__/memory-test.ts
@@ -29,6 +29,10 @@ describe("a memory history", () => {
     expect(typeof history.index).toBe("number");
   });
 
+  it("has an entries property", () => {
+    expect(Array.isArray(history.entries)).toBe(true);
+  });
+
   it("knows how to create hrefs", () => {
     const href = history.createHref({
       pathname: "/the/path",

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -215,6 +215,10 @@ export type MemoryHistoryOptions = {
  */
 export interface MemoryHistory extends History {
   /**
+   * The history stack entries.
+   */
+  readonly entries: Location[];
+  /**
    * The current index in the history stack.
    */
   readonly index: number;
@@ -273,6 +277,9 @@ export function createMemoryHistory(
   }
 
   let history: MemoryHistory = {
+    get entries() {
+      return entries.slice();
+    },
     get index() {
       return index;
     },


### PR DESCRIPTION
hi

i have electron app and i use ReactRouterDom and MemoryRouter to manager navigation in app

my problem is that i have backward and forward buttons in my app exactly like the buttons in the browser, i can use navigate(-1) and navigate(1) functions to make them work, but i didn't find anyway to know when to disable them, i searched source code of this library to find a way to do that but as i see it is impossible without source change.
so i made this commit and Pull Request to fix that.

any way the memory history should not be restricted like other history implementations, if there is reason that someone used memory history instead of other history implementations it's that.

sorry for bad English.