### PR TITLE
Update examples to use react-jsx

### DIFF
--- a/docs/guides/ssr.md
+++ b/docs/guides/ssr.md
@@ -143,7 +143,7 @@ Once we've sent the HTML back to the browser, we'll need to "hydrate" the applic
 
 ```jsx filename=entry-client.jsx lines=[10-15]
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import {
   createBrowserRouter,
   RouterProvider,
@@ -275,7 +275,7 @@ app.listen(3000);
 And finally, you'll need a similar file to "hydrate" the app with your JavaScript bundle that includes the very same `App` component. Note the use of `BrowserRouter` instead of `StaticRouter`.
 
 ```js filename=client.entry.js
-import ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 

--- a/docs/start/_tutorial.md
+++ b/docs/start/_tutorial.md
@@ -74,7 +74,7 @@ Actually, that "!" doesn't look boring at all. This is pretty exciting. We sat o
 Finally, go make sure `index.js` or `main.jsx` (depending on the bundler you used) is actually boring:
 
 ```tsx filename=src/main.jsx
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import App from "./App";
 
 const root = ReactDOM.createRoot(
@@ -98,7 +98,7 @@ npm run dev
 First things first, we want to connect your app to the browser's URL: import `BrowserRouter` and render it around your whole app.
 
 ```tsx lines=[2,9-11] filename=src/main.jsx
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
@@ -177,7 +177,7 @@ export default function Invoices() {
 Finally, let's teach React Router how to render our app at different URLs by creating our first "Route Config" inside of `main.jsx` or `index.js`.
 
 ```tsx lines=[2,4-5,8-9,15-21] filename=src/main.jsx
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
   Routes,
@@ -217,7 +217,7 @@ Let's get some automatic, persistent layout handling by doing just two things:
 First let's nest the routes. Right now the expenses and invoices routes are siblings to the app, we want to make them _children_ of the app route:
 
 ```jsx lines=[17-20] filename=src/main.jsx
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import {
   BrowserRouter,
   Routes,

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -18,7 +18,7 @@ This enables faster user experiences because the browser doesn't need to request
 Client side routing is enabled by creating a `Router` and linking/submitting to pages with `Link` and `<Form>`:
 
 ```jsx [10,16,27]
-import React from "react";
+import * as React from "react";
 import { createRoot } from "react-dom/client";
 import {
   createBrowserRouter,

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -68,8 +68,8 @@ The `main.jsx` file is the entry point. Open it up and we'll put React Router on
 👉 **Create and render a [browser router][createbrowserrouter] in `main.jsx`**
 
 ```jsx lines=[3-6,9-14,18] filename=src/main.jsx
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import {
   createBrowserRouter,
   RouterProvider,

--- a/examples/auth/src/main.tsx
+++ b/examples/auth/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/auth/tsconfig.json
+++ b/examples/auth/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx",
+    "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]
 }

--- a/examples/basic-data-router/src/app.tsx
+++ b/examples/basic-data-router/src/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   createBrowserRouter,
   RouterProvider,

--- a/examples/basic-data-router/src/main.tsx
+++ b/examples/basic-data-router/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import App from "./app";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/examples/basic-data-router/tsconfig.json
+++ b/examples/basic-data-router/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Routes, Route, Outlet, Link } from "react-router-dom";
 
 export default function App() {

--- a/examples/basic/src/main.tsx
+++ b/examples/basic/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/custom-filter-link/src/main.tsx
+++ b/examples/custom-filter-link/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/custom-filter-link/tsconfig.json
+++ b/examples/custom-filter-link/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/custom-link/src/App.tsx
+++ b/examples/custom-link/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import {
   Routes,
   Route,

--- a/examples/custom-link/src/main.tsx
+++ b/examples/custom-link/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/custom-link/tsconfig.json
+++ b/examples/custom-link/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/custom-query-parsing/src/main.tsx
+++ b/examples/custom-query-parsing/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/custom-query-parsing/tsconfig.json
+++ b/examples/custom-query-parsing/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "include": ["src", "types"],
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ESNext",
@@ -15,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
-  }
+  },
+  "include": ["./src", "./types"],
 }

--- a/examples/data-router/src/app.tsx
+++ b/examples/data-router/src/app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router-dom";
 import {
   Await,

--- a/examples/data-router/src/main.tsx
+++ b/examples/data-router/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import App from "./app";
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/examples/data-router/tsconfig.json
+++ b/examples/data-router/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/error-boundaries/src/app.tsx
+++ b/examples/error-boundaries/src/app.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 
 import "./index.css";

--- a/examples/error-boundaries/src/main.tsx
+++ b/examples/error-boundaries/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
 import App from "./app";
 

--- a/examples/error-boundaries/src/routes.tsx
+++ b/examples/error-boundaries/src/routes.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { LoaderFunctionArgs } from "react-router-dom";
 import {
   isRouteErrorResponse,

--- a/examples/error-boundaries/tsconfig.json
+++ b/examples/error-boundaries/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/lazy-loading-router-provider/src/App.tsx
+++ b/examples/lazy-loading-router-provider/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import {
   Outlet,
   Link,

--- a/examples/lazy-loading-router-provider/src/main.tsx
+++ b/examples/lazy-loading-router-provider/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
 import "./index.css";
 import App from "./App";

--- a/examples/lazy-loading-router-provider/src/pages/About.tsx
+++ b/examples/lazy-loading-router-provider/src/pages/About.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useLoaderData } from "react-router-dom";
 
 export async function loader() {

--- a/examples/lazy-loading-router-provider/src/pages/Dashboard.tsx
+++ b/examples/lazy-loading-router-provider/src/pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Outlet, Link, useLoaderData } from "react-router-dom";
 
 export function DashboardLayout() {

--- a/examples/lazy-loading-router-provider/tsconfig.json
+++ b/examples/lazy-loading-router-provider/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/lazy-loading/src/main.tsx
+++ b/examples/lazy-loading/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/lazy-loading/src/pages/About.tsx
+++ b/examples/lazy-loading/src/pages/About.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 function AboutPage() {
   return (
     <div>

--- a/examples/lazy-loading/src/pages/Dashboard.tsx
+++ b/examples/lazy-loading/src/pages/Dashboard.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Routes, Route, Outlet, Link } from "react-router-dom";
 
 export default function Dashboard() {

--- a/examples/lazy-loading/tsconfig.json
+++ b/examples/lazy-loading/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/modal/package-lock.json
+++ b/examples/modal/package-lock.json
@@ -7,15 +7,15 @@
       "name": "modal",
       "dependencies": {
         "@reach/dialog": "0.18.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "react-router-dom": "^6.8.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "^5.0.2",
         "@types/node": "18.x",
-        "@types/react": "^18.0.27",
-        "@types/react-dom": "^18.0.10",
+        "@types/react": "^17.0.59",
+        "@types/react-dom": "^17.0.20",
         "@vitejs/plugin-react": "^3.0.1",
         "typescript": "^4.9.5",
         "vite": "^4.0.4"
@@ -518,13 +518,14 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.0.27",
-      "dev": true,
-      "license": "MIT",
+      "version": "17.0.59",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.59.tgz",
+      "integrity": "sha512-gSON5zWYIGyoBcycCE75E9+r6dCC2dHdsrVkOEiIYNU5+Q28HcBAuqvDuxHcCbMfHBHdeT5Tva/AFn3rnMKE4g==",
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -532,16 +533,17 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.10",
+      "version": "17.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.20.tgz",
+      "integrity": "sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "@types/react": "^17"
       }
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -648,7 +650,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -957,10 +959,12 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -977,14 +981,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-focus-lock": {
@@ -1146,10 +1152,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "license": "MIT",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/semver": {

--- a/examples/modal/package.json
+++ b/examples/modal/package.json
@@ -8,15 +8,15 @@
   },
   "dependencies": {
     "@reach/dialog": "0.18.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-router-dom": "^6.8.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^5.0.2",
     "@types/node": "18.x",
-    "@types/react": "^18.0.27",
-    "@types/react-dom": "^18.0.10",
+    "@types/react": "^17.0.59",
+    "@types/react-dom": "^17.0.20",
     "@vitejs/plugin-react": "^3.0.1",
     "typescript": "^4.9.5",
     "vite": "^4.0.4"

--- a/examples/modal/src/main.tsx
+++ b/examples/modal/src/main.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root")).render(
+ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
+  document.getElementById("root")
 );

--- a/examples/modal/tsconfig.json
+++ b/examples/modal/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/multi-app/home/main.jsx
+++ b/examples/multi-app/home/main.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import HomeApp from "./App";

--- a/examples/multi-app/inbox/main.jsx
+++ b/examples/multi-app/inbox/main.jsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import InboxApp from "./App";

--- a/examples/navigation-blocking/src/app.tsx
+++ b/examples/navigation-blocking/src/app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import type { unstable_Blocker as Blocker } from "react-router-dom";
 import {
   createBrowserRouter,

--- a/examples/navigation-blocking/src/main.tsx
+++ b/examples/navigation-blocking/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import App from "./app";
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/examples/navigation-blocking/tsconfig.json
+++ b/examples/navigation-blocking/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/notes/src/main.jsx
+++ b/examples/notes/src/main.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
 import App from "./app";
 

--- a/examples/notes/tsconfig.json
+++ b/examples/notes/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src", "../../build/node_modules"]

--- a/examples/route-objects/src/App.tsx
+++ b/examples/route-objects/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import type { RouteObject } from "react-router-dom";
 import { Outlet, Link, useRoutes, useParams } from "react-router-dom";
 

--- a/examples/route-objects/src/main.tsx
+++ b/examples/route-objects/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/route-objects/tsconfig.json
+++ b/examples/route-objects/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/scroll-restoration/src/app.tsx
+++ b/examples/scroll-restoration/src/app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import type { Location, useMatches } from "react-router-dom";
 import {
   createBrowserRouter,

--- a/examples/scroll-restoration/src/main.tsx
+++ b/examples/scroll-restoration/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import App from "./app";
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/examples/scroll-restoration/tsconfig.json
+++ b/examples/scroll-restoration/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/search-params/src/main.tsx
+++ b/examples/search-params/src/main.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";

--- a/examples/search-params/tsconfig.json
+++ b/examples/search-params/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "importsNotUsedAsValues": "error"
   },
   "include": ["./src"]

--- a/examples/ssr-data-router/src/App.tsx
+++ b/examples/ssr-data-router/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import type { RouteObject } from "react-router-dom";
 import { Outlet, Link, useLoaderData, redirect } from "react-router-dom";
 

--- a/examples/ssr-data-router/src/entry.client.tsx
+++ b/examples/ssr-data-router/src/entry.client.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import {
   createBrowserRouter,
   matchRoutes,

--- a/examples/ssr-data-router/src/lazy.tsx
+++ b/examples/ssr-data-router/src/lazy.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useLoaderData } from "react-router-dom";
 
 interface LazyLoaderData {

--- a/examples/ssr-data-router/tsconfig.json
+++ b/examples/ssr-data-router/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "types": ["vite/client"],
     "importsNotUsedAsValues": "error"
   },

--- a/examples/ssr/src/App.tsx
+++ b/examples/ssr/src/App.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Routes, Route, Outlet, Link } from "react-router-dom";
 
 export default function App() {

--- a/examples/ssr/src/entry.client.tsx
+++ b/examples/ssr/src/entry.client.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import ReactDOM from "react-dom/client";
+import * as ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import "./index.css";

--- a/examples/ssr/tsconfig.json
+++ b/examples/ssr/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "types": ["vite/client"],
     "importsNotUsedAsValues": "error"
   },


### PR DESCRIPTION
Update `examples/` to use `"jsx": "react-jsx"` in `tsconfig.json` to avoid needing `import * as React from 'react'` in JSX files.