### PR TITLE
Allow revalidations to complete if submitting fetcher is deleted

### DIFF
--- a/.changeset/delete-submit-fetcher.md
+++ b/.changeset/delete-submit-fetcher.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Allow fetcher revalidations to complete if submitting fetcher is deleted


### PR DESCRIPTION
Do not abort revalidations if the submitting fetcher is deleted right after it's action completes

Closes https://github.com/remix-run/remix/issues/6458