### PR TITLE
Strip basename from location provided to getKey

### DIFF
--- a/.changeset/strip-basename-getkey.md
+++ b/.changeset/strip-basename-getkey.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix `basename` not being stripped from the location provided to `<ScrollRestoration getKey>`

--- a/.changeset/strip-basename-getkey.md
+++ b/.changeset/strip-basename-getkey.md
@@ -2,4 +2,4 @@
 "@remix-run/router": patch
 ---
 
-Fix `basename` not being stripped from the location provided to `<ScrollRestoration getKey>`
+Strip `basename` from the `location` provided to `<ScrollRestoration getKey>` to match the `useLocation` behavior

--- a/package.json
+++ b/package.json
@@ -118,10 +118,10 @@
       "none": "15.8 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "12.0 kB"
+      "none": "12.1 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "17.9 kB"
+      "none": "18.1 kB"
     }
   }
 }

--- a/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
+++ b/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-router-dom";
 
 describe(`ScrollRestoration`, () => {
-  it("renders the first route that matches the URL", () => {
+  it("removes the basename from the location provided to getKey", () => {
     let getKey = jest.fn(() => "mykey");
     let testWindow = getWindowImpl("/base");
     window.scrollTo = () => {};

--- a/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
+++ b/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
@@ -1,0 +1,85 @@
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { render, prettyDOM, fireEvent, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  Link,
+  Outlet,
+  RouterProvider,
+  ScrollRestoration,
+  createBrowserRouter,
+} from "react-router-dom";
+
+describe(`ScrollRestoration`, () => {
+  it("renders the first route that matches the URL", () => {
+    let getKey = jest.fn(() => "mykey");
+    let testWindow = getWindowImpl("/base");
+    window.scrollTo = () => {};
+
+    let router = createBrowserRouter(
+      [
+        {
+          path: "/",
+          Component() {
+            return (
+              <>
+                <Outlet />
+                <ScrollRestoration getKey={getKey} />
+              </>
+            );
+          },
+          children: [
+            {
+              index: true,
+              Component() {
+                return <Link to="/page">/page</Link>;
+              },
+            },
+            {
+              path: "page",
+              Component() {
+                return <h1>Page</h1>;
+              },
+            },
+          ],
+        },
+      ],
+      { basename: "/base", window: testWindow }
+    );
+    let { container } = render(<RouterProvider router={router} />);
+
+    expect(getKey.mock.calls.length).toBe(1);
+    // @ts-expect-error
+    expect(getKey.mock.calls[0][0].pathname).toBe("/"); // restore
+
+    expect(getHtml(container)).toMatch("/page");
+    fireEvent.click(screen.getByText("/page"));
+    expect(getHtml(container)).toMatch("Page");
+
+    expect(getKey.mock.calls.length).toBe(3);
+    // @ts-expect-error
+    expect(getKey.mock.calls[1][0].pathname).toBe("/"); // save
+    // @ts-expect-error
+    expect(getKey.mock.calls[2][0].pathname).toBe("/page"); // restore
+  });
+});
+
+function getWindowImpl(initialUrl: string): Window {
+  // Need to use our own custom DOM in order to get a working history
+  const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
+  dom.window.history.replaceState(null, "", initialUrl);
+  return dom.window as unknown as Window;
+}
+
+function getHtml(container: HTMLElement) {
+  return prettyDOM(container, undefined, {
+    highlight: false,
+    theme: {
+      comment: null,
+      content: null,
+      prop: null,
+      tag: null,
+      value: null,
+    },
+  });
+}

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1255,13 +1255,11 @@ function useScrollRestoration({
     // Enable scroll restoration in the router
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useLayoutEffect(() => {
-      let disableScrollRestoration = router?.enableScrollRestoration(
-        savedScrollPositions,
-        () => window.scrollY,
-        getKey
+      let getKeyWithoutBasename: GetScrollRestorationKeyFunction | undefined =
+        getKey && basename !== "/"
           ? (location, matches) =>
               getKey(
-                // Strip the basename to match useLocation
+                // Strip the basename to match useLocation()
                 {
                   ...location,
                   pathname:
@@ -1270,7 +1268,11 @@ function useScrollRestoration({
                 },
                 matches
               )
-          : undefined
+          : getKey;
+      let disableScrollRestoration = router?.enableScrollRestoration(
+        savedScrollPositions,
+        () => window.scrollY,
+        getKeyWithoutBasename
       );
       return () => disableScrollRestoration && disableScrollRestoration();
     }, [router, basename, getKey]);

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1208,6 +1208,7 @@ function useScrollRestoration({
   let { restoreScrollPosition, preventScrollReset } = useDataRouterState(
     DataRouterStateHook.UseScrollRestoration
   );
+  let { basename } = React.useContext(NavigationContext);
   let location = useLocation();
   let matches = useMatches();
   let navigation = useNavigation();
@@ -1258,9 +1259,20 @@ function useScrollRestoration({
         savedScrollPositions,
         () => window.scrollY,
         getKey
+          ? (location, matches) =>
+              getKey(
+                {
+                  ...location,
+                  pathname:
+                    stripBasename(location.pathname, basename) ||
+                    location.pathname,
+                },
+                matches
+              )
+          : undefined
       );
       return () => disableScrollRestoration && disableScrollRestoration();
-    }, [router, getKey]);
+    }, [router, basename, getKey]);
 
     // Restore scrolling when state.restoreScrollPosition changes
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1261,6 +1261,7 @@ function useScrollRestoration({
         getKey
           ? (location, matches) =>
               getKey(
+                // Strip the basename to match useLocation
                 {
                   ...location,
                   pathname:

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6959,6 +6959,37 @@ describe("a router", () => {
         expect(t.router.state.preventScrollReset).toBe(false);
       });
 
+      it("strips the basename from the location provided to getKey", async () => {
+        let t = setup({
+          routes: SCROLL_ROUTES,
+          basename: "/base",
+          initialEntries: ["/base"],
+          hydrationData: {
+            loaderData: {
+              index: "INDEX_DATA",
+            },
+          },
+        });
+
+        let positions = { "/tasks": 100 };
+        let activeScrollPosition = 0;
+        let pathname;
+        t.router.enableScrollRestoration(
+          positions,
+          () => activeScrollPosition,
+          (l) => {
+            pathname = l.pathname;
+            return l.pathname;
+          }
+        );
+
+        let nav1 = await t.navigate("/base/tasks");
+        await nav1.loaders.tasks.resolve("TASKS");
+        expect(pathname).toBe("/tasks");
+        expect(t.router.state.restoreScrollPosition).toBe(100);
+        expect(t.router.state.preventScrollReset).toBe(false);
+      });
+
       it("restores scroll on GET submissions", async () => {
         let t = setup({
           routes: SCROLL_ROUTES,

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -6959,7 +6959,7 @@ describe("a router", () => {
         expect(t.router.state.preventScrollReset).toBe(false);
       });
 
-      it("strips the basename from the location provided to getKey", async () => {
+      it("does not strip the basename from the location provided to getKey", async () => {
         let t = setup({
           routes: SCROLL_ROUTES,
           basename: "/base",
@@ -6971,7 +6971,7 @@ describe("a router", () => {
           },
         });
 
-        let positions = { "/tasks": 100 };
+        let positions = { "/base/tasks": 100 };
         let activeScrollPosition = 0;
         let pathname;
         t.router.enableScrollRestoration(
@@ -6985,7 +6985,7 @@ describe("a router", () => {
 
         let nav1 = await t.navigate("/base/tasks");
         await nav1.loaders.tasks.resolve("TASKS");
-        expect(pathname).toBe("/tasks");
+        expect(pathname).toBe("/base/tasks");
         expect(t.router.state.restoreScrollPosition).toBe(100);
         expect(t.router.state.preventScrollReset).toBe(false);
       });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2452,15 +2452,11 @@ export function createRouter(init: RouterInit): Router {
 
   function getScrollKey(location: Location, matches: AgnosticDataRouteMatch[]) {
     if (getScrollRestorationKey) {
-      let loc = {
-        ...location,
-        pathname:
-          stripBasename(location.pathname, basename) || location.pathname,
-      };
-      let userMatches = matches.map((m) =>
-        createUseMatchesMatch(m, state.loaderData)
+      let key = getScrollRestorationKey(
+        location,
+        matches.map((m) => createUseMatchesMatch(m, state.loaderData))
       );
-      return getScrollRestorationKey(loc, userMatches) || location.key;
+      return key || location.key;
     }
     return location.key;
   }


### PR DESCRIPTION
Fixes issue raised in https://github.com/remix-run/react-router/discussions/9565#discussioncomment-6053841

We were calling `getKey` inconsistently.  From the `usePageHide` hook it was the `useLocation` value (not including `basename`) but from inside the router it was the `router.state.location` (including `basename`).  Now it's always the user-land version without the `basename`