### PR TITLE
Use react concurrent mode state in RouterProvider

### DIFF
--- a/.changeset/young-glasses-smoke.md
+++ b/.changeset/young-glasses-smoke.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+[internal] use concurrent mode state

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
       "none": "12.0 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "17.9 kB"
+      "none": "18.0 kB"
     }
   }
 }

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -116,12 +116,12 @@ export function RouterProvider({
       <DataRouterContext.Provider value={dataRouterContext}>
         <DataRouterStateContext.Provider value={state}>
           <Router
-            basename={router.basename}
-            location={router.state.location}
-            navigationType={router.state.historyAction}
+            basename={basename}
+            location={state.location}
+            navigationType={state.historyAction}
             navigator={navigator}
           >
-            {router.state.initialized ? (
+            {state.initialized ? (
               <DataRoutes routes={router.routes} state={state} />
             ) : (
               fallbackElement


### PR DESCRIPTION
Now that's we're using `startTransition` we can't look directly at `router.state` in `RouterProvider`