### PR TITLE
Updated history.md  : Corrected link to history.block documentation

### DIFF
--- a/packages/react-router/docs/api/history.md
+++ b/packages/react-router/docs/api/history.md
@@ -22,7 +22,7 @@ The following terms are also used:
 - `go(n)` - (function) Moves the pointer in the history stack by `n` entries
 - `goBack()` - (function) Equivalent to `go(-1)`
 - `goForward()` - (function) Equivalent to `go(1)`
-- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/remix-run/history/blob/main/docs/blocking-transitions.md)
+- `block(prompt)` - (function) Prevents navigation (see [the history docs](https://github.com/remix-run/history/blob/v4/docs/Blocking.md)
 
 ## history is mutable
 


### PR DESCRIPTION
The link to history.block documentation was pointing to v5 of the history package, the version used in react-router v5 is v4