### PR TITLE
Update package.json - error in blitzstack

### DIFF
--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -12,6 +12,7 @@
     "react-router-dom": "^6.8.0"
   },
   "devDependencies": {
+    "@esbuild/linux-x64": "^0.17.19",
     "@rollup/plugin-replace": "^5.0.2",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",


### PR DESCRIPTION
@esbuild/linux-x64 package missing when launching vite