### PR TITLE
Fix feature detection of React.startTransition

### DIFF
--- a/.changeset/silly-eagles-divide.md
+++ b/.changeset/silly-eagles-divide.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+Adjust feature detection of `React.startTransition` to fix webpack + react 17 compilation error

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -300,6 +300,11 @@ export interface BrowserRouterProps {
   window?: Window;
 }
 
+// Webpack + React 17 fails to compile on the usage of `React.startTransition` or
+// `React["startTransition"]` even if it's behind a feature detection of
+// `"startTransition" in React`. Moving this to a constant avoids the issue :/
+const START_TRANSITION = "startTransition";
+
 /**
  * A `<Router>` for use in web browsers. Provides the cleanest URLs.
  */
@@ -320,8 +325,8 @@ export function BrowserRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      "startTransition" in React
-        ? React.startTransition(() => setStateImpl(newState))
+      START_TRANSITION in React
+        ? React[START_TRANSITION](() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -363,8 +368,8 @@ export function HashRouter({ basename, children, window }: HashRouterProps) {
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      "startTransition" in React
-        ? React.startTransition(() => setStateImpl(newState))
+      START_TRANSITION in React
+        ? React[START_TRANSITION](() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -402,8 +407,8 @@ function HistoryRouter({ basename, children, history }: HistoryRouterProps) {
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      "startTransition" in React
-        ? React.startTransition(() => setStateImpl(newState))
+      START_TRANSITION in React
+        ? React[START_TRANSITION](() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -54,6 +54,11 @@ export interface RouterProviderProps {
   router: RemixRouter;
 }
 
+// Webpack + React 17 fails to compile on the usage of `React.startTransition` or
+// `React["startTransition"]` even if it's behind a feature detection of
+// `"startTransition" in React`. Moving this to a constant avoids the issue :/
+const START_TRANSITION = "startTransition";
+
 /**
  * Given a Remix Router instance, render the appropriate UI
  */
@@ -66,8 +71,8 @@ export function RouterProvider({
   let [state, setStateImpl] = React.useState(router.state);
   let setState = React.useCallback(
     (newState: RouterState) => {
-      "startTransition" in React
-        ? React.startTransition(() => setStateImpl(newState))
+      START_TRANSITION in React
+        ? React[START_TRANSITION](() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -178,8 +183,8 @@ export function MemoryRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      "startTransition" in React
-        ? React.startTransition(() => setStateImpl(newState))
+      START_TRANSITION in React
+        ? React[START_TRANSITION](() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]


### PR DESCRIPTION
I'm not quite sure why the current feature detection approach wasn't sufficient 😕 .  It works fine in `vite` but apparently has issues in `webpack`.  the react team doesn't do anything funny like this in their [`useSyncExternalStore` shim package](https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreShim.js#L13) and I can't imagine that has issues on `webpack` and React 17.

Either way, moving to a constant seems to fix the webpack compilation issue.

Closes #10566