### PR TITLE
Fix unstable_useBlocker key issues in strict mode

### DIFF
--- a/.changeset/blocker-key-strict-mode.md
+++ b/.changeset/blocker-key-strict-mode.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+Fix `unstable_useBlocker` key issues in `StrictMode`

--- a/.changeset/strip-blocker-basename.md
+++ b/.changeset/strip-blocker-basename.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Strip `basename` from locations provided to `unstable_useBlocker` functions to match `useLocation`

--- a/package.json
+++ b/package.json
@@ -112,10 +112,10 @@
       "none": "45 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.4 kB"
+      "none": "13.5 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "15.8 kB"
+      "none": "15.9 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "12.1 kB"

--- a/package.json
+++ b/package.json
@@ -112,10 +112,10 @@
       "none": "45 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.5 kB"
+      "none": "13.7 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "15.9 kB"
+      "none": "16.1 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "12.1 kB"

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -955,6 +955,8 @@ export function useBlocker(shouldBlock: boolean | BlockerFunction): Blocker {
     return () => router.deleteBlocker(key);
   }, [router, setBlocker, setBlockerKey, blockerFunction]);
 
+  // Prefer the blocker from state since DataRouterContext is memoized so this
+  // ensures we update on blocker state updates
   return blockerKey && state.blockers.has(blockerKey)
     ? state.blockers.get(blockerKey)!
     : blocker;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {
+import type {
   Blocker,
   BlockerFunction,
   Location,
@@ -12,7 +12,6 @@ import {
   Router as RemixRouter,
   RevalidationState,
   To,
-  stripBasename,
 } from "@remix-run/router";
 import {
   Action as NavigationType,
@@ -23,6 +22,7 @@ import {
   matchRoutes,
   parsePath,
   resolveTo,
+  stripBasename,
   IDLE_BLOCKER,
   UNSAFE_getPathContributingMatches as getPathContributingMatches,
   UNSAFE_warning as warning,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -893,8 +893,9 @@ export function createRouter(init: RouterInit): Router {
               init.history.go(delta);
             },
             reset() {
-              deleteBlocker(blockerKey!);
-              updateState({ blockers: new Map(router.state.blockers) });
+              let blockers = new Map(state.blockers);
+              blockers.set(blockerKey!, IDLE_BLOCKER);
+              updateState({ blockers });
             },
           });
           return;
@@ -991,9 +992,7 @@ export function createRouter(init: RouterInit): Router {
 
     // On a successful navigation we can assume we got through all blockers
     // so we can start fresh
-    for (let [key] of blockerFunctions) {
-      deleteBlocker(key);
-    }
+    blockerFunctions.clear();
 
     // Always respect the user flag.  Otherwise don't reset on mutation
     // submission navigations unless they redirect
@@ -1032,7 +1031,7 @@ export function createRouter(init: RouterInit): Router {
         newState.matches || state.matches
       ),
       preventScrollReset,
-      blockers: new Map(state.blockers),
+      blockers: new Map(),
     });
 
     // Reset stateful navigation vars
@@ -1130,8 +1129,10 @@ export function createRouter(init: RouterInit): Router {
           navigate(to, opts);
         },
         reset() {
-          deleteBlocker(blockerKey!);
-          updateState({ blockers: new Map(state.blockers) });
+          // TODO: Crate new map before mutating - same for fetchers if possible
+          let blockers = new Map(state.blockers);
+          blockers.set(blockerKey!, IDLE_BLOCKER);
+          updateState({ blockers });
         },
       });
       return;
@@ -2378,8 +2379,9 @@ export function createRouter(init: RouterInit): Router {
       `Invalid blocker state transition: ${blocker.state} -> ${newBlocker.state}`
     );
 
-    state.blockers.set(key, newBlocker);
-    updateState({ blockers: new Map(state.blockers) });
+    let blockers = new Map(state.blockers);
+    blockers.set(key, newBlocker);
+    updateState({ blockers });
   }
 
   function shouldBlockNavigation({

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -992,6 +992,7 @@ export function createRouter(init: RouterInit): Router {
 
     // On a successful navigation we can assume we got through all blockers
     // so we can start fresh
+    let blockers = new Map();
     blockerFunctions.clear();
 
     // Always respect the user flag.  Otherwise don't reset on mutation
@@ -1031,7 +1032,7 @@ export function createRouter(init: RouterInit): Router {
         newState.matches || state.matches
       ),
       preventScrollReset,
-      blockers: new Map(),
+      blockers,
     });
 
     // Reset stateful navigation vars

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1129,7 +1129,6 @@ export function createRouter(init: RouterInit): Router {
           navigate(to, opts);
         },
         reset() {
-          // TODO: Crate new map before mutating - same for fetchers if possible
           let blockers = new Map(state.blockers);
           blockers.set(blockerKey!, IDLE_BLOCKER);
           updateState({ blockers });


### PR DESCRIPTION
Fix issues with internal blocker `key` generation in `StrictMode`

Closes #10073
Closes #10144

Also strips the `basename` (if present) from the `currentLocation`/`nextLocation` we expose out to the user to match `useLocation` behavior.  This was discovered as part of https://github.com/remix-run/react-router/pull/10550#issuecomment-1574091175