### PR TITLE
Fix webpack/terser startTransition minification bug in production mode

### DIFF
--- a/.changeset/start-transition-minification.md
+++ b/.changeset/start-transition-minification.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+Work around webpack/terser `React.startTransition` minification bug in production mode

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -300,10 +300,24 @@ export interface BrowserRouterProps {
   window?: Window;
 }
 
-// Webpack + React 17 fails to compile on the usage of `React.startTransition` or
-// `React["startTransition"]` even if it's behind a feature detection of
-// `"startTransition" in React`. Moving this to a constant avoids the issue :/
+// Webpack + React 17 fails to compile on any of the following:
+// * import { startTransition } from "react"
+// * import * as React from from "react";
+//   "startTransition" in React ? React.startTransition(() => setState()) : setState()
+// * import * as React from from "react";
+//   "startTransition" in React ? React["startTransition"](() => setState()) : setState()
+//
+// Moving it to a constant such as the following solves the Webpack/React 17 issue:
+// * import * as React from from "react";
+//   const START_TRANSITION = "startTransition";
+//   START_TRANSITION in React ? React[START_TRANSITION](() => setState()) : setState()
+//
+// However, that introduces webpack/terser minification issues in production builds
+// in React 18 where minification/obfuscation ends up removing the call of
+// React.startTransition entirely from the first half of the ternary.  Grabbing
+// this reference once up front resolves that issue.
 const START_TRANSITION = "startTransition";
+const startTransitionImpl = React[START_TRANSITION];
 
 /**
  * A `<Router>` for use in web browsers. Provides the cleanest URLs.
@@ -325,8 +339,8 @@ export function BrowserRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      START_TRANSITION in React
-        ? React[START_TRANSITION](() => setStateImpl(newState))
+      startTransitionImpl
+        ? startTransitionImpl(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -368,8 +382,8 @@ export function HashRouter({ basename, children, window }: HashRouterProps) {
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      START_TRANSITION in React
-        ? React[START_TRANSITION](() => setStateImpl(newState))
+      startTransitionImpl
+        ? startTransitionImpl(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -407,8 +421,8 @@ function HistoryRouter({ basename, children, history }: HistoryRouterProps) {
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      START_TRANSITION in React
-        ? React[START_TRANSITION](() => setStateImpl(newState))
+      startTransitionImpl
+        ? startTransitionImpl(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -54,10 +54,24 @@ export interface RouterProviderProps {
   router: RemixRouter;
 }
 
-// Webpack + React 17 fails to compile on the usage of `React.startTransition` or
-// `React["startTransition"]` even if it's behind a feature detection of
-// `"startTransition" in React`. Moving this to a constant avoids the issue :/
+// Webpack + React 17 fails to compile on any of the following:
+// * import { startTransition } from "react"
+// * import * as React from from "react";
+//   "startTransition" in React ? React.startTransition(() => setState()) : setState()
+// * import * as React from from "react";
+//   "startTransition" in React ? React["startTransition"](() => setState()) : setState()
+//
+// Moving it to a constant such as the following solves the Webpack/React 17 issue:
+// * import * as React from from "react";
+//   const START_TRANSITION = "startTransition";
+//   START_TRANSITION in React ? React[START_TRANSITION](() => setState()) : setState()
+//
+// However, that introduces webpack/terser minification issues in production builds
+// in React 18 where minification/obfuscation ends up removing the call of
+// React.startTransition entirely from the first half of the ternary.  Grabbing
+// this reference once up front resolves that issue.
 const START_TRANSITION = "startTransition";
+const startTransitionImpl = React[START_TRANSITION];
 
 /**
  * Given a Remix Router instance, render the appropriate UI
@@ -71,8 +85,8 @@ export function RouterProvider({
   let [state, setStateImpl] = React.useState(router.state);
   let setState = React.useCallback(
     (newState: RouterState) => {
-      START_TRANSITION in React
-        ? React[START_TRANSITION](() => setStateImpl(newState))
+      startTransitionImpl
+        ? startTransitionImpl(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]
@@ -183,8 +197,8 @@ export function MemoryRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      START_TRANSITION in React
-        ? React[START_TRANSITION](() => setStateImpl(newState))
+      startTransitionImpl
+        ? startTransitionImpl(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl]


### PR DESCRIPTION
This fixes the `webpack`/`terser` production build minification issue discovered in #10579 where in production mode the code would minify down such that the first half of the following ternary wouldn't actually be called:

```js
// React Router source code
// In module scope
const START_TRANSITION = "startTransition";

// Inside BrowserRouter/etc.
let setState = React.useCallback((newState) => {
    START_TRANSITION in React
      ? React[START_TRANSITION](() => setStateImpl(newState))
      : setStateImpl(newState);
  },
  [setStateImpl]
);
```

This would minify down to the following using `webpack`, where `const _ = "startTransition"` and `f` is `setStateImpl`:

```js
// Minified production webpack build
p=o.useCallback((e=>{_ in(r||(r=n.t(o,2)))||f(e)}),[f]);
```

Which expands to:

```js
p = o.useCallback(e=>{
  _ in (r || (r = n.t(o,2))) || f(e)
}, [f]);
```

And thus `setStateImpl` (`f`) never gets executed in the case that `React.startTransition` is defined.

This does not seem to be an issue building in production mode with `vite`, which minifies down to the following where `const jE="startTransition"` and `m` is `setstateImpl`:

```
// Minified production vite build
b=B.useCallback(O=>{jE in EE?EE[jE](()=>m(O)):m(O)},[m]);
```

and expands to:

```
b = B.useCallback(O=>{
  jE in EE ? EE[jE](()=>m(O)) : m(O)
}, [m]);
```

Closes #10579 (partially)