### PR TITLE
Avoid calling shouldRevalidate on interrupted initial load fetchers

### DIFF
--- a/.changeset/skip-fetcher-revalidate.md
+++ b/.changeset/skip-fetcher-revalidate.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Avoid calling `shouldRevalidate` for fetchers that have not yet completed a data load

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "46.4 kB"
+      "none": "46.5 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.8 kB"


### PR DESCRIPTION
If an initial `fetcher.load` is interrupted by a navigation, we should not try to call `shouldRevalidate` for the interrupted fetcher since it still performing the initial load and therefore it's not a revalidation.  This is specifically crucial in Remix apps where the "load" also encompasses loading the JS route module, so until the first one completes we don't even have a `shouldRevalidate` implementation to call.

Also ensures we properly abort in-progress `fetcher.load` calls that are re-loaded in this manner.

Closes #10473 