### PR TITLE
Add body/content-length to redirect response

### DIFF
--- a/.changeset/redirect-content-length.md
+++ b/.changeset/redirect-content-length.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Ensure `redirect` responses have a `Content-Length` header to be spec compliant. We also add a small HTML body indicating the new location to follow best practices.

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "46.5 kB"
+      "none": "46.8 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.8 kB"

--- a/packages/router/__tests__/utils-test.ts
+++ b/packages/router/__tests__/utils-test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+
+import { redirect } from "../index";
+
+describe("utils", () => {
+  it("redirects default to 302", async () => {
+    let response = redirect("http://test.com");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("http://test.com");
+  });
+
+  it("redirects accept a ResponseInit as a number", async () => {
+    let response = redirect("http://test.com", 301);
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("http://test.com");
+  });
+
+  it("redirects accept a ResponseInit as an object", async () => {
+    let response = redirect("http://test.com", {
+      status: 301,
+      statusText: "jawn",
+    });
+    expect(response.status).toBe(301);
+    expect(response.statusText).toBe("jawn");
+    expect(response.headers.get("Location")).toBe("http://test.com");
+  });
+
+  it("redirects include an HTML body and content length", async () => {
+    let response = redirect("http://test.com");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=UTF-8"
+    );
+    expect(await response.text()).toBe(
+      "<html>" +
+        "<head>" +
+        '<meta http-equiv="content-type" content="text/html;charset=utf-8">' +
+        "<title>302 Moved</title>" +
+        "</head>" +
+        "<body>" +
+        "<h1>302 Moved</h1>" +
+        'The document has moved <a href="http://test.com">here</a>.' +
+        "</body>" +
+        "</html>"
+    );
+    expect(response.headers.get("Content-Length")).toBe("205");
+  });
+});


### PR DESCRIPTION
From my reading of the spec, we _need_ to add a `Content-Length` header.  We _can_ add the HTML body but don't have to.  I can easily be talked out of including the body in favor of just `Content-Length: 0`

Read through this thread for background which talks about the different specs wording over time: https://github.com/traefik/traefik/issues/4456

Closes https://github.com/remix-run/remix/issues/5595