### PR TITLE
Fix elementId not decoded when emulate native hash scroll

### DIFF
--- a/.changeset/dirty-coats-warn.md
+++ b/.changeset/dirty-coats-warn.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Fix elementId not decoded when emulate native hash scroll

--- a/contributors.yml
+++ b/contributors.yml
@@ -219,3 +219,4 @@
 - yuleicul
 - zheng-chuang
 - holynewbie
+- istarkov

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1354,7 +1354,9 @@ function useScrollRestoration({
 
       // try to scroll to the hash
       if (location.hash) {
-        let el = document.getElementById(location.hash.slice(1));
+        let el = document.getElementById(
+          decodeURIComponent(location.hash.slice(1))
+        );
         if (el) {
           el.scrollIntoView();
           return;


### PR DESCRIPTION
closes #10641 