### PR TITLE
docs(use-submit): explicit encType

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,6 +16,7 @@
 - andreiduca
 - antonmontrezor
 - appden
+- arjunyel
 - arnassavickas
 - aroyan
 - avipatel97

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -99,7 +99,7 @@ submit([
 The default behavior if you submit a JSON object is to encode the data into `FormData`:
 
 ```tsx
-submit({ key: "value" });
+submit({ key: "value", { encType: "application/x-www-form-urlencoded" });
 // will serialize into request.formData() in your action
 ```
 


### PR DESCRIPTION
"This behavior will likely change in the future when React Router releases v7, so it's best to make any JSON object submissions explicit with either encType: "application/x-www-form-urlencoded" or encType: "application/json" to ease your eventual v7 migration path." https://github.com/remix-run/remix/releases/tag/remix%401.18.0