### PR TITLE
fix: useBlocker useEffect infinite loop

### DIFF
--- a/.changeset/lucky-lamps-lick.md
+++ b/.changeset/lucky-lamps-lick.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix `unstable_useBlocker` infinite loop

--- a/contributors.yml
+++ b/contributors.yml
@@ -62,6 +62,7 @@
 - emzoumpo
 - engpetermwangi
 - ericschn
+- fernandojbf
 - FilipJirsak
 - frontsideair
 - fyzhu

--- a/packages/react-router/__tests__/useBlocker-test.tsx
+++ b/packages/react-router/__tests__/useBlocker-test.tsx
@@ -1,0 +1,448 @@
+import * as React from "react";
+import * as TestRenderer from "react-test-renderer";
+import {
+  useNavigate,
+  unstable_useBlocker,
+  createMemoryRouter,
+  RouterProvider,
+} from "react-router";
+
+describe("useBlocker", () => {
+  describe("should block navigation", () => {
+    it("passing true as argument", () => {
+      const ref = React.createRef();
+      function Home() {
+        const result = unstable_useBlocker(true);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findByType("button");
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+                  <div>
+                    <h1>
+                      Home
+                    </h1>
+                    <button
+                      onClick={[Function]}
+                    >
+                      click me
+                    </button>
+                  </div>
+                `);
+
+      expect(ref.current).toMatchObject({
+        location: {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/about",
+          search: "",
+          state: null,
+        },
+        proceed: expect.any(Function),
+        reset: expect.any(Function),
+        state: "blocked",
+      });
+    });
+
+    it("passing a function that returns true", () => {
+      const fn = jest.fn().mockReturnValue(true);
+      const ref = React.createRef();
+
+      function Home() {
+        const result = unstable_useBlocker(fn);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findByType("button");
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+                    <div>
+                      <h1>
+                        Home
+                      </h1>
+                      <button
+                        onClick={[Function]}
+                      >
+                        click me
+                      </button>
+                    </div>
+                  `);
+
+      expect(ref.current).toMatchObject({
+        location: {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/about",
+          search: "",
+          state: null,
+        },
+        proceed: expect.any(Function),
+        reset: expect.any(Function),
+        state: "blocked",
+      });
+    });
+  });
+
+  describe("should NOT block navigation", () => {
+    it("passing false as argument", () => {
+      const ref = React.createRef();
+      function Home() {
+        const result = unstable_useBlocker(false);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findByType("button");
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+
+      expect(ref.current).toMatchObject({
+        location: undefined,
+        proceed: undefined,
+        reset: undefined,
+        state: "unblocked",
+      });
+    });
+
+    it("passing a function that returns false", () => {
+      const fn = jest.fn().mockReturnValue(false);
+
+      const ref = React.createRef();
+      function Home() {
+        const result = unstable_useBlocker(fn);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findByType("button");
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+   <h1>
+     About
+   </h1>
+ `);
+
+      expect(ref.current).toMatchObject({
+        location: undefined,
+        proceed: undefined,
+        reset: undefined,
+        state: "unblocked",
+      });
+    });
+  });
+
+  describe("should stop blocking after change (update)", () => {
+    it("should stop blocking after changing state (boolean)", () => {
+      const ref = React.createRef();
+      function Home() {
+        const [state, setState] = React.useState(true);
+        const result = unstable_useBlocker(state);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+
+        function enableBlock() {
+          setState(false);
+        }
+
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={enableBlock}>enableBlock</button>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findAllByType("button")[1];
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <div>
+          <h1>
+            Home
+          </h1>
+          <button
+            onClick={[Function]}
+          >
+            enableBlock
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            click me
+          </button>
+        </div>
+      `);
+
+      expect(ref.current).toMatchObject({
+        location: {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/about",
+          search: "",
+          state: null,
+        },
+        proceed: expect.any(Function),
+        reset: expect.any(Function),
+        state: "blocked",
+      });
+
+      // update blocker to stop blocking
+      // @ts-expect-error
+      let updater = renderer.root.findAllByType("button")[0];
+      TestRenderer.act(() => updater.props.onClick());
+
+      // @ts-expect-error
+      button = renderer.root.findAllByType("button")[1];
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <h1>
+          About
+        </h1>
+      `);
+    });
+
+    it("should stop blocking after changing state (function)", () => {
+      const ref = React.createRef();
+      function Home() {
+        const [state, setState] = React.useState(true);
+        const result = unstable_useBlocker(() => state);
+        let navigate = useNavigate();
+
+        // @ts-expect-error
+        ref.current = result;
+
+        function enableBlock() {
+          setState(false);
+        }
+
+        function handleClick() {
+          navigate("/about");
+        }
+
+        return (
+          <div>
+            <h1>Home</h1>
+            <button onClick={enableBlock}>enableBlock</button>
+            <button onClick={handleClick}>click me</button>
+          </div>
+        );
+      }
+      const routes = [
+        {
+          path: "/home",
+          element: <Home />,
+        },
+        { path: "/about", element: <h1>About</h1> },
+      ];
+
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/home"],
+        initialIndex: 1,
+      });
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(<RouterProvider router={router} />);
+      });
+
+      // @ts-expect-error
+      let button = renderer.root.findAllByType("button")[1];
+      TestRenderer.act(() => button.props.onClick());
+
+      expect(ref.current).toMatchObject({
+        location: {
+          hash: "",
+          key: expect.any(String),
+          pathname: "/about",
+          search: "",
+          state: null,
+        },
+        proceed: expect.any(Function),
+        reset: expect.any(Function),
+        state: "blocked",
+      });
+
+      // update blocker to stop blocking
+      // @ts-expect-error
+      let updater = renderer.root.findAllByType("button")[0];
+      TestRenderer.act(() => updater.props.onClick());
+
+      // @ts-expect-error
+      button = renderer.root.findAllByType("button")[1];
+      TestRenderer.act(() => button.props.onClick());
+
+      // @ts-expect-error
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+          <h1>
+            About
+          </h1>
+        `);
+    });
+  });
+});


### PR DESCRIPTION
- Fix the infinite loop present in useBlocker.
- Introduces some unit tests to find if the hook breaks the basic functionalities

I believe that will fix remix issue introduced by react-router -> https://github.com/remix-run/remix/issues/6704

Feedback always welcome
(hope the .changeset is correct 😕 😃)

Cheers