### PR TITLE
reduce internal states in useBlocker

### DIFF
--- a/.changeset/hungry-ladybugs-dream.md
+++ b/.changeset/hungry-ladybugs-dream.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+reduce number of internal state in useBlocker

--- a/contributors.yml
+++ b/contributors.yml
@@ -63,6 +63,7 @@
 - emzoumpo
 - engpetermwangi
 - ericschn
+- fernandojbf
 - FilipJirsak
 - frontsideair
 - fyzhu


### PR DESCRIPTION
This PR reduces the number of internal states used in `useBlocker`

I believe this solution works and brings less useEffects interactions with internal state.

With StrictMode we will continue to have 2 ids. But we will never have an orphan blocker. The first ID will be added and removed making the code more deterministic.

For the normal mode (no strict mode) the id generation only works once and the effect makes always the same action (adding and removing on unmount).

I believe this simplifies the solution.
