### PR TITLE
docs(hooks/use-outlet-context): update typings

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -222,3 +222,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- valerii15298

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -49,7 +49,7 @@ export default function Dashboard() {
   return (
     <div>
       <h1>Dashboard</h1>
-      <Outlet context={{ user }} />
+      <Outlet context={{ user } satisfies ContextType} />
     </div>
   );
 }


### PR DESCRIPTION
In previous version when you change type of a user in `useState` or just pass wrong data in the context you wouldn't get a typescript error. In other words only context consumer uses `ContextType` but not producer, which is wrong bcs as I said when you change type of data in the producer(without changing ContexrType) => the consumer would still assume the old data is passed.

This commit adds better typescript support, so that when you change data passed into context you will get ts error if the data does not satisfy ContextType and you will be forced to update context related stuff everywhere where it is needed(bcs typescript will show you)