### PR TITLE
Return the navigate promise

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -46,6 +46,7 @@
 - codeape2
 - coryhouse
 - cvbuelow
+- DanielSchiavini
 - damianstasik
 - danielberndt
 - dauletbaev

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1018,7 +1018,7 @@ function useNavigateStable(): NavigateFunction {
       if (!activeRef.current) return;
 
       if (typeof to === "number") {
-        return router.navigate(to, options);
+        return router.navigate(to);
       }
       return router.navigate(to, { fromRouteId: id, ...options });
     },

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1018,10 +1018,9 @@ function useNavigateStable(): NavigateFunction {
       if (!activeRef.current) return;
 
       if (typeof to === "number") {
-        router.navigate(to);
-      } else {
-        router.navigate(to, { fromRouteId: id, ...options });
+        return router.navigate(to, options);
       }
+      return router.navigate(to, { fromRouteId: id, ...options });
     },
     [router, id]
   );


### PR DESCRIPTION
When navigate throws errors, it's impossible for the calling application to catch them. Navigate returns a promise and that promise should be returned to the caller.