### PR TITLE
improve types for `Path`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -33,6 +33,7 @@
 - brockross
 - brookslybrand
 - brophdawg11
+- brunocrosier
 - btav
 - bvangraafeiland
 - CanRau

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -36,17 +36,17 @@ export interface Path {
   /**
    * A URL pathname, beginning with a /.
    */
-  pathname: string;
+  pathname: `/${string}`;
 
   /**
    * A URL search string, beginning with a ?.
    */
-  search: string;
+  search: `?${string}`;
 
   /**
    * A URL fragment identifier, beginning with a #.
    */
-  hash: string;
+  hash: `#${string}`;
 }
 
 /**


### PR DESCRIPTION
currently the types for `pathname`, `search` and `hash` are all `string`, with a comment indicating that they should start with a `/`, `?` and `#` respectively

this PR improves the types for each of the three by using template literal types

for example

```ts

// Before
pathname: 'some-pathname-without-initial-slash' // no type error

// After: 
pathname: 'some-pathname-without-initial-slash' // type error
```