### PR TITLE
Properly handle fetcher redirects interrupted by normal navigations

### DIFF
--- a/.changeset/fetcher-redirect-interrupt.md
+++ b/.changeset/fetcher-redirect-interrupt.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Properly handle fetcher redirects interrupted by normal navigations

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "46.6 kB"
+      "none": "46.8 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.8 kB"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "46.8 kB"
+      "none": "46.9 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.8 kB"


### PR DESCRIPTION
If a fetcher loader/action is in-flight, and a new navigation is started, and then the loader/action completes with a redirect, we should be ignoring the redirect since the navigation came after it.

Closes https://github.com/remix-run/remix/issues/6695