### PR TITLE
Fix lazy typings

### DIFF
--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -10,6 +10,7 @@ import type {
   StaticHandlerContext,
   To,
   TrackedPromise,
+  LazyRouteFunction,
 } from "@remix-run/router";
 import type { Action as NavigationType } from "@remix-run/router";
 
@@ -30,7 +31,7 @@ export interface IndexRouteObject {
   errorElement?: React.ReactNode | null;
   Component?: React.ComponentType | null;
   ErrorBoundary?: React.ComponentType | null;
-  lazy?: AgnosticIndexRouteObject["lazy"];
+  lazy?: LazyRouteFunction<RouteObject>;
 }
 
 export interface NonIndexRouteObject {
@@ -48,7 +49,7 @@ export interface NonIndexRouteObject {
   errorElement?: React.ReactNode | null;
   Component?: React.ComponentType | null;
   ErrorBoundary?: React.ComponentType | null;
-  lazy?: AgnosticNonIndexRouteObject["lazy"];
+  lazy?: LazyRouteFunction<RouteObject>;
 }
 
 export type RouteObject = IndexRouteObject | NonIndexRouteObject;


### PR DESCRIPTION
Quick follow up to https://github.com/remix-run/react-router/pull/10634 which was only allowing agnostic properties to be returned from `lazy`