### PR TITLE
Properly decode element id when emulating hash scrolling

### DIFF
--- a/.changeset/decode-hash-scroll.md
+++ b/.changeset/decode-hash-scroll.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Properly decode element id when emulating hash scrolling via `<ScrollRestoration>`

--- a/.changeset/dirty-coats-warn.md
+++ b/.changeset/dirty-coats-warn.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Fix elementId not decoded when emulate native hash scroll

--- a/.changeset/dirty-coats-warn.md
+++ b/.changeset/dirty-coats-warn.md
@@ -1,5 +1,0 @@
----
-"react-router-dom": minor
----
-
-Fix elementId not decoded when emulate native hash scroll

--- a/contributors.yml
+++ b/contributors.yml
@@ -222,5 +222,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
-- holynewbie
 - istarkov

--- a/contributors.yml
+++ b/contributors.yml
@@ -222,3 +222,5 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- holynewbie
+- istarkov

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1384,7 +1384,9 @@ function useScrollRestoration({
 
       // try to scroll to the hash
       if (location.hash) {
-        let el = document.getElementById(location.hash.slice(1));
+        let el = document.getElementById(
+          decodeURIComponent(location.hash.slice(1))
+        );
         if (el) {
           el.scrollIntoView();
           return;


### PR DESCRIPTION
Supersedes https://github.com/remix-run/react-router/pull/10642

Closes #10641 