### PR TITLE
fix(react-router-dom): Fix `usePrompt` invalid blocker state transition

### DIFF
--- a/.changeset/prompt-effect-order.md
+++ b/.changeset/prompt-effect-order.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Reorder effects in `unstable_usePrompt` to avoid throwing an exception if the prompt is unblocked and a navigation is performed syncronously

--- a/contributors.yml
+++ b/contributors.yml
@@ -223,3 +223,4 @@
 - yuleicul
 - zheng-chuang
 - istarkov
+- louis-young

--- a/packages/react-router-dom/__tests__/use-prompt-test.tsx
+++ b/packages/react-router-dom/__tests__/use-prompt-test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   Link,
   RouterProvider,
@@ -7,145 +7,120 @@ import {
   unstable_usePrompt as usePrompt,
 } from "../index";
 import "@testing-library/jest-dom";
-
-const PromptRoute = ({ when, message }: Parameters<typeof usePrompt>[0]) => {
-  usePrompt({ when, message });
-
-  return (
-    <>
-      <h1>Prompt Route</h1>
-
-      <Link to="/arbitrary">Navigate to arbitrary route</Link>
-    </>
-  );
-};
-
-const ArbitraryRoute = () => {
-  return <h1>Arbitrary Route</h1>;
-};
+import { JSDOM } from "jsdom";
 
 describe("usePrompt", () => {
   afterEach(() => {
     jest.clearAllMocks();
-
-    window.history.pushState({}, "", "/");
   });
 
   describe("when navigation is blocked", () => {
-    it("shows the confirmation prompt and does not navigate when the confirmation prompt is cancelled", () => {
-      const when = true;
-      const message = "__MESSAGE__";
-
-      const router = createBrowserRouter([
-        {
-          path: "/",
-          element: <PromptRoute when={when} message={message} />,
-        },
-        {
-          path: "/arbitrary",
-          element: <ArbitraryRoute />,
-        },
-      ]);
-
-      render(<RouterProvider router={router} />);
-
-      expect(
-        screen.getByRole("heading", { name: "Prompt Route" })
-      ).toBeInTheDocument();
-
+    it("shows window.confirm and blocks navigation when it returns false", async () => {
+      let testWindow = getWindowImpl("/");
       const windowConfirmMock = jest
         .spyOn(window, "confirm")
         .mockImplementationOnce(() => false);
 
-      act(() => {
-        screen
-          .getByRole("link", { name: "Navigate to arbitrary route" })
-          .click();
-      });
-
-      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, message);
-
-      expect(
-        screen.getByRole("heading", { name: "Prompt Route" })
-      ).toBeInTheDocument();
-    });
-
-    it("shows the confirmation prompt and navigates when the confirmation prompt is accepted", () => {
-      const when = true;
-      const message = "__MESSAGE__";
-
-      const router = createBrowserRouter([
-        {
-          path: "/",
-          element: <PromptRoute when={when} message={message} />,
-        },
-        {
-          path: "/arbitrary",
-          element: <ArbitraryRoute />,
-        },
-      ]);
+      let router = createBrowserRouter(
+        [
+          {
+            path: "/",
+            Component() {
+              usePrompt({ when: true, message: "Are you sure??" });
+              return <Link to="/arbitrary">Navigate</Link>;
+            },
+          },
+          {
+            path: "/arbitrary",
+            Component: () => <h1>Arbitrary</h1>,
+          },
+        ],
+        { window: testWindow }
+      );
 
       render(<RouterProvider router={router} />);
+      expect(screen.getByText("Navigate")).toBeInTheDocument();
 
-      expect(
-        screen.getByRole("heading", { name: "Prompt Route" })
-      ).toBeInTheDocument();
+      fireEvent.click(screen.getByText("Navigate"));
+      await new Promise((r) => setTimeout(r, 0));
 
+      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, "Are you sure??");
+      expect(screen.getByText("Navigate")).toBeInTheDocument();
+    });
+
+    it("shows window.confirm and navigates when it returns true", async () => {
+      let testWindow = getWindowImpl("/");
       const windowConfirmMock = jest
         .spyOn(window, "confirm")
         .mockImplementationOnce(() => true);
 
-      act(() => {
-        screen
-          .getByRole("link", { name: "Navigate to arbitrary route" })
-          .click();
-      });
+      let router = createBrowserRouter(
+        [
+          {
+            path: "/",
+            Component() {
+              usePrompt({ when: true, message: "Are you sure??" });
+              return <Link to="/arbitrary">Navigate</Link>;
+            },
+          },
+          {
+            path: "/arbitrary",
+            Component: () => <h1>Arbitrary</h1>,
+          },
+        ],
+        { window: testWindow }
+      );
 
-      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, message);
+      render(<RouterProvider router={router} />);
+      expect(screen.getByText("Navigate")).toBeInTheDocument();
 
-      expect(
-        screen.getByRole("heading", { name: "Arbitrary Route" })
-      ).toBeInTheDocument();
+      fireEvent.click(screen.getByText("Navigate"));
+      await waitFor(() => screen.getByText("Arbitrary"));
+
+      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, "Are you sure??");
+      expect(screen.getByText("Arbitrary")).toBeInTheDocument();
     });
   });
 
   describe("when navigation is not blocked", () => {
-    it("navigates without showing the confirmation prompt", () => {
-      const when = false;
-      const message = "__MESSAGE__";
-
-      const router = createBrowserRouter([
-        {
-          path: "/",
-          element: <PromptRoute when={when} message={message} />,
-        },
-        {
-          path: "/arbitrary",
-          element: <ArbitraryRoute />,
-        },
-      ]);
-
-      render(<RouterProvider router={router} />);
-
-      expect(
-        screen.getByRole("heading", { name: "Prompt Route" })
-      ).toBeInTheDocument();
-
+    it("navigates without showing window.confirm", async () => {
+      let testWindow = getWindowImpl("/");
       const windowConfirmMock = jest
         .spyOn(window, "confirm")
-        .mockImplementationOnce(() => false);
+        .mockImplementation(() => true);
 
-      act(() => {
-        screen
-          .getByRole("link", { name: "Navigate to arbitrary route" })
-          .click();
-      });
+      let router = createBrowserRouter(
+        [
+          {
+            path: "/",
+            Component() {
+              usePrompt({ when: false, message: "Are you sure??" });
+              return <Link to="/arbitrary">Navigate</Link>;
+            },
+          },
+          {
+            path: "/arbitrary",
+            Component: () => <h1>Arbitrary</h1>,
+          },
+        ],
+        { window: testWindow }
+      );
+
+      render(<RouterProvider router={router} />);
+      expect(screen.getByText("Navigate")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Navigate"));
+      await waitFor(() => screen.getByText("Arbitrary"));
 
       expect(windowConfirmMock).not.toHaveBeenCalled();
-
-      expect(
-        screen.getByRole("heading", { name: "Arbitrary Route" })
-      ).toBeInTheDocument();
+      expect(screen.getByText("Arbitrary")).toBeInTheDocument();
     });
   });
 });
+
+function getWindowImpl(initialUrl: string, isHash = false): Window {
+  // Need to use our own custom DOM in order to get a working history
+  const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
+  dom.window.history.replaceState(null, "", (isHash ? "#" : "") + initialUrl);
+  return dom.window as unknown as Window;
+}

--- a/packages/react-router-dom/__tests__/use-prompt-test.tsx
+++ b/packages/react-router-dom/__tests__/use-prompt-test.tsx
@@ -1,0 +1,151 @@
+import * as React from "react";
+import { act, render, screen } from "@testing-library/react";
+import {
+  Link,
+  RouterProvider,
+  createBrowserRouter,
+  unstable_usePrompt as usePrompt,
+} from "../index";
+import "@testing-library/jest-dom";
+
+const PromptRoute = ({ when, message }: Parameters<typeof usePrompt>[0]) => {
+  usePrompt({ when, message });
+
+  return (
+    <>
+      <h1>Prompt Route</h1>
+
+      <Link to="/arbitrary">Navigate to arbitrary route</Link>
+    </>
+  );
+};
+
+const ArbitraryRoute = () => {
+  return <h1>Arbitrary Route</h1>;
+};
+
+describe("usePrompt", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+
+    window.history.pushState({}, "", "/");
+  });
+
+  describe("when navigation is blocked", () => {
+    it("shows the confirmation prompt and does not navigate when the confirmation prompt is cancelled", () => {
+      const when = true;
+      const message = "__MESSAGE__";
+
+      const router = createBrowserRouter([
+        {
+          path: "/",
+          element: <PromptRoute when={when} message={message} />,
+        },
+        {
+          path: "/arbitrary",
+          element: <ArbitraryRoute />,
+        },
+      ]);
+
+      render(<RouterProvider router={router} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Prompt Route" })
+      ).toBeInTheDocument();
+
+      const windowConfirmMock = jest
+        .spyOn(window, "confirm")
+        .mockImplementationOnce(() => false);
+
+      act(() => {
+        screen
+          .getByRole("link", { name: "Navigate to arbitrary route" })
+          .click();
+      });
+
+      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, message);
+
+      expect(
+        screen.getByRole("heading", { name: "Prompt Route" })
+      ).toBeInTheDocument();
+    });
+
+    it("shows the confirmation prompt and navigates when the confirmation prompt is accepted", () => {
+      const when = true;
+      const message = "__MESSAGE__";
+
+      const router = createBrowserRouter([
+        {
+          path: "/",
+          element: <PromptRoute when={when} message={message} />,
+        },
+        {
+          path: "/arbitrary",
+          element: <ArbitraryRoute />,
+        },
+      ]);
+
+      render(<RouterProvider router={router} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Prompt Route" })
+      ).toBeInTheDocument();
+
+      const windowConfirmMock = jest
+        .spyOn(window, "confirm")
+        .mockImplementationOnce(() => true);
+
+      act(() => {
+        screen
+          .getByRole("link", { name: "Navigate to arbitrary route" })
+          .click();
+      });
+
+      expect(windowConfirmMock).toHaveBeenNthCalledWith(1, message);
+
+      expect(
+        screen.getByRole("heading", { name: "Arbitrary Route" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when navigation is not blocked", () => {
+    it("navigates without showing the confirmation prompt", () => {
+      const when = false;
+      const message = "__MESSAGE__";
+
+      const router = createBrowserRouter([
+        {
+          path: "/",
+          element: <PromptRoute when={when} message={message} />,
+        },
+        {
+          path: "/arbitrary",
+          element: <ArbitraryRoute />,
+        },
+      ]);
+
+      render(<RouterProvider router={router} />);
+
+      expect(
+        screen.getByRole("heading", { name: "Prompt Route" })
+      ).toBeInTheDocument();
+
+      const windowConfirmMock = jest
+        .spyOn(window, "confirm")
+        .mockImplementationOnce(() => false);
+
+      act(() => {
+        screen
+          .getByRole("link", { name: "Navigate to arbitrary route" })
+          .click();
+      });
+
+      expect(windowConfirmMock).not.toHaveBeenCalled();
+
+      expect(
+        screen.getByRole("heading", { name: "Arbitrary Route" })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1462,21 +1462,21 @@ function usePrompt({ when, message }: { when: boolean; message: string }) {
   let blocker = useBlocker(when);
 
   React.useEffect(() => {
-    if (blocker.state === "blocked" && !when) {
-      blocker.reset();
-    }
-  }, [blocker, when]);
-
-  React.useEffect(() => {
     if (blocker.state === "blocked") {
       let proceed = window.confirm(message);
       if (proceed) {
-        setTimeout(blocker.proceed, 0);
+        blocker.proceed();
       } else {
         blocker.reset();
       }
     }
   }, [blocker, message]);
+
+  React.useEffect(() => {
+    if (blocker.state === "blocked" && !when) {
+      blocker.reset();
+    }
+  }, [blocker, when]);
 }
 
 export { usePrompt as unstable_usePrompt };


### PR DESCRIPTION
PR for #10489.

This pull request fixes the `usePrompt` invalid blocker state transition invariant exception.

Essentially, when navigating, if we should block navigation, we update the blocker for the derived blocker key so that it's in a "blocked" state. In the proceed function for this blocker, we then update the blocker so that it's in a "proceeding" state. In the reset function for this blocker, we reset the blocker to the `IDLE_BLOCKER` (which results in an "unblocked" state). 

In the `updateBlocker` function, we receive the blocker key as a parameter and update it. What was happening here is that by the time we came to proceed the blocker, it was in a "proceeding" state, causing the invariant to throw an exception according to the state-machine-like logic (logically, as this makes no sense). 

The blocker was in this state because in the `usePrompt` hook, there are two effects: one that resets the blocker when the `when` parameter changes, and one that proceeds the blocker after confirmation. These two effects were essentially fighting each other; the first effect was resetting the blocker _just_ before the second effect attempted to proceed it, leading to the unexpected state transition. 

What I've done (after reasoning about this with [brophdawg11](https://github.com/brophdawg11), thanks for your time and expertise Matt) is both reversed the definition order of the effects so that we first attempt to proceed a blocker when appropriate, and also removed the `setTimeout` wrapping the call to `blocker.proceed` as I think this defers the execution of the function, which probably isn't what we want here.

This appears to fix the problem 🎉 

### Changes

- Remove the `setTimeout` wrapping `blocker.proceed`. This defers the execution of the function, but I don't think that's what we want here.
- Reorder the `useEffect`s so that we attempt to proceed first when appropriate and prevent resetting a blocker that we're about to proceed.

### Notes

- If anyone knows exactly why the `setTimeout` wrapping `blocker.proceed` was required, or why anything I've done here doesn't sound like a good idea then please let me know 🙂 