### PR TITLE
Initial-load fetchers should not automatically revalidate on GET navigations

### DIFF
--- a/.changeset/initial-load-fetcher.md
+++ b/.changeset/initial-load-fetcher.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Initial-load fetchers should not automatically revalidate on GET navigations

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3395,11 +3395,6 @@ function getMatchesToLoad(
       return;
     }
 
-    // Don't revalidate an actively redirecting fetcher
-    if (fetchRedirectIds.has(key)) {
-      return;
-    }
-
     let fetcherMatches = matchRoutes(routesToUse, f.path, basename);
 
     // If the fetcher path no longer matches, push it in with null matches so
@@ -3425,7 +3420,10 @@ function getMatchesToLoad(
     let fetcherMatch = getTargetMatch(fetcherMatches, f.path);
 
     let shouldRevalidate = false;
-    if (cancelledFetcherLoads.includes(key)) {
+    if (fetchRedirectIds.has(key)) {
+      // Never trigger a revalidation of an actively redirecting fetcher
+      shouldRevalidate = false;
+    } else if (cancelledFetcherLoads.includes(key)) {
       // Always revalidate if the fetcher was cancelled
       shouldRevalidate = true;
     } else if (

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3403,7 +3403,9 @@ function getMatchesToLoad(
     let fetcherMatches = matchRoutes(routesToUse, f.path, basename);
 
     // If the fetcher path no longer matches, push it in with null matches so
-    // we can trigger a 404 in callLoadersAndMaybeResolveData
+    // we can trigger a 404 in callLoadersAndMaybeResolveData.  Note this is
+    // currently only a use-case for Remix HMR where the route tree can change
+    // at runtime and remove a route previously loaded via a fetcher
     if (!fetcherMatches) {
       revalidatingFetchers.push({
         key,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3395,6 +3395,11 @@ function getMatchesToLoad(
       return;
     }
 
+    // Don't revalidate an actively redirecting fetcher
+    if (fetchRedirectIds.has(key)) {
+      return;
+    }
+
     let fetcherMatches = matchRoutes(routesToUse, f.path, basename);
 
     // If the fetcher path no longer matches, push it in with null matches so
@@ -3418,10 +3423,7 @@ function getMatchesToLoad(
     let fetcherMatch = getTargetMatch(fetcherMatches, f.path);
 
     let shouldRevalidate = false;
-    if (fetchRedirectIds.has(key)) {
-      // Never trigger a revalidation of an actively redirecting fetcher
-      shouldRevalidate = false;
-    } else if (cancelledFetcherLoads.includes(key)) {
+    if (cancelledFetcherLoads.includes(key)) {
       // Always revalidate if the fetcher was cancelled
       shouldRevalidate = true;
     } else if (


### PR DESCRIPTION
Follow up to https://github.com/remix-run/react-router/pull/10623 which inadvertently started revalidating initial-load fetchers on GET navigations, when it should only revalidate (without calling `shouldRevalidate`) on explicit revalidations (submissions, `useRevalidate`, etc.).  

Discord thread in which this was raised: https://discord.com/channels/770287896669978684/1128075241579614208/1128080680417501215