### PR TITLE
Add support to force reload on redirect with `X-Remix-Reload-Document` header

### DIFF
--- a/.changeset/x-remix-reload-document.md
+++ b/.changeset/x-remix-reload-document.md
@@ -6,4 +6,4 @@
 "@remix-run/router": minor
 ---
 
-Add support for the new `X-Remix-Reload-Document` header on loader responses to trigger a document reload of the redirected location
+Add support for the new `X-Remix-Reload-Document` header on `loader`/`action` responses to trigger a document reload of the redirected location

--- a/.changeset/x-remix-reload-document.md
+++ b/.changeset/x-remix-reload-document.md
@@ -1,0 +1,9 @@
+---
+"react-router": minor
+"react-router-dom": minor
+"react-router-dom-v5-compat": minor
+"react-router-native": minor
+"@remix-run/router": minor
+---
+
+Add support for the new `X-Remix-Reload-Document` header on loader responses to trigger a document reload of the redirected location

--- a/.changeset/x-remix-reload-document.md
+++ b/.changeset/x-remix-reload-document.md
@@ -6,4 +6,4 @@
 "@remix-run/router": minor
 ---
 
-Add support for the new `X-Remix-Reload-Document` header on `loader`/`action` responses to trigger a document reload of the redirected location
+Add's a new `redirectDocument()` function which allows users to specify that a redirect from a `loader`/`action` should trigger a document reload (via `window.location`) instead of attempting to navigate to the redirected location via React Router

--- a/contributors.yml
+++ b/contributors.yml
@@ -225,3 +225,4 @@
 - smithki
 - istarkov
 - louis-young
+- robbtraister

--- a/docs/fetch/redirectDocument.md
+++ b/docs/fetch/redirectDocument.md
@@ -7,7 +7,7 @@ new: true
 
 This is a small wrapper around [`redirect`][redirect] that will trigger a document-level redirect to the new location instead of a client-side navigation.
 
-This is most useful when you have a Remix app living next to a non-Remix app on the same domain and need to redirect from the Remix app to the non-Remix app:
+This is most useful when you have a React Router app living next to a separate app on the same domain and need to redirect from the React Router app to the other app via `window.location` instead of a React Router navigation:
 
 ```jsx
 import { redirectDocument } from "react-router-dom";

--- a/docs/fetch/redirectDocument.md
+++ b/docs/fetch/redirectDocument.md
@@ -1,0 +1,46 @@
+---
+title: redirectDocument
+new: true
+---
+
+# `redirectDocument`
+
+This is a small wrapper around [`redirect`][redirect] that will trigger a document-level redirect to the new location instead of a client-side navigation.
+
+This is most useful when you have a Remix app living next to a non-Remix app on the same domain and need to redirect from the Remix app to the non-Remix app:
+
+```jsx
+import { redirectDocument } from "react-router-dom";
+
+const loader = async () => {
+  const user = await getUser();
+  if (!user) {
+    return redirectDocument("/otherapp/login");
+  }
+  return null;
+};
+```
+
+## Type Declaration
+
+```ts
+type RedirectFunction = (
+  url: string,
+  init?: number | ResponseInit
+) => Response;
+```
+
+## `url`
+
+The URL to redirect to.
+
+```js
+redirectDocument("/otherapp/login");
+```
+
+## `init`
+
+The [Response][response] options to be used in the response.
+
+[response]: https://developer.mozilla.org/en-US/docs/Web/API/Response/Response
+[redirect]: ./redirect

--- a/package.json
+++ b/package.json
@@ -109,19 +109,19 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "47.2 kB"
+      "none": "47.4 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.8 kB"
+      "none": "13.9 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "16.2 kB"
+      "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "12.8 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "18.7 kB"
+      "none": "18.9 kB"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "47.4 kB"
+      "none": "47.5 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"

--- a/packages/react-router-dom-v5-compat/index.ts
+++ b/packages/react-router-dom-v5-compat/index.ts
@@ -158,7 +158,7 @@ export {
   Form,
   json,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   useActionData,
   useAsyncError,
   useAsyncValue,

--- a/packages/react-router-dom-v5-compat/index.ts
+++ b/packages/react-router-dom-v5-compat/index.ts
@@ -158,6 +158,7 @@ export {
   Form,
   json,
   redirect,
+  redirectWithReload,
   useActionData,
   useAsyncError,
   useAsyncValue,

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -152,7 +152,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -152,6 +152,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
+  redirectWithReload,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -87,7 +87,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -87,6 +87,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
+  redirectWithReload,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -39,7 +39,7 @@ import {
   matchRoutes,
   parsePath,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   resolvePath,
   UNSAFE_warning as warning,
 } from "@remix-run/router";
@@ -188,7 +188,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -39,6 +39,7 @@ import {
   matchRoutes,
   parsePath,
   redirect,
+  redirectWithReload,
   resolvePath,
   UNSAFE_warning as warning,
 } from "@remix-run/router";
@@ -187,6 +188,7 @@ export {
   matchRoutes,
   parsePath,
   redirect,
+  redirectWithReload,
   renderMatches,
   resolvePath,
   useActionData,

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -7005,42 +7005,34 @@ describe("a router", () => {
     });
 
     it("processes redirects with document reload if header is present (assign)", async () => {
-      let urls = ["/redirect"];
+      let t = setup({ routes: REDIRECT_ROUTES });
 
-      for (let url of urls) {
-        let t = setup({ routes: REDIRECT_ROUTES });
+      let A = await t.navigate("/parent/child", {
+        formMethod: "post",
+        formData: createFormData({}),
+      });
 
-        let A = await t.navigate("/parent/child", {
-          formMethod: "post",
-          formData: createFormData({}),
-        });
-
-        await A.actions.child.redirectReturn(url, 301, {
-          "X-Remix-Reload-Document": "true",
-        });
-        expect(t.window.location.assign).toHaveBeenCalledWith(url);
-        expect(t.window.location.replace).not.toHaveBeenCalled();
-      }
+      await A.actions.child.redirectReturn("/redirect", 301, {
+        "X-Remix-Reload-Document": "true",
+      });
+      expect(t.window.location.assign).toHaveBeenCalledWith("/redirect");
+      expect(t.window.location.replace).not.toHaveBeenCalled();
     });
 
     it("processes redirects with document reload if header is present (replace)", async () => {
-      let urls = ["/redirect"];
+      let t = setup({ routes: REDIRECT_ROUTES });
 
-      for (let url of urls) {
-        let t = setup({ routes: REDIRECT_ROUTES });
+      let A = await t.navigate("/parent/child", {
+        formMethod: "post",
+        formData: createFormData({}),
+        replace: true,
+      });
 
-        let A = await t.navigate("/parent/child", {
-          formMethod: "post",
-          formData: createFormData({}),
-          replace: true,
-        });
-
-        await A.actions.child.redirectReturn(url, 301, {
-          "X-Remix-Reload-Document": "true",
-        });
-        expect(t.window.location.replace).toHaveBeenCalledWith(url);
-        expect(t.window.location.assign).not.toHaveBeenCalled();
-      }
+      await A.actions.child.redirectReturn("/redirect", 301, {
+        "X-Remix-Reload-Document": "true",
+      });
+      expect(t.window.location.replace).toHaveBeenCalledWith("/redirect");
+      expect(t.window.location.assign).not.toHaveBeenCalled();
     });
 
     it("properly handles same-origin absolute URLs", async () => {

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -7004,6 +7004,45 @@ describe("a router", () => {
       }
     });
 
+    it("processes redirects with document reload if header is present (assign)", async () => {
+      let urls = ["/redirect"];
+
+      for (let url of urls) {
+        let t = setup({ routes: REDIRECT_ROUTES });
+
+        let A = await t.navigate("/parent/child", {
+          formMethod: "post",
+          formData: createFormData({}),
+        });
+
+        await A.actions.child.redirectReturn(url, 301, {
+          "X-Remix-Reload-Document": "true",
+        });
+        expect(t.window.location.assign).toHaveBeenCalledWith(url);
+        expect(t.window.location.replace).not.toHaveBeenCalled();
+      }
+    });
+
+    it("processes redirects with document reload if header is present (replace)", async () => {
+      let urls = ["/redirect"];
+
+      for (let url of urls) {
+        let t = setup({ routes: REDIRECT_ROUTES });
+
+        let A = await t.navigate("/parent/child", {
+          formMethod: "post",
+          formData: createFormData({}),
+          replace: true,
+        });
+
+        await A.actions.child.redirectReturn(url, 301, {
+          "X-Remix-Reload-Document": "true",
+        });
+        expect(t.window.location.replace).toHaveBeenCalledWith(url);
+        expect(t.window.location.assign).not.toHaveBeenCalled();
+      }
+    });
+
     it("properly handles same-origin absolute URLs", async () => {
       let t = setup({ routes: REDIRECT_ROUTES });
 

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -39,6 +39,7 @@ export {
   matchRoutes,
   normalizePathname,
   redirect,
+  redirectWithReload,
   resolvePath,
   resolveTo,
   stripBasename,

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -39,7 +39,7 @@ export {
   matchRoutes,
   normalizePathname,
   redirect,
-  redirectWithReload,
+  redirectDocument,
   resolvePath,
   resolveTo,
   stripBasename,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2119,13 +2119,11 @@ export function createRouter(init: RouterInit): Router {
         isDocumentReload = true;
       } else if (ABSOLUTE_URL_REGEX.test(redirect.location)) {
         const url = init.history.createURL(redirect.location);
-        if (url.origin !== routerWindow.location.origin) {
+        isDocumentReload =
           // Hard reload if it's an absolute URL to a new origin
-          isDocumentReload = true;
-        } else {
+          url.origin !== routerWindow.location.origin ||
           // Hard reload if it's an absolute URL that does not match our basename
-          isDocumentReload = stripBasename(url.pathname, basename) == null;
-        }
+          stripBasename(url.pathname, basename) == null;
       }
 
       if (isDocumentReload) {

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -43,6 +43,7 @@ export interface RedirectResult {
   status: number;
   location: string;
   revalidate: boolean;
+  reloadDocument?: boolean;
 }
 
 /**

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1486,6 +1486,23 @@ export const redirect: RedirectFunction = (url, init = 302) => {
 };
 
 /**
+ * A redirect response with a forced document reload. Sets a custom header to
+ * trigger the client-side reload.
+ * Defaults to "302 Found".
+ */
+export const redirectWithReload: RedirectFunction = (url, init = 302) => {
+  let responseInit = init;
+  if (typeof responseInit === "number") {
+    responseInit = { status: responseInit };
+  }
+
+  responseInit.headers = new Headers(responseInit.headers);
+  responseInit.headers.set("X-Remix-Reload-Document", "true");
+
+  return redirect(url, responseInit);
+};
+
+/**
  * @private
  * Utility class we use to hold auto-unwrapped 4xx/5xx Response bodies
  */

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1490,7 +1490,7 @@ export const redirect: RedirectFunction = (url, init = 302) => {
  * Sets the status code and the `Location` header.
  * Defaults to "302 Found".
  */
-export const redirectWithReload: RedirectFunction = (url, init) => {
+export const redirectDocument: RedirectFunction = (url, init) => {
   let response = redirect(url, init);
   response.headers.set("X-Remix-Reload-Document", "true");
   return response;

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1486,20 +1486,14 @@ export const redirect: RedirectFunction = (url, init = 302) => {
 };
 
 /**
- * A redirect response with a forced document reload. Sets a custom header to
- * trigger the client-side reload.
+ * A redirect response that will force a document reload to the new location.
+ * Sets the status code and the `Location` header.
  * Defaults to "302 Found".
  */
-export const redirectWithReload: RedirectFunction = (url, init = 302) => {
-  let responseInit = init;
-  if (typeof responseInit === "number") {
-    responseInit = { status: responseInit };
-  }
-
-  responseInit.headers = new Headers(responseInit.headers);
-  responseInit.headers.set("X-Remix-Reload-Document", "true");
-
-  return redirect(url, responseInit);
+export const redirectWithReload: RedirectFunction = (url, init) => {
+  let response = redirect(url, init);
+  response.headers.set("X-Remix-Reload-Document", "true");
+  return response;
 };
 
 /**


### PR DESCRIPTION
Sometimes we want to force a document reload when redirecting on the same origin. This PR adds support for a custom header (`X-Remix-Reload-Document`), which, when present, tells the router to trigger a document reload when handling a redirect in the browser.

My use-case for this behavior is using remix as an OAuth login app, sharing the same origin with other apps, each served on a separate basename (behind a reverse proxy). On the final stage of the login flow, the response may either fail or succeed. In the case of failure, we return an error message without a page reload and remain within the remix app. In the case of success, we redirect to the target application. Since the result is dynamic, we cannot set `reloadDocument` in the request form. Since the target application is served externally from remix, we cannot use a history redirect. And we cannot rely on a success page to trigger a client-side redirect as that won't work without javascript.

The only solution that works in all cases (including without javascript) is a custom header included with the redirect response that is then used to trigger a document reload in the client router.

I have an example repo with this implementation patched here: https://github.com/robbtraister/remix-hard-redirect

I also added and exported a `redirectWithReload` utility function that appends the header in question so you don't need to remember or type it.

Link to the [Open Development discussion](https://github.com/remix-run/react-router/discussions/9859)
