### PR TITLE
Stabilize useRevalidator

### DIFF
--- a/.changeset/stable-use-revalidator.md
+++ b/.changeset/stable-use-revalidator.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Ensure `useRevalidator` is referentially stable across re-renders if revalidations are not actively occuring

--- a/packages/react-router-dom/__tests__/concurrent-mode-navigations-test.tsx
+++ b/packages/react-router-dom/__tests__/concurrent-mode-navigations-test.tsx
@@ -13,12 +13,13 @@ import {
 import {
   act,
   fireEvent,
-  prettyDOM,
   render,
   screen,
   waitFor,
 } from "@testing-library/react";
 import { JSDOM } from "jsdom";
+import createDeferred from "../../router/__tests__/utils/createDeferred";
+import getHtml from "react-router/__tests__/utils/getHtml";
 
 describe("Handles concurrent mode features during navigations", () => {
   function getComponents() {
@@ -377,37 +378,4 @@ function getWindowImpl(initialUrl: string, isHash = false): Window {
   const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
   dom.window.history.replaceState(null, "", (isHash ? "#" : "") + initialUrl);
   return dom.window as unknown as Window;
-}
-
-function getHtml(container: HTMLElement) {
-  return prettyDOM(container, undefined, {
-    highlight: false,
-  });
-}
-
-async function tick() {
-  await new Promise((r) => setTimeout(r, 0));
-}
-
-function createDeferred() {
-  let resolve: (val?: any) => Promise<void>;
-  let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
-      res(val);
-      await tick();
-      await promise;
-    };
-    reject = async (error?: Error) => {
-      rej(error);
-      await promise.catch(() => tick());
-    };
-  });
-  return {
-    promise,
-    //@ts-ignore
-    resolve,
-    //@ts-ignore
-    reject,
-  };
 }

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -6,7 +6,6 @@ import {
   fireEvent,
   waitFor,
   screen,
-  prettyDOM,
 } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import type { ErrorResponse, Fetcher } from "@remix-run/router";
@@ -36,6 +35,9 @@ import {
   useSearchParams,
   createRoutesFromElements,
 } from "react-router-dom";
+
+import createDeferred from "../../router/__tests__/utils/createDeferred";
+import getHtml from "../../react-router/__tests__/utils/getHtml";
 
 testDomRouter("<DataBrowserRouter>", createBrowserRouter, (url) =>
   getWindowImpl(url, false)
@@ -5925,48 +5927,9 @@ function testDomRouter(
   });
 }
 
-function createDeferred() {
-  let resolve: (val?: any) => Promise<void>;
-  let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
-      res(val);
-      try {
-        await promise;
-      } catch (e) {}
-    };
-    reject = async (error?: Error) => {
-      rej(error);
-      try {
-        await promise;
-      } catch (e) {}
-    };
-  });
-  return {
-    promise,
-    //@ts-ignore
-    resolve,
-    //@ts-ignore
-    reject,
-  };
-}
-
 function getWindowImpl(initialUrl: string, isHash = false): Window {
   // Need to use our own custom DOM in order to get a working history
   const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
   dom.window.history.replaceState(null, "", (isHash ? "#" : "") + initialUrl);
   return dom.window as unknown as Window;
-}
-
-function getHtml(container: HTMLElement) {
-  return prettyDOM(container, undefined, {
-    highlight: false,
-    theme: {
-      comment: null,
-      content: null,
-      prop: null,
-      tag: null,
-      value: null,
-    },
-  });
 }

--- a/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
+++ b/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom";
 import * as React from "react";
-import { render, prettyDOM, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
   Link,
@@ -9,6 +9,8 @@ import {
   ScrollRestoration,
   createBrowserRouter,
 } from "react-router-dom";
+
+import getHtml from "../../react-router/__tests__/utils/getHtml";
 
 describe(`ScrollRestoration`, () => {
   it("removes the basename from the location provided to getKey", () => {
@@ -69,17 +71,4 @@ function getWindowImpl(initialUrl: string): Window {
   const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
   dom.window.history.replaceState(null, "", initialUrl);
   return dom.window as unknown as Window;
-}
-
-function getHtml(container: HTMLElement) {
-  return prettyDOM(container, undefined, {
-    highlight: false,
-    theme: {
-      comment: null,
-      content: null,
-      prop: null,
-      tag: null,
-      value: null,
-    },
-  });
 }

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -10,7 +10,9 @@ import {
   createMemoryRouter,
   useLocation,
 } from "react-router";
-import { prettyDOM, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import getHtml from "../../react-router/__tests__/utils/getHtml";
 
 describe("<Navigate>", () => {
   describe("with an absolute href", () => {
@@ -1153,9 +1155,3 @@ describe("concurrent mode", () => {
     });
   });
 });
-
-function getHtml(container: HTMLElement) {
-  return prettyDOM(container, undefined, {
-    highlight: false,
-  });
-}

--- a/packages/react-router/__tests__/use-revalidator-test.tsx
+++ b/packages/react-router/__tests__/use-revalidator-test.tsx
@@ -19,7 +19,7 @@ import {
   useRouteError,
 } from "react-router";
 import MemoryNavigate from "./utils/MemoryNavigate";
-import getHtml from "./utils/getHTML";
+import getHtml from "./utils/getHtml";
 
 describe("useRevalidator", () => {
   it("reloads data using useRevalidator", async () => {

--- a/packages/react-router/__tests__/use-revalidator-test.tsx
+++ b/packages/react-router/__tests__/use-revalidator-test.tsx
@@ -1,0 +1,286 @@
+import "@testing-library/jest-dom";
+import {
+  fireEvent,
+  queryByText,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import {
+  Outlet,
+  Route,
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+  useLoaderData,
+  useNavigation,
+  useRevalidator,
+  useRouteError,
+} from "react-router";
+import MemoryNavigate from "./utils/MemoryNavigate";
+import getHtml from "./utils/getHTML";
+
+describe("useRevalidator", () => {
+  it("reloads data using useRevalidator", async () => {
+    let count = 1;
+    let router = createMemoryRouter(
+      createRoutesFromElements(
+        <Route path="/" element={<Layout />}>
+          <Route
+            path="foo"
+            loader={async () => `count=${++count}`}
+            element={<Foo />}
+          />
+        </Route>
+      ),
+      {
+        initialEntries: ["/foo"],
+        hydrationData: {
+          loaderData: {
+            "0-0": "count=1",
+          },
+        },
+      }
+    );
+    let { container } = render(<RouterProvider router={router} />);
+
+    function Layout() {
+      let navigation = useNavigation();
+      let { revalidate, state } = useRevalidator();
+      return (
+        <div>
+          <button onClick={() => revalidate()}>Revalidate</button>
+          <p>{navigation.state}</p>
+          <p>{state}</p>
+          <Outlet />
+        </div>
+      );
+    }
+
+    function Foo() {
+      let data = useLoaderData() as string;
+      return <p>{data}</p>;
+    }
+
+    expect(getHtml(container)).toMatchInlineSnapshot(`
+    "<div>
+      <div>
+        <button>
+          Revalidate
+        </button>
+        <p>
+          idle
+        </p>
+        <p>
+          idle
+        </p>
+        <p>
+          count=1
+        </p>
+      </div>
+    </div>"
+  `);
+
+    fireEvent.click(screen.getByText("Revalidate"));
+    expect(getHtml(container)).toMatchInlineSnapshot(`
+    "<div>
+      <div>
+        <button>
+          Revalidate
+        </button>
+        <p>
+          idle
+        </p>
+        <p>
+          loading
+        </p>
+        <p>
+          count=1
+        </p>
+      </div>
+    </div>"
+  `);
+
+    await waitFor(() => screen.getByText("count=2"));
+    expect(getHtml(container)).toMatchInlineSnapshot(`
+    "<div>
+      <div>
+        <button>
+          Revalidate
+        </button>
+        <p>
+          idle
+        </p>
+        <p>
+          idle
+        </p>
+        <p>
+          count=2
+        </p>
+      </div>
+    </div>"
+  `);
+  });
+
+  it("allows a successful useRevalidator to resolve the error boundary (loader + child boundary)", async () => {
+    let shouldFail = true;
+    let router = createMemoryRouter(
+      createRoutesFromElements(
+        <Route
+          path="/"
+          Component={() => (
+            <>
+              <MemoryNavigate to="child">/child</MemoryNavigate>
+              <Outlet />
+            </>
+          )}
+        >
+          <Route
+            path="child"
+            loader={() => {
+              if (shouldFail) {
+                shouldFail = false;
+                throw new Error("Broken");
+              } else {
+                return "Fixed";
+              }
+            }}
+            Component={() => <p>{("Child:" + useLoaderData()) as string}</p>}
+            ErrorBoundary={() => {
+              let { revalidate } = useRevalidator();
+              return (
+                <>
+                  <p>{"Error:" + (useRouteError() as Error).message}</p>
+                  <button onClick={() => revalidate()}>Try again</button>
+                </>
+              );
+            }}
+          />
+        </Route>
+      )
+    );
+
+    let { container } = render(
+      <div>
+        <RouterProvider router={router} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText("/child"));
+    await waitFor(() => screen.getByText("Error:Broken"));
+    expect(getHtml(container)).toMatch("Error:Broken");
+    expect(router.state.errors).not.toBe(null);
+
+    fireEvent.click(screen.getByText("Try again"));
+    await waitFor(() => {
+      expect(queryByText(container, "Child:Fixed")).toBeInTheDocument();
+    });
+    expect(getHtml(container)).toMatch("Child:Fixed");
+    expect(router.state.errors).toBe(null);
+  });
+
+  it("allows a successful useRevalidator to resolve the error boundary (loader + parent boundary)", async () => {
+    let shouldFail = true;
+    let router = createMemoryRouter(
+      createRoutesFromElements(
+        <Route
+          path="/"
+          Component={() => (
+            <>
+              <MemoryNavigate to="child">/child</MemoryNavigate>
+              <Outlet />
+            </>
+          )}
+          ErrorBoundary={() => {
+            let { revalidate } = useRevalidator();
+            return (
+              <>
+                <p>{"Error:" + (useRouteError() as Error).message}</p>
+                <button onClick={() => revalidate()}>Try again</button>
+              </>
+            );
+          }}
+        >
+          <Route
+            path="child"
+            loader={() => {
+              if (shouldFail) {
+                shouldFail = false;
+                throw new Error("Broken");
+              } else {
+                return "Fixed";
+              }
+            }}
+            Component={() => <p>{("Child:" + useLoaderData()) as string}</p>}
+          />
+        </Route>
+      )
+    );
+
+    let { container } = render(
+      <div>
+        <RouterProvider router={router} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByText("/child"));
+    await waitFor(() => screen.getByText("Error:Broken"));
+    expect(getHtml(container)).toMatch("Error:Broken");
+    expect(router.state.errors).not.toBe(null);
+
+    fireEvent.click(screen.getByText("Try again"));
+    await waitFor(() => {
+      expect(queryByText(container, "Child:Fixed")).toBeInTheDocument();
+    });
+    expect(getHtml(container)).toMatch("Child:Fixed");
+    expect(router.state.errors).toBe(null);
+  });
+
+  it("is stable across location changes", async () => {
+    let count = 0;
+    let router = createMemoryRouter([
+      {
+        path: "/",
+        Component() {
+          let revalidator = useRevalidator();
+
+          React.useEffect(() => {
+            count++;
+          }, [revalidator]);
+          return (
+            <div>
+              <MemoryNavigate to="/">Link to Home</MemoryNavigate>{" "}
+              <MemoryNavigate to="/foo">Link to Foo</MemoryNavigate>
+              <Outlet />
+            </div>
+          );
+        },
+        children: [
+          {
+            index: true,
+            Component() {
+              return <h1>Home Page</h1>;
+            },
+          },
+          {
+            path: "foo",
+            Component() {
+              return <h1>Foo Page</h1>;
+            },
+          },
+        ],
+      },
+    ]);
+
+    render(<RouterProvider router={router} />);
+
+    fireEvent.click(screen.getByText("Link to Foo"));
+    await waitFor(() => screen.getByText("Foo Page"));
+
+    fireEvent.click(screen.getByText("Link to Home"));
+    await waitFor(() => screen.getByText("Home Page"));
+
+    expect(count).toBe(1);
+  });
+});

--- a/packages/react-router/__tests__/utils/MemoryNavigate.tsx
+++ b/packages/react-router/__tests__/utils/MemoryNavigate.tsx
@@ -1,0 +1,44 @@
+import type { FormMethod } from "@remix-run/router";
+import { joinPaths } from "@remix-run/router";
+import * as React from "react";
+import { UNSAFE_DataRouterContext } from "react-router";
+
+export default function MemoryNavigate({
+  to,
+  formMethod,
+  formData,
+  children,
+}: {
+  to: string;
+  formMethod?: FormMethod;
+  formData?: FormData;
+  children: React.ReactNode;
+}) {
+  let dataRouterContext = React.useContext(UNSAFE_DataRouterContext);
+
+  let onClickHandler = React.useCallback(
+    async (event: React.MouseEvent) => {
+      event.preventDefault();
+      if (formMethod && formData) {
+        dataRouterContext?.router.navigate(to, { formMethod, formData });
+      } else {
+        dataRouterContext?.router.navigate(to);
+      }
+    },
+    [dataRouterContext, to, formMethod, formData]
+  );
+
+  // Only prepend the basename to the rendered href, send the non-prefixed `to`
+  // value into the router since it will prepend the basename
+  let basename = dataRouterContext?.basename;
+  let href = to;
+  if (basename && basename !== "/") {
+    href = to === "/" ? basename : joinPaths([basename, to]);
+  }
+
+  return formData ? (
+    <form onClick={onClickHandler} children={children} />
+  ) : (
+    <a href={href} onClick={onClickHandler} children={children} />
+  );
+}

--- a/packages/react-router/__tests__/utils/getHtml.ts
+++ b/packages/react-router/__tests__/utils/getHtml.ts
@@ -1,0 +1,7 @@
+import { prettyDOM } from "@testing-library/react";
+
+export default function getHtml(container: HTMLElement) {
+  return prettyDOM(container, undefined, {
+    highlight: false,
+  });
+}

--- a/packages/react-router/__tests__/utils/tick.ts
+++ b/packages/react-router/__tests__/utils/tick.ts
@@ -1,0 +1,3 @@
+export default async function tick() {
+  await new Promise((r) => setTimeout(r, 0));
+}

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -821,10 +821,13 @@ export function useNavigation() {
 export function useRevalidator() {
   let dataRouterContext = useDataRouterContext(DataRouterHook.UseRevalidator);
   let state = useDataRouterState(DataRouterStateHook.UseRevalidator);
-  return {
-    revalidate: dataRouterContext.router.revalidate,
-    state: state.revalidation,
-  };
+  return React.useMemo(
+    () => ({
+      revalidate: dataRouterContext.router.revalidate,
+      state: state.revalidation,
+    }),
+    [dataRouterContext.router.revalidate, state.revalidation]
+  );
 }
 
 /**

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -129,29 +129,6 @@ function invariant(value: any, message?: string) {
   }
 }
 
-function createDeferred() {
-  let resolve: (val?: any) => Promise<void>;
-  let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
-      res(val);
-      await tick();
-      await promise;
-    };
-    reject = async (error?: Error) => {
-      rej(error);
-      await promise.catch(() => tick());
-    };
-  });
-  return {
-    promise,
-    //@ts-ignore
-    resolve,
-    //@ts-ignore
-    reject,
-  };
-}
-
 function createFormData(obj: Record<string, string>): FormData {
   let formData = new FormData();
   Object.entries(obj).forEach((e) => formData.append(e[0], e[1]));
@@ -4972,8 +4949,7 @@ describe("a router", () => {
       await t.navigate("/tasks", {
         // @ts-expect-error
         formMethod: "head",
-        // @ts-expect-error
-        formData: formData,
+        formData,
       });
       expect(t.router.state.navigation.state).toBe("idle");
       expect(t.router.state.location).toMatchObject({
@@ -5013,7 +4989,6 @@ describe("a router", () => {
       await t.navigate("/tasks", {
         // @ts-expect-error
         formMethod: "options",
-        // @ts-expect-error
         formData: formData,
       });
       expect(t.router.state.navigation.state).toBe("idle");
@@ -17429,3 +17404,28 @@ describe("a router", () => {
     });
   });
 });
+
+// We use a slightly modified version of createDeferred here that incoudes the
+// tick() calls to let the router finish updating
+function createDeferred() {
+  let resolve: (val?: any) => Promise<void>;
+  let reject: (error?: Error) => Promise<void>;
+  let promise = new Promise((res, rej) => {
+    resolve = async (val: any) => {
+      res(val);
+      await tick();
+      await promise;
+    };
+    reject = async (error?: Error) => {
+      rej(error);
+      await promise.catch(() => tick());
+    };
+  });
+  return {
+    promise,
+    //@ts-ignore
+    resolve,
+    //@ts-ignore
+    reject,
+  };
+}

--- a/packages/router/__tests__/utils/createDeferred.ts
+++ b/packages/router/__tests__/utils/createDeferred.ts
@@ -1,0 +1,25 @@
+export default function createDeferred() {
+  let resolve: (val?: any) => Promise<void>;
+  let reject: (error?: Error) => Promise<void>;
+  let promise = new Promise((res, rej) => {
+    resolve = async (val: any) => {
+      res(val);
+      try {
+        await promise;
+      } catch (e) {}
+    };
+    reject = async (error?: Error) => {
+      rej(error);
+      try {
+        await promise;
+      } catch (e) {}
+    };
+  });
+  return {
+    promise,
+    //@ts-ignore
+    resolve,
+    //@ts-ignore
+    reject,
+  };
+}


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/10706

I also restructured some unit tests in 28d8eed9004e730b14bbe646706c224097006798.  Began with pulling out `useRevalidator` tests from the larger `data-memory-router-test` and then that led to moving some utils to standalone files and leveraging them instead of copy/pasting them across test suites.
