### PR TITLE
Fix syntax highlighting in docs for useOutletContext

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -119,6 +119,7 @@
 - koojaa
 - KostiantynPopovych
 - KutnerUri
+- kylegirard
 - landisdesign
 - latin-1
 - lequangdongg

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -36,7 +36,7 @@ function Child() {
 
 If you're using TypeScript, we recommend the parent component provide a custom hook for accessing the context value. This makes it easier for consumers to get nice typings, control consumers, and know who's consuming the context value. Here's a more realistic example:
 
-```tsx filename=src/routes/dashboard.tsx lines=[13, 19]
+```tsx filename=src/routes/dashboard.tsx lines=[13,19]
 import * as React from "react";
 import type { User } from "./types";
 import { Outlet, useOutletContext } from "react-router-dom";


### PR DESCRIPTION
Note: documentation only change.



### The issue 
Lines that were intended to be highlighted are not. The array used to define the lines to highlight does not allow for spaces.

![issue_screenshot1](https://github.com/remix-run/react-router/assets/1444753/ec30aef8-41d5-48e9-9e61-485884e0efad)

![issue_screenshot2](https://github.com/remix-run/react-router/assets/1444753/d0eaecbf-d344-4867-a24a-ab9235b4d95b)

### Resolution
Remove the spaces in the line number array. 
![resolution_screenshot](https://github.com/remix-run/react-router/assets/1444753/50aee214-2725-457d-98fa-2c0e36f6ed44)