### PR TITLE
Prepare for Remix v2

### DIFF
--- a/.changeset/remix-v2-prep.md
+++ b/.changeset/remix-v2-prep.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Removed internal API only required for the Remix v1 back-compat layer and no longer needed in Remix v2. (`_isFetchActionRedirect`, `_hasFetcherDoneAnything`).

--- a/.changeset/remix-v2-prep.md
+++ b/.changeset/remix-v2-prep.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/router": patch
+"@remix-run/router": minor
 ---
 
 Removed internal API only required for the Remix v1 back-compat layer and no longer needed in Remix v2. (`_isFetchActionRedirect`, `_hasFetcherDoneAnything`).

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "47.1 kB"
+      "none": "47.2 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "47.5 kB"
+      "none": "47.1 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -8871,7 +8871,6 @@ describe("a router", () => {
           formEncType: undefined,
           formData: undefined,
           data: undefined,
-          " _hasFetcherDoneAnything ": true,
         });
 
         await dfd.resolve("DATA");
@@ -8881,7 +8880,6 @@ describe("a router", () => {
           formEncType: undefined,
           formData: undefined,
           data: "DATA",
-          " _hasFetcherDoneAnything ": true,
         });
 
         expect(router._internalFetchControllers.size).toBe(0);
@@ -9410,7 +9408,6 @@ describe("a router", () => {
           formAction: undefined,
           formEncType: undefined,
           formData: undefined,
-          " _hasFetcherDoneAnything ": true,
         });
         expect(t.router.state.historyAction).toBe("PUSH");
         expect(t.router.state.location.pathname).toBe("/bar");

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -526,7 +526,6 @@ type FetcherStates<TData = any> = {
     formData: undefined;
     json: undefined;
     data: TData | undefined;
-    " _hasFetcherDoneAnything "?: boolean;
   };
   Loading: {
     state: "loading";
@@ -537,7 +536,6 @@ type FetcherStates<TData = any> = {
     formData: Submission["formData"] | undefined;
     json: Submission["json"] | undefined;
     data: TData | undefined;
-    " _hasFetcherDoneAnything "?: boolean;
   };
   Submitting: {
     state: "submitting";
@@ -548,7 +546,6 @@ type FetcherStates<TData = any> = {
     formData: Submission["formData"];
     json: Submission["json"];
     data: TData | undefined;
-    " _hasFetcherDoneAnything "?: boolean;
   };
 };
 
@@ -4471,7 +4468,6 @@ function getLoadingFetcher(
       json: submission.json,
       text: submission.text,
       data,
-      " _hasFetcherDoneAnything ": true,
     };
     return fetcher;
   } else {
@@ -4484,7 +4480,6 @@ function getLoadingFetcher(
       json: undefined,
       text: undefined,
       data,
-      " _hasFetcherDoneAnything ": true,
     };
     return fetcher;
   }
@@ -4503,7 +4498,6 @@ function getSubmittingFetcher(
     json: submission.json,
     text: submission.text,
     data: existingFetcher ? existingFetcher.data : undefined,
-    " _hasFetcherDoneAnything ": true,
   };
   return fetcher;
 }
@@ -4518,7 +4512,6 @@ function getDoneFetcher(data: Fetcher["data"]): FetcherStates["Idle"] {
     json: undefined,
     text: undefined,
     data,
-    " _hasFetcherDoneAnything ": true,
   };
   return fetcher;
 }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1787,7 +1787,6 @@ export function createRouter(init: RouterInit): Router {
 
         return startRedirectNavigation(state, actionResult, {
           submission,
-          isFetchActionRedirect: true,
         });
       }
     }
@@ -2087,26 +2086,18 @@ export function createRouter(init: RouterInit): Router {
     {
       submission,
       replace,
-      isFetchActionRedirect,
     }: {
       submission?: Submission;
       replace?: boolean;
-      isFetchActionRedirect?: boolean;
     } = {}
   ) {
     if (redirect.revalidate) {
       isRevalidationRequired = true;
     }
 
-    let redirectLocation = createLocation(
-      state.location,
-      redirect.location,
-      // TODO: This can be removed once we get rid of useTransition in Remix v2
-      {
-        _isRedirect: true,
-        ...(isFetchActionRedirect ? { _isFetchActionRedirect: true } : {}),
-      }
-    );
+    let redirectLocation = createLocation(state.location, redirect.location, {
+      _isRedirect: true,
+    });
     invariant(
       redirectLocation,
       "Expected a location on the redirect navigation"


### PR DESCRIPTION
Removing some internals needed for the Remix v1 back-compat layer that can be removed in Remix v2.

Current experimental: `0.0.0-experimental-f728258d`

Replaces https://github.com/remix-run/react-router/pull/10211