### PR TITLE
Add setTimeout back to unstable_usePrompt

### DIFF
--- a/.changeset/prompt-add-back-settimeout.md
+++ b/.changeset/prompt-add-back-settimeout.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+[Remove] add back in `setTimeout` removal from `usePrompt`

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1465,7 +1465,7 @@ function usePrompt({ when, message }: { when: boolean; message: string }) {
     if (blocker.state === "blocked") {
       let proceed = window.confirm(message);
       if (proceed) {
-        blocker.proceed();
+        setTimeout(blocker.proceed, 0);
       } else {
         blocker.reset();
       }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1465,6 +1465,9 @@ function usePrompt({ when, message }: { when: boolean; message: string }) {
     if (blocker.state === "blocked") {
       let proceed = window.confirm(message);
       if (proceed) {
+        // This timeout is needed to avoid a weird "race" on POP navigations
+        // between the `window.history` revert navigation and the result of
+        // `window.confirm`
         setTimeout(blocker.proceed, 0);
       } else {
         blocker.reset();


### PR DESCRIPTION
Add back in the `setTimeout` that was removed in #10687 since it causes issues with `navigate(-1)`.  This wasn't specifically removed to fix anything in the original bug.  

I wasn't able to get a unit test exposing this though because it seems to be some sort of race between `window.history` and `window.confirm` where the `window.history` revert operation doesn't land until after the `window.confirm`.  This doesn't happen in a unit test with a mocked `window.confirm`.

Closes #10714 