### PR TITLE
docs(routers/create-browser-router): fix docs-info links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -181,6 +181,7 @@
 - ryanflorence
 - ryanhiebert
 - sanketshah19
+- sbolel
 - scarf005
 - senseibarni
 - sergiodxa

--- a/docs/routers/create-browser-router.md
+++ b/docs/routers/create-browser-router.md
@@ -9,9 +9,7 @@ This is the recommended router for all React Router web projects. It uses the [D
 
 It also enables the v6.4 data APIs like [loaders][loader], [actions][action], [fetchers][fetcher] and more.
 
-<docs-info>
-Due to the decoupling of fetching and rendering in the design of the data APIs, you should create your router outside of the React tree with a statically defined set of routes. For more information on this design, please see the [Remixing React Router][remixing-react-router] blog post and the W[When to Fetch][when-to-fetch] conference talk.
-</docs-info>
+<docs-info>Due to the decoupling of fetching and rendering in the design of the data APIs, you should create your router outside of the React tree with a statically defined set of routes. For more information on this design, please see the [Remixing React Router][remixing-react-router] blog post and the [When to Fetch][when-to-fetch] conference talk.</docs-info>
 
 ```tsx lines=[4,11-24]
 import * as React from "react";

--- a/docs/routers/router-provider.md
+++ b/docs/routers/router-provider.md
@@ -24,9 +24,7 @@ interface RouterProviderProps {
 
 All [data router][picking-a-router] objects are passed to this component to render your app and enable the rest of the data APIs.
 
-<docs-info>
-Due to the decoupling of fetching and rendering in the design of the data APIs, you should create your router outside of the React tree with a statically defined set of routes. For more information on this design, please see the [Remixing React Router][remixing-react-router] blog post and the W[When to Fetch][when-to-fetch] conference talk.
-</docs-info>
+<docs-info>Due to the decoupling of fetching and rendering in the design of the data APIs, you should create your router outside of the React tree with a statically defined set of routes. For more information on this design, please see the [Remixing React Router][remixing-react-router] blog post and the [When to Fetch][when-to-fetch] conference talk.</docs-info>
 
 ```jsx lines=[24]
 import {


### PR DESCRIPTION
### Summary

- Fixes #10725

### Screenshots

- Before
  - ![image](https://github.com/remix-run/react-router/assets/1915925/b765631a-d519-4999-8958-f8386fbeb61e)

- After
  - ![image](https://github.com/remix-run/react-router/assets/1915925/76fa77b5-54f0-44ca-bd0c-e11793873c63)


