### PR TITLE
docs(examples/auth-router-provider): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -162,6 +162,7 @@
 - ms10596
 - ned-park
 - nilubisan
+- Nismit
 - nnhjs
 - noisypigeon
 - Obi-Dann

--- a/examples/auth-router-provider/README.md
+++ b/examples/auth-router-provider/README.md
@@ -15,7 +15,7 @@ Be sure to pay attention to the following features in this example:
 
 - The use of a standalone object _outside of the React tree_ that manages our authentication state
 - The use of `loader` functions to check for user authentication
-- The use of `redirect` from the `/protexted` `loader` when the user is not logged in
+- The use of `redirect` from the `/protected` `loader` when the user is not logged in
 - The use of a `<Form>` and an `action` to perform the login
 - The use of a `from` search param and a `redirectTo` hidden input to preserve the previous location so you can send the user there after they authenticate
 - The use of `<Form replace>` to replace the `/login` route in the history stack so the user doesn't return to the login page when clicking the back button after logging in


### PR DESCRIPTION
I think it should be `protected`