### PR TITLE
useSearchParams Bug Fix | Do not regenerate the setSearchParams function when the searchParams change

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -179,6 +179,7 @@
 - rubeonline
 - ryanflorence
 - ryanhiebert
+- rwilliams3088
 - sanketshah19
 - scarf005
 - senseibarni

--- a/packages/react-router-dom/__tests__/search-params-test.tsx
+++ b/packages/react-router-dom/__tests__/search-params-test.tsx
@@ -193,22 +193,17 @@ describe("useSearchParams", () => {
 
     function TestComponent(params: Readonly<TestParams>) {
       const { incrementParamsUpdateCount, incrementSetterUpdateCount } = params;
-      const lastParamsRef = React.useRef<URLSearchParams>();
-      const lastSetterRef = React.useRef<SetURLSearchParams>();
-
       const queryRef = React.useRef<HTMLInputElement>(null);
       const [searchParams, setSearchParams] = useSearchParams({ q: "" });
       const query = searchParams.get("q")!;
 
-      if(lastParamsRef.current !== searchParams) {
+      React.useEffect(() => {
         incrementParamsUpdateCount();
-      }
-      lastParamsRef.current = searchParams;
+      }, [searchParams]);
 
-      if(lastSetterRef.current !== setSearchParams) {
+      React.useEffect(() => {
         incrementSetterUpdateCount();
-      }
-      lastSetterRef.current = setSearchParams;
+      }, [setSearchParams]);
 
       function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();

--- a/packages/react-router-dom/__tests__/search-params-test.tsx
+++ b/packages/react-router-dom/__tests__/search-params-test.tsx
@@ -1,7 +1,8 @@
+import { renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import { act } from "react-dom/test-utils";
-import { MemoryRouter, Routes, Route, useSearchParams } from "react-router-dom";
+import { MemoryRouter, Routes, Route, useSearchParams, SetURLSearchParams } from "react-router-dom";
 
 describe("useSearchParams", () => {
   let node: HTMLDivElement;
@@ -181,5 +182,111 @@ describe("useSearchParams", () => {
     expect(node.innerHTML).toMatchInlineSnapshot(
       `"<p>value=initial&amp;a=1&amp;b=2</p>"`
     );
+  });
+
+  it("does not modify the setSearchParams reference when the searchParams change", async () => {
+    interface TestParams {
+      incrementParamsUpdateCount: () => number;
+      incrementSetterUpdateCount: () => number;
+    }
+
+    function TestComponent(params: Readonly<TestParams>) {
+      const { incrementParamsUpdateCount, incrementSetterUpdateCount } = params;
+      const lastParamsRef = React.useRef<URLSearchParams>();
+      const lastSetterRef = React.useRef<SetURLSearchParams>();
+
+      const queryRef = React.useRef<HTMLInputElement>(null);
+      const [searchParams, setSearchParams] = useSearchParams({ q: "" });
+      const query = searchParams.get("q")!;
+
+      if(lastParamsRef.current !== searchParams) {
+        incrementParamsUpdateCount();
+      }
+      lastParamsRef.current = searchParams;
+
+      if(lastSetterRef.current !== setSearchParams) {
+        incrementSetterUpdateCount();
+      }
+      lastSetterRef.current = setSearchParams;
+
+      function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (queryRef.current) {
+          setSearchParams({ q: queryRef.current.value });
+        }
+      }
+
+      return (
+        <div>
+          <p>The current query is "{query}".</p>
+          <form onSubmit={handleSubmit}>
+            <input name="q" defaultValue={query} ref={queryRef} />
+          </form>
+        </div>
+      );
+    }
+
+    function TestApp(params: TestParams) {
+      return (
+        <MemoryRouter initialEntries={["/search?q=Something"]}>
+          <Routes>
+            <Route path="search" element={<TestComponent {...params} />} />
+          </Routes>
+        </MemoryRouter>
+      );
+    }
+
+    const state = {
+      paramsUpdateCount: 0,
+      setterUpdateCount: 0
+    };
+
+    const params: TestParams = {
+      incrementParamsUpdateCount: () => ++state.paramsUpdateCount,
+      incrementSetterUpdateCount: () => ++state.setterUpdateCount
+    };
+
+    // Initial Rendering of the TestApp
+    // The TestComponent should increment both the paramsUpdateCount and setterUpdateCount to 1
+    act(() => {
+      ReactDOM.createRoot(node).render(<TestApp {...params} />);
+    });
+
+    let form = node.querySelector("form")!;
+    let queryInput = node.querySelector<HTMLInputElement>("input[name=q]")!;
+    await waitFor(() => {
+      expect(form).toBeDefined();
+      expect(queryInput).toBeDefined();
+      expect(state.paramsUpdateCount).toEqual(1);
+      expect(state.setterUpdateCount).toEqual(1);
+    });
+
+    // Modify the search params via the form in the TestComponent.
+    // This should trigger a re-render of the component and update the paramsUpdateCount (only)
+    act(() => {
+      queryInput.value = "Something+Else";
+      form.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true })
+      );
+    });
+
+    await waitFor(() => {
+      expect(state.paramsUpdateCount).toEqual(2);
+      expect(state.setterUpdateCount).toEqual(1);
+    });
+
+    // Third Times The Charm 
+    // Verifies that the setter is still valid
+    act(() => {
+      queryInput.value = "on+a+boat";
+      form.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true })
+      );
+    });
+
+    await waitFor(() => {
+      expect(state.paramsUpdateCount).toEqual(3);
+      expect(state.setterUpdateCount).toEqual(1);
+    });
   });
 });

--- a/packages/react-router-dom/__tests__/search-params-test.tsx
+++ b/packages/react-router-dom/__tests__/search-params-test.tsx
@@ -1,8 +1,9 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import { act } from "react-dom/test-utils";
-import { MemoryRouter, Routes, Route, useSearchParams, SetURLSearchParams } from "react-router-dom";
+import type { SetURLSearchParams } from "react-router-dom";
+import { MemoryRouter, Routes, Route, useSearchParams } from "react-router-dom";
 
 describe("useSearchParams", () => {
   let node: HTMLDivElement;

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -991,36 +991,42 @@ export function useSearchParams(
       `user.`
   );
 
+  let location = useLocation();
   let defaultSearchParamsRef = React.useRef(createSearchParams(defaultInit));
   let hasSetSearchParamsRef = React.useRef(false);
-  let searchParamsRef = React.useRef<URLSearchParams>(defaultSearchParamsRef.current);
 
-  let location = useLocation();
-  let searchParams = React.useMemo(
-    () => {
-      // Only merge in the defaults if we haven't yet called setSearchParams.
-      // Once we call that we want those to take precedence, otherwise you can't
-      // remove a param with setSearchParams({}) if it has an initial value
-      searchParamsRef.current = getSearchParamsForLocation(
-        location.search,
-        hasSetSearchParamsRef.current ? null : defaultSearchParamsRef.current
-      );
-      return searchParamsRef.current;
-    },
-    [location.search]
+  let [searchParams, __setSearchParams] = React.useState<URLSearchParams>(
+    getSearchParamsForLocation( location.search, defaultSearchParamsRef.current )
   );
+  let searchParamsRef  = React.useRef<URLSearchParams>(searchParams);
+
+  let initializedRef = React.useRef<boolean>(false);
+  React.useEffect(() => {
+    // Prevent re-assigning the search params on initialization
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      return;
+    }
+
+    // Only merge in the defaults if we haven't yet called setSearchParams.
+    // Once we call that we want those to take precedence, otherwise you can't
+    // remove a param with setSearchParams({}) if it has an initial value
+    searchParamsRef.current = getSearchParamsForLocation(
+      location.search,
+      hasSetSearchParamsRef.current ? null : defaultSearchParamsRef.current
+    );
+
+    __setSearchParams(searchParamsRef.current);
+  }, [location.search, __setSearchParams]);
 
   let navigate = useNavigate();
-  let setSearchParams = React.useCallback<SetURLSearchParams>(
-    (nextInit, navigateOptions) => {
-      const newSearchParams = createSearchParams(
-        typeof nextInit === "function" ? nextInit(searchParamsRef.current) : nextInit
-      );
-      hasSetSearchParamsRef.current = true;
-      navigate("?" + newSearchParams, navigateOptions);
-    },
-    [navigate]
-  );
+  let setSearchParams = React.useCallback<SetURLSearchParams>((nextInit, navigateOptions) => {
+    const newSearchParams = createSearchParams(
+      typeof nextInit === "function" ? nextInit(searchParamsRef.current) : nextInit
+    );
+    hasSetSearchParamsRef.current = true;
+    navigate("?" + newSearchParams, navigateOptions);
+  },[navigate]);
 
   return [searchParams, setSearchParams];
 }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -993,17 +993,20 @@ export function useSearchParams(
 
   let defaultSearchParamsRef = React.useRef(createSearchParams(defaultInit));
   let hasSetSearchParamsRef = React.useRef(false);
+  let searchParamsRef = React.useRef<URLSearchParams>(defaultSearchParamsRef.current);
 
   let location = useLocation();
   let searchParams = React.useMemo(
-    () =>
+    () => {
       // Only merge in the defaults if we haven't yet called setSearchParams.
       // Once we call that we want those to take precedence, otherwise you can't
       // remove a param with setSearchParams({}) if it has an initial value
-      getSearchParamsForLocation(
+      searchParamsRef.current = getSearchParamsForLocation(
         location.search,
         hasSetSearchParamsRef.current ? null : defaultSearchParamsRef.current
-      ),
+      );
+      return searchParamsRef.current;
+    },
     [location.search]
   );
 
@@ -1011,12 +1014,12 @@ export function useSearchParams(
   let setSearchParams = React.useCallback<SetURLSearchParams>(
     (nextInit, navigateOptions) => {
       const newSearchParams = createSearchParams(
-        typeof nextInit === "function" ? nextInit(searchParams) : nextInit
+        typeof nextInit === "function" ? nextInit(searchParamsRef.current) : nextInit
       );
       hasSetSearchParamsRef.current = true;
       navigate("?" + newSearchParams, navigateOptions);
     },
-    [navigate, searchParams]
+    [navigate]
   );
 
   return [searchParams, setSearchParams];

--- a/packages/react-router-native/__tests__/search-params-test.tsx
+++ b/packages/react-router-native/__tests__/search-params-test.tsx
@@ -24,7 +24,7 @@ describe("useSearchParams", () => {
     return <View>{children}</View>;
   }
 
-  it("reads and writes the search string", () => {
+  it("reads and writes the search string", async () => {
     function SearchPage() {
       let [searchParams, setSearchParams] = useSearchParams({ q: "" });
       let [query, setQuery] = React.useState(searchParams.get("q")!);
@@ -45,7 +45,7 @@ describe("useSearchParams", () => {
     }
 
     let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
+    await TestRenderer.act(async () => {
       renderer = TestRenderer.create(
         <NativeRouter initialEntries={["/search?q=Michael+Jackson"]}>
           <Routes>
@@ -55,24 +55,22 @@ describe("useSearchParams", () => {
       );
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(renderer!.toJSON()).toMatchSnapshot();
 
-    let textInput = renderer.root.findByType(TextInput);
-
-    TestRenderer.act(() => {
+    await TestRenderer.act(() => {
+      let textInput = renderer.root.findByType(TextInput);
       textInput.props.onChangeText("Ryan Florence");
     });
 
-    let searchForm = renderer.root.findByType(SearchForm);
-
-    TestRenderer.act(() => {
+    await TestRenderer.act(() => {
+      let searchForm = renderer.root.findByType(SearchForm);
       searchForm.props.onSubmit();
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(renderer!.toJSON()).toMatchSnapshot();
   });
 
-  it("reads and writes the search string (functional update)", () => {
+  it("reads and writes the search string (functional update)", async () => {
     function SearchPage() {
       let [searchParams, setSearchParams] = useSearchParams({ q: "" });
       let [query, setQuery] = React.useState(searchParams.get("q")!);
@@ -98,7 +96,7 @@ describe("useSearchParams", () => {
     }
 
     let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
+    await TestRenderer.act(() => {
       renderer = TestRenderer.create(
         <NativeRouter initialEntries={["/search?q=Michael+Jackson"]}>
           <Routes>
@@ -108,18 +106,17 @@ describe("useSearchParams", () => {
       );
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
-
-    let searchForm = renderer.root.findByType(SearchForm);
+    expect(renderer!.toJSON()).toMatchSnapshot();
 
     TestRenderer.act(() => {
+      let searchForm = renderer.root.findByType(SearchForm);
       searchForm.props.onSubmit();
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(renderer!.toJSON()).toMatchSnapshot();
   });
 
-  it("allows removal of search params when a default is provided", () => {
+  it("allows removal of search params when a default is provided", async () => {
     function SearchPage() {
       let [searchParams, setSearchParams] = useSearchParams({
         value: "initial",
@@ -134,7 +131,7 @@ describe("useSearchParams", () => {
     }
 
     let renderer: TestRenderer.ReactTestRenderer;
-    TestRenderer.act(() => {
+    await TestRenderer.act(() => {
       renderer = TestRenderer.create(
         <NativeRouter initialEntries={["/search?value=initial"]}>
           <Routes>
@@ -144,15 +141,14 @@ describe("useSearchParams", () => {
       );
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(renderer!.toJSON()).toMatchSnapshot();
 
-    let button = renderer.root.findByType(Button);
-
-    TestRenderer.act(() => {
+    await TestRenderer.act(() => {
+      let button = renderer.root.findByType(Button);
       button.props.onClick();
     });
 
-    expect(renderer.toJSON()).toMatchSnapshot();
+    expect(renderer!.toJSON()).toMatchSnapshot();
   });
 
   it("does not modify the setSearchParams reference when the searchParams change", async () => {
@@ -168,15 +164,15 @@ describe("useSearchParams", () => {
       const [searchParams, setSearchParams] = useSearchParams({ q: "" });
       const [query] = React.useState(searchParams.get("q")!);
 
-      if(lastParamsRef.current !== searchParams) {
+      React.useEffect(() => {
+        lastParamsRef.current = searchParams;
         incrementParamsUpdateCount();
-      }
-      lastParamsRef.current = searchParams;
+      }, [searchParams, incrementParamsUpdateCount]);
 
-      if(lastSetterRef.current !== setSearchParams) {
+      React.useEffect(() => {
+        lastSetterRef.current = setSearchParams;
         incrementSetterUpdateCount();
-      }
-      lastSetterRef.current = setSearchParams;
+      }, [setSearchParams, incrementSetterUpdateCount]);
 
       function handleSubmit() {
         setSearchParams(cur => {
@@ -217,7 +213,7 @@ describe("useSearchParams", () => {
     // Initial Rendering of the TestApp
     // The TestComponent should increment both the paramsUpdateCount and setterUpdateCount to 1
     let renderer: TestRenderer.ReactTestRenderer;
-    await TestRenderer.act(() => {
+    TestRenderer.act(() => {
       renderer = TestRenderer.create(<TestApp {...params}/>);
     });
 
@@ -227,7 +223,7 @@ describe("useSearchParams", () => {
     // Modify the search params via the form in the TestComponent.
     // This should trigger a re-render of the component and update the paramsUpdateCount (only)
     const searchForm = renderer!.root.findByType(SearchForm);
-    await TestRenderer.act(() => {
+    TestRenderer.act(() => {
       searchForm.props.onSubmit();
     });
 
@@ -237,7 +233,7 @@ describe("useSearchParams", () => {
     // Third Times The Charm 
     // Verifies that the setter is still valid now that we aren't regenerating each time the
     // searchParams reference changes
-    await TestRenderer.act(() => {
+    TestRenderer.act(() => {
       searchForm.props.onSubmit();
     });
 

--- a/packages/react-router-native/__tests__/search-params-test.tsx
+++ b/packages/react-router-native/__tests__/search-params-test.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { View, Text, TextInput } from "react-native";
+import type {
+  SetURLSearchParams} from "react-router-native";
 import {
   NativeRouter,
   Routes,
   Route,
-  useSearchParams,
-  SetURLSearchParams,
+  useSearchParams
 } from "react-router-native";
 import * as TestRenderer from "react-test-renderer";
 
@@ -165,7 +166,7 @@ describe("useSearchParams", () => {
       const lastParamsRef = React.useRef<URLSearchParams>();
       const lastSetterRef = React.useRef<SetURLSearchParams>();
       const [searchParams, setSearchParams] = useSearchParams({ q: "" });
-      const [query, setQuery] = React.useState(searchParams.get("q")!);
+      const [query] = React.useState(searchParams.get("q")!);
 
       if(lastParamsRef.current !== searchParams) {
         incrementParamsUpdateCount();

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -290,6 +290,7 @@ export function useSearchParams(
 ): [URLSearchParams, SetURLSearchParams] {
   let defaultSearchParamsRef = React.useRef(createSearchParams(defaultInit));
   let hasSetSearchParamsRef = React.useRef(false);
+  let searchParamsRef = React.useRef<URLSearchParams>(defaultSearchParamsRef.current);
 
   let location = useLocation();
   let searchParams = React.useMemo(() => {
@@ -305,6 +306,7 @@ export function useSearchParams(
       }
     }
 
+    searchParamsRef.current = searchParams;
     return searchParams;
   }, [location.search]);
 
@@ -312,12 +314,12 @@ export function useSearchParams(
   let setSearchParams = React.useCallback<SetURLSearchParams>(
     (nextInit, navigateOpts) => {
       const newSearchParams = createSearchParams(
-        typeof nextInit === "function" ? nextInit(searchParams) : nextInit
+        typeof nextInit === "function" ? nextInit(searchParamsRef.current) : nextInit
       );
       hasSetSearchParamsRef.current = true;
       navigate("?" + newSearchParams, navigateOpts);
     },
-    [navigate, searchParams]
+    [navigate]
   );
 
   return [searchParams, setSearchParams];


### PR DESCRIPTION
I was encountering re-rendering errors in React and narrowed down the root cause to the useSearchParams() function. It turns out that the present implementation will unnecessarily regenerate the setSearchParams function every time the searchParams reference changes. If you are passing around the setSearchParams function to child components, you will find that the child components keeps getting re-rendered whenever the searchParams change - even if the child component isn't dependent upon the searchParams. 

Example:
```
const Child = (props: ChildProps) => {
   const { setSearchParams } = props;
   ...
   // The child will be re-rendered and this effect will be triggered everytime you click the button w/o the bug fix
   useEffect(() => { console.log(`setSearchParams ref update!`) }, [setSearchParams]);
   ...
   return (<Button onClick={() => setSearchParams(...)}>Click Me!</Button>);
}

const Parent = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   ...
   return (<Child setSearchParams={setSearchParams} ... />);
}
```