### PR TITLE
Support optional path segments in `matchPath`

### DIFF
--- a/.changeset/support-optional-path-segments-in-match-path.md
+++ b/.changeset/support-optional-path-segments-in-match-path.md
@@ -1,6 +1,5 @@
 ---
-"react-router": patch
-"@remix-run/router": patch
+"@remix-run/router": minor
 ---
 
-Added support for optional path segments in `matchPath`
+Add support for optional path segments in `matchPath`

--- a/.changeset/support-optional-path-segments-in-match-path.md
+++ b/.changeset/support-optional-path-segments-in-match-path.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+Added support for optional path segments in `matchPath`

--- a/contributors.yml
+++ b/contributors.yml
@@ -88,6 +88,7 @@
 - ianflynnwork
 - IbraRouisDev
 - igniscyan
+- imjordanxd
 - infoxicator
 - IsaiStormBlesed
 - Isammoc

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "48.3 kB"
+      "none": "48.7 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"

--- a/packages/react-router/__tests__/matchPath-test.tsx
+++ b/packages/react-router/__tests__/matchPath-test.tsx
@@ -245,6 +245,53 @@ describe("matchPath", () => {
   });
 });
 
+describe("matchPath optional segments", () => {
+  it("should match when optional segment is provided", () => {
+    const match = matchPath("/:lang?/user/:id", "/en/user/123");
+    expect(match).toMatchObject({ params: { lang: "en", id: "123" } });
+  });
+
+  it("should match when optional segment is *not* provided", () => {
+    const match = matchPath("/:lang?/user/:id", "/user/123");
+    expect(match).toMatchObject({ params: { lang: undefined, id: "123" } });
+  });
+
+  it("should match when middle optional segment is provided", () => {
+    const match = matchPath("/user/:lang?/:id", "/user/en/123");
+    expect(match).toMatchObject({ params: { lang: "en", id: "123" } });
+  });
+
+  it("should match when middle optional segment is *not* provided", () => {
+    const match = matchPath("/user/:lang?/:id", "/user/123");
+    expect(match).toMatchObject({ params: { lang: undefined, id: "123" } });
+  });
+
+  it("should match when end optional segment is provided", () => {
+    const match = matchPath("/user/:id/:lang?", "/user/123/en");
+    expect(match).toMatchObject({ params: { lang: "en", id: "123" } });
+  });
+
+  it("should match when end optional segment is *not* provided", () => {
+    const match = matchPath("/user/:id/:lang?", "/user/123");
+    expect(match).toMatchObject({ params: { lang: undefined, id: "123" } });
+  });
+
+  it("should match multiple optional segments and none are provided", () => {
+    const match = matchPath("/:lang?/user/:id?", "/user");
+    expect(match).toMatchObject({ params: { lang: undefined, id: undefined } });
+  });
+
+  it("should match multiple optional segments and one is provided", () => {
+    const match = matchPath("/:lang?/user/:id?", "/en/user");
+    expect(match).toMatchObject({ params: { lang: "en", id: undefined } });
+  });
+
+  it("should match multiple optional segments and all are provided", () => {
+    const match = matchPath("/:lang?/user/:id?", "/en/user/123");
+    expect(match).toMatchObject({ params: { lang: "en", id: "123" } });
+  });
+});
+
 describe("matchPath *", () => {
   it("matches the root URL", () => {
     expect(matchPath("*", "/")).toMatchObject({


### PR DESCRIPTION
### Overview
Adds support for optional path segments in `matchPath`. Resolves #9862