### PR TITLE
Fix actionResult type on shouldRevalidate args

### DIFF
--- a/.changeset/should-revalidate-action-result-type.md
+++ b/.changeset/should-revalidate-action-result-type.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix type for `actionResult` on the arguments object passed to `shouldRevalidate`

--- a/docs/route/should-revalidate.md
+++ b/docs/route/should-revalidate.md
@@ -5,6 +5,32 @@ new: true
 
 # `shouldRevalidate`
 
+<details>
+  <summary>Type declaration</summary>
+
+```ts
+interface ShouldRevalidateFunction {
+  (args: ShouldRevalidateFunctionArgs): boolean;
+}
+
+interface ShouldRevalidateFunctionArgs {
+  currentUrl: URL;
+  currentParams: AgnosticDataRouteMatch["params"];
+  nextUrl: URL;
+  nextParams: AgnosticDataRouteMatch["params"];
+  formMethod?: Submission["formMethod"];
+  formAction?: Submission["formAction"];
+  formEncType?: Submission["formEncType"];
+  text?: Submission["text"];
+  formData?: Submission["formData"];
+  json?: Submission["json"];
+  actionResult?: any;
+  defaultShouldRevalidate: boolean;
+}
+```
+
+</details>
+
 This function allows you opt-out of revalidation for a route's loader as an optimization.
 
 <docs-warning>This feature only works if using a data router, see [Picking a Router][pickingarouter]</docs-warning>
@@ -52,27 +78,6 @@ If you define `shouldRevalidate` on a route, it will first check the function be
 Note that this is only for data that has already been loaded, is currently rendered, and will continue to be rendered at the new URL. Data for new routes and fetchers at the new URL will always be fetched initially.
 
 <docs-warning>Using this API risks your UI getting out of sync with your data, use with caution!</docs-warning>
-
-## Type Declaration
-
-```ts
-interface ShouldRevalidateFunction {
-  (args: {
-    currentUrl: URL;
-    currentParams: AgnosticDataRouteMatch["params"];
-    nextUrl: URL;
-    nextParams: AgnosticDataRouteMatch["params"];
-    formMethod?: Submission["formMethod"];
-    formAction?: Submission["formAction"];
-    formEncType?: Submission["formEncType"];
-    formData?: Submission["formData"];
-    json?: Submission["json"];
-    text?: Submission["text"];
-    actionResult?: any;
-    defaultShouldRevalidate: boolean;
-  }): boolean;
-}
-```
 
 [action]: ./action
 [form]: ../components/form

--- a/docs/route/should-revalidate.md
+++ b/docs/route/should-revalidate.md
@@ -68,7 +68,7 @@ interface ShouldRevalidateFunction {
     formData?: Submission["formData"];
     json?: Submission["json"];
     text?: Submission["text"];
-    actionResult?: DataResult;
+    actionResult?: any;
     defaultShouldRevalidate: boolean;
   }): boolean;
 }

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -34,7 +34,7 @@ import type {
   AgnosticNonIndexRouteObject,
   AgnosticRouteObject,
   DeferredData,
-  ShouldRevalidateArgs,
+  ShouldRevalidateFunctionArgs,
   TrackedPromise,
 } from "../utils";
 import {
@@ -1861,7 +1861,7 @@ describe("a router", () => {
       router.navigate("/params/aValue/bValue");
       await tick();
       expect(rootLoader.mock.calls.length).toBe(1);
-      let expectedArg: ShouldRevalidateArgs = {
+      let expectedArg: ShouldRevalidateFunctionArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {
@@ -1926,7 +1926,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      let expectedArg: ShouldRevalidateArgs = {
+      let expectedArg: ShouldRevalidateFunctionArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {},
@@ -1980,7 +1980,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      let expectedArg: ShouldRevalidateArgs = {
+      let expectedArg: ShouldRevalidateFunctionArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {},
@@ -2026,7 +2026,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      let expectedArg: Partial<ShouldRevalidateArgs> = {
+      let expectedArg: Partial<ShouldRevalidateFunctionArgs> = {
         formMethod: "post",
         formAction: "/",
         formEncType: "application/json",
@@ -2068,7 +2068,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      let expectedArg: Partial<ShouldRevalidateArgs> = {
+      let expectedArg: Partial<ShouldRevalidateFunctionArgs> = {
         formMethod: "post",
         formAction: "/",
         formEncType: "text/plain",

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -34,6 +34,7 @@ import type {
   AgnosticNonIndexRouteObject,
   AgnosticRouteObject,
   DeferredData,
+  ShouldRevalidateArgs,
   TrackedPromise,
 } from "../utils";
 import {
@@ -1860,7 +1861,7 @@ describe("a router", () => {
       router.navigate("/params/aValue/bValue");
       await tick();
       expect(rootLoader.mock.calls.length).toBe(1);
-      expect(shouldRevalidate.mock.calls[0][0]).toMatchObject({
+      let expectedArg: ShouldRevalidateArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {
@@ -1870,7 +1871,8 @@ describe("a router", () => {
         nextUrl: expect.URL("http://localhost/params/aValue/bValue"),
         defaultShouldRevalidate: false,
         actionResult: undefined,
-      });
+      };
+      expect(shouldRevalidate.mock.calls[0][0]).toMatchObject(expectedArg);
       rootLoader.mockClear();
       shouldRevalidate.mockClear();
 
@@ -1924,7 +1926,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      expect(arg).toMatchObject({
+      let expectedArg: ShouldRevalidateArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {},
@@ -1934,7 +1936,8 @@ describe("a router", () => {
         formAction: "/child",
         formEncType: "application/x-www-form-urlencoded",
         actionResult: "ACTION",
-      });
+      };
+      expect(arg).toMatchObject(expectedArg);
       // @ts-expect-error
       expect(Object.fromEntries(arg.formData)).toEqual({ key: "value" });
 
@@ -1977,7 +1980,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      expect(arg).toMatchObject({
+      let expectedArg: ShouldRevalidateArgs = {
         currentParams: {},
         currentUrl: expect.URL("http://localhost/child"),
         nextParams: {},
@@ -1987,7 +1990,8 @@ describe("a router", () => {
         formAction: "/child",
         formEncType: "application/x-www-form-urlencoded",
         actionResult: undefined,
-      });
+      };
+      expect(arg).toMatchObject(expectedArg);
       // @ts-expect-error
       expect(Object.fromEntries(arg.formData)).toEqual({ key: "value" });
 
@@ -2022,7 +2026,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      expect(arg).toMatchObject({
+      let expectedArg: Partial<ShouldRevalidateArgs> = {
         formMethod: "post",
         formAction: "/",
         formEncType: "application/json",
@@ -2030,7 +2034,8 @@ describe("a router", () => {
         formData: undefined,
         json: { key: "value" },
         actionResult: "ACTION",
-      });
+      };
+      expect(arg).toMatchObject(expectedArg);
 
       router.dispose();
     });
@@ -2063,7 +2068,7 @@ describe("a router", () => {
       expect(shouldRevalidate.mock.calls.length).toBe(1);
       // @ts-expect-error
       let arg = shouldRevalidate.mock.calls[0][0];
-      expect(arg).toMatchObject({
+      let expectedArg: Partial<ShouldRevalidateArgs> = {
         formMethod: "post",
         formAction: "/",
         formEncType: "text/plain",
@@ -2071,7 +2076,8 @@ describe("a router", () => {
         formData: undefined,
         json: undefined,
         actionResult: "ACTION",
-      });
+      };
+      expect(arg).toMatchObject(expectedArg);
 
       router.dispose();
     });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -28,7 +28,7 @@ import type {
   RedirectResult,
   RouteData,
   RouteManifest,
-  ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   Submission,
   SuccessResult,
   V7_FormMethod,
@@ -3513,7 +3513,7 @@ function isNewRouteInstance(
 
 function shouldRevalidateLoader(
   loaderMatch: AgnosticDataRouteMatch,
-  arg: Parameters<ShouldRevalidateFunction>[0]
+  arg: ShouldRevalidateFunctionArgs
 ) {
   if (loaderMatch.route.shouldRevalidate) {
     let routeChoice = loaderMatch.route.shouldRevalidate(arg);

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -175,6 +175,24 @@ export interface ActionFunction {
 }
 
 /**
+ * Arguments passed to shouldRevalidate function
+ */
+export interface ShouldRevalidateArgs {
+  currentUrl: URL;
+  currentParams: AgnosticDataRouteMatch["params"];
+  nextUrl: URL;
+  nextParams: AgnosticDataRouteMatch["params"];
+  formMethod?: Submission["formMethod"];
+  formAction?: Submission["formAction"];
+  formEncType?: Submission["formEncType"];
+  text?: Submission["text"];
+  formData?: Submission["formData"];
+  json?: Submission["json"];
+  actionResult?: any;
+  defaultShouldRevalidate: boolean;
+}
+
+/**
  * Route shouldRevalidate function signature.  This runs after any submission
  * (navigation or fetcher), so we flatten the navigation/fetcher submission
  * onto the arguments.  It shouldn't matter whether it came from a navigation
@@ -182,20 +200,7 @@ export interface ActionFunction {
  * have to re-run based on the data models that were potentially mutated.
  */
 export interface ShouldRevalidateFunction {
-  (args: {
-    currentUrl: URL;
-    currentParams: AgnosticDataRouteMatch["params"];
-    nextUrl: URL;
-    nextParams: AgnosticDataRouteMatch["params"];
-    formMethod?: Submission["formMethod"];
-    formAction?: Submission["formAction"];
-    formEncType?: Submission["formEncType"];
-    text?: Submission["text"];
-    formData?: Submission["formData"];
-    json?: Submission["json"];
-    actionResult?: DataResult;
-    defaultShouldRevalidate: boolean;
-  }): boolean;
+  (args: ShouldRevalidateArgs): boolean;
 }
 
 /**

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -177,7 +177,7 @@ export interface ActionFunction {
 /**
  * Arguments passed to shouldRevalidate function
  */
-export interface ShouldRevalidateArgs {
+export interface ShouldRevalidateFunctionArgs {
   currentUrl: URL;
   currentParams: AgnosticDataRouteMatch["params"];
   nextUrl: URL;
@@ -200,7 +200,7 @@ export interface ShouldRevalidateArgs {
  * have to re-run based on the data models that were potentially mutated.
  */
 export interface ShouldRevalidateFunction {
-  (args: ShouldRevalidateArgs): boolean;
+  (args: ShouldRevalidateFunctionArgs): boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/remix-run/remix/issues/5759.

This type issue was picked up if I added type annotations to the args objects in the test suite, so I've also added those as part of this fix.