### PR TITLE
Add a new optional AbortController parameter to defer

### DIFF
--- a/.changeset/defer-abort-controller.md
+++ b/.changeset/defer-abort-controller.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Add a new optional `AbortController` parameter to `defer`

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -12616,15 +12616,15 @@ describe("a router", () => {
 
       let A = await t.navigate("/lazy");
       let dfd = createDeferred();
-      let controller = new AbortController();
+      let deferController = new AbortController();
       await A.loaders.lazy.resolve(
-        defer({ lazy: dfd.promise }, null, controller)
+        defer({ lazy: dfd.promise }, null, deferController)
       );
 
       // Interrupt pending deferred's from /lazy navigation
       let B = await t.navigate("/");
       expect(A.loaders.lazy.signal.aborted).toBe(false);
-      expect(controller.signal.aborted).toBe(true);
+      expect(deferController.signal.aborted).toBe(true);
 
       await B.loaders.index.resolve("INDEX*");
       expect(t.router.state).toMatchObject({
@@ -12652,17 +12652,17 @@ describe("a router", () => {
 
       // Route to lazy
       let A = await t.navigate("/lazy");
-      let controller = new AbortController();
 
       // Navigate away from /lazy before it's loader returns the defer()
       let B = await t.navigate("/");
       expect(A.loaders.lazy.signal.aborted).toBe(true);
 
       let dfd = createDeferred();
+      let deferController = new AbortController();
       await A.loaders.lazy.resolve(
-        defer({ lazy: dfd.promise }, null, controller)
+        defer({ lazy: dfd.promise }, null, deferController)
       );
-      expect(controller.signal.aborted).toBe(true);
+      expect(deferController.signal.aborted).toBe(true);
 
       await B.loaders.index.resolve("INDEX*");
       expect(t.router.state).toMatchObject({
@@ -12697,20 +12697,20 @@ describe("a router", () => {
 
       // Route to lazy
       let A = await t.navigate("/lazy/child");
-      let controller = new AbortController();
 
       let dfd = createDeferred();
+      let deferController = new AbortController();
       await A.loaders.lazy.resolve(
-        defer({ lazy: dfd.promise }, null, controller)
+        defer({ lazy: dfd.promise }, null, deferController)
       );
-      expect(controller.signal.aborted).toBe(false);
+      expect(deferController.signal.aborted).toBe(false);
 
       // Navigate away from /lazy after it's loader returns the defer() but
       // before /child's loader finishes so the request is aborted which gets
       // proxied through to the lazy loaders already resolved defer() instance
       let B = await t.navigate("/");
       expect(A.loaders.lazy.signal.aborted).toBe(true);
-      expect(controller.signal.aborted).toBe(true);
+      expect(deferController.signal.aborted).toBe(true);
 
       await A.loaders.child.resolve("CHILD");
 


### PR DESCRIPTION
POC for https://github.com/remix-run/react-router/discussions/10786 which would let users provide an `AbortController` to `defer`

```js
// Current
function loader({ request }) {
  // request.signal is only aborted on a navigation interruption.  Once 
  // our loaders resolve, the navigation is complete, but we can still 
  // interrupt the pending deferreds by clicking another link on the 
  // destination page.  So there's no way to know that the request 
  // succeeded but promise got cancelled (or at least we stopped 
  // waiting for it to settle)
  let promise = fetchData();
  return defer({ data: promise }); 
}
```


```js
// New
function loader({ request }) {
  // Now, users can create their own controller and hand it to defer(), 
  // and we'll abort that if we end up cancelling the deferreds.  Either 
  // via a navigation interruption or a post-navigation pending-UI 
  // cancellation
  let controller = new AbortController();
  let promise = fetchData(controller.signal);  
  return defer({ data: promise }, null, controller);
}
``` 
  

Note, the second parameter to `defer` is a `ResponseInit` (just like `json`), so I made this a standalone 3rd param to be explicit/simple/clear.  We _could_ override the second param and also allow `defer({ data: promise }, controller)` if we wanted though.  