### PR TITLE
Add and export ShouldRevalidateArgs interface

### DIFF
--- a/.changeset/early-coins-share.md
+++ b/.changeset/early-coins-share.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+Export ShouldRevalidateArgs interface

--- a/contributors.yml
+++ b/contributors.yml
@@ -111,6 +111,7 @@
 - johnpangalos
 - jonkoops
 - jrakotoharisoa
+- juanpprieto
 - kachun333
 - kantuni
 - kark

--- a/docs/route/should-revalidate.md
+++ b/docs/route/should-revalidate.md
@@ -56,21 +56,23 @@ Note that this is only for data that has already been loaded, is currently rende
 ## Type Declaration
 
 ```ts
+interface ShouldRevalidateArgs {
+  currentUrl: URL;
+  currentParams: AgnosticDataRouteMatch["params"];
+  nextUrl: URL;
+  nextParams: AgnosticDataRouteMatch["params"];
+  formMethod?: Submission["formMethod"];
+  formAction?: Submission["formAction"];
+  formEncType?: Submission["formEncType"];
+  text?: Submission["text"];
+  formData?: Submission["formData"];
+  json?: Submission["json"];
+  actionResult?: DataResult;
+  defaultShouldRevalidate: boolean;
+}
+
 interface ShouldRevalidateFunction {
-  (args: {
-    currentUrl: URL;
-    currentParams: AgnosticDataRouteMatch["params"];
-    nextUrl: URL;
-    nextParams: AgnosticDataRouteMatch["params"];
-    formMethod?: Submission["formMethod"];
-    formAction?: Submission["formAction"];
-    formEncType?: Submission["formEncType"];
-    formData?: Submission["formData"];
-    json?: Submission["json"];
-    text?: Submission["text"];
-    actionResult?: DataResult;
-    defaultShouldRevalidate: boolean;
-  }): boolean;
+  (args: ShouldRevalidateArgs): boolean;
 }
 ```
 

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -19,6 +19,7 @@ import type {
   RedirectFunction,
   RelativeRoutingType,
   Router as RemixRouter,
+  ShouldRevalidateArgs,
   ShouldRevalidateFunction,
   To,
   InitialEntry,
@@ -163,9 +164,11 @@ export type {
   RouterProviderProps,
   RoutesProps,
   Search,
+  ShouldRevalidateArgs,
   ShouldRevalidateFunction,
   To,
 };
+
 export {
   AbortedDeferredError,
   Await,

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -22,6 +22,7 @@ export type {
   PathMatch,
   PathPattern,
   RedirectFunction,
+  ShouldRevalidateArgs,
   ShouldRevalidateFunction,
   V7_FormMethod,
 } from "./utils";

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -23,7 +23,7 @@ import type {
   Submission,
   SuccessResult,
   AgnosticRouteMatch,
-  ShouldRevalidateFunction,
+  ShouldRevalidateArgs,
   RouteManifest,
   ImmutableRouteKey,
   ActionFunction,
@@ -3513,7 +3513,7 @@ function isNewRouteInstance(
 
 function shouldRevalidateLoader(
   loaderMatch: AgnosticDataRouteMatch,
-  arg: Parameters<ShouldRevalidateFunction>[0]
+  arg: ShouldRevalidateArgs
 ) {
   if (loaderMatch.route.shouldRevalidate) {
     let routeChoice = loaderMatch.route.shouldRevalidate(arg);

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -175,6 +175,24 @@ export interface ActionFunction {
 }
 
 /**
+ * Route shouldRevalidate function arguments.
+ */
+export interface ShouldRevalidateArgs {
+  currentUrl: URL;
+  currentParams: AgnosticDataRouteMatch["params"];
+  nextUrl: URL;
+  nextParams: AgnosticDataRouteMatch["params"];
+  formMethod?: Submission["formMethod"];
+  formAction?: Submission["formAction"];
+  formEncType?: Submission["formEncType"];
+  text?: Submission["text"];
+  formData?: Submission["formData"];
+  json?: Submission["json"];
+  actionResult?: DataResult;
+  defaultShouldRevalidate: boolean;
+}
+
+/**
  * Route shouldRevalidate function signature.  This runs after any submission
  * (navigation or fetcher), so we flatten the navigation/fetcher submission
  * onto the arguments.  It shouldn't matter whether it came from a navigation
@@ -182,20 +200,7 @@ export interface ActionFunction {
  * have to re-run based on the data models that were potentially mutated.
  */
 export interface ShouldRevalidateFunction {
-  (args: {
-    currentUrl: URL;
-    currentParams: AgnosticDataRouteMatch["params"];
-    nextUrl: URL;
-    nextParams: AgnosticDataRouteMatch["params"];
-    formMethod?: Submission["formMethod"];
-    formAction?: Submission["formAction"];
-    formEncType?: Submission["formEncType"];
-    text?: Submission["text"];
-    formData?: Submission["formData"];
-    json?: Submission["json"];
-    actionResult?: DataResult;
-    defaultShouldRevalidate: boolean;
-  }): boolean;
+  (args: ShouldRevalidateArgs): boolean;
 }
 
 /**


### PR DESCRIPTION

Create and export `ShouldRevalidateArgs` so that it can be later exported also in `@remix-run/react`.

This would allow to export `shouldRevalidate` as a non arrow function

```ts
import type {ShouldRevalidateArgs} from '@remix-run/react'

export function shouldRevalidate(args: ShouldRevalidateArgs) {...}
```