### PR TITLE
Export ShouldRevalidateFunctionArgs interface

### DIFF
--- a/.changeset/export-should-revalidate-args.md
+++ b/.changeset/export-should-revalidate-args.md
@@ -1,0 +1,9 @@
+---
+"react-router-dom-v5-compat": patch
+"react-router-native": patch
+"react-router-dom": patch
+"react-router": patch
+"@remix-run/router": patch
+---
+
+Export `ShouldRevalidateFunctionArgs` interface

--- a/.changeset/short-rocks-buy.md
+++ b/.changeset/short-rocks-buy.md
@@ -1,5 +1,0 @@
----
-"@remix-run/router": patch
----
-
-Export ShouldRevalidateFunctionArgs interface

--- a/.changeset/short-rocks-buy.md
+++ b/.changeset/short-rocks-buy.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Export ShouldRevalidateFunctionArgs interface

--- a/contributors.yml
+++ b/contributors.yml
@@ -111,6 +111,7 @@
 - jonkoops
 - jrakotoharisoa
 - kachun333
+- juanpprieto
 - kantuni
 - kark
 - KAROTT7

--- a/packages/react-router-dom-v5-compat/index.ts
+++ b/packages/react-router-dom-v5-compat/index.ts
@@ -98,6 +98,7 @@ export type {
   ScrollRestorationProps,
   Search,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   SubmitFunction,
   SubmitOptions,
   To,

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -127,6 +127,7 @@ export type {
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   To,
 } from "react-router";
 export {

--- a/packages/react-router-native/index.tsx
+++ b/packages/react-router-native/index.tsx
@@ -62,6 +62,7 @@ export type {
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   To,
 } from "react-router";
 export {

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -23,6 +23,7 @@ import type {
   Router as RemixRouter,
   FutureConfig as RouterFutureConfig,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   To,
 } from "@remix-run/router";
 import {
@@ -162,6 +163,7 @@ export type {
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   To,
   Blocker as unstable_Blocker,
   BlockerFunction as unstable_BlockerFunction,

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -21,8 +21,8 @@ export type {
   PathMatch,
   PathPattern,
   RedirectFunction,
-  ShouldRevalidateFunctionArgs,
   ShouldRevalidateFunction,
+  ShouldRevalidateFunctionArgs,
   TrackedPromise,
   V7_FormMethod,
 } from "./utils";

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -21,6 +21,7 @@ export type {
   PathMatch,
   PathPattern,
   RedirectFunction,
+  ShouldRevalidateFunctionArgs,
   ShouldRevalidateFunction,
   TrackedPromise,
   V7_FormMethod,


### PR DESCRIPTION
export `ShouldRevalidateFunctionArgs` so that it can be later exported also in `@remix-run/react`.

This would allow to export `shouldRevalidate` as a non arrow function in Remix

```ts
import type {ShouldRevalidateFunctionArgs} from '@remix-run/react'

export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {...}
```