### PR TITLE
Add optional location state type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -177,6 +177,7 @@
 - pcattori
 - petersendidit
 - promet99
+- psea
 - pyitphyoaung
 - rimian
 - RobHannay

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -89,9 +89,9 @@ if (__DEV__) {
   AwaitContext.displayName = "Await";
 }
 
-export interface NavigateOptions {
+export interface NavigateOptions<State = any> {
   replace?: boolean;
-  state?: any;
+  state?: State | null;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
 }

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -98,7 +98,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/hooks/use-location
  */
-export function useLocation(): Location {
+export function useLocation<State>(): Location<State> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the
@@ -147,8 +147,8 @@ export function useMatch<
 /**
  * The interface for the navigate() function returned from useNavigate().
  */
-export interface NavigateFunction {
-  (to: To, options?: NavigateOptions): void;
+export interface NavigateFunction<State = any> {
+  (to: To, options?: NavigateOptions<State>): void;
   (delta: number): void;
 }
 
@@ -175,7 +175,7 @@ function useIsomorphicLayoutEffect(
  *
  * @see https://reactrouter.com/hooks/use-navigate
  */
-export function useNavigate(): NavigateFunction {
+export function useNavigate<State = any>(): NavigateFunction<State> {
   let { isDataRoute } = React.useContext(RouteContext);
   // Conditional usage is OK here because the usage of a data router is static
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -53,11 +53,11 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location extends Path {
+export interface Location<State = any> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: any;
+  state: State | null;
 
   /**
    * A unique string associated with this location. May be used to safely store


### PR DESCRIPTION
It was already discussed at #8515 
Giving it another shot :-) 
yes, it doesn't provide type guarantees but maybe one has changed his mind, since it gives a little bit of ergonomics to pass an optional state instead of narrowing externally. Also it forces to deal with `null` when no state is provided.

use case:
```ts
type MyLocationState = { value: string }

const { state } = useLocation<MyLocationState>();
console.log(state?.value) 
```