### PR TITLE
chore(router): update generic names

### DIFF
--- a/.changeset/gold-ghosts-draw.md
+++ b/.changeset/gold-ghosts-draw.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+[REMOVE] Use long generic names

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -56,11 +56,11 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location<S = any> extends Path {
+export interface Location<State = any> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */
-  state: S;
+  state: State;
 
   /**
    * A unique string associated with this location. May be used to safely store
@@ -100,8 +100,8 @@ export interface Listener {
 
 /**
  * Describes a location that is the destination of some navigation, either via
- * `history.push` or `history.replace`. May be either a URL or the pieces of a
- * URL path.
+ * `history.push` or `history.replace`. This may be either a URL or the pieces
+ * of a URL path.
  */
 export type To = string | Partial<Path>;
 
@@ -503,7 +503,7 @@ export function warning(cond: any, message: string) {
     try {
       // Welcome to debugging history!
       //
-      // This error is thrown as a convenience so you can more easily
+      // This error is thrown as a convenience, so you can more easily
       // find the source for a warning that appears in the console by
       // enabling "pause on exceptions" in your JavaScript debugger.
       throw new Error(message);

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -145,16 +145,19 @@ interface DataFunctionArgs<Context> {
 
 // TODO: (v7) Change the defaults from any to unknown in and remove Remix wrappers:
 //   ActionFunction, ActionFunctionArgs, LoaderFunction, LoaderFunctionArgs
+//   Also, make them a type alias instead of an interface
 
 /**
  * Arguments passed to loader functions
  */
-export interface LoaderFunctionArgs<C = any> extends DataFunctionArgs<C> {}
+export interface LoaderFunctionArgs<Context = any>
+  extends DataFunctionArgs<Context> {}
 
 /**
  * Arguments passed to action functions
  */
-export interface ActionFunctionArgs<C = any> extends DataFunctionArgs<C> {}
+export interface ActionFunctionArgs<Context = any>
+  extends DataFunctionArgs<Context> {}
 
 /**
  * Loaders and actions can return anything except `undefined` (`null` is a
@@ -166,15 +169,19 @@ type DataFunctionValue = Response | NonNullable<unknown> | null;
 /**
  * Route loader function signature
  */
-export interface LoaderFunction<C = any> {
-  (args: LoaderFunctionArgs<C>): Promise<DataFunctionValue> | DataFunctionValue;
+export interface LoaderFunction<Context = any> {
+  (args: LoaderFunctionArgs<Context>):
+    | Promise<DataFunctionValue>
+    | DataFunctionValue;
 }
 
 /**
  * Route action function signature
  */
-export interface ActionFunction<C = any> {
-  (args: ActionFunctionArgs<C>): Promise<DataFunctionValue> | DataFunctionValue;
+export interface ActionFunction<Context = any> {
+  (args: ActionFunctionArgs<Context>):
+    | Promise<DataFunctionValue>
+    | DataFunctionValue;
 }
 
 /**
@@ -353,10 +360,10 @@ type PathParam<Path extends string> =
       _PathParam<Path>;
 
 // Attempt to parse the given string segment. If it fails, then just return the
-// plain string type as a default fallback. Otherwise return the union of the
+// plain string type as a default fallback. Otherwise, return the union of the
 // parsed string literals that were referenced as dynamic segments in the route.
 export type ParamParseKey<Segment extends string> =
-  // if could not find path params, fallback to `string`
+  // if you could not find path params, fallback to `string`
   [PathParam<Segment>] extends [never] ? string : PathParam<Segment>;
 
 /**
@@ -400,7 +407,7 @@ function isIndexRoute(
   return route.index === true;
 }
 
-// Walk the route tree generating unique IDs where necessary so we are working
+// Walk the route tree generating unique IDs where necessary, so we are working
 // solely with AgnosticDataRouteObject's within the Router
 export function convertRoutesToDataRoutes(
   routes: AgnosticRouteObject[],
@@ -493,12 +500,12 @@ export function matchRoutes<
   return matches;
 }
 
-export interface UIMatch<D = unknown, H = unknown> {
+export interface UIMatch<Data = unknown, Handle = unknown> {
   id: string;
   pathname: string;
   params: AgnosticRouteMatch["params"];
-  data: D;
-  handle: H;
+  data: Data;
+  handle: Handle;
 }
 
 export function convertRouteMatchToUiMatch(
@@ -567,7 +574,7 @@ function flattenRoutes<
     let path = joinPaths([parentPath, meta.relativePath]);
     let routesMeta = parentsMeta.concat(meta);
 
-    // Add the children before adding this route to the array so we traverse the
+    // Add the children before adding this route to the array, so we traverse the
     // route tree depth-first and child routes appear before their parents in
     // the "flattened" version.
     if (route.children && route.children.length > 0) {
@@ -644,10 +651,10 @@ function explodeOptionalSegments(path: string): string[] {
   let result: string[] = [];
 
   // All child paths with the prefix.  Do this for all children before the
-  // optional version for all children so we get consistent ordering where the
+  // optional version for all children, so we get consistent ordering where the
   // parent optional aspect is preferred as required.  Otherwise, we can get
   // child sections interspersed where deeper optional segments are higher than
-  // parent optional segments, where for example, /:two would explodes _earlier_
+  // parent optional segments, where for example, /:two would explode _earlier_
   // then /:one.  By always including the parent as required _for all children_
   // first, we avoid this issue
   result.push(
@@ -656,7 +663,7 @@ function explodeOptionalSegments(path: string): string[] {
     )
   );
 
-  // Then if this is an optional value, add all child versions without
+  // Then, if this is an optional value, add all child versions without
   if (isOptional) {
     result.push(...restExploded);
   }
@@ -972,7 +979,7 @@ function compilePath(
     regexpSource += "\\/*$";
   } else if (path !== "" && path !== "/") {
     // If our path is non-empty and contains anything beyond an initial slash,
-    // then we have _some_ form of path in our regex so we should expect to
+    // then we have _some_ form of path in our regex, so we should expect to
     // match only if we find the end of this path segment.  Look for an optional
     // non-captured trailing slash (to match a portion of the URL) or the end
     // of the path (if we've matched to the end).  We used to do this with a


### PR DESCRIPTION
Follow-up of @brophdawg11's #10843 for the reasons mentioned in my remark (see https://github.com/remix-run/react-router/pull/10843#pullrequestreview-1611895961)

> In the light of named tuple elements, I've seen something passing by to do the same for generic elements as well, so I think it would be better to have long names instead
> 
> https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#named-and-anonymous-tuple-elements