### PR TITLE
Handle case when session storage is blocked

### DIFF
--- a/.changeset/soft-forks-cough.md
+++ b/.changeset/soft-forks-cough.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Gracefully handle cases where sessionStorage is unavailable when using ScrollRestoration

--- a/.changeset/soft-forks-cough.md
+++ b/.changeset/soft-forks-cough.md
@@ -2,4 +2,4 @@
 "react-router-dom": patch
 ---
 
-Gracefully handle cases where sessionStorage is unavailable when using ScrollRestoration
+Log a warning and fail gracefully in `ScrollRestoration` when `sessionStorage` is unavailable

--- a/contributors.yml
+++ b/contributors.yml
@@ -51,6 +51,7 @@
 - danielberndt
 - daniilguit
 - dauletbaev
+- david-bezero
 - david-crespo
 - decadentsavant
 - DigitalNaut

--- a/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
+++ b/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
@@ -14,7 +14,9 @@ import getHtml from "../../react-router/__tests__/utils/getHtml";
 
 describe(`ScrollRestoration`, () => {
   it("restores the scroll position for a page when re-visited", () => {
-    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleWarnMock = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
 
     let testWindow = getWindowImpl("/base");
     const mockScroll = jest.fn();
@@ -28,7 +30,9 @@ describe(`ScrollRestoration`, () => {
             return (
               <>
                 <Outlet />
-                <ScrollRestoration getKey={(location) => "test1-" + location.pathname} />
+                <ScrollRestoration
+                  getKey={(location) => "test1-" + location.pathname}
+                />
               </>
             );
           },
@@ -119,7 +123,9 @@ describe(`ScrollRestoration`, () => {
   });
 
   it("fails gracefully if sessionStorage is not available", () => {
-    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const consoleWarnMock = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
 
     let testWindow = getWindowImpl("/base");
     const mockScroll = jest.fn();
@@ -127,7 +133,7 @@ describe(`ScrollRestoration`, () => {
 
     jest.spyOn(window, "sessionStorage", "get").mockImplementation(() => {
       throw new Error("denied");
-    })
+    });
 
     let router = createBrowserRouter(
       [
@@ -137,7 +143,9 @@ describe(`ScrollRestoration`, () => {
             return (
               <>
                 <Outlet />
-                <ScrollRestoration getKey={(location) => "test2-" + location.pathname} />
+                <ScrollRestoration
+                  getKey={(location) => "test2-" + location.pathname}
+                />
               </>
             );
           },
@@ -172,8 +180,9 @@ describe(`ScrollRestoration`, () => {
     ]);
 
     expect(consoleWarnMock).toHaveBeenCalledWith(
-      expect.stringContaining("Scroll restoration will not work"),
-      expect.anything(),
+      expect.stringContaining(
+        "Failed to save scroll positions in sessionStorage"
+      )
     );
 
     consoleWarnMock.mockRestore();
@@ -184,13 +193,23 @@ const testPages = [
   {
     index: true,
     Component() {
-      return <p>On page 1<br /><Link to="/page">Go to page 2</Link></p>;
+      return (
+        <p>
+          On page 1<br />
+          <Link to="/page">Go to page 2</Link>
+        </p>
+      );
     },
   },
   {
     path: "page",
     Component() {
-      return <p>On page 2<br /><Link to="/">Go to page 1</Link></p>;
+      return (
+        <p>
+          On page 2<br />
+          <Link to="/">Go to page 1</Link>
+        </p>
+      );
     },
   },
 ];

--- a/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
+++ b/packages/react-router-dom/__tests__/scroll-restoration-test.tsx
@@ -13,6 +13,59 @@ import {
 import getHtml from "../../react-router/__tests__/utils/getHtml";
 
 describe(`ScrollRestoration`, () => {
+  it("restores the scroll position for a page when re-visited", () => {
+    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    let testWindow = getWindowImpl("/base");
+    const mockScroll = jest.fn();
+    window.scrollTo = mockScroll;
+
+    let router = createBrowserRouter(
+      [
+        {
+          path: "/",
+          Component() {
+            return (
+              <>
+                <Outlet />
+                <ScrollRestoration getKey={(location) => "test1-" + location.pathname} />
+              </>
+            );
+          },
+          children: testPages,
+        },
+      ],
+      { basename: "/base", window: testWindow }
+    );
+    let { container } = render(<RouterProvider router={router} />);
+
+    expect(getHtml(container)).toMatch("On page 1");
+
+    // simulate scrolling
+    Object.defineProperty(window, "scrollY", { writable: true, value: 100 });
+
+    // leave page
+    window.dispatchEvent(new Event("pagehide"));
+    fireEvent.click(screen.getByText("Go to page 2"));
+    expect(getHtml(container)).toMatch("On page 2");
+
+    // return to page
+    window.dispatchEvent(new Event("pagehide"));
+    fireEvent.click(screen.getByText("Go to page 1"));
+
+    expect(getHtml(container)).toMatch("On page 1");
+
+    // check scroll activity
+    expect(mockScroll.mock.calls).toEqual([
+      [0, 0],
+      [0, 0],
+      [0, 100], // restored
+    ]);
+
+    expect(consoleWarnMock).not.toHaveBeenCalled();
+    consoleWarnMock.mockRestore();
+  });
+
   it("removes the basename from the location provided to getKey", () => {
     let getKey = jest.fn(() => "mykey");
     let testWindow = getWindowImpl("/base");
@@ -64,7 +117,83 @@ describe(`ScrollRestoration`, () => {
     // @ts-expect-error
     expect(getKey.mock.calls[2][0].pathname).toBe("/page"); // restore
   });
+
+  it("fails gracefully if sessionStorage is not available", () => {
+    const consoleWarnMock = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    let testWindow = getWindowImpl("/base");
+    const mockScroll = jest.fn();
+    window.scrollTo = mockScroll;
+
+    jest.spyOn(window, "sessionStorage", "get").mockImplementation(() => {
+      throw new Error("denied");
+    })
+
+    let router = createBrowserRouter(
+      [
+        {
+          path: "/",
+          Component() {
+            return (
+              <>
+                <Outlet />
+                <ScrollRestoration getKey={(location) => "test2-" + location.pathname} />
+              </>
+            );
+          },
+          children: testPages,
+        },
+      ],
+      { basename: "/base", window: testWindow }
+    );
+    let { container } = render(<RouterProvider router={router} />);
+
+    expect(getHtml(container)).toMatch("On page 1");
+
+    // simulate scrolling
+    Object.defineProperty(window, "scrollY", { writable: true, value: 100 });
+
+    // leave page
+    window.dispatchEvent(new Event("pagehide"));
+    fireEvent.click(screen.getByText("Go to page 2"));
+    expect(getHtml(container)).toMatch("On page 2");
+
+    // return to page
+    window.dispatchEvent(new Event("pagehide"));
+    fireEvent.click(screen.getByText("Go to page 1"));
+
+    expect(getHtml(container)).toMatch("On page 1");
+
+    // check scroll activity
+    expect(mockScroll.mock.calls).toEqual([
+      [0, 0],
+      [0, 0],
+      [0, 100], // restored (still possible because the user hasn't left the page)
+    ]);
+
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("Scroll restoration will not work"),
+      expect.anything(),
+    );
+
+    consoleWarnMock.mockRestore();
+  });
 });
+
+const testPages = [
+  {
+    index: true,
+    Component() {
+      return <p>On page 1<br /><Link to="/page">Go to page 2</Link></p>;
+    },
+  },
+  {
+    path: "page",
+    Component() {
+      return <p>On page 2<br /><Link to="/">Go to page 1</Link></p>;
+    },
+  },
+];
 
 function getWindowImpl(initialUrl: string): Window {
   // Need to use our own custom DOM in order to get a working history

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1325,10 +1325,14 @@ function useScrollRestoration({
           storageKey || SCROLL_RESTORATION_STORAGE_KEY,
           JSON.stringify(savedScrollPositions)
         );
-        window.history.scrollRestoration = "auto";
       } catch (error) {
-        console.warn("Failed to record scroll position in session storage. Scroll restoration will not work.", error);
+        warning(
+          false,
+          "Failed to save scroll positions in sessionStorage, <ScrollRestoration /> will not work properly."
+        );
+        console.warn(error);
       }
+      window.history.scrollRestoration = "auto";
     }, [storageKey, getKey, navigation.state, location, matches])
   );
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1320,11 +1320,15 @@ function useScrollRestoration({
         let key = (getKey ? getKey(location, matches) : null) || location.key;
         savedScrollPositions[key] = window.scrollY;
       }
-      sessionStorage.setItem(
-        storageKey || SCROLL_RESTORATION_STORAGE_KEY,
-        JSON.stringify(savedScrollPositions)
-      );
-      window.history.scrollRestoration = "auto";
+      try {
+        sessionStorage.setItem(
+          storageKey || SCROLL_RESTORATION_STORAGE_KEY,
+          JSON.stringify(savedScrollPositions)
+        );
+        window.history.scrollRestoration = "auto";
+      } catch (error) {
+        console.warn("Failed to record scroll position in session storage. Scroll restoration will not work.", error);
+      }
     }, [storageKey, getKey, navigation.state, location, matches])
   );
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1328,9 +1328,8 @@ function useScrollRestoration({
       } catch (error) {
         warning(
           false,
-          "Failed to save scroll positions in sessionStorage, <ScrollRestoration /> will not work properly."
+          `Failed to save scroll positions in sessionStorage, <ScrollRestoration /> will not work properly (${error}).`
         );
-        console.warn(error);
       }
       window.history.scrollRestoration = "auto";
     }, [storageKey, getKey, navigation.state, location, matches])


### PR DESCRIPTION
As discussed in #10842

This writes a descriptive warning to the console if `sessionStorage` is unavailable for any reason, but allows the scroll saving/resetting to continue working as much as possible (until the user leaves the page we still have the scroll positions in a global variable)

It also retro-fits a "happy-path" test for `ScrollRestoration` to confirm the scroll position is correctly reset and no warnings are printed.

Interestingly, writing the test turned up a behaviour quirk where the default `getKey` implementation fails to save the scroll position for the first page viewed (since its `location.key` is `default` on the first visit). I haven't attempted to fix this; I'm not even sure if it's a real issue outside the test environment.