### PR TITLE
Specify `ErrorResponse` as interface to provide obvious contract

### DIFF
--- a/.changeset/error-response-type.md
+++ b/.changeset/error-response-type.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix `ErrorResponse` type to avoid leaking internal field

--- a/contributors.yml
+++ b/contributors.yml
@@ -238,3 +238,4 @@
 - yionr
 - yuleicul
 - zheng-chuang
+- sgrishchenko

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1533,11 +1533,17 @@ export const redirectDocument: RedirectFunction = (url, init) => {
   return response;
 };
 
+export interface ErrorResponse {
+  status: number;
+  statusText: string;
+  data: any;
+}
+
 /**
  * @private
  * Utility class we use to hold auto-unwrapped 4xx/5xx Response bodies
  */
-export class ErrorResponseImpl {
+export class ErrorResponseImpl implements ErrorResponse {
   status: number;
   statusText: string;
   data: any;
@@ -1561,11 +1567,6 @@ export class ErrorResponseImpl {
     }
   }
 }
-
-// We don't want the class exported since usage of it at runtime is an
-// implementation detail, but we do want to export the shape so folks can
-// build their own abstractions around instances via isRouteErrorResponse()
-export type ErrorResponse = InstanceType<typeof ErrorResponseImpl>;
 
 /**
  * Check if the given error is an ErrorResponse generated from a 4xx/5xx

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1542,6 +1542,10 @@ export interface ErrorResponse {
 /**
  * @private
  * Utility class we use to hold auto-unwrapped 4xx/5xx Response bodies
+ *
+ * We don't export the class for public use since it's an implementation
+ * detail, but we export the interface above so folks can build their own
+ * abstractions around instances via isRouteErrorResponse()
  */
 export class ErrorResponseImpl implements ErrorResponse {
   status: number;

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1533,11 +1533,11 @@ export const redirectDocument: RedirectFunction = (url, init) => {
   return response;
 };
 
-export interface ErrorResponse {
+export type ErrorResponse = {
   status: number;
   statusText: string;
   data: any;
-}
+};
 
 /**
  * @private


### PR DESCRIPTION
There is problem in current declaration of `ErrorResponse`: the private field leaks to the public contract. So `ErrorResponse` type behaves very strange on usage (see [playground](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true&exactOptionalPropertyTypes=true&ts=5.1.6#code/JYWwDg9gTgLgBAbwKJStASgUwM6QHbaYC+cAZmiHAEQACUmIwAHgLRQCueA9GuzJlCoAoEQGMIBePVwTCALjgo0ULDIKY4AXkRC4euNhgBDGO2wKALACYANLv2GTZgCqYmMBVX6Gqd-XAATEyMFBCIhIiA)).
I propose to simplify the declaration of `ErrorResponse` and declare it's public interface obviously.