### PR TITLE
Clarify createBrowserHistory is no longer in RR-Dom

### DIFF
--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -125,9 +125,11 @@ window.addEventListener("popstate", () => {
 
 But that only fires when the user clicks the back or forward buttons. There is no event for when the programmer called `window.history.pushState` or `window.history.replaceState`.
 
-That's where a React Router specific `history` object comes into play. It provides a way to "listen for [URL](#url)" changes whether the [history action](#history-actions) is **push**, **pop**, or **replace**.
+That's where a React Router specific `history` object comes into play. It provides a way to "listen for [URL](#url)" changes whether the [history action](#history-actions) is **push**, **pop**, or **replace**. If you need to use this feature you'll need to use the @remix-run/router package, as this does not come with react-router-dom. An alternative that may work for you is to import createBrowserHistory from the history peer-dependency.
 
 ```js
+import { createBrowserHistory } from "@remix-run/router";
+
 let history = createBrowserHistory();
 history.listen(({ location, action }) => {
   // this is called whenever new locations come in


### PR DESCRIPTION
In React-Router DOM v5, I was able to import createBrowserHistory from history, but here it was referred to as if it's part of the react-router-dom library directly. I was surprised that the documentation referred to this functionality but it's actually part of a different sub-library. I'm not sure what I wrote here is correct, but it would be helpful to clarify where we should get createBrowserHistory, and if it's still safe to use the one from 'history' and caveats for the scenarios that it would be worth it to download a whole ’nother package just for this functionality.

In the v5 documentation it's clear that you can import createBrowserHistory from the history peerDependency. Here I'm still to find out if that's the case: https://v5.reactrouter.com/web/api/Router. In either 