### PR TITLE
feat: support loader/action requestContext on the client

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -218,6 +218,11 @@ interface DOMRouterOpts {
   future?: Partial<Omit<RouterFutureConfig, "v7_prependBasename">>;
   hydrationData?: HydrationState;
   window?: Window;
+
+  /**
+   * This value is passed to the `requestContext` property in your loader/action functions.
+   */
+  requestContext?: unknown;
 }
 
 export function createBrowserRouter(
@@ -234,6 +239,7 @@ export function createBrowserRouter(
     hydrationData: opts?.hydrationData || parseHydrationData(),
     routes,
     mapRouteProperties,
+    requestContext: opts?.requestContext,
   }).initialize();
 }
 
@@ -251,6 +257,7 @@ export function createHashRouter(
     hydrationData: opts?.hydrationData || parseHydrationData(),
     routes,
     mapRouteProperties,
+    requestContext: opts?.requestContext,
   }).initialize();
 }
 

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -354,6 +354,7 @@ export interface RouterInit {
   future?: Partial<FutureConfig>;
   hydrationData?: HydrationState;
   window?: Window;
+  requestContext?: unknown;
 }
 
 /**
@@ -865,6 +866,8 @@ export function createRouter(init: RouterInit): Router {
   // Flag to ignore the next history update, so we can revert the URL change on
   // a POP navigation that was blocked by the user without touching router state
   let ignoreNextHistoryUpdate = false;
+
+  let requestContext = init.requestContext;
 
   // Initialize the router, all side effects should be kicked off from here.
   // Implemented as a Fluent API for ease of:
@@ -1387,7 +1390,8 @@ export function createRouter(init: RouterInit): Router {
         matches,
         manifest,
         mapRouteProperties,
-        basename
+        basename,
+        { requestContext }
       );
 
       if (request.signal.aborted) {
@@ -2193,7 +2197,8 @@ export function createRouter(init: RouterInit): Router {
           matches,
           manifest,
           mapRouteProperties,
-          basename
+          basename,
+          { requestContext }
         )
       ),
       ...fetchersToLoad.map((f) => {
@@ -2205,7 +2210,8 @@ export function createRouter(init: RouterInit): Router {
             f.matches,
             manifest,
             mapRouteProperties,
-            basename
+            basename,
+            { requestContext }
           );
         } else {
           let error: ErrorResult = {


### PR DESCRIPTION
Addresses this request: https://github.com/remix-run/react-router/discussions/9856

This change allows the end user to pass requestContext into the browser router, just like they can when calling the static router query handlers. Not sure if ya'll are willing to consider this change (or if where I put the options makes sense, etc), but it was simple so I figured I'd open it. Or if that middleware proposal is being worked on and supersedes this.

It doesn't involve React.Context, nor does it require rendering.

It allows for isomorphic data loader functions. A good example is the react-query use case - on the server the queryClient needs to be created per request and passed in (can't do singleton, so the existing static router requestContext functionality is perfect for this). However, then we're left with loaders that are broken on the client, since they're expecting queryClient in the requestContext object. With this change, we can now pass the queryClient in when creating the browser router.

Example react-query use case:

```tsx
// in the client entry:

const queryClient = new QueryClient();

const router = createBrowserRouter(routes, {
    // same as the existing server functionality.. 
    // Now that we can pass requestContext on the client as well, the loader functions
    // can work as-is in both server/client contexts
    requestContext: { queryClient },
});

// mount the app 
```

I'm not very familiar with the react-router codebase, so I may have missed some areas that need further adjustment.