### PR TITLE
Feature/show fallback on loading

### DIFF
--- a/.changeset/sour-pants-warn.md
+++ b/.changeset/sour-pants-warn.md
@@ -1,0 +1,6 @@
+---
+"react-router": minor
+---
+
+Adds a new prop to the RouterProvider component that allows devs to show fallbackElement during navigation between routes in case that routes have loaders. The devs that want to use this feature must add showFallbackOnLoading to the RouterProvider component. For the ones who want the current behaviour no changes are needed.  
+

--- a/contributors.yml
+++ b/contributors.yml
@@ -188,6 +188,7 @@
 - RobHannay
 - rtmann
 - rubeonline
+- rurquia
 - ryanflorence
 - ryanhiebert
 - sanketshah19

--- a/docs/routers/router-provider.md
+++ b/docs/routers/router-provider.md
@@ -14,6 +14,7 @@ declare function RouterProvider(
 ): React.ReactElement;
 
 interface RouterProviderProps {
+  showFallbackOnLoading?: boolean;
   fallbackElement?: React.ReactNode;
   router: Router;
   future?: Partial<FutureConfig>;
@@ -64,6 +65,18 @@ If you are not server rendering your app, `createBrowserRouter` will initiate al
 ```tsx
 <RouterProvider
   router={router}
+  fallbackElement={<SpinnerOfDoom />}
+/>
+```
+
+## `showFallbackOnLoading`
+
+It will show `fallbackElement` between navigations if destination has a loader.
+
+```tsx
+<RouterProvider
+  router={router}
+  showFallbackOnLoading
   fallbackElement={<SpinnerOfDoom />}
 />
 ```

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -54,6 +54,7 @@ export interface FutureConfig {
 }
 
 export interface RouterProviderProps {
+  showFallbackOnLoading?: boolean;
   fallbackElement?: React.ReactNode;
   router: RemixRouter;
   future?: Partial<FutureConfig>;
@@ -87,6 +88,7 @@ const startTransitionImpl = React[START_TRANSITION];
  * Given a Remix Router instance, render the appropriate UI
  */
 export function RouterProvider({
+  showFallbackOnLoading = false,
   fallbackElement,
   router,
   future,
@@ -152,7 +154,8 @@ export function RouterProvider({
             navigationType={state.historyAction}
             navigator={navigator}
           >
-            {state.initialized ? (
+            {state.initialized &&
+            (!showFallbackOnLoading || state.navigation.state !== "loading") ? (
               <DataRoutes routes={router.routes} state={state} />
             ) : (
               fallbackElement


### PR DESCRIPTION
The component `fallbackElement` its been showed while router and first `loader` are working for the first time, before everything is initialized. As some routes can have `loader` also, i find useful to have the option to use the same `fallbackElement` when navigating to them. It will help to deduplicate code in my routes.