### PR TITLE
[Docs]: Use consistent feature warnings

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -216,6 +216,7 @@
 - tkindy
 - tlinhart
 - tom-sherman
+- tomasr8
 - triangularcube
 - trungpv1601
 - turansky

--- a/docs/route/action.md
+++ b/docs/route/action.md
@@ -7,7 +7,7 @@ new: true
 
 Route actions are the "writes" to route [loader][loader] "reads". They provide a way for apps to perform data mutations with simple HTML and HTTP semantics while React Router abstracts away the complexity of asynchronous UI and revalidation. This gives you the simple mental model of HTML + HTTP (where the browser handles the asynchrony and revalidation) with the behavior and UX capabilities of modern SPAs.
 
-<docs-error>This feature only works if using a data router like [`createBrowserRouter`][createbrowserrouter]</docs-error>
+<docs-warning>This feature only works if using a data router, see [Picking a Router][pickingarouter]</docs-warning>
 
 ```tsx
 <Route

--- a/docs/route/error-element.md
+++ b/docs/route/error-element.md
@@ -9,7 +9,7 @@ When exceptions are thrown in [loaders][loader], [actions][action], or component
 
 <docs-info>If you do not wish to specify a React element (i.e., `errorElement={<MyErrorBoundary />}`) you may specify an `ErrorBoundary` component instead (i.e., `ErrorBoundary={MyErrorBoundary}`) and React Router will call `createElement` for you internally.</docs-info>
 
-<docs-error>This feature only works if using a data router like [`createBrowserRouter`][createbrowserrouter]</docs-error>
+<docs-warning>This feature only works if using a data router, see [Picking a Router][pickingarouter]</docs-warning>
 
 ```tsx
 <Route


### PR DESCRIPTION
Related issue: #10905 

The vast majority of the warnings use `<docs-warning>` so I went with that.