### PR TITLE
Add startViewTransition support

### DIFF
--- a/.changeset/start-view-transition.md
+++ b/.changeset/start-view-transition.md
@@ -1,0 +1,44 @@
+---
+"react-router-dom": minor
+"react-router": minor
+"@remix-run/router": minor
+---
+
+Add support for the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition) via `document.startViewTransition` to enable CSS animated transitions on SPA navigations in your application.
+
+The simplest approach to enabling a View Transition in your React Router app is via the new `<Link unstable_viewTransition>` prop. This will cause the navigation DOM update to be wrapped in `document.startViewTransition` which will enable transitions for the DOM update. Without any additional CSS styles, you'll get a basic cross-fade animation for your page.
+
+If you need to apply more fine-grained styles for your animations, you can leverage the `unstable_useViewTransitionState` hook which will tell you when a transition is ion progress and you can use that to apply classes or styles:
+
+```jsx
+function ImageLink(to, src, alt) {
+  let isTransitioning = unstable_useViewTransitionState(to);
+  return (
+    <Link to={to} unstable_viewTransition>
+      <img
+        src={src}
+        alt={alt}
+        style={{
+          viewTransitionName: isTransitioning ? "image-expand" : "",
+        }}
+      />
+    </Link>
+  );
+}
+```
+
+You can also use the `<NavLink unstable_viewTransition>` shorthand which will manage the hook usage for you and automatically add a `transitioning` class to the `<a>` during the transition:
+
+```css
+a.transitioning img {
+  view-transition-name: "image-expand";
+}
+```
+
+```jsx
+<NavLink to={to} unstable_viewTransition>
+  <img src={src} alt={alt} />
+</NavLink>
+```
+
+For more information on using the View Transitions API, please refer to the [Smooth and simple transitions with the View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions/) guide from the Google Chrome team.

--- a/.changeset/start-view-transition.md
+++ b/.changeset/start-view-transition.md
@@ -8,7 +8,7 @@ Add support for the [View Transitions API](https://developer.mozilla.org/en-US/d
 
 The simplest approach to enabling a View Transition in your React Router app is via the new `<Link unstable_viewTransition>` prop. This will cause the navigation DOM update to be wrapped in `document.startViewTransition` which will enable transitions for the DOM update. Without any additional CSS styles, you'll get a basic cross-fade animation for your page.
 
-If you need to apply more fine-grained styles for your animations, you can leverage the `unstable_useViewTransitionState` hook which will tell you when a transition is ion progress and you can use that to apply classes or styles:
+If you need to apply more fine-grained styles for your animations, you can leverage the `unstable_useViewTransitionState` hook which will tell you when a transition is in progress and you can use that to apply classes or styles:
 
 ```jsx
 function ImageLink(to, src, alt) {
@@ -40,5 +40,7 @@ a.transitioning img {
   <img src={src} alt={alt} />
 </NavLink>
 ```
+
+For an example usage of View Transitions with React Router, check out [our fork](https://github.com/brophdawg11/react-router-records) of the [Astro Records](https://github.com/Charca/astro-records) demo.
 
 For more information on using the View Transitions API, please refer to the [Smooth and simple transitions with the View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions/) guide from the Google Chrome team.

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -5,6 +5,40 @@ new: true
 
 # `<Form>`
 
+<details>
+  <summary>Type declaration</summary>
+
+```tsx
+declare function Form(props: FormProps): React.ReactElement;
+
+export interface LinkProps
+  extends React.FormHTMLAttributes<HTMLFormElement> {
+  method?: "get" | "post" | "put" | "patch" | "delete";
+  encType?:
+    | "application/x-www-form-urlencoded"
+    | "multipart/form-data"
+    | "text/plain";
+  action?: string;
+  relative?: "route" | "path";
+  preventScrollReset?: boolean;
+  onSubmit?: React.FormEventHandler<HTMLFormElement>;
+  reloadDocument?: boolean;
+  replace?: boolean;
+  state?: any;
+  unstable_viewTransition?: boolean;
+}
+
+type To = string | Partial<Path>;
+
+interface Path {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+```
+
+</details>
+
 The Form component is a wrapper around a plain HTML [form][htmlform] that emulates the browser for client side routing and data mutations. It is _not_ a form validation/state management library like you might be used to in the React ecosystem (for that, we recommend the browser's built in [HTML Form Validation][formvalidation] and data validation on your backend server).
 
 <docs-warning>This feature only works if using a data router, see [Picking a Router][pickingarouter]</docs-warning>
@@ -243,6 +277,14 @@ If you are using [`<ScrollRestoration>`][scrollrestoration], this lets you preve
 
 See also: [`<Link preventScrollReset>`][link-preventscrollreset]
 
+## `unstable_viewTransition`
+
+The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+
+<docs-warn>
+Please note that this API is marked unstable and may be subject to breaking changes without a major release.
+</docs-warn>
+
 # Examples
 
 TODO: More examples
@@ -349,3 +391,5 @@ You can access those values from the `request.url`
 [scrollrestoration]: ./scroll-restoration
 [link-preventscrollreset]: ./link#preventscrollreset
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
+[use-view-transition-state]: ../hooks//use-view-transition-state
+[view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -12,7 +12,7 @@ title: Link
 ```tsx
 declare function Link(props: LinkProps): React.ReactElement;
 
-interface LinkProps
+export interface LinkProps
   extends Omit<
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     "href"
@@ -23,6 +23,7 @@ interface LinkProps
   reloadDocument?: boolean;
   preventScrollReset?: boolean;
   relative?: "route" | "path";
+  unstable_viewTransition?: boolean;
 }
 
 type To = string | Partial<Path>;
@@ -146,8 +147,18 @@ let { state } = useLocation();
 
 The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
 
+## `unstable_viewTransition`
+
+The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+
+<docs-warn>
+Please note that this API is marked unstable and may be subject to breaking changes without a major release.
+</docs-warn>
+
 [link-native]: ./link-native
 [scrollrestoration]: ./scroll-restoration
 [history-replace-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
 [history-push-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/pushState
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
+[use-view-transition-state]: ../hooks//use-view-transition-state
+[view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -149,7 +149,41 @@ The `reloadDocument` property can be used to skip client side routing and let th
 
 ## `unstable_viewTransition`
 
-The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`:
+
+```jsx
+<Link to={to} unstable_viewTransition>
+```
+
+If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state]:
+
+```jsx
+function ImageLink(to) {
+  let isTransitioning = unstable_useViewTransitionState(to);
+  return (
+    <Link to={to} unstable_viewTransition>
+      <p
+        style={{
+          viewTransitionName: isTransitioning
+            ? "image-title"
+            : "",
+        }}
+      >
+        Image Number {idx}
+      </p>
+      <img
+        src={src}
+        alt={`Img ${idx}`}
+        style={{
+          viewTransitionName: isTransitioning
+            ? "image-expand"
+            : "",
+        }}
+      />
+    </Link>
+  );
+}
+```
 
 <docs-warn>
 Please note that this API is marked unstable and may be subject to breaking changes without a major release.

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -144,6 +144,33 @@ a.transitioning img {
 
 You may also use the `className`/`style` props or the render props passed to `children` to further customize based on the `isTransitioning` value.
 
+```jsx
+<NavLink to={to} unstable_viewTransition>
+  {({ isTransitioning }) => (
+    <>
+      <p
+        style={{
+          viewTransitionName: isTransitioning
+            ? "image-title"
+            : "",
+        }}
+      >
+        Image Number {idx}
+      </p>
+      <img
+        src={src}
+        alt={`Img ${idx}`}
+        style={{
+          viewTransitionName: isTransitioning
+            ? "image-expand"
+            : "",
+        }}
+      />
+    </>
+  )}
+</NavLink>
+```
+
 <docs-warn>
 Please note that this API is marked unstable and may be subject to breaking changes without a major release.
 </docs-warn>

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -4,7 +4,11 @@ title: NavLink
 
 # `<NavLink>`
 
-A `<NavLink>` is a special kind of `<Link>` that knows whether or not it is "active" or "pending". This is useful when building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.
+A `<NavLink>` is a special kind of `<Link>` that knows whether or not it is "active", "pending", or "transitioning". This is useful in a few different scenarios:
+
+- When building a navigation menu, such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected
+- It provides useful context for assistive technology like screen readers
+- It provides a "transitioning" value to give you finer-grained control over [View Transitions][view-transitions]
 
 ```tsx
 import { NavLink } from "react-router-dom";
@@ -42,8 +46,12 @@ The `className` prop works like a normal className, but you can also pass it a f
 ```tsx
 <NavLink
   to="/messages"
-  className={({ isActive, isPending }) =>
-    isPending ? "pending" : isActive ? "active" : ""
+  className={({ isActive, isPending, isTransitioning }) =>
+    [
+      isPending ? "pending" : "",
+      isActive ? "active" : "",
+      isTransitioning ? "transitioning" : "",
+    ].join(" ")
   }
 >
   Messages
@@ -57,10 +65,11 @@ The `style` prop works like a normal style prop, but you can also pass it a func
 ```tsx
 <NavLink
   to="/messages"
-  style={({ isActive, isPending }) => {
+  style={({ isActive, isPending, isTransitioning }) => {
     return {
       fontWeight: isActive ? "bold" : "",
       color: isPending ? "red" : "black",
+      viewTransitionName: isTransitioning ? "slide" : "",
     };
   }}
 >
@@ -74,7 +83,7 @@ You can pass a render prop as children to customize the content of the `<NavLink
 
 ```tsx
 <NavLink to="/tasks">
-  {({ isActive, isPending }) => (
+  {({ isActive, isPending, isTransitioning }) => (
     <span className={isActive ? "active" : ""}>Tasks</span>
   )}
 </NavLink>
@@ -112,4 +121,33 @@ When a `NavLink` is active it will automatically apply `<a aria-current="page">`
 
 The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
 
+## `unstable_viewTransition`
+
+The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. By default, during the transition a `transitioning` class will be added to the `<a>` element that you can use to customize the view transition.
+
+```css
+a.transitioning p {
+  view-transition-name: "image-title";
+}
+
+a.transitioning img {
+  view-transition-name: "image-expand";
+}
+```
+
+```jsx
+<NavLink to={to} unstable_viewTransition>
+  <p>Image Number {idx}</p>
+  <img src={src} alt={`Img ${idx}`} />
+</NavLink>
+```
+
+You may also use the `className`/`style` props or the render props passed to `children` to further customize based on the `isTransitioning` value.
+
+<docs-warn>
+Please note that this API is marked unstable and may be subject to breaking changes without a major release.
+</docs-warn>
+
 [aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
+[view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API
+[use-view-transition-state]: ../hooks//use-view-transition-state

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -85,9 +85,19 @@ function EditContact() {
 }
 ```
 
+## `options.unstable_viewTransition`
+
+The `unstable_viewTransition` option enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+
+<docs-warn>
+Please note that this API is marked unstable and may be subject to breaking changes without a major release.
+</docs-warn>
+
 [link]: ../components/link
 [redirect]: ../fetch/redirect
 [loaders]: ../route/loader
 [actions]: ../route/action
 [history-state]: https://developer.mozilla.org/en-US/docs/Web/API/History/state
 [scrollrestoration]: ../components/scroll-restoration
+[use-view-transition-state]: ../hooks//use-view-transition-state
+[view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -150,7 +150,7 @@ submit(null, {
 <Form action="/logout" method="post" />;
 ```
 
-Because submissions are navigations, the options may also contain the other navigation related props from [`<Form>`][form] such as `replace`, `state`, `preventScrollReset`, `relative`, etc.
+Because submissions are navigations, the options may also contain the other navigation related props from [`<Form>`][form] such as `replace`, `state`, `preventScrollReset`, `relative`, `unstable_viewTransition` etc.
 
 [pickingarouter]: ../routers/picking-a-router
 [form]: ../components/form

--- a/docs/hooks/use-view-transition-state.md
+++ b/docs/hooks/use-view-transition-state.md
@@ -1,0 +1,50 @@
+---
+title: unstable_useViewTransitionState
+---
+
+# `unstable_useViewTransitionState`
+
+<details>
+  <summary>Type declaration</summary>
+
+```tsx
+declare function unstable_useViewTransitionState(
+  to: To,
+  opts: { relative?: "route" : "path" } = {}
+): boolean;
+
+type To = string | Partial<Path>;
+
+interface Path {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+```
+
+</details>
+
+This hook returns `true` when there is an active [View Transition][view-transitions] to the specified location. This can be used to apply finer-grained styles to elements to further customize the view transition. This requires that view transitions have been enabled for the given navigation via the [unstable_viewTransition][link-view-transition] prop on the `Link` (or the `Form`, `navigate`, or `submit` call).
+
+Consider clicking on an image in a list that you need to expand into the hero image on the destination page:
+
+```jsx
+function NavImage({ src, alt, id }) {
+  let to = `/images/${idx}`;
+  let vt = unstable_useViewTransitionState(href);
+  return (
+    <Link to={to} unstable_viewTransition>
+      <img
+        src={src}
+        alt={alt}
+        style={{
+          viewTransitionName: vt ? "image-expand" : "",
+        }}
+      />
+    </Link>
+  );
+}
+```
+
+[link-view-transition]: ../components/link#unstable_viewtransition
+[view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

--- a/examples/view-transitions/.gitignore
+++ b/examples/view-transitions/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local

--- a/examples/view-transitions/.stackblitzrc
+++ b/examples/view-transitions/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": true,
+  "startCommand": "npm run dev"
+}

--- a/examples/view-transitions/README.md
+++ b/examples/view-transitions/README.md
@@ -1,0 +1,14 @@
+---
+title: View Transitions
+toc: false
+---
+
+# startViewTransition (Experimental)
+
+This example demonstrates a simple usage of a Data Router with `document.startViewTransition` enabled.
+
+## Preview
+
+Open this example on [StackBlitz](https://stackblitz.com):
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/remix-run/react-router/tree/brophdawg11/start-view-transition/examples/view-transitions?file=src/App.tsx)

--- a/examples/view-transitions/index.html
+++ b/examples/view-transitions/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Router - Basic Data Router Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/view-transitions/package-lock.json
+++ b/examples/view-transitions/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "basic-data-router",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "basic-data-router",
+      "dependencies": {
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-router-dom": "^6.10.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-replace": "5.0.2",
+        "@types/node": "18.11.18",
+        "@types/react": "18.0.27",
+        "@types/react-dom": "18.0.10",
+        "@vitejs/plugin-react": "3.0.1",
+        "typescript": "4.9.5",
+        "vite": "4.0.4"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.3.tgz",
+      "integrity": "sha512-aNtko9OPOwVESUFp3MZfD8Uzxl7JzSeJpd7npIoxCasU37PFbAQRpKglkaKwlHOyeJdrREpo8TW8ldrkYWwvIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.1.tgz",
+      "integrity": "sha512-Hkqu7J4ynysSXxmAahpN1jjRwVJ+NdpraFLIWflgjpVob3KNyK3/tIUc7Q7szed8WMp0JNa7Qtd1E9Oo22F9gA==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.22.0",
+        "@babel/helper-compilation-targets": "^7.22.1",
+        "@babel/helper-module-transforms": "^7.22.1",
+        "@babel/helpers": "^7.22.0",
+        "@babel/parser": "^7.22.0",
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.3.tgz",
+      "integrity": "sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.3",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.1.tgz",
+      "integrity": "sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.22.0",
+        "@babel/helper-validator-option": "^7.21.0",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz",
+      "integrity": "sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.21.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz",
+      "integrity": "sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.1",
+        "@babel/helper-module-imports": "^7.21.4",
+        "@babel/helper-simple-access": "^7.21.5",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
+      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.21.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.3.tgz",
+      "integrity": "sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.21.9",
+        "@babel/traverse": "^7.22.1",
+        "@babel/types": "^7.22.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
+      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.21.0.tgz",
+      "integrity": "sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
+      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.21.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.21.9.tgz",
+      "integrity": "sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "@babel/parser": "^7.21.9",
+        "@babel/types": "^7.21.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.4.tgz",
+      "integrity": "sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.22.3",
+        "@babel/helper-environment-visitor": "^7.22.1",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.22.4",
+        "@babel/types": "^7.22.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.21.5",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.27.tgz",
+      "integrity": "sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
+      "dev": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.1.tgz",
+      "integrity": "sha512-mx+QvYwIbbpOIJw+hypjnW1lAbKDHtWK5ibkF/V1/oMBu8HU/chb+SnqJDAsLq1+7rGqjktCEomMTM5KShzUKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.20.7",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.27.0",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.21.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
+      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001489",
+        "electron-to-chromium": "^1.4.411",
+        "node-releases": "^2.0.12",
+        "update-browserslist-db": "^1.0.11"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001494",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz",
+      "integrity": "sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.419.tgz",
+      "integrity": "sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.16.17",
+        "@esbuild/android-arm64": "0.16.17",
+        "@esbuild/android-x64": "0.16.17",
+        "@esbuild/darwin-arm64": "0.16.17",
+        "@esbuild/darwin-x64": "0.16.17",
+        "@esbuild/freebsd-arm64": "0.16.17",
+        "@esbuild/freebsd-x64": "0.16.17",
+        "@esbuild/linux-arm": "0.16.17",
+        "@esbuild/linux-arm64": "0.16.17",
+        "@esbuild/linux-ia32": "0.16.17",
+        "@esbuild/linux-loong64": "0.16.17",
+        "@esbuild/linux-mips64el": "0.16.17",
+        "@esbuild/linux-ppc64": "0.16.17",
+        "@esbuild/linux-riscv64": "0.16.17",
+        "@esbuild/linux-s390x": "0.16.17",
+        "@esbuild/linux-x64": "0.16.17",
+        "@esbuild/netbsd-x64": "0.16.17",
+        "@esbuild/openbsd-x64": "0.16.17",
+        "@esbuild/sunos-x64": "0.16.17",
+        "@esbuild/win32-arm64": "0.16.17",
+        "@esbuild/win32-ia32": "0.16.17",
+        "@esbuild/win32-x64": "0.16.17"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
+      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "dev": true
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.1.tgz",
+      "integrity": "sha512-ybRdFVHOoljGEFILHLd2g/qateqUdjE6YS41WXq4p3C/WwD3xtWxV4FYWETA1u9TeXQc5K8L8zHE5d/scOvrOQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.16.3",
+        "postcss": "^8.4.20",
+        "resolve": "^1.22.1",
+        "rollup": "^3.7.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 14",
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    }
+  }
+}

--- a/examples/view-transitions/package-lock.json
+++ b/examples/view-transitions/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^0.0.0-experimental-b8437806"
+        "react-router-dom": "^6.16.0"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "5.0.2",
@@ -769,9 +769,9 @@
       "dev": true
     },
     "node_modules/@remix-run/router": {
-      "version": "0.0.0-experimental-b8437806",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-0.0.0-experimental-b8437806.tgz",
-      "integrity": "sha512-uANtg7FnBtIAjhdkqYOv2BH8u+jbKJW4Y9QZ7ADsttiX6rIW/vxU3cJawU9qZY0kCFNQ1pDpMBae9s4qCrIOZQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
+      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1318,11 +1318,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "0.0.0-experimental-b8437806",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-0.0.0-experimental-b8437806.tgz",
-      "integrity": "sha512-oVtvd0W0Aagfx+SMM5mZDm6EoRJxl1NJnNMFs9aIql9IGGQArelbYcLfGwHdLwAKYHdtYVpv6UDbng+Hl27Esw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
+      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-b8437806"
+        "@remix-run/router": "1.9.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1332,12 +1332,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "0.0.0-experimental-b8437806",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-0.0.0-experimental-b8437806.tgz",
-      "integrity": "sha512-cOh+BLUsX+sy3HqfPTelmajgWTpToOxrSvPLj1EEOIAmC601Xrnw/1t5CBV2ii4Lo+oryWQUZ7mgjnJyywCaFQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0.tgz",
+      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
       "dependencies": {
-        "@remix-run/router": "0.0.0-experimental-b8437806",
-        "react-router": "0.0.0-experimental-b8437806"
+        "@remix-run/router": "1.9.0",
+        "react-router": "6.16.0"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/examples/view-transitions/package-lock.json
+++ b/examples/view-transitions/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "^6.10.0"
+        "react-router-dom": "^0.0.0-experimental-b8437806"
       },
       "devDependencies": {
         "@rollup/plugin-replace": "5.0.2",
@@ -769,9 +769,9 @@
       "dev": true
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "version": "0.0.0-experimental-b8437806",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-0.0.0-experimental-b8437806.tgz",
+      "integrity": "sha512-uANtg7FnBtIAjhdkqYOv2BH8u+jbKJW4Y9QZ7ADsttiX6rIW/vxU3cJawU9qZY0kCFNQ1pDpMBae9s4qCrIOZQ==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1318,11 +1318,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "0.0.0-experimental-b8437806",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-0.0.0-experimental-b8437806.tgz",
+      "integrity": "sha512-oVtvd0W0Aagfx+SMM5mZDm6EoRJxl1NJnNMFs9aIql9IGGQArelbYcLfGwHdLwAKYHdtYVpv6UDbng+Hl27Esw==",
       "dependencies": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "0.0.0-experimental-b8437806"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1332,12 +1332,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "0.0.0-experimental-b8437806",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-0.0.0-experimental-b8437806.tgz",
+      "integrity": "sha512-cOh+BLUsX+sy3HqfPTelmajgWTpToOxrSvPLj1EEOIAmC601Xrnw/1t5CBV2ii4Lo+oryWQUZ7mgjnJyywCaFQ==",
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "0.0.0-experimental-b8437806",
+        "react-router": "0.0.0-experimental-b8437806"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/examples/view-transitions/package.json
+++ b/examples/view-transitions/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "basic-data-router",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-router-dom": "^6.10.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-replace": "5.0.2",
+    "@types/node": "18.11.18",
+    "@types/react": "18.0.27",
+    "@types/react-dom": "18.0.10",
+    "@vitejs/plugin-react": "3.0.1",
+    "typescript": "4.9.5",
+    "vite": "4.0.4"
+  }
+}

--- a/examples/view-transitions/package.json
+++ b/examples/view-transitions/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^0.0.0-experimental-b8437806"
+    "react-router-dom": "^6.16.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "5.0.2",

--- a/examples/view-transitions/package.json
+++ b/examples/view-transitions/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "^6.10.0"
+    "react-router-dom": "^0.0.0-experimental-b8437806"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "5.0.2",

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -1,0 +1,16 @@
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 1s;
+}
+
+h1 {
+  font-size: 3rem;
+}
+
+.is-loading {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: lightgrey;
+  padding: 0.5rem;
+}

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -1,16 +1,46 @@
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation-duration: 500ms;
-}
-
-h1 {
-  font-size: 3rem;
-}
-
 .is-loading {
   position: absolute;
   top: 0;
   right: 0;
   background-color: lightgrey;
   padding: 0.5rem;
+}
+
+/* Magicawesomeness */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-from-right {
+  from {
+    transform: translateX(500px);
+  }
+}
+
+@keyframes slide-to-left {
+  to {
+    transform: translateX(-500px);
+  }
+}
+
+.content {
+  view-transition-name: content;
+}
+
+::view-transition-old(content) {
+  animation: 500ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+}
+
+::view-transition-new(content) {
+  animation: 500ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
 }

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -1,6 +1,6 @@
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation-duration: 1s;
+  animation-duration: 500ms;
 }
 
 h1 {

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -36,11 +36,48 @@
 }
 
 ::view-transition-old(content) {
-  animation: 500ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
-    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
+  /* animation: 500ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left; */
 }
 
 ::view-transition-new(content) {
-  animation: 500ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
-    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
+  /* animation: 500ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right; */
+}
+
+.image-list > div {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: 10px;
+}
+
+.image-list img {
+  max-width: 100%;
+  contain: layout;
+}
+
+.image-detail img {
+  max-width: 100%;
+  view-transition-name: image-expand;
+  contain: layout;
+}
+
+::view-transition-old(image-expand),
+::view-transition-new(image-expand) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+.image-list p {
+  width: fit-content;
+}
+
+.image-detail h1 {
+  view-transition-name: image-title;
+  width: fit-content;
+}
+
+::view-transition-old(image-title),
+::view-transition-new(image-title) {
 }

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -57,6 +57,10 @@
   contain: layout;
 }
 
+.image-list a.transitioning img {
+  view-transition-name: image-expand;
+}
+
 .image-detail img {
   max-width: 100%;
   view-transition-name: image-expand;
@@ -73,11 +77,11 @@
   width: fit-content;
 }
 
+.image-list a.transitioning p {
+  view-transition-name: image-title;
+}
+
 .image-detail h1 {
   view-transition-name: image-title;
   width: fit-content;
-}
-
-::view-transition-old(image-title),
-::view-transition-new(image-title) {
 }

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -36,13 +36,13 @@
 }
 
 ::view-transition-old(content) {
-  /* animation: 500ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
-    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left; */
+  animation: 500ms cubic-bezier(0.4, 0, 1, 1) both fade-out,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-to-left;
 }
 
 ::view-transition-new(content) {
-  /* animation: 500ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
-    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right; */
+  animation: 500ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in,
+    500ms cubic-bezier(0.4, 0, 0.2, 1) both slide-from-right;
 }
 
 .image-list > div {

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -63,8 +63,11 @@
 
 .image-detail img {
   max-width: 100%;
-  view-transition-name: image-expand;
   contain: layout;
+}
+
+.image-detail.transitioning img {
+  view-transition-name: image-expand;
 }
 
 ::view-transition-old(image-expand),
@@ -82,6 +85,9 @@
 }
 
 .image-detail h1 {
-  view-transition-name: image-title;
   width: fit-content;
+}
+
+.image-detail.transitioning h1 {
+  view-transition-name: image-title;
 }

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -66,11 +66,10 @@
   contain: layout;
 }
 
-.image-detail.transitioning img {
+.image-detail img {
   view-transition-name: image-expand;
 }
 
-::view-transition-old(image-expand),
 ::view-transition-new(image-expand) {
   animation: none;
   mix-blend-mode: normal;
@@ -88,6 +87,6 @@
   width: fit-content;
 }
 
-.image-detail.transitioning h1 {
+.image-detail h1 {
   view-transition-name: image-title;
 }

--- a/examples/view-transitions/src/index.css
+++ b/examples/view-transitions/src/index.css
@@ -70,7 +70,8 @@
   view-transition-name: image-expand;
 }
 
-::view-transition-new(image-expand) {
+::view-transition-old(image-expand):not(:only-child),
+::view-transition-new(image-expand):not(:only-child) {
   animation: none;
   mix-blend-mode: normal;
 }

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -134,7 +134,7 @@ const router = createBrowserRouter(
     future: {
       // Prevent react router from await-ing defer() promises for revalidating
       // loaders, which includes changing search params on the active route
-      v7_deferRevalidateFallbacks: true,
+      v7_fallbackOnDeferRevalidation: true,
     },
   }
 );
@@ -188,7 +188,7 @@ function Nav() {
               ✅ It also uses a location-based key on the suspense boundary so
               revalidations will trigger a fresh fallback. Click this link again
               while on the page to see this behavior (requires
-              v7_deferRevalidateFallbacks: true)
+              v7_fallbackOnDeferRevalidation: true)
             </li>
             <li>
               ❌ Without the key on the suspense boundary, it will animate in

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import * as ReactDOMClient from "react-dom/client";
+import {
+  createBrowserRouter,
+  Link,
+  RouterProvider,
+  useNavigation,
+} from "react-router-dom";
+import "./index.css";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    Component() {
+      let navigation = useNavigation();
+      let isLoading = navigation.state !== "idle";
+      return (
+        <>
+          <h1>Home</h1>
+          <Link to="/test">Test</Link>
+          <p>
+            The /test route has a 1s delay in it's loader, so the DOM transition
+            doesn't start until the loader completes
+          </p>
+          {isLoading ? <div className="is-loading">Loading...</div> : null}
+        </>
+      );
+    },
+  },
+  {
+    path: "/test",
+    async loader() {
+      await new Promise((r) => setTimeout(r, 1000));
+      return null;
+    },
+    Component() {
+      let navigation = useNavigation();
+      let isLoading = navigation.state !== "idle";
+      return (
+        <>
+          <h1>Test</h1>
+          <Link to="/">Home</Link>
+          <p>
+            The home route has no loader so it starts transitioning immediately
+          </p>
+          {isLoading ? <div className="is-loading">Loading...</div> : null}
+        </>
+      );
+    },
+  },
+]);
+
+const rootElement = document.getElementById("root") as HTMLElement;
+ReactDOMClient.createRoot(rootElement).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -1,58 +1,219 @@
 import * as React from "react";
 import * as ReactDOMClient from "react-dom/client";
 import {
+  Await,
   createBrowserRouter,
+  defer,
+  json,
   Link,
+  Outlet,
   RouterProvider,
+  useLoaderData,
+  useLocation,
   useNavigation,
 } from "react-router-dom";
 import "./index.css";
 
-const router = createBrowserRouter([
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      Component() {
+        let navigation = useNavigation();
+        return (
+          <>
+            {navigation.state !== "idle" ? (
+              <div className="is-loading">Loading...</div>
+            ) : null}
+            <Nav />
+            <div className="content">
+              <Outlet />
+            </div>
+          </>
+        );
+      },
+      children: [
+        {
+          index: true,
+          Component() {
+            return <h1>Home</h1>;
+          },
+        },
+        {
+          path: "loader",
+          async loader() {
+            await new Promise((r) => setTimeout(r, 1000));
+            return json({ message: "LOADER DATA" });
+          },
+          Component() {
+            let data = useLoaderData() as { message: string };
+            return (
+              <>
+                <h1>Test</h1>
+                <p>Loader Data: {data.message}</p>
+              </>
+            );
+          },
+        },
+        {
+          path: "defer",
+          async loader({ request }) {
+            let value = new URL(request.url).searchParams.get("value") || "";
+            await new Promise((r) => setTimeout(r, 500));
+            return defer({
+              value,
+              critical: "CRITICAL PATH DATA " + value,
+              lazy: new Promise((r) =>
+                setTimeout(() => r("LAZY DATA " + value), 2500)
+              ),
+            });
+          },
+          Component() {
+            let data = useLoaderData() as {
+              value: string;
+              critical: string;
+              lazy: Promise<string>;
+            };
+            return (
+              <>
+                <h1>Defer {data.value}</h1>
+                <p>Critical Data: {data.critical}</p>
+                {/*
+                  use a key on then suspense boundary to trigger a fallback
+                  on location changes
+                */}
+                <React.Suspense
+                  fallback={<p>Suspense boundary in the route...</p>}
+                  key={useLocation().key}
+                >
+                  <Await resolve={data.lazy}>
+                    {(value) => <p>Lazy Data: {value}</p>}
+                  </Await>
+                </React.Suspense>
+              </>
+            );
+          },
+        },
+        {
+          path: "defer-no-boundary",
+          async loader({ request }) {
+            let value = new URL(request.url).searchParams.get("value") || "";
+            await new Promise((r) => setTimeout(r, 500));
+            return defer({
+              value,
+              critical: "CRITICAL PATH DATA - NO BOUNDARY " + value,
+              lazy: new Promise((r) =>
+                setTimeout(() => r("LAZY DATA - NO BOUNDARY " + value), 1000)
+              ),
+            });
+          },
+          Component() {
+            let data = useLoaderData() as {
+              value: string;
+              data: string;
+              critical: string;
+              lazy: Promise<string>;
+            };
+            return (
+              <>
+                <h1>Defer No Boundary {data.value}</h1>
+                <p>Critical Data: {data.critical}</p>
+                <div>
+                  <Await resolve={data.lazy}>
+                    {(value) => <p>Lazy Data: {value}</p>}
+                  </Await>
+                </div>
+              </>
+            );
+          },
+        },
+      ],
+    },
+  ],
   {
-    path: "/",
-    Component() {
-      let navigation = useNavigation();
-      let isLoading = navigation.state !== "idle";
-      return (
-        <>
-          <h1>Home</h1>
-          <Link to="/test">Test</Link>
-          <p>
-            The /test route has a 1s delay in it's loader, so the DOM transition
-            doesn't start until the loader completes
-          </p>
-          {isLoading ? <div className="is-loading">Loading...</div> : null}
-        </>
-      );
+    future: {
+      // Prevent react router from await-ing defer() promises for revalidating
+      // loaders, which includes changing search params on the active route
+      v7_deferRevalidateFallbacks: true,
     },
-  },
-  {
-    path: "/test",
-    async loader() {
-      await new Promise((r) => setTimeout(r, 1000));
-      return null;
-    },
-    Component() {
-      let navigation = useNavigation();
-      let isLoading = navigation.state !== "idle";
-      return (
-        <>
-          <h1>Test</h1>
-          <Link to="/">Home</Link>
-          <p>
-            The home route has no loader so it starts transitioning immediately
-          </p>
-          {isLoading ? <div className="is-loading">Loading...</div> : null}
-        </>
-      );
-    },
-  },
-]);
+  }
+);
 
 const rootElement = document.getElementById("root") as HTMLElement;
 ReactDOMClient.createRoot(rootElement).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <RouterProvider
+      router={router}
+      future={{
+        // Wrap all state updates in React.startTransition()
+        v7_startTransition: true,
+        // Wrap all completed navigation state updates in
+        // document.startViewTransition()
+        unstable_startViewTransition: true,
+      }}
+    />
   </React.StrictMode>
 );
+
+function Nav() {
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Link to="/">Home</Link>
+          <ul>
+            <li>
+              ✅ The / route has no loader is should be an immediate/synchronous
+              transition
+            </li>
+          </ul>
+        </li>
+        <li>
+          <Link to="/loader">Loader Delay</Link>
+          <ul>
+            <li>
+              ✅ The /loader route has a 1 second loader delay, and updates the
+              DOM synchronously upon completion
+            </li>
+          </ul>
+        </li>
+        <li>
+          <Link to="/defer">Deferred Data</Link>
+          <ul>
+            <li>
+              The /defer route has a a 500ms loader delay with a 1s defer call
+              that will Suspend in the destination route
+            </li>
+            <li>
+              ✅ It also uses a location-based key on the suspense boundary so
+              revalidations will trigger a fresh fallback. Click this link again
+              while on the page to see this behavior (requires
+              v7_deferRevalidateFallbacks: true)
+            </li>
+            <li>
+              ❌ Without the key on the suspense boundary, it will animate in
+              the current boundary on top of itself
+            </li>
+          </ul>
+        </li>
+        <li>
+          <Link to="/defer-no-boundary">Deferred Data (without boundary)</Link>
+          <ul>
+            <li>
+              The /defer-no-boundary route has a a 500ms loader delay with a 1s
+              defer call without a Suspense boundary in the destination route
+            </li>
+            <li>
+              ❌ This is where things go awry because without a boundary the
+              usage of React.startTransition causes React to freeze the current
+              UI in place so we animate the current page and then the updates
+              snap in. This is where I think React needs to be involved since
+              they decide when it's finally OK to update the DOM inside
+              startTransition
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -83,14 +83,14 @@ const router = createBrowserRouter(
             return json({ message: "ACTION DATA" });
           },
           Component() {
-            let data = useActionData() as { message: string };
+            let data = useActionData() as { message: string } | undefined;
             React.useEffect(() => {
               document.title = "Action";
             }, []);
             return (
               <>
                 <h1>Action Page</h1>
-                <p>Action Data: {data.message}</p>
+                <p>Action Data: {data?.message}</p>
               </>
             );
           },
@@ -214,16 +214,11 @@ const router = createBrowserRouter(
           path: "images/:id",
           Component() {
             let params = useParams();
-            // Conditionally apply the transition styles only when navigating _to_
-            // this route.  If we apply them statically, clicking back to the home
-            // page from this view leaves the image stuck during the animation
-            // since it has no corresponding element to shrink into
-            let vt = unstable_useViewTransitionState(".");
             React.useEffect(() => {
               document.title = "Image " + params.id;
             }, [params.id]);
             return (
-              <div className={`image-detail ${vt ? "transitioning" : ""}`}>
+              <div className={`image-detail`}>
                 <h1>Image Number {params.id}</h1>
                 <img src={images[Number(params.id)]} alt={`${params.id}`} />
               </div>

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -155,6 +155,7 @@ const router = createBrowserRouter(
                       <p>Image Number {idx}</p>
                       <img src={src} alt={`Img ${idx}`} />
                     </NavLink>
+                    // <NavImage key={src} src={src} idx={idx} />
                   ))}
                 </div>
               </div>
@@ -189,6 +190,24 @@ const router = createBrowserRouter(
     },
   }
 );
+
+function NavImage({ src, idx }: { src: string; idx: number }) {
+  let href = `/images/${idx}`;
+  let isTransitioning = unstable_useViewTransition(href);
+  console.log(href, isTransitioning);
+  return (
+    <NavLink to={href}>
+      <p style={{ viewTransitionName: isTransitioning ? "image-title" : "" }}>
+        Image Number {idx}
+      </p>
+      <img
+        src={src}
+        alt={`Img ${idx}`}
+        style={{ viewTransitionName: isTransitioning ? "image-expand" : "" }}
+      />
+    </NavLink>
+  );
+}
 
 const rootElement = document.getElementById("root") as HTMLElement;
 ReactDOMClient.createRoot(rootElement).render(

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -10,6 +10,7 @@ import {
   Outlet,
   RouterProvider,
   unstable_useViewTransition,
+  unstable_useViewTransitionFrom,
   useLoaderData,
   useNavigation,
   useParams,
@@ -35,7 +36,6 @@ const router = createBrowserRouter(
       Component() {
         // turn on basic view transitions for the whole app
         unstable_useViewTransition();
-        // unstable_useViewTransition("/loader");
 
         let navigation = useNavigation();
 
@@ -165,8 +165,13 @@ const router = createBrowserRouter(
           path: "images/:id",
           Component() {
             let params = useParams();
+            let isTransitioning = unstable_useViewTransitionFrom("/images");
             return (
-              <div className="image-detail">
+              <div
+                className={`image-detail ${
+                  isTransitioning ? "transitioning" : ""
+                }`}
+              >
                 <h1>Image Number {params.id}</h1>
                 <img src={images[Number(params.id)]} alt={`${params.id}`} />
               </div>

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   Outlet,
   RouterProvider,
-  unstable_unstable_useViewTransitions,
+  unstable_useViewTransitions,
   useLoaderData,
   useNavigation,
   useParams,
@@ -36,7 +36,7 @@ const router = createBrowserRouter(
           React.useState(true);
 
         // turn on basic view transitions for the whole app
-        unstable_unstable_useViewTransitions(enableViewTransitions);
+        unstable_useViewTransitions(enableViewTransitions);
 
         let navigation = useNavigation();
 
@@ -152,7 +152,7 @@ const router = createBrowserRouter(
           path: "images",
           Component() {
             // Animate list image into detail image
-            unstable_unstable_useViewTransitions(({ nextLocation }) => {
+            unstable_useViewTransitions(({ nextLocation }) => {
               // TODO: Should we be able to return false here to opt out of
               // calling startViewTransition?
               if (!/^\/images\/\d+$/.test(nextLocation.pathname)) {
@@ -210,40 +210,38 @@ const router = createBrowserRouter(
             let params = useParams();
 
             // Animate detail image into list image
-            unstable_unstable_useViewTransitions(
-              ({ currentLocation, nextLocation }) => {
-                // TODO: Should we be able to return false here to opt out of
-                // calling startViewTransition?
-                if (!/^\/images$/.test(nextLocation.pathname)) {
-                  return;
-                }
-
-                LOG("before dom update");
-
-                return (transition) => {
-                  LOG("after dom update", transition);
-                  let anchor = document.querySelector(
-                    `.image-list a[href="${currentLocation.pathname}"]`
-                  );
-                  let title = anchor?.previousElementSibling!;
-                  let img = anchor?.firstElementChild!;
-                  // @ts-ignore
-                  title.style.viewTransitionName = "image-title";
-                  // @ts-ignore
-                  img.style.viewTransitionName = "image-expand";
-                  transition.ready.finally(() => {
-                    LOG("transition ready");
-                  });
-                  transition.finished.finally(() => {
-                    LOG("transition finished");
-                    // @ts-ignore
-                    title.style.viewTransitionName = "";
-                    // @ts-ignore
-                    img.style.viewTransitionName = "";
-                  });
-                };
+            unstable_useViewTransitions(({ currentLocation, nextLocation }) => {
+              // TODO: Should we be able to return false here to opt out of
+              // calling startViewTransition?
+              if (!/^\/images$/.test(nextLocation.pathname)) {
+                return;
               }
-            );
+
+              LOG("before dom update");
+
+              return (transition) => {
+                LOG("after dom update", transition);
+                let anchor = document.querySelector(
+                  `.image-list a[href="${currentLocation.pathname}"]`
+                );
+                let title = anchor?.previousElementSibling!;
+                let img = anchor?.firstElementChild!;
+                // @ts-ignore
+                title.style.viewTransitionName = "image-title";
+                // @ts-ignore
+                img.style.viewTransitionName = "image-expand";
+                transition.ready.finally(() => {
+                  LOG("transition ready");
+                });
+                transition.finished.finally(() => {
+                  LOG("transition finished");
+                  // @ts-ignore
+                  title.style.viewTransitionName = "";
+                  // @ts-ignore
+                  img.style.viewTransitionName = "";
+                });
+              };
+            });
 
             return (
               <div className="image-detail">

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -179,7 +179,11 @@ const router = createBrowserRouter(
                 <div>
                   {images.map((src, idx) => (
                     // Adds 'transitioning' class to the <a> during the transition
-                    <NavLink key={src} to={`/images/${idx}`}>
+                    <NavLink
+                      key={src}
+                      to={`/images/${idx}`}
+                      unstable_viewTransition
+                    >
                       <p>Image Number {idx}</p>
                       <img src={src} alt={`Img ${idx}`} />
                     </NavLink>
@@ -278,7 +282,9 @@ function Nav() {
     <nav>
       <ul>
         <li>
-          <Link to="/">Home</Link>
+          <Link to="/" unstable_viewTransition>
+            Home
+          </Link>
           <ul>
             <li>
               The / route has no loader is should be an immediate/synchronous
@@ -310,6 +316,7 @@ function Nav() {
             method="post"
             action="/action"
             style={{ display: "inline-block" }}
+            unstable_viewTransition
           >
             <button type="submit" style={{ display: "inline-block" }}>
               Action with delay
@@ -338,7 +345,9 @@ function Nav() {
           </ul>
         </li>
         <li>
-          <Link to="/images">Image Gallery Example</Link>
+          <Link to="/images" unstable_viewTransition>
+            Image Gallery Example
+          </Link>
         </li>
         <li>
           <Link to={`/defer?value=${value}`} unstable_viewTransition>

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   Outlet,
   RouterProvider,
-  unstable_useViewTransition,
+  unstable_unstable_useViewTransitions,
   useLoaderData,
   useNavigation,
   useParams,
@@ -36,7 +36,7 @@ const router = createBrowserRouter(
           React.useState(true);
 
         // turn on basic view transitions for the whole app
-        unstable_useViewTransition(enableViewTransitions);
+        unstable_unstable_useViewTransitions(enableViewTransitions);
 
         let navigation = useNavigation();
 
@@ -152,7 +152,7 @@ const router = createBrowserRouter(
           path: "images",
           Component() {
             // Animate list image into detail image
-            unstable_useViewTransition(({ nextLocation }) => {
+            unstable_unstable_useViewTransitions(({ nextLocation }) => {
               // TODO: Should we be able to return false here to opt out of
               // calling startViewTransition?
               if (!/^\/images\/\d+$/.test(nextLocation.pathname)) {
@@ -210,38 +210,40 @@ const router = createBrowserRouter(
             let params = useParams();
 
             // Animate detail image into list image
-            unstable_useViewTransition(({ currentLocation, nextLocation }) => {
-              // TODO: Should we be able to return false here to opt out of
-              // calling startViewTransition?
-              if (!/^\/images$/.test(nextLocation.pathname)) {
-                return;
+            unstable_unstable_useViewTransitions(
+              ({ currentLocation, nextLocation }) => {
+                // TODO: Should we be able to return false here to opt out of
+                // calling startViewTransition?
+                if (!/^\/images$/.test(nextLocation.pathname)) {
+                  return;
+                }
+
+                LOG("before dom update");
+
+                return (transition) => {
+                  LOG("after dom update", transition);
+                  let anchor = document.querySelector(
+                    `.image-list a[href="${currentLocation.pathname}"]`
+                  );
+                  let title = anchor?.previousElementSibling!;
+                  let img = anchor?.firstElementChild!;
+                  // @ts-ignore
+                  title.style.viewTransitionName = "image-title";
+                  // @ts-ignore
+                  img.style.viewTransitionName = "image-expand";
+                  transition.ready.finally(() => {
+                    LOG("transition ready");
+                  });
+                  transition.finished.finally(() => {
+                    LOG("transition finished");
+                    // @ts-ignore
+                    title.style.viewTransitionName = "";
+                    // @ts-ignore
+                    img.style.viewTransitionName = "";
+                  });
+                };
               }
-
-              LOG("before dom update");
-
-              return (transition) => {
-                LOG("after dom update", transition);
-                let anchor = document.querySelector(
-                  `.image-list a[href="${currentLocation.pathname}"]`
-                );
-                let title = anchor?.previousElementSibling!;
-                let img = anchor?.firstElementChild!;
-                // @ts-ignore
-                title.style.viewTransitionName = "image-title";
-                // @ts-ignore
-                img.style.viewTransitionName = "image-expand";
-                transition.ready.finally(() => {
-                  LOG("transition ready");
-                });
-                transition.finished.finally(() => {
-                  LOG("transition finished");
-                  // @ts-ignore
-                  title.style.viewTransitionName = "";
-                  // @ts-ignore
-                  img.style.viewTransitionName = "";
-                });
-              };
-            });
+            );
 
             return (
               <div className="image-detail">

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -10,7 +10,6 @@ import {
   RouterProvider,
   unstable_useViewTransition,
   useLoaderData,
-  useLocation,
   useNavigation,
   useParams,
 } from "react-router-dom";

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -98,18 +98,13 @@ const router = createBrowserRouter(
         {
           path: "defer",
           async loader({ request }) {
-            let value = new URL(request.url).searchParams.get("value") || "";
             return defer({
-              value,
-              critical: "CRITICAL PATH DATA " + value,
-              lazy: new Promise((r) =>
-                setTimeout(() => r("LAZY DATA " + value), 1000)
-              ),
+              critical: "CRITICAL PATH DATA",
+              lazy: new Promise((r) => setTimeout(() => r("LAZY DATA"), 1000)),
             });
           },
           Component() {
             let data = useLoaderData() as {
-              value: string;
               critical: string;
               lazy: Promise<string>;
             };
@@ -118,7 +113,7 @@ const router = createBrowserRouter(
             }, []);
             return (
               <>
-                <h1>Defer {data.value}</h1>
+                <h1>Defer</h1>
                 <p>Critical Data: {data.critical}</p>
                 <React.Suspense
                   fallback={<p>Suspense boundary in the route...</p>}
@@ -272,7 +267,6 @@ ReactDOMClient.createRoot(rootElement).render(
 function Nav() {
   let navigate = useNavigate();
   let submit = useSubmit();
-  let value = Math.round(Math.random() * 100);
   return (
     <nav>
       <ul>
@@ -345,7 +339,7 @@ function Nav() {
           </Link>
         </li>
         <li>
-          <Link to={`/defer?value=${value}`} unstable_viewTransition>
+          <Link to={`/defer`} unstable_viewTransition>
             Deferred Data
           </Link>
           <ul>

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -28,209 +28,200 @@ const images = [
   "https://remix.run/blog-images/headers/remix-conf.jpg",
 ];
 
-const router = createBrowserRouter(
-  [
-    {
-      path: "/",
-      Component() {
-        let navigation = useNavigation();
-
-        return (
-          <>
-            {navigation.state !== "idle" ? (
-              <div className="is-loading">Loading...</div>
-            ) : null}
-            <Nav />
-            <div className="content">
-              <Outlet />
-            </div>
-          </>
-        );
-      },
-      children: [
-        {
-          index: true,
-          Component() {
-            React.useEffect(() => {
-              document.title = "Home";
-            }, []);
-            return <h1>Home</h1>;
-          },
-        },
-        {
-          path: "loader",
-          async loader() {
-            await new Promise((r) => setTimeout(r, 1000));
-            return json({ message: "LOADER DATA" });
-          },
-          Component() {
-            let data = useLoaderData() as { message: string };
-            React.useEffect(() => {
-              document.title = "Loader";
-            }, []);
-            return (
-              <>
-                <h1>Loader Page</h1>
-                <p>Loader Data: {data.message}</p>
-              </>
-            );
-          },
-        },
-        {
-          path: "action",
-          async action() {
-            await new Promise((r) => setTimeout(r, 1000));
-            return json({ message: "ACTION DATA" });
-          },
-          Component() {
-            let data = useActionData() as { message: string } | undefined;
-            React.useEffect(() => {
-              document.title = "Action";
-            }, []);
-            return (
-              <>
-                <h1>Action Page</h1>
-                <p>Action Data: {data?.message}</p>
-              </>
-            );
-          },
-        },
-        {
-          path: "defer",
-          async loader({ request }) {
-            return defer({
-              critical: "CRITICAL PATH DATA",
-              lazy: new Promise((r) => setTimeout(() => r("LAZY DATA"), 1000)),
-            });
-          },
-          Component() {
-            let data = useLoaderData() as {
-              critical: string;
-              lazy: Promise<string>;
-            };
-            React.useEffect(() => {
-              document.title = "Defer";
-            }, []);
-            return (
-              <>
-                <h1>Defer</h1>
-                <p>Critical Data: {data.critical}</p>
-                <React.Suspense
-                  fallback={<p>Suspense boundary in the route...</p>}
-                  key={useLocation().key}
-                >
-                  <Await resolve={data.lazy}>
-                    {(value) => <p>Lazy Data: {value}</p>}
-                  </Await>
-                </React.Suspense>
-              </>
-            );
-          },
-        },
-        {
-          path: "defer-no-boundary",
-          async loader({ request }) {
-            let value = new URL(request.url).searchParams.get("value") || "";
-            return defer({
-              value,
-              critical: "CRITICAL PATH DATA - NO BOUNDARY " + value,
-              lazy: new Promise((r) =>
-                setTimeout(() => r("LAZY DATA - NO BOUNDARY " + value), 1000)
-              ),
-            });
-          },
-          Component() {
-            let data = useLoaderData() as {
-              value: string;
-              data: string;
-              critical: string;
-              lazy: Promise<string>;
-            };
-            React.useEffect(() => {
-              document.title = "Defer (No Boundary)";
-            }, []);
-            return (
-              <>
-                <h1>Defer No Boundary {data.value}</h1>
-                <p>Critical Data: {data.critical}</p>
-                <div>
-                  <Await resolve={data.lazy}>
-                    {(value) => <p>Lazy Data: {value}</p>}
-                  </Await>
-                </div>
-              </>
-            );
-          },
-        },
-        {
-          path: "images",
-          Component() {
-            React.useEffect(() => {
-              document.title = "Images";
-            }, []);
-            return (
-              <div className="image-list">
-                <h1>Image List</h1>
-                <div>
-                  {images.map((src, idx) => (
-                    // Adds 'transitioning' class to the <a> during the transition
-                    <NavLink
-                      key={src}
-                      to={`/images/${idx}`}
-                      unstable_viewTransition
-                    >
-                      <p>Image Number {idx}</p>
-                      <img src={src} alt={`Img ${idx}`} />
-                    </NavLink>
-
-                    // Render prop approach similar to isActive/isPending
-                    // <NavLink
-                    //   key={src}
-                    //   to={`/images/${idx}`}
-                    //   unstable_viewTransition
-                    // >
-                    //   {({ isTransitioning }) => (
-                    //     <div className={isTransitioning ? "transitioning" : ""}>
-                    //       <p>Image Number {idx}</p>
-                    //       <img src={src} alt={`Img ${idx}`} />
-                    //     </div>
-                    //   )}
-                    // </NavLink>
-
-                    // Manual hook based approach
-                    // <NavImage key={src} src={src} idx={idx} />
-                  ))}
-                </div>
-              </div>
-            );
-          },
-        },
-        {
-          path: "images/:id",
-          Component() {
-            let params = useParams();
-            React.useEffect(() => {
-              document.title = "Image " + params.id;
-            }, [params.id]);
-            return (
-              <div className={`image-detail`}>
-                <h1>Image Number {params.id}</h1>
-                <img src={images[Number(params.id)]} alt={`${params.id}`} />
-              </div>
-            );
-          },
-        },
-      ],
-    },
-  ],
+const router = createBrowserRouter([
   {
-    future: {
-      // Prevent react router from await-ing defer() promises for revalidating
-      // loaders, which includes changing search params on the active route
-      unstable_fallbackOnDeferRevalidation: true,
+    path: "/",
+    Component() {
+      let navigation = useNavigation();
+
+      return (
+        <>
+          {navigation.state !== "idle" ? (
+            <div className="is-loading">Loading...</div>
+          ) : null}
+          <Nav />
+          <div className="content">
+            <Outlet />
+          </div>
+        </>
+      );
     },
-  }
-);
+    children: [
+      {
+        index: true,
+        Component() {
+          React.useEffect(() => {
+            document.title = "Home";
+          }, []);
+          return <h1>Home</h1>;
+        },
+      },
+      {
+        path: "loader",
+        async loader() {
+          await new Promise((r) => setTimeout(r, 1000));
+          return json({ message: "LOADER DATA" });
+        },
+        Component() {
+          let data = useLoaderData() as { message: string };
+          React.useEffect(() => {
+            document.title = "Loader";
+          }, []);
+          return (
+            <>
+              <h1>Loader Page</h1>
+              <p>Loader Data: {data.message}</p>
+            </>
+          );
+        },
+      },
+      {
+        path: "action",
+        async action() {
+          await new Promise((r) => setTimeout(r, 1000));
+          return json({ message: "ACTION DATA" });
+        },
+        Component() {
+          let data = useActionData() as { message: string } | undefined;
+          React.useEffect(() => {
+            document.title = "Action";
+          }, []);
+          return (
+            <>
+              <h1>Action Page</h1>
+              <p>Action Data: {data?.message}</p>
+            </>
+          );
+        },
+      },
+      {
+        path: "defer",
+        async loader({ request }) {
+          return defer({
+            critical: "CRITICAL PATH DATA",
+            lazy: new Promise((r) => setTimeout(() => r("LAZY DATA"), 1000)),
+          });
+        },
+        Component() {
+          let data = useLoaderData() as {
+            critical: string;
+            lazy: Promise<string>;
+          };
+          React.useEffect(() => {
+            document.title = "Defer";
+          }, []);
+          return (
+            <>
+              <h1>Defer</h1>
+              <p>Critical Data: {data.critical}</p>
+              <React.Suspense
+                fallback={<p>Suspense boundary in the route...</p>}
+                key={useLocation().key}
+              >
+                <Await resolve={data.lazy}>
+                  {(value) => <p>Lazy Data: {value}</p>}
+                </Await>
+              </React.Suspense>
+            </>
+          );
+        },
+      },
+      {
+        path: "defer-no-boundary",
+        async loader({ request }) {
+          let value = new URL(request.url).searchParams.get("value") || "";
+          return defer({
+            value,
+            critical: "CRITICAL PATH DATA - NO BOUNDARY " + value,
+            lazy: new Promise((r) =>
+              setTimeout(() => r("LAZY DATA - NO BOUNDARY " + value), 1000)
+            ),
+          });
+        },
+        Component() {
+          let data = useLoaderData() as {
+            value: string;
+            data: string;
+            critical: string;
+            lazy: Promise<string>;
+          };
+          React.useEffect(() => {
+            document.title = "Defer (No Boundary)";
+          }, []);
+          return (
+            <>
+              <h1>Defer No Boundary {data.value}</h1>
+              <p>Critical Data: {data.critical}</p>
+              <div>
+                <Await resolve={data.lazy}>
+                  {(value) => <p>Lazy Data: {value}</p>}
+                </Await>
+              </div>
+            </>
+          );
+        },
+      },
+      {
+        path: "images",
+        Component() {
+          React.useEffect(() => {
+            document.title = "Images";
+          }, []);
+          return (
+            <div className="image-list">
+              <h1>Image List</h1>
+              <div>
+                {images.map((src, idx) => (
+                  // Adds 'transitioning' class to the <a> during the transition
+                  <NavLink
+                    key={src}
+                    to={`/images/${idx}`}
+                    unstable_viewTransition
+                  >
+                    <p>Image Number {idx}</p>
+                    <img src={src} alt={`Img ${idx}`} />
+                  </NavLink>
+
+                  // Render prop approach similar to isActive/isPending
+                  // <NavLink
+                  //   key={src}
+                  //   to={`/images/${idx}`}
+                  //   unstable_viewTransition
+                  // >
+                  //   {({ isTransitioning }) => (
+                  //     <div className={isTransitioning ? "transitioning" : ""}>
+                  //       <p>Image Number {idx}</p>
+                  //       <img src={src} alt={`Img ${idx}`} />
+                  //     </div>
+                  //   )}
+                  // </NavLink>
+
+                  // Manual hook based approach
+                  // <NavImage key={src} src={src} idx={idx} />
+                ))}
+              </div>
+            </div>
+          );
+        },
+      },
+      {
+        path: "images/:id",
+        Component() {
+          let params = useParams();
+          React.useEffect(() => {
+            document.title = "Image " + params.id;
+          }, [params.id]);
+          return (
+            <div className={`image-detail`}>
+              <h1>Image Number {params.id}</h1>
+              <img src={images[Number(params.id)]} alt={`${params.id}`} />
+            </div>
+          );
+        },
+      },
+    ],
+  },
+]);
 
 function NavImage({ src, idx }: { src: string; idx: number }) {
   let href = `/images/${idx}`;

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -34,12 +34,9 @@ const router = createBrowserRouter(
     {
       path: "/",
       Component() {
-        let [enableViewTransitions, setEnableViewTransitions] =
-          React.useState(true);
-
         // turn on basic view transitions for the whole app
-        //unstable_useViewTransitions(enableViewTransitions);
-        unstable_useViewTransition("/loader");
+        unstable_useViewTransition();
+        // unstable_useViewTransition("/loader");
 
         let navigation = useNavigation();
 
@@ -50,14 +47,6 @@ const router = createBrowserRouter(
             ) : null}
             <Nav />
             <div className="content">
-              <button
-                onClick={() => setEnableViewTransitions(!enableViewTransitions)}
-              >
-                {enableViewTransitions
-                  ? "Disable view startViewTransition"
-                  : "Enable startViewTransition"}
-              </button>
-              <br />
               <Outlet />
             </div>
           </>
@@ -193,33 +182,34 @@ const router = createBrowserRouter(
                 <h1>Image List</h1>
                 <div>
                   {images.map((src, idx) => (
-                    <React.Fragment key={src}>
-                      {/* <NavImage key={src} src={src} idx={idx} /> */}
-                      <NavLink to={`/images/${idx}`} unstable_viewTransition>
-                        {({ isTransitioning }) => (
-                          <>
-                            <p
-                              style={{
-                                viewTransitionName: isTransitioning
-                                  ? "image-title"
-                                  : "",
-                              }}
-                            >
-                              Image Number {idx}
-                            </p>
-                            <img
-                              src={src}
-                              alt={`Img ${idx}`}
-                              style={{
-                                viewTransitionName: isTransitioning
-                                  ? "image-expand"
-                                  : "",
-                              }}
-                            />
-                          </>
-                        )}
-                      </NavLink>
-                    </React.Fragment>
+                    <NavLink
+                      key={src}
+                      to={`/images/${idx}`}
+                      unstable_viewTransition
+                    >
+                      {({ isTransitioning }) => (
+                        <>
+                          <p
+                            style={{
+                              viewTransitionName: isTransitioning
+                                ? "image-title"
+                                : "",
+                            }}
+                          >
+                            Image Number {idx}
+                          </p>
+                          <img
+                            src={src}
+                            alt={`Img ${idx}`}
+                            style={{
+                              viewTransitionName: isTransitioning
+                                ? "image-expand"
+                                : "",
+                            }}
+                          />
+                        </>
+                      )}
+                    </NavLink>
                   ))}
                 </div>
               </div>
@@ -336,7 +326,7 @@ function Nav() {
           </ul>
         </li>
         <li>
-          <NavLink to="/loader">Loader Delay</NavLink>
+          <Link to="/loader">Loader Delay</Link>
           <ul>
             <li>
               The /loader route has a 1 second loader delay, and updates the DOM

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -6,8 +6,10 @@ import {
   defer,
   json,
   Link,
+  NavLink,
   Outlet,
   RouterProvider,
+  unstable_useViewTransition,
   unstable_useViewTransitions,
   useLoaderData,
   useNavigation,
@@ -36,7 +38,8 @@ const router = createBrowserRouter(
           React.useState(true);
 
         // turn on basic view transitions for the whole app
-        unstable_useViewTransitions(enableViewTransitions);
+        //unstable_useViewTransitions(enableViewTransitions);
+        unstable_useViewTransition("/loader");
 
         let navigation = useNavigation();
 
@@ -152,53 +155,72 @@ const router = createBrowserRouter(
           path: "images",
           Component() {
             // Animate list image into detail image
-            unstable_useViewTransitions(({ nextLocation }) => {
-              // TODO: Should we be able to return false here to opt out of
-              // calling startViewTransition?
-              if (!/^\/images\/\d+$/.test(nextLocation.pathname)) {
-                return;
-              }
+            // unstable_useViewTransitions(({ nextLocation }) => {
+            //   // TODO: Should we be able to return false here to opt out of
+            //   // calling startViewTransition?
+            //   if (!/^\/images\/\d+$/.test(nextLocation.pathname)) {
+            //     return false;
+            //   }
 
-              LOG("before dom update");
-              let anchor = document.querySelector(
-                `.image-list a[href="${nextLocation.pathname}"]`
-              );
-              let title = anchor?.previousElementSibling!;
-              let img = anchor?.firstElementChild!;
-              // @ts-ignore
-              title.style.viewTransitionName = "image-title";
-              // @ts-ignore
-              img.style.viewTransitionName = "image-expand";
+            //   LOG("before dom update");
+            //   let anchor = document.querySelector(
+            //     `.image-list a[href="${nextLocation.pathname}"]`
+            //   );
+            //   let title = anchor?.previousElementSibling!;
+            //   let img = anchor?.firstElementChild!;
+            //   // @ts-ignore
+            //   title.style.viewTransitionName = "image-title";
+            //   // @ts-ignore
+            //   img.style.viewTransitionName = "image-expand";
 
-              return (transition) => {
-                LOG("after dom update", transition);
-                transition.ready.finally(() => {
-                  LOG("transition ready");
-                });
-                transition.finished.finally(() => {
-                  LOG("transition finished");
-                  // @ts-ignore
-                  title.style.viewTransitionName = "";
-                  // @ts-ignore
-                  img.style.viewTransitionName = "";
-                });
-              };
-            });
+            //   return (transition) => {
+            //     LOG("after dom update", transition);
+            //     transition.ready.finally(() => {
+            //       LOG("transition ready");
+            //     });
+            //     transition.finished.finally(() => {
+            //       LOG("transition finished");
+            //       // @ts-ignore
+            //       title.style.viewTransitionName = "";
+            //       // @ts-ignore
+            //       img.style.viewTransitionName = "";
+            //     });
+            //   };
+            // });
 
             return (
               <div className="image-list">
                 <h1>Image List</h1>
                 <div>
-                  {images.map((src, idx) => {
-                    return (
-                      <div key={src}>
-                        <p>Image Number {idx}</p>
-                        <Link to={`/images/${idx}`}>
-                          <img src={src} alt={`Img ${idx}`} />
-                        </Link>
-                      </div>
-                    );
-                  })}
+                  {images.map((src, idx) => (
+                    <React.Fragment key={src}>
+                      {/* <NavImage key={src} src={src} idx={idx} /> */}
+                      <NavLink to={`/images/${idx}`} unstable_viewTransition>
+                        {({ isTransitioning }) => (
+                          <>
+                            <p
+                              style={{
+                                viewTransitionName: isTransitioning
+                                  ? "image-title"
+                                  : "",
+                              }}
+                            >
+                              Image Number {idx}
+                            </p>
+                            <img
+                              src={src}
+                              alt={`Img ${idx}`}
+                              style={{
+                                viewTransitionName: isTransitioning
+                                  ? "image-expand"
+                                  : "",
+                              }}
+                            />
+                          </>
+                        )}
+                      </NavLink>
+                    </React.Fragment>
+                  ))}
                 </div>
               </div>
             );
@@ -209,39 +231,39 @@ const router = createBrowserRouter(
           Component() {
             let params = useParams();
 
-            // Animate detail image into list image
-            unstable_useViewTransitions(({ currentLocation, nextLocation }) => {
-              // TODO: Should we be able to return false here to opt out of
-              // calling startViewTransition?
-              if (!/^\/images$/.test(nextLocation.pathname)) {
-                return;
-              }
+            // // Animate detail image into list image
+            // unstable_useViewTransitions(({ currentLocation, nextLocation }) => {
+            //   // TODO: Should we be able to return false here to opt out of
+            //   // calling startViewTransition?
+            //   if (!/^\/images$/.test(nextLocation.pathname)) {
+            //     return false;
+            //   }
 
-              LOG("before dom update");
+            //   LOG("before dom update");
 
-              return (transition) => {
-                LOG("after dom update", transition);
-                let anchor = document.querySelector(
-                  `.image-list a[href="${currentLocation.pathname}"]`
-                );
-                let title = anchor?.previousElementSibling!;
-                let img = anchor?.firstElementChild!;
-                // @ts-ignore
-                title.style.viewTransitionName = "image-title";
-                // @ts-ignore
-                img.style.viewTransitionName = "image-expand";
-                transition.ready.finally(() => {
-                  LOG("transition ready");
-                });
-                transition.finished.finally(() => {
-                  LOG("transition finished");
-                  // @ts-ignore
-                  title.style.viewTransitionName = "";
-                  // @ts-ignore
-                  img.style.viewTransitionName = "";
-                });
-              };
-            });
+            //   return (transition) => {
+            //     LOG("after dom update", transition);
+            //     let anchor = document.querySelector(
+            //       `.image-list a[href="${currentLocation.pathname}"]`
+            //     );
+            //     let title = anchor?.previousElementSibling!;
+            //     let img = anchor?.firstElementChild!;
+            //     // @ts-ignore
+            //     title.style.viewTransitionName = "image-title";
+            //     // @ts-ignore
+            //     img.style.viewTransitionName = "image-expand";
+            //     transition.ready.finally(() => {
+            //       LOG("transition ready");
+            //     });
+            //     transition.finished.finally(() => {
+            //       LOG("transition finished");
+            //       // @ts-ignore
+            //       title.style.viewTransitionName = "";
+            //       // @ts-ignore
+            //       img.style.viewTransitionName = "";
+            //     });
+            //   };
+            // });
 
             return (
               <div className="image-detail">
@@ -262,6 +284,29 @@ const router = createBrowserRouter(
     },
   }
 );
+
+function NavImage({ src, idx }: { src: string; idx: number }) {
+  let href = `/images/${idx}`;
+  let vt = unstable_useViewTransition(href);
+  return (
+    <div>
+      <p
+        style={{ viewTransitionName: vt.isTransitioning ? "image-title" : "" }}
+      >
+        Image Number {idx}
+      </p>
+      <Link to={href}>
+        <img
+          src={src}
+          alt={`Img ${idx}`}
+          style={{
+            viewTransitionName: vt.isTransitioning ? "image-expand" : "",
+          }}
+        />
+      </Link>
+    </div>
+  );
+}
 
 const rootElement = document.getElementById("root") as HTMLElement;
 ReactDOMClient.createRoot(rootElement).render(
@@ -291,7 +336,7 @@ function Nav() {
           </ul>
         </li>
         <li>
-          <Link to="/loader">Loader Delay</Link>
+          <NavLink to="/loader">Loader Delay</NavLink>
           <ul>
             <li>
               The /loader route has a 1 second loader delay, and updates the DOM

--- a/examples/view-transitions/src/main.tsx
+++ b/examples/view-transitions/src/main.tsx
@@ -10,7 +10,6 @@ import {
   Outlet,
   RouterProvider,
   unstable_useViewTransition,
-  unstable_useViewTransitions,
   useLoaderData,
   useNavigation,
   useParams,
@@ -143,40 +142,6 @@ const router = createBrowserRouter(
         {
           path: "images",
           Component() {
-            // Animate list image into detail image
-            // unstable_useViewTransitions(({ nextLocation }) => {
-            //   // TODO: Should we be able to return false here to opt out of
-            //   // calling startViewTransition?
-            //   if (!/^\/images\/\d+$/.test(nextLocation.pathname)) {
-            //     return false;
-            //   }
-
-            //   LOG("before dom update");
-            //   let anchor = document.querySelector(
-            //     `.image-list a[href="${nextLocation.pathname}"]`
-            //   );
-            //   let title = anchor?.previousElementSibling!;
-            //   let img = anchor?.firstElementChild!;
-            //   // @ts-ignore
-            //   title.style.viewTransitionName = "image-title";
-            //   // @ts-ignore
-            //   img.style.viewTransitionName = "image-expand";
-
-            //   return (transition) => {
-            //     LOG("after dom update", transition);
-            //     transition.ready.finally(() => {
-            //       LOG("transition ready");
-            //     });
-            //     transition.finished.finally(() => {
-            //       LOG("transition finished");
-            //       // @ts-ignore
-            //       title.style.viewTransitionName = "";
-            //       // @ts-ignore
-            //       img.style.viewTransitionName = "";
-            //     });
-            //   };
-            // });
-
             return (
               <div className="image-list">
                 <h1>Image List</h1>
@@ -187,28 +152,8 @@ const router = createBrowserRouter(
                       to={`/images/${idx}`}
                       unstable_viewTransition
                     >
-                      {({ isTransitioning }) => (
-                        <>
-                          <p
-                            style={{
-                              viewTransitionName: isTransitioning
-                                ? "image-title"
-                                : "",
-                            }}
-                          >
-                            Image Number {idx}
-                          </p>
-                          <img
-                            src={src}
-                            alt={`Img ${idx}`}
-                            style={{
-                              viewTransitionName: isTransitioning
-                                ? "image-expand"
-                                : "",
-                            }}
-                          />
-                        </>
-                      )}
+                      <p>Image Number {idx}</p>
+                      <img src={src} alt={`Img ${idx}`} />
                     </NavLink>
                   ))}
                 </div>
@@ -220,41 +165,6 @@ const router = createBrowserRouter(
           path: "images/:id",
           Component() {
             let params = useParams();
-
-            // // Animate detail image into list image
-            // unstable_useViewTransitions(({ currentLocation, nextLocation }) => {
-            //   // TODO: Should we be able to return false here to opt out of
-            //   // calling startViewTransition?
-            //   if (!/^\/images$/.test(nextLocation.pathname)) {
-            //     return false;
-            //   }
-
-            //   LOG("before dom update");
-
-            //   return (transition) => {
-            //     LOG("after dom update", transition);
-            //     let anchor = document.querySelector(
-            //       `.image-list a[href="${currentLocation.pathname}"]`
-            //     );
-            //     let title = anchor?.previousElementSibling!;
-            //     let img = anchor?.firstElementChild!;
-            //     // @ts-ignore
-            //     title.style.viewTransitionName = "image-title";
-            //     // @ts-ignore
-            //     img.style.viewTransitionName = "image-expand";
-            //     transition.ready.finally(() => {
-            //       LOG("transition ready");
-            //     });
-            //     transition.finished.finally(() => {
-            //       LOG("transition finished");
-            //       // @ts-ignore
-            //       title.style.viewTransitionName = "";
-            //       // @ts-ignore
-            //       img.style.viewTransitionName = "";
-            //     });
-            //   };
-            // });
-
             return (
               <div className="image-detail">
                 <h1>Image Number {params.id}</h1>
@@ -270,33 +180,10 @@ const router = createBrowserRouter(
     future: {
       // Prevent react router from await-ing defer() promises for revalidating
       // loaders, which includes changing search params on the active route
-      v7_fallbackOnDeferRevalidation: true,
+      unstable_fallbackOnDeferRevalidation: true,
     },
   }
 );
-
-function NavImage({ src, idx }: { src: string; idx: number }) {
-  let href = `/images/${idx}`;
-  let vt = unstable_useViewTransition(href);
-  return (
-    <div>
-      <p
-        style={{ viewTransitionName: vt.isTransitioning ? "image-title" : "" }}
-      >
-        Image Number {idx}
-      </p>
-      <Link to={href}>
-        <img
-          src={src}
-          alt={`Img ${idx}`}
-          style={{
-            viewTransitionName: vt.isTransitioning ? "image-expand" : "",
-          }}
-        />
-      </Link>
-    </div>
-  );
-}
 
 const rootElement = document.getElementById("root") as HTMLElement;
 ReactDOMClient.createRoot(rootElement).render(

--- a/examples/view-transitions/src/vite-env.d.ts
+++ b/examples/view-transitions/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/view-transitions/tsconfig.json
+++ b/examples/view-transitions/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "importsNotUsedAsValues": "error"
+  },
+  "include": ["./src"]
+}

--- a/examples/view-transitions/vite.config.ts
+++ b/examples/view-transitions/vite.config.ts
@@ -1,0 +1,39 @@
+import * as path from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import rollupReplace from "@rollup/plugin-replace";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  server: {
+    port: 3000,
+  },
+  plugins: [
+    rollupReplace({
+      preventAssignment: true,
+      values: {
+        __DEV__: JSON.stringify(true),
+        "process.env.NODE_ENV": JSON.stringify("development"),
+      },
+    }),
+    react(),
+  ],
+  resolve: process.env.USE_SOURCE
+    ? {
+        alias: {
+          "@remix-run/router": path.resolve(
+            __dirname,
+            "../../packages/router/index.ts"
+          ),
+          "react-router": path.resolve(
+            __dirname,
+            "../../packages/react-router/index.ts"
+          ),
+          "react-router-dom": path.resolve(
+            __dirname,
+            "../../packages/react-router-dom/index.tsx"
+          ),
+        },
+      }
+    : {},
+});

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
       "none": "48.3 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "15.1 kB"
+      "none": "15.2 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
       "none": "17.6 kB"

--- a/package.json
+++ b/package.json
@@ -110,19 +110,19 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "47.3 kB"
+      "none": "48.3 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.9 kB"
+      "none": "15.1 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "16.3 kB"
+      "none": "17.6 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "12.8 kB"
+      "none": "13.6 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "18.9 kB"
+      "none": "19.9 kB"
     }
   }
 }

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -5942,6 +5942,90 @@ function testDomRouter(
         `);
       });
     });
+
+    describe("view transitions", () => {
+      it("applies view transitions to navigations when opted in", async () => {
+        let testWindow = getWindow("/");
+        let spy = jest.fn((cb) => {
+          cb();
+          return {
+            ready: Promise.resolve(),
+            finished: Promise.resolve(),
+            updateCallbackDone: Promise.resolve(),
+            skipTransition: () => {},
+          };
+        });
+        testWindow.document.startViewTransition = spy;
+
+        let router = createTestRouter(
+          [
+            {
+              path: "/",
+              Component() {
+                return (
+                  <div>
+                    <Link to="/a">/a</Link>
+                    <Link to="/b" unstable_viewTransition>
+                      /b
+                    </Link>
+                    <Form action="/c">
+                      <button type="submit">/c</button>
+                    </Form>
+                    <Form action="/d" unstable_viewTransition>
+                      <button type="submit">/d</button>
+                    </Form>
+                    <Outlet />
+                  </div>
+                );
+              },
+              children: [
+                {
+                  index: true,
+                  Component: () => <h1>Home</h1>,
+                },
+                {
+                  path: "a",
+                  Component: () => <h1>A</h1>,
+                },
+                {
+                  path: "b",
+                  Component: () => <h1>B</h1>,
+                },
+                {
+                  path: "c",
+                  action: () => null,
+                  Component: () => <h1>C</h1>,
+                },
+                {
+                  path: "d",
+                  action: () => null,
+                  Component: () => <h1>D</h1>,
+                },
+              ],
+            },
+          ],
+          { window: testWindow }
+        );
+        render(<RouterProvider router={router} />);
+
+        expect(screen.getByText("Home")).toBeDefined();
+        fireEvent.click(screen.getByText("/a"));
+        await waitFor(() => screen.getByText("A"));
+        expect(spy).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByText("/b"));
+        await waitFor(() => screen.getByText("B"));
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByText("/c"));
+        await waitFor(() => screen.getByText("C"));
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByText("/d"));
+        await waitFor(() => screen.getByText("D"));
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+    });
   });
 }
 

--- a/packages/react-router-dom/__tests__/exports-test.tsx
+++ b/packages/react-router-dom/__tests__/exports-test.tsx
@@ -4,7 +4,6 @@ import * as ReactRouterDOM from "react-router-dom";
 let nonReExportedKeys = new Set([
   "UNSAFE_mapRouteProperties",
   "UNSAFE_useRoutesImpl",
-  "UNSAFE_startTransitionImpl",
 ]);
 
 describe("react-router-dom", () => {

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -2,6 +2,7 @@ import type {
   FormEncType,
   HTMLFormMethod,
   RelativeRoutingType,
+  ViewTransitionFunction,
 } from "@remix-run/router";
 import { stripBasename, UNSAFE_warning as warning } from "@remix-run/router";
 
@@ -193,6 +194,11 @@ export interface SubmitOptions {
    * navigation when using the <ScrollRestoration> component
    */
   preventScrollReset?: boolean;
+
+  /**
+   * Allow submissions to enable view transitions
+   */
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -198,7 +198,7 @@ export interface SubmitOptions {
   /**
    * Allow submissions to enable view transitions
    */
-  viewTransition?: boolean | ViewTransitionFunction;
+  unstable_viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -198,7 +198,7 @@ export interface SubmitOptions {
   /**
    * Allow submissions to enable view transitions
    */
-  unstable_viewTransition?: boolean | ViewTransitionFunction;
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -193,6 +193,11 @@ export interface SubmitOptions {
    * navigation when using the <ScrollRestoration> component
    */
   preventScrollReset?: boolean;
+
+  /**
+   * Enable view transitions on this submission navigation
+   */
+  unstable_viewTransition?: boolean;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -2,7 +2,6 @@ import type {
   FormEncType,
   HTMLFormMethod,
   RelativeRoutingType,
-  ViewTransitionFunction,
 } from "@remix-run/router";
 import { stripBasename, UNSAFE_warning as warning } from "@remix-run/router";
 
@@ -194,11 +193,6 @@ export interface SubmitOptions {
    * navigation when using the <ScrollRestoration> component
    */
   preventScrollReset?: boolean;
-
-  /**
-   * Allow submissions to enable view transitions
-   */
-  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -503,7 +503,7 @@ export interface LinkProps
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   to: To;
-  viewTransition?: boolean | ViewTransitionFunction;
+  unstable_viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const isBrowser =
@@ -527,7 +527,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       to,
       preventScrollReset,
-      viewTransition,
+      unstable_viewTransition,
       ...rest
     },
     ref
@@ -577,7 +577,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       preventScrollReset,
       relative,
-      viewTransition,
+      unstable_viewTransition,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -787,7 +787,7 @@ export interface FormProps extends FetcherFormProps {
   /**
    * Boolean/function to enable/disable view transitions
    */
-  viewTransition?: boolean | ViewTransitionFunction;
+  unstable_viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**
@@ -831,7 +831,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       submit,
       relative,
       preventScrollReset,
-      viewTransition,
+      unstable_viewTransition,
       ...props
     },
     forwardedRef
@@ -857,7 +857,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
         state,
         relative,
         preventScrollReset,
-        viewTransition,
+        unstable_viewTransition,
       });
     };
 
@@ -947,14 +947,14 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state,
     preventScrollReset,
     relative,
-    viewTransition,
+    unstable_viewTransition,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    viewTransition?: boolean | ViewTransitionFunction;
+    unstable_viewTransition?: boolean | ViewTransitionFunction;
   } = {}
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
@@ -973,13 +973,12 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
             ? replaceProp
             : createPath(location) === createPath(path);
 
-        debugger;
         navigate(to, {
           replace,
           state,
           preventScrollReset,
           relative,
-          viewTransition,
+          unstable_viewTransition,
         });
       }
     },
@@ -993,7 +992,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       to,
       preventScrollReset,
       relative,
-      viewTransition,
+      unstable_viewTransition,
     ]
   );
 }
@@ -1118,7 +1117,7 @@ export function useSubmit(): SubmitFunction {
 
       router.navigate(options.action || action, {
         preventScrollReset: options.preventScrollReset,
-        viewTransition: options.viewTransition,
+        unstable_viewTransition: options.unstable_viewTransition,
         formData,
         body,
         formMethod: options.method || (method as HTMLFormMethod),

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1532,8 +1532,6 @@ function useViewTransitions(
   }, [router, viewTransition]);
 }
 
-export { useViewTransitions as unstable_useViewTransitions };
-
 /**
  * Localized version of useViewTransitions to enable view transitions for a
  * specific destination href. Returns an isTransitioning value that you can

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -503,7 +503,6 @@ export interface LinkProps
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   to: To;
-  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const isBrowser =
@@ -527,7 +526,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       to,
       preventScrollReset,
-      viewTransition,
       ...rest
     },
     ref
@@ -577,7 +575,6 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       preventScrollReset,
       relative,
-      viewTransition,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -783,11 +780,6 @@ export interface FormProps extends FetcherFormProps {
    * State object to add to the history stack entry for this navigation
    */
   state?: any;
-
-  /**
-   * Boolean/function to enable/disable view transitions
-   */
-  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**
@@ -831,7 +823,6 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       submit,
       relative,
       preventScrollReset,
-      viewTransition,
       ...props
     },
     forwardedRef
@@ -857,7 +848,6 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
         state,
         relative,
         preventScrollReset,
-        viewTransition,
       });
     };
 
@@ -947,14 +937,12 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state,
     preventScrollReset,
     relative,
-    viewTransition,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    viewTransition?: boolean | ViewTransitionFunction;
   } = {}
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
@@ -973,14 +961,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
             ? replaceProp
             : createPath(location) === createPath(path);
 
-        debugger;
-        navigate(to, {
-          replace,
-          state,
-          preventScrollReset,
-          relative,
-          viewTransition,
-        });
+        navigate(to, { replace, state, preventScrollReset, relative });
       }
     },
     [
@@ -993,7 +974,6 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       to,
       preventScrollReset,
       relative,
-      viewTransition,
     ]
   );
 }
@@ -1118,7 +1098,6 @@ export function useSubmit(): SubmitFunction {
 
       router.navigate(options.action || action, {
         preventScrollReset: options.preventScrollReset,
-        viewTransition: options.viewTransition,
         formData,
         body,
         formMethod: options.method || (method as HTMLFormMethod),

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -648,7 +648,11 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
     let routerState = React.useContext(DataRouterStateContext);
     let { navigator } = React.useContext(NavigationContext);
     let isTransitioning =
-      useViewTransitionState(path) && unstable_viewTransition === true;
+      routerState != null &&
+      // Conditional usage is OK here because the usage of a data router is static
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useViewTransitionState(path) &&
+      unstable_viewTransition === true;
 
     let toPathname = navigator.encodeLocation
       ? navigator.encodeLocation(path).pathname

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1538,14 +1538,10 @@ function useViewTransitionState(
 ) {
   let vtContext = React.useContext(ViewTransitionContext);
   let path = useResolvedPath(to, { relative: opts.relative });
-  if (!vtContext.isTransitioning) {
-    return false;
-  }
-  let isTransitioning =
+  return (
     vtContext.isTransitioning &&
-    matchPath(path.pathname, vtContext.nextLocation.pathname) != null;
-  console.log("isTransitioning", path.pathname, isTransitioning);
-  return isTransitioning;
+    matchPath(path.pathname, vtContext.nextLocation.pathname) != null
+  );
 }
 
 export { useViewTransitionState as unstable_useViewTransitionState };

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -237,6 +237,7 @@ export function createBrowserRouter(
     hydrationData: opts?.hydrationData || parseHydrationData(),
     routes,
     mapRouteProperties,
+    window: opts?.window,
   }).initialize();
 }
 
@@ -254,6 +255,7 @@ export function createHashRouter(
     hydrationData: opts?.hydrationData || parseHydrationData(),
     routes,
     mapRouteProperties,
+    window: opts?.window,
   }).initialize();
 }
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1537,11 +1537,37 @@ function useViewTransitionState(
   opts: { relative?: RelativeRoutingType } = {}
 ) {
   let vtContext = React.useContext(ViewTransitionContext);
-  let path = useResolvedPath(to, { relative: opts.relative });
-  return (
-    vtContext.isTransitioning &&
-    matchPath(path.pathname, vtContext.nextLocation.pathname) != null
+  let { basename } = useDataRouterContext(
+    DataRouterHook.useViewTransitionState
   );
+  let path = useResolvedPath(to, { relative: opts.relative });
+  if (vtContext.isTransitioning) {
+    let currentPath =
+      stripBasename(vtContext.currentLocation.pathname, basename) ||
+      vtContext.currentLocation.pathname;
+    let nextPath =
+      stripBasename(vtContext.nextLocation.pathname, basename) ||
+      vtContext.nextLocation.pathname;
+
+    // Transition is active if we're going to or coming from the indicated
+    // destination.  This ensures that other PUSH navigations that reverse
+    // an indicated transition apply.  I.e., on the list view you have:
+    //
+    //   <NavLink to="/details/1" unstable_viewTransition>
+    //
+    // If you click the breadcrumb back to the list view:
+    //
+    //   <NavLink to="/list" unstable_viewTransition>
+    //
+    // We should apply the transition because it's indicated as active going
+    // from /list -> /details/1 and therefore should be active on the reverse
+    // (even though this isn't strictly a POP reverse)
+    return (
+      matchPath(path.pathname, nextPath) != null ||
+      matchPath(path.pathname, currentPath) != null
+    );
+  }
+  return false;
 }
 
 export { useViewTransitionState as unstable_useViewTransitionState };

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1499,7 +1499,7 @@ export { usePrompt as unstable_usePrompt };
 
 let viewTransitionId = 0;
 
-export function useViewTransition(
+export function useViewTransitions(
   viewTransition?: boolean | ViewTransitionFunction
 ): void {
   let { router } = useDataRouterContext(DataRouterHook.UseViewTransition);
@@ -1516,6 +1516,6 @@ export function useViewTransition(
   }, [router, viewTransition]);
 }
 
-export { useViewTransition as unstable_useViewTransition };
+export { useViewTransitions as unstable_useViewTransitions };
 
 //#endregion

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -503,7 +503,7 @@ export interface LinkProps
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   to: To;
-  unstable_viewTransition?: boolean | ViewTransitionFunction;
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 const isBrowser =
@@ -527,7 +527,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       to,
       preventScrollReset,
-      unstable_viewTransition,
+      viewTransition,
       ...rest
     },
     ref
@@ -577,7 +577,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       preventScrollReset,
       relative,
-      unstable_viewTransition,
+      viewTransition,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -787,7 +787,7 @@ export interface FormProps extends FetcherFormProps {
   /**
    * Boolean/function to enable/disable view transitions
    */
-  unstable_viewTransition?: boolean | ViewTransitionFunction;
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**
@@ -831,7 +831,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
       submit,
       relative,
       preventScrollReset,
-      unstable_viewTransition,
+      viewTransition,
       ...props
     },
     forwardedRef
@@ -857,7 +857,7 @@ const FormImpl = React.forwardRef<HTMLFormElement, FormImplProps>(
         state,
         relative,
         preventScrollReset,
-        unstable_viewTransition,
+        viewTransition,
       });
     };
 
@@ -947,14 +947,14 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state,
     preventScrollReset,
     relative,
-    unstable_viewTransition,
+    viewTransition,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    unstable_viewTransition?: boolean | ViewTransitionFunction;
+    viewTransition?: boolean | ViewTransitionFunction;
   } = {}
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
@@ -973,12 +973,13 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
             ? replaceProp
             : createPath(location) === createPath(path);
 
+        debugger;
         navigate(to, {
           replace,
           state,
           preventScrollReset,
           relative,
-          unstable_viewTransition,
+          viewTransition,
         });
       }
     },
@@ -992,7 +993,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       to,
       preventScrollReset,
       relative,
-      unstable_viewTransition,
+      viewTransition,
     ]
   );
 }
@@ -1117,7 +1118,7 @@ export function useSubmit(): SubmitFunction {
 
       router.navigate(options.action || action, {
         preventScrollReset: options.preventScrollReset,
-        unstable_viewTransition: options.unstable_viewTransition,
+        viewTransition: options.viewTransition,
         formData,
         body,
         formMethod: options.method || (method as HTMLFormMethod),

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -335,6 +335,9 @@ export function createStaticRouter(
     deleteBlocker() {
       throw msg("deleteBlocker");
     },
+    addViewTransition() {
+      throw msg("addViewTransition");
+    },
     _internalFetchControllers: new Map(),
     _internalActiveDeferreds: new Map(),
     _internalSetRoutes() {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -300,6 +300,9 @@ export function createStaticRouter(
     get routes() {
       return dataRoutes;
     },
+    get window() {
+      return undefined;
+    },
     initialize() {
       throw msg("initialize");
     },

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -335,9 +335,6 @@ export function createStaticRouter(
     deleteBlocker() {
       throw msg("deleteBlocker");
     },
-    addViewTransition() {
-      throw msg("addViewTransition");
-    },
     _internalFetchControllers: new Map(),
     _internalActiveDeferreds: new Map(),
     _internalSetRoutes() {

--- a/packages/react-router-native/__tests__/exports-test.tsx
+++ b/packages/react-router-native/__tests__/exports-test.tsx
@@ -4,7 +4,7 @@ import * as ReactRouterNative from "react-router-native";
 let nonReExportedKeys = new Set([
   "UNSAFE_mapRouteProperties",
   "UNSAFE_useRoutesImpl",
-  "UNSAFE_startTransitionImpl",
+  "UNSAFE_ViewTransitionContext",
 ]);
 
 describe("react-router-native", () => {

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -27,6 +27,7 @@ import type {
   ShouldRevalidateFunctionArgs,
   To,
   UIMatch,
+  ViewTransitionFunction,
 } from "@remix-run/router";
 import {
   AbortedDeferredError,
@@ -171,6 +172,7 @@ export type {
   UIMatch,
   Blocker as unstable_Blocker,
   BlockerFunction as unstable_BlockerFunction,
+  ViewTransitionFunction,
 };
 export {
   AbortedDeferredError,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -27,7 +27,6 @@ import type {
   ShouldRevalidateFunctionArgs,
   To,
   UIMatch,
-  ViewTransitionFunction,
 } from "@remix-run/router";
 import {
   AbortedDeferredError,
@@ -173,7 +172,6 @@ export type {
   UIMatch,
   Blocker as unstable_Blocker,
   BlockerFunction as unstable_BlockerFunction,
-  ViewTransitionFunction,
 };
 export {
   AbortedDeferredError,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -90,6 +90,7 @@ import {
   LocationContext,
   NavigationContext,
   RouteContext,
+  ViewTransitionContext,
 } from "./lib/context";
 import type { NavigateFunction } from "./lib/hooks";
 import {
@@ -310,6 +311,7 @@ export {
   LocationContext as UNSAFE_LocationContext,
   NavigationContext as UNSAFE_NavigationContext,
   RouteContext as UNSAFE_RouteContext,
+  ViewTransitionContext as UNSAFE_ViewTransitionContext,
   mapRouteProperties as UNSAFE_mapRouteProperties,
   useRouteId as UNSAFE_useRouteId,
   useRoutesImpl as UNSAFE_useRoutesImpl,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -170,7 +170,8 @@ export function RouterProvider({
     (newState: RouterState, { viewTransitionOpts }) => {
       if (
         !viewTransitionOpts ||
-        typeof document.startViewTransition !== "function"
+        router.window == null ||
+        typeof router.window.document.startViewTransition !== "function"
       ) {
         // Mid-navigation state update, or startViewTransition isn't available
         optInStartTransition(() => setStateImpl(newState));
@@ -194,7 +195,7 @@ export function RouterProvider({
         });
       }
     },
-    [optInStartTransition, transition, renderDfd]
+    [optInStartTransition, transition, renderDfd, router.window]
   );
 
   // Need to use a layout effect here so we are subscribed early enough to
@@ -213,10 +214,10 @@ export function RouterProvider({
   // DOM and then wait on the Deferred to resolve (indicating the DOM update has
   // happened)
   React.useEffect(() => {
-    if (renderDfd && pendingState) {
+    if (renderDfd && pendingState && router.window) {
       let newState = pendingState;
       let renderPromise = renderDfd.promise;
-      let transition = document.startViewTransition(async () => {
+      let transition = router.window.document.startViewTransition(async () => {
         optInStartTransition(() => setStateImpl(newState));
         await renderPromise;
       });
@@ -228,7 +229,7 @@ export function RouterProvider({
       });
       setTransition(transition);
     }
-  }, [optInStartTransition, pendingState, renderDfd]);
+  }, [optInStartTransition, pendingState, renderDfd, router.window]);
 
   // When the new location finally renders and is committed to the DOM, this
   // effect will run to resolve the transition

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -167,7 +167,10 @@ export function RouterProvider({
   );
 
   let setState = React.useCallback<RouterSubscriber>(
-    (newState: RouterState, { viewTransitionOpts }) => {
+    (
+      newState: RouterState,
+      { unstable_viewTransitionOpts: viewTransitionOpts }
+    ) => {
       if (
         !viewTransitionOpts ||
         router.window == null ||

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -150,7 +150,8 @@ export function RouterProvider({
   let [transition, setTransition] = React.useState<ViewTransition>();
   let [interruption, setInterruption] = React.useState<{
     state: RouterState;
-    location: Location;
+    currentLocation: Location;
+    nextLocation: Location;
   }>();
   let { v7_startTransition } = future || {};
 
@@ -180,13 +181,15 @@ export function RouterProvider({
         transition.skipTransition();
         setInterruption({
           state: newState,
-          location: viewTransitionOpts.nextLocation,
+          currentLocation: viewTransitionOpts.currentLocation,
+          nextLocation: viewTransitionOpts.nextLocation,
         });
       } else {
         // Completed navigation update with opted-in view transitions, let 'er rip
         setPendingState(newState);
         setVtContext({
           isTransitioning: true,
+          currentLocation: viewTransitionOpts.currentLocation,
           nextLocation: viewTransitionOpts.nextLocation,
         });
       }
@@ -246,7 +249,8 @@ export function RouterProvider({
       setPendingState(interruption.state);
       setVtContext({
         isTransitioning: true,
-        nextLocation: interruption.location,
+        currentLocation: interruption.currentLocation,
+        nextLocation: interruption.nextLocation,
       });
       setInterruption(undefined);
     }

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -158,9 +158,8 @@ export function RouterProvider({
       flushSyncSafe(() => {
         setVtContext({
           isTransitioning: true,
-          historyAction: newState.historyAction,
-          currentLocation: viewTransitionOpts.prevLocation,
-          nextLocation: newState.location,
+          currentLocation: viewTransitionOpts.currentLocation,
+          nextLocation: viewTransitionOpts.nextLocation,
         });
       });
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -99,16 +99,6 @@ export interface RouterProviderProps {
 */
 const START_TRANSITION = "startTransition";
 const startTransitionImpl = React[START_TRANSITION];
-const FLUSH_SYNC = "flushSync";
-const flushSyncImpl = ReactDOM[FLUSH_SYNC];
-
-function flushSyncSafe(cb: () => void) {
-  if (flushSyncImpl) {
-    flushSyncImpl(cb);
-  } else {
-    cb();
-  }
-}
 
 function startTransitionSafe(cb: () => void) {
   if (startTransitionImpl) {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -191,7 +191,6 @@ export function RouterProvider({
         setPendingState(newState);
         setVtContext({
           isTransitioning: true,
-          currentLocation: viewTransitionOpts.currentLocation,
           nextLocation: viewTransitionOpts.nextLocation,
         });
       } else {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -141,6 +141,11 @@ class Deferred<T> {
   }
 }
 
+// FIXME: Remove
+function LOG(...args: any[]) {
+  console.debug(new Date().toISOString(), ...args);
+}
+
 /**
  * Given a Remix Router instance, render the appropriate UI
  */
@@ -160,6 +165,8 @@ export function RouterProvider({
   let [transition, setTransition] = React.useState<any>();
   let { v7_startTransition } = future || {};
 
+  LOG("render", state.location.pathname);
+
   let optInStartTransition = React.useCallback(
     (cb: () => void) => {
       if (v7_startTransition) {
@@ -173,12 +180,14 @@ export function RouterProvider({
 
   let setState = React.useCallback<RouterSubscriber>(
     (newState: RouterState, { viewTransitionOpts }) => {
+      LOG("subscriber callback", newState.location.pathname);
       if (
         viewTransitionOpts &&
         typeof document.startViewTransition === "function"
       ) {
         // If this is a completed navigation update with opted-in view transitions,
         // kick off a transition via the ViewTransitionContext
+        LOG("setVtContext({ isTransitioning: true })");
         setPendingState(newState);
         setVtContext({
           isTransitioning: true,
@@ -200,7 +209,9 @@ export function RouterProvider({
   // When we start a view transition, create a Deferred we can use for the
   // eventual "completed" render
   React.useEffect(() => {
+    LOG("create deferred effect");
     if (vtContext.isTransitioning) {
+      LOG("creating deferred");
       setRenderDfd(new Deferred<void>());
     }
   }, [vtContext.isTransitioning]);
@@ -209,15 +220,19 @@ export function RouterProvider({
   // DOM and then wait on the Deferred to resolve (indicating the DOM update has
   // happened)
   React.useEffect(() => {
+    LOG("startViewTransition effect");
     if (renderDfd && pendingState) {
       let promise = renderDfd.promise;
       let newState = pendingState;
+      LOG("transition = document.startViewTransition()");
       let transition = document.startViewTransition(async () => {
+        LOG("React.startTransition(() => setTransition()/setState())");
         optInStartTransition(() => {
           setTransition(transition);
           setStateImpl(newState);
         });
         await promise;
+        LOG("done with view transition");
       });
 
       // TODO: Handle interrupted transitions with transition.skipTransition()
@@ -227,14 +242,18 @@ export function RouterProvider({
   // When the new location finally renders and is committed to the DOM, this
   // effect will run to resolve the transition
   React.useEffect(() => {
+    LOG("resolve deferred effect");
     if (
       renderDfd &&
       pendingState &&
       state.location.key === pendingState.location.key
     ) {
       transition.finished.finally(() => {
+        // TODO: Is this enough to not need the view transition callback functions?
+        LOG("setVtContext({ isTransitioning: false })");
         setVtContext({ isTransitioning: false });
       });
+      LOG("deferred.resolve()");
       renderDfd.resolve();
       setRenderDfd(undefined);
       setTransition(undefined);

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -12,6 +12,7 @@ import type {
   StaticHandlerContext,
   To,
   TrackedPromise,
+  ViewTransitionFunction,
 } from "@remix-run/router";
 
 // Create react-specific types from the agnostic types in @remix-run/router to
@@ -94,6 +95,7 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -95,7 +95,7 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  viewTransition?: boolean | ViewTransitionFunction;
+  unstable_viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -90,6 +90,7 @@ export type ViewTransitionContextObject =
     }
   | {
       isTransitioning: true;
+      currentLocation: Location;
       nextLocation: Location;
     };
 

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -87,7 +87,6 @@ if (__DEV__) {
 export type ViewTransitionContextObject =
   | {
       isTransitioning: false;
-      location?: undefined;
     }
   | {
       isTransitioning: true;

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -84,6 +84,24 @@ if (__DEV__) {
   DataRouterStateContext.displayName = "DataRouterState";
 }
 
+export type ViewTransitionContextObject =
+  | {
+      isTransitioning: false;
+      location?: undefined;
+    }
+  | {
+      isTransitioning: true;
+      historyAction: NavigationType;
+      currentLocation: Location;
+      nextLocation: Location;
+    };
+
+export const ViewTransitionContext =
+  React.createContext<ViewTransitionContextObject>({ isTransitioning: false });
+if (__DEV__) {
+  ViewTransitionContext.displayName = "ViewTransition";
+}
+
 export const AwaitContext = React.createContext<TrackedPromise | null>(null);
 if (__DEV__) {
   AwaitContext.displayName = "Await";

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -91,7 +91,6 @@ export type ViewTransitionContextObject =
     }
   | {
       isTransitioning: true;
-      historyAction: NavigationType;
       currentLocation: Location;
       nextLocation: Location;
     };

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -12,7 +12,6 @@ import type {
   StaticHandlerContext,
   To,
   TrackedPromise,
-  ViewTransitionFunction,
 } from "@remix-run/router";
 
 // Create react-specific types from the agnostic types in @remix-run/router to
@@ -95,7 +94,6 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -91,7 +91,6 @@ export type ViewTransitionContextObject =
     }
   | {
       isTransitioning: true;
-      currentLocation: Location;
       nextLocation: Location;
     };
 

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -95,7 +95,7 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  unstable_viewTransition?: boolean | ViewTransitionFunction;
+  viewTransition?: boolean | ViewTransitionFunction;
 }
 
 /**

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -111,6 +111,7 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
+  unstable_viewTransition?: boolean;
 }
 
 /**

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -13,7 +13,6 @@ import type {
   RevalidationState,
   To,
   UIMatch,
-  ViewTransitionFunction,
 } from "@remix-run/router";
 import {
   IDLE_BLOCKER,

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -13,6 +13,7 @@ import type {
   RevalidationState,
   To,
   UIMatch,
+  ViewTransitionFunction,
 } from "@remix-run/router";
 import {
   IDLE_BLOCKER,

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -17699,7 +17699,7 @@ describe("a router", () => {
           navigation: IDLE_NAVIGATION,
           location: expect.objectContaining({ pathname: "/a" }),
         }),
-        { viewTransitionOpts: undefined }
+        { unstable_viewTransitionOpts: undefined }
       );
 
       // PUSH /a -> /b - w/ transition
@@ -17710,7 +17710,7 @@ describe("a router", () => {
           location: expect.objectContaining({ pathname: "/b" }),
         }),
         {
-          viewTransitionOpts: {
+          unstable_viewTransitionOpts: {
             currentLocation: expect.objectContaining({ pathname: "/a" }),
             nextLocation: expect.objectContaining({ pathname: "/b" }),
           },
@@ -17725,7 +17725,7 @@ describe("a router", () => {
           location: expect.objectContaining({ pathname: "/a" }),
         }),
         {
-          viewTransitionOpts: {
+          unstable_viewTransitionOpts: {
             // Args reversed on POP so same hooks apply
             currentLocation: expect.objectContaining({ pathname: "/a" }),
             nextLocation: expect.objectContaining({ pathname: "/b" }),
@@ -17740,7 +17740,7 @@ describe("a router", () => {
           navigation: IDLE_NAVIGATION,
           location: expect.objectContaining({ pathname: "/" }),
         }),
-        { viewTransitionOpts: undefined }
+        { unstable_viewTransitionOpts: undefined }
       );
 
       unsubscribe();

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -17683,6 +17683,70 @@ describe("a router", () => {
       expect(router.state.matches[0].route.path).toBe("/path");
     });
   });
+
+  describe("view transitions", () => {
+    it("only enables view transitions when specified for the navigation", () => {
+      let t = setup({
+        routes: [{ path: "/" }, { path: "/a" }, { path: "/b" }],
+      });
+      let spy = jest.fn();
+      let unsubscribe = t.router.subscribe(spy);
+
+      // PUSH / -> /a - w/o transition
+      t.navigate("/a");
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          navigation: IDLE_NAVIGATION,
+          location: expect.objectContaining({ pathname: "/a" }),
+        }),
+        { viewTransitionOpts: undefined }
+      );
+
+      // PUSH /a -> /b - w/ transition
+      t.navigate("/b", { unstable_viewTransition: true });
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          navigation: IDLE_NAVIGATION,
+          location: expect.objectContaining({ pathname: "/b" }),
+        }),
+        {
+          viewTransitionOpts: {
+            currentLocation: expect.objectContaining({ pathname: "/a" }),
+            nextLocation: expect.objectContaining({ pathname: "/b" }),
+          },
+        }
+      );
+
+      // POP /b -> /a - w/ transition (cached from above)
+      t.navigate(-1);
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          navigation: IDLE_NAVIGATION,
+          location: expect.objectContaining({ pathname: "/a" }),
+        }),
+        {
+          viewTransitionOpts: {
+            // Args reversed on POP so same hooks apply
+            currentLocation: expect.objectContaining({ pathname: "/a" }),
+            nextLocation: expect.objectContaining({ pathname: "/b" }),
+          },
+        }
+      );
+
+      // POP /a -> / - No transition
+      t.navigate(-1);
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          navigation: IDLE_NAVIGATION,
+          location: expect.objectContaining({ pathname: "/" }),
+        }),
+        { viewTransitionOpts: undefined }
+      );
+
+      unsubscribe();
+      t.router.dispose();
+    });
+  });
 });
 
 // We use a slightly modified version of createDeferred here that incoudes the

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -967,12 +967,28 @@ export function createRouter(init: RouterInit): Router {
     subscribers.forEach((subscriber) => subscriber(state));
   }
 
+  function completeNavigation(
+    location: Location,
+    newState: Partial<Omit<RouterState, "action" | "location" | "navigation">>
+  ) {
+    // @ts-expect-error
+    if (typeof document !== "undefined" && document.startViewTransition) {
+      // TODO: Do we need a flushSync here?
+      // @ts-expect-error
+      document.startViewTransition(() =>
+        completeNavigationForRealz(location, newState)
+      );
+    } else {
+      completeNavigationForRealz(location, newState);
+    }
+  }
+
   // Complete a navigation returning the state.navigation back to the IDLE_NAVIGATION
   // and setting state.[historyAction/location/matches] to the new route.
   // - Location is a required param
   // - Navigation will always be set to IDLE_NAVIGATION
   // - Can pass any other state in newState
-  function completeNavigation(
+  function completeNavigationForRealz(
     location: Location,
     newState: Partial<Omit<RouterState, "action" | "location" | "navigation">>
   ): void {

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -375,7 +375,7 @@ export interface RouterInit {
   mapRouteProperties?: MapRoutePropertiesFunction;
   future?: Partial<FutureConfig>;
   hydrationData?: HydrationState;
-  viewTransition?: ViewTransitionFunction;
+  unstable_viewTransition?: ViewTransitionFunction;
   window?: Window;
 }
 
@@ -454,7 +454,7 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
   replace?: boolean;
   state?: any;
   fromRouteId?: string;
-  viewTransition?: boolean | ViewTransitionFunction;
+  unstable_viewTransition?: boolean | ViewTransitionFunction;
 };
 
 // Only allowed for submission navigations
@@ -1244,7 +1244,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError: error,
       preventScrollReset,
       replace: opts && opts.replace,
-      viewTransition: opts && opts.viewTransition,
+      unstable_viewTransition: opts && opts.unstable_viewTransition,
     });
   }
 
@@ -1294,7 +1294,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError?: ErrorResponseImpl;
       startUninterruptedRevalidation?: boolean;
       preventScrollReset?: boolean;
-      viewTransition?: boolean | ViewTransitionFunction;
+      unstable_viewTransition?: boolean | ViewTransitionFunction;
       replace?: boolean;
     }
   ): Promise<void> {
@@ -1313,8 +1313,8 @@ export function createRouter(init: RouterInit): Router {
     pendingPreventScrollReset = (opts && opts.preventScrollReset) === true;
 
     pendingNavigationViewTransition =
-      opts && typeof opts.viewTransition !== "undefined"
-        ? opts?.viewTransition
+      opts && opts.unstable_viewTransition != null
+        ? opts.unstable_viewTransition
         : null;
 
     let routesToUse = inFlightDataRoutes || dataRoutes;

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -337,7 +337,7 @@ export type HydrationState = Partial<
 export interface FutureConfig {
   v7_normalizeFormMethod: boolean;
   v7_prependBasename: boolean;
-  v7_deferRevalidateFallbacks: boolean;
+  v7_fallbackOnDeferRevalidation: boolean;
 }
 
 /**
@@ -745,7 +745,7 @@ export function createRouter(init: RouterInit): Router {
   let future: FutureConfig = {
     v7_normalizeFormMethod: false,
     v7_prependBasename: false,
-    v7_deferRevalidateFallbacks: false,
+    v7_fallbackOnDeferRevalidation: false,
     ...init.future,
   };
   // Cleanup function for history
@@ -2234,16 +2234,16 @@ export function createRouter(init: RouterInit): Router {
       // avoid re-triggering fallbacks.  Users can opt out of this behavior via
       // the flag and handle fallbacks with startTransition and Suspense keys
       // themselves
-      !future.v7_deferRevalidateFallbacks
-        ? resolveDeferredResults(
+      future.v7_fallbackOnDeferRevalidation
+        ? null
+        : resolveDeferredResults(
             currentMatches,
             matchesToLoad,
             loaderResults,
             loaderResults.map(() => request.signal),
             false,
             state.loaderData
-          )
-        : null,
+          ),
       // Fetchers do not support deferred and always resolve
       resolveDeferredResults(
         currentMatches,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -337,7 +337,6 @@ export type HydrationState = Partial<
 export interface FutureConfig {
   v7_normalizeFormMethod: boolean;
   v7_prependBasename: boolean;
-  unstable_fallbackOnDeferRevalidation: boolean;
 }
 
 /**
@@ -755,7 +754,6 @@ export function createRouter(init: RouterInit): Router {
   let future: FutureConfig = {
     v7_normalizeFormMethod: false,
     v7_prependBasename: false,
-    unstable_fallbackOnDeferRevalidation: false,
     ...init.future,
   };
   // Cleanup function for history
@@ -2276,20 +2274,14 @@ export function createRouter(init: RouterInit): Router {
     let fetcherResults = results.slice(matchesToLoad.length);
 
     await Promise.all([
-      // By default, route deferred data is resolved if it's a revalidation to
-      // avoid re-triggering fallbacks.  Users can opt out of this behavior via
-      // the flag and handle fallbacks with startTransition and Suspense keys
-      // themselves
-      future.unstable_fallbackOnDeferRevalidation
-        ? null
-        : resolveDeferredResults(
-            currentMatches,
-            matchesToLoad,
-            loaderResults,
-            loaderResults.map(() => request.signal),
-            false,
-            state.loaderData
-          ),
+      resolveDeferredResults(
+        currentMatches,
+        matchesToLoad,
+        loaderResults,
+        loaderResults.map(() => request.signal),
+        false,
+        state.loaderData
+      ),
       // Fetchers do not support deferred and always resolve
       resolveDeferredResults(
         currentMatches,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -2208,7 +2208,7 @@ export function createRouter(init: RouterInit): Router {
           ...activeSubmission,
           formAction: redirect.location,
         },
-        // Preserve this flag across redirects)
+        // Preserve this flag across redirects
         preventScrollReset: pendingPreventScrollReset,
       });
     } else {
@@ -2282,7 +2282,6 @@ export function createRouter(init: RouterInit): Router {
         false,
         state.loaderData
       ),
-      // Fetchers do not support deferred and always resolve
       resolveDeferredResults(
         currentMatches,
         fetchersToLoad.map((f) => f.match),

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -389,6 +389,7 @@ export interface StaticHandler {
 }
 
 type ViewTransitionOpts = {
+  currentLocation: Location;
   nextLocation: Location;
 };
 
@@ -1093,28 +1094,31 @@ export function createRouter(init: RouterInit): Router {
     // On POP, enable transitions if they were enabled on the original navigation
     if (pendingAction === HistoryAction.Pop) {
       // Forward takes precedence so they behave like the original navigation
-      let priorNavs = appliedViewTransitions.get(state.location.key);
-      if (priorNavs && priorNavs.has(location.key)) {
+      let priorPaths = appliedViewTransitions.get(state.location.pathname);
+      if (priorPaths && priorPaths.has(location.pathname)) {
         viewTransitionOpts = {
+          currentLocation: state.location,
           nextLocation: location,
         };
-      } else if (appliedViewTransitions.has(location.key)) {
+      } else if (appliedViewTransitions.has(location.pathname)) {
         // If we don't have a previous forward nav, assume we're popping back to
         // the new location and enable if that location previously enabled
         viewTransitionOpts = {
+          currentLocation: location,
           nextLocation: state.location,
         };
       }
     } else if (pendingViewTransitionEnabled) {
       // Store the applied transition on PUSH/REPLACE
-      let toKeys = appliedViewTransitions.get(state.location.key);
-      if (toKeys) {
-        toKeys.add(location.key);
+      let toPaths = appliedViewTransitions.get(state.location.pathname);
+      if (toPaths) {
+        toPaths.add(location.pathname);
       } else {
-        toKeys = new Set<string>([location.key]);
-        appliedViewTransitions.set(state.location.key, toKeys);
+        toPaths = new Set<string>([location.pathname]);
+        appliedViewTransitions.set(state.location.pathname, toPaths);
       }
       viewTransitionOpts = {
+        currentLocation: state.location,
         nextLocation: location,
       };
     }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -408,7 +408,7 @@ export interface RouterSubscriber {
   (
     state: RouterState,
     opts: {
-      viewTransitionOpts?: ViewTransitionOpts;
+      unstable_viewTransitionOpts?: ViewTransitionOpts;
     }
   ): void;
 }
@@ -1015,7 +1015,7 @@ export function createRouter(init: RouterInit): Router {
       ...newState,
     };
     subscribers.forEach((subscriber) =>
-      subscriber(state, { viewTransitionOpts })
+      subscriber(state, { unstable_viewTransitionOpts: viewTransitionOpts })
     );
   }
 

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -390,7 +390,6 @@ export interface StaticHandler {
 }
 
 type ViewTransitionOpts = {
-  currentLocation: Location;
   nextLocation: Location;
 };
 
@@ -1078,13 +1077,11 @@ export function createRouter(init: RouterInit): Router {
       if (appliedViewTransitions.has(key(location, state.location))) {
         // POP backward - reversing a navigation that enabled transitions
         viewTransitionOpts = {
-          currentLocation: location,
           nextLocation: state.location,
         };
       } else if (appliedViewTransitions.has(key(state.location, location))) {
         // POP forward - replaying a navigation that enabled transitions
         viewTransitionOpts = {
-          currentLocation: state.location,
           nextLocation: location,
         };
       }
@@ -1093,7 +1090,6 @@ export function createRouter(init: RouterInit): Router {
       let transitionKey = key(state.location, location);
       appliedViewTransitions.add(transitionKey);
       viewTransitionOpts = {
-        currentLocation: state.location,
         nextLocation: location,
       };
     }

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -359,7 +359,7 @@ type ViewTransition = {
 export type ViewTransitionFunction = (args: {
   currentLocation: Location;
   nextLocation: Location;
-}) => void | ((transition: ViewTransition) => void | Promise<void>);
+}) => void | boolean | ((transition: ViewTransition) => void | Promise<void>);
 
 /**
  * Initialization options for createRouter

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -375,7 +375,7 @@ export interface RouterInit {
   mapRouteProperties?: MapRoutePropertiesFunction;
   future?: Partial<FutureConfig>;
   hydrationData?: HydrationState;
-  unstable_viewTransition?: ViewTransitionFunction;
+  viewTransition?: ViewTransitionFunction;
   window?: Window;
 }
 
@@ -454,7 +454,7 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
   replace?: boolean;
   state?: any;
   fromRouteId?: string;
-  unstable_viewTransition?: boolean | ViewTransitionFunction;
+  viewTransition?: boolean | ViewTransitionFunction;
 };
 
 // Only allowed for submission navigations
@@ -1244,7 +1244,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError: error,
       preventScrollReset,
       replace: opts && opts.replace,
-      unstable_viewTransition: opts && opts.unstable_viewTransition,
+      viewTransition: opts && opts.viewTransition,
     });
   }
 
@@ -1294,7 +1294,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError?: ErrorResponseImpl;
       startUninterruptedRevalidation?: boolean;
       preventScrollReset?: boolean;
-      unstable_viewTransition?: boolean | ViewTransitionFunction;
+      viewTransition?: boolean | ViewTransitionFunction;
       replace?: boolean;
     }
   ): Promise<void> {
@@ -1313,8 +1313,8 @@ export function createRouter(init: RouterInit): Router {
     pendingPreventScrollReset = (opts && opts.preventScrollReset) === true;
 
     pendingNavigationViewTransition =
-      opts && opts.unstable_viewTransition != null
-        ? opts.unstable_viewTransition
+      opts && typeof opts.viewTransition !== "undefined"
+        ? opts?.viewTransition
         : null;
 
     let routesToUse = inFlightDataRoutes || dataRoutes;

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1069,17 +1069,16 @@ export function createRouter(init: RouterInit): Router {
     }
 
     let viewTransitionOpts: ViewTransitionOpts | undefined;
-    let key = (a: Location, b: Location) => [a.key, b.key].join("-");
 
     // For POP navigations, we enable transitions if iff they were enabled on
     // the original navigation
     if (pendingAction === HistoryAction.Pop) {
-      if (appliedViewTransitions.has(key(location, state.location))) {
+      if (appliedViewTransitions.has(location.key)) {
         // POP backward - reversing a navigation that enabled transitions
         viewTransitionOpts = {
           nextLocation: state.location,
         };
-      } else if (appliedViewTransitions.has(key(state.location, location))) {
+      } else if (appliedViewTransitions.has(state.location.key)) {
         // POP forward - replaying a navigation that enabled transitions
         viewTransitionOpts = {
           nextLocation: location,
@@ -1087,7 +1086,7 @@ export function createRouter(init: RouterInit): Router {
       }
     } else if (pendingViewTransitionEnabled) {
       // Store the applied transition on PUSH/REPLACE
-      let transitionKey = key(state.location, location);
+      let transitionKey = state.location.key;
       appliedViewTransitions.add(transitionKey);
       viewTransitionOpts = {
         nextLocation: location,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -84,6 +84,14 @@ export interface Router {
    * @internal
    * PRIVATE - DO NOT USE
    *
+   * Return the window associated with the router
+   */
+  get window(): RouterInit["window"];
+
+  /**
+   * @internal
+   * PRIVATE - DO NOT USE
+   *
    * Initialize the router, including adding history listeners and kicking off
    * initial data fetches.  Returns a function to cleanup listeners and abort
    * any in-progress loads
@@ -2590,6 +2598,9 @@ export function createRouter(init: RouterInit): Router {
     },
     get routes() {
       return dataRoutes;
+    },
+    get window() {
+      return routerWindow;
     },
     initialize,
     subscribe,


### PR DESCRIPTION
This PR adds initial support for `document.startViewTransition` behind some `unstable_` APIs so we can get it out into folks hands and start getting some feedback.  Right now it's pretty abstracted and opt-in at the link level.  We're hoping that once folks start using it we can figure out what other types of complex use-cases exist that we can't yet handle with these APIs.

There are 2 new APIs
* `unstable_viewTransition` flag on `Link`/`NavLink`/`navigate`/`submit` which enables the usage of `document.startViewTransition` for that navigation
  * [Link docs](https://github.com/remix-run/react-router/blob/brophdawg11/start-view-transition/docs/components/link.md#unstable_viewtransition)
  * [NavLink docs](https://github.com/remix-run/react-router/blob/brophdawg11/start-view-transition/docs/components/nav-link.md#unstable_viewtransition) 
* `unstable_useViewTransitionState(to)` - a hook that tells you if there is an active transition to the indicated location (or from a POP/reverse PUSH navigation)
  * [Docs](https://github.com/remix-run/react-router/blob/brophdawg11/start-view-transition/docs/hooks/use-view-transition-state.md) 

Please see the changeset and docs for more info.

Live demo: https://github.com/brophdawg11/react-router-records

<br/>
<br/>

**TODO:**
 * [x] Unit tests