### PR TITLE
Fix optional parameter matching

### DIFF
--- a/.changeset/real-cups-pump.md
+++ b/.changeset/real-cups-pump.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix optional parameter matching

--- a/contributors.yml
+++ b/contributors.yml
@@ -167,6 +167,7 @@
 - morleytatro
 - ms10596
 - ned-park
+- neemzy
 - nilubisan
 - Nismit
 - nnhjs

--- a/packages/router/__tests__/match-path-test.ts
+++ b/packages/router/__tests__/match-path-test.ts
@@ -1,0 +1,30 @@
+import { matchPath } from "@remix-run/router";
+
+describe("matchPath", () => {
+  describe("given a pattern with optional parameters", () => {
+    it("matches paths with or without these optional parameters", () => {
+      const pattern = { path: "/foo/:bar?/:baz?" };
+
+      expect(matchPath(pattern, "/foo/bar/baz")).toEqual({
+        params: { bar: "bar", baz: "baz" },
+        pathname: "/foo/bar/baz",
+        pathnameBase: "/foo/bar/baz",
+        pattern
+      });
+
+      expect(matchPath(pattern, "/foo/bar")).toEqual({
+        params: { bar: "bar", baz: "" },
+        pathname: "/foo/bar",
+        pathnameBase: "/foo/bar",
+        pattern
+      });
+
+      expect(matchPath(pattern, "/foo")).toEqual({
+        params: { bar: "", baz: "" },
+        pathname: "/foo",
+        pathnameBase: "/foo",
+        pattern
+      });
+    });
+  });
+});

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -962,10 +962,10 @@ function compilePath(
     path
       .replace(/\/*\*?$/, "") // Ignore trailing / and /*, we'll handle it below
       .replace(/^\/*/, "/") // Make sure it has a leading /
-      .replace(/[\\.*+^$?{}|()[\]]/g, "\\$&") // Escape special regex chars
-      .replace(/\/:(\w+)/g, (_: string, paramName: string) => {
+      .replace(/[\\.*+^${}|()[\]]/g, "\\$&") // Escape special regex chars
+      .replace(/\/:(\w+)(\??)/g, (_: string, paramName: string, optional: string) => {
         paramNames.push(paramName);
-        return "/([^\\/]+)";
+        return `/${optional}([^\\/]+)${optional}`;
       });
 
   if (path.endsWith("*")) {


### PR DESCRIPTION
If I understood correctly, optional parameter (e.g. `/foo/:bar?`) support was [initially dropped in v6](https://reactrouter.com/en/main/upgrading/v5#note-on-route-path-patterns) before [being reintroduced](https://reactrouter.com/en/main/route/route#optional-segments). However, upon trying to migrate an app from v5 to v6, I realized `matchPath` returns `null` when trying to match a path against a pattern containing optional parameters, even though it should match.

This PR fixes this, but in a probably hazardous way. This allows me to keep working on said migration while, hopefully, I can discuss this problem with you (and eventually implement a better solution for it).

Thanks!