### PR TITLE
Add support for fetcher key specification and persistence

### DIFF
--- a/.changeset/fetcher-key.md
+++ b/.changeset/fetcher-key.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Add support for manual fetcher key specification via `useFetcher({ key: string })` so you can access the same fetcher instance from different components in your application without prop-drilling ([RFC](https://github.com/remix-run/remix/discussions/7698))

--- a/.changeset/fetcher-persist-router
+++ b/.changeset/fetcher-persist-router
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Add a new `opts.persist` option for `router.fetch` submission calls that will delay the cleanup of the fetcher until it returns to an `idle` state

--- a/.changeset/fetcher-persist.md
+++ b/.changeset/fetcher-persist.md
@@ -1,0 +1,8 @@
+---
+"react-router-dom": minor
+---
+
+Add support for submitting fetcher persistence via `useFetcher({ persist: true })` ([RFC](https://github.com/remix-run/remix/discussions/7698))
+
+- When `persist` is specified, if the submitting fetcher is unmounted while it is active, it will persist via `useFetchers()` until it returns back to an `idle` state
+- This allows you to accessing pending/optimistic UI data via `useFetchers()` for fetchers whose components have since unmounted

--- a/.changeset/fix-type-bug.md
+++ b/.changeset/fix-type-bug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fixed a bug in the `Router` `getFetcher`/`deleteFetcher` type definition which incorrectly specified `key` as an optional parameter

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "48.3 kB"
+      "none": "48.6 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"
@@ -122,7 +122,7 @@
       "none": "15.9 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.1 kB"
+      "none": "22.2 kB"
     }
   }
 }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1552,7 +1552,7 @@ export function useFetcher<TData = any>({
     `useFetcher can only be used on routes that contain a unique "id"`
   );
 
-  let [_fetcherKey] = React.useState(() => String(++fetcherId));
+  let [_fetcherKey] = React.useState(() => `__${String(++fetcherId)}`);
   let fetcherKey = key ? key : _fetcherKey;
   let [Form] = React.useState(() => {
     invariant(routeId, `No routeId available for fetcher.Form()`);

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1506,10 +1506,14 @@ export function useFormAction(
   return createPath(path);
 }
 
-function createFetcherForm(fetcherKey: string, routeId: string) {
+function createFetcherForm(
+  fetcherKey: string,
+  routeId: string,
+  persist: boolean
+) {
   let FetcherForm = React.forwardRef<HTMLFormElement, FetcherFormProps>(
     (props, ref) => {
-      let submit = useSubmitFetcher(fetcherKey, routeId);
+      let submit = useSubmitFetcher(fetcherKey, routeId, persist);
       return <FormImpl {...props} ref={ref} submit={submit} />;
     }
   );
@@ -1552,16 +1556,16 @@ export function useFetcher<TData = any>({
   let fetcherKey = key ? key : _fetcherKey;
   let [Form] = React.useState(() => {
     invariant(routeId, `No routeId available for fetcher.Form()`);
-    return createFetcherForm(fetcherKey, routeId);
+    return createFetcherForm(fetcherKey, routeId, persist === true);
   });
   let [load] = React.useState(() => (href: string) => {
     invariant(router, "No router available for fetcher.load()");
     invariant(routeId, "No routeId available for fetcher.load()");
     router.fetch(fetcherKey, routeId, href);
   });
-  let submit = useSubmitFetcher(fetcherKey, routeId);
+  let submit = useSubmitFetcher(fetcherKey, routeId, persist === true);
 
-  let fetcher = router.getFetcher<TData>(fetcherKey, persist);
+  let fetcher = router.getFetcher<TData>(fetcherKey);
 
   let fetcherWithComponents = React.useMemo(
     () => ({

--- a/packages/router/__tests__/lazy-test.ts
+++ b/packages/router/__tests__/lazy-test.ts
@@ -119,8 +119,8 @@ describe("lazily loaded route modules", () => {
       expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
 
       await loaderDfd.resolve("LAZY LOADER");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER");
     });
 
     it("fetches lazy route modules on fetcher.submit", async () => {
@@ -140,8 +140,8 @@ describe("lazily loaded route modules", () => {
       expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
 
       await actionDfd.resolve("LAZY ACTION");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY ACTION");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY ACTION");
     });
 
     it("fetches lazy route modules on staticHandler.query()", async () => {
@@ -574,8 +574,8 @@ describe("lazily loaded route modules", () => {
       await loaderDfdA.resolve("LAZY LOADER A");
       await loaderDfdB.resolve("LAZY LOADER B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER B");
       expect(lazyLoaderStubA).not.toHaveBeenCalled();
       expect(lazyloaderStubB).toHaveBeenCalledTimes(2);
     });
@@ -615,8 +615,8 @@ describe("lazily loaded route modules", () => {
       await actionDfdA.resolve("LAZY ACTION A");
       await actionDfdB.resolve("LAZY ACTION B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY ACTION B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY ACTION B");
       expect(lazyActionStubA).not.toHaveBeenCalled();
       expect(lazyActionStubB).toHaveBeenCalledTimes(2);
     });
@@ -740,8 +740,8 @@ describe("lazily loaded route modules", () => {
       await loaderDfdA.resolve("LAZY LOADER A");
       await loaderDfdB.resolve("LAZY LOADER B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER B");
       expect(lazyLoaderStubA).not.toHaveBeenCalled();
       expect(lazyLoaderStubB).toHaveBeenCalledTimes(2);
     });

--- a/packages/router/__tests__/redirects-test.ts
+++ b/packages/router/__tests__/redirects-test.ts
@@ -156,10 +156,7 @@ describe("redirects", () => {
       loaderData: {},
       errors: null,
     });
-    expect(t.router.state.fetchers.get("key")).toMatchObject({
-      state: "idle",
-      data: undefined,
-    });
+    expect(t.router.state.fetchers.get("key")).toBeUndefined();
   });
 
   it("supports relative routing in redirects (from child fetch loader)", async () => {

--- a/packages/router/__tests__/revalidate-test.ts
+++ b/packages/router/__tests__/revalidate-test.ts
@@ -898,17 +898,13 @@ describe("router.revalidate", () => {
     let key = "key";
     let F = await t.fetch("/", key);
     await F.loaders.root.resolve("ROOT_DATA*");
-    expect(t.router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "ROOT_DATA*",
-    });
+    expect(t.router.state.fetchers.get(key)).toBeUndefined();
+    expect(t.fetcherData.get(key)).toBe("ROOT_DATA*");
 
     let R = await t.revalidate();
     await R.loaders.root.resolve("ROOT_DATA**");
     await R.loaders.index.resolve("INDEX_DATA");
-    expect(t.router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "ROOT_DATA**",
-    });
+    expect(t.router.state.fetchers.get(key)).toBeUndefined();
+    expect(t.fetcherData.get(key)).toBe("ROOT_DATA**");
   });
 });

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2511,10 +2511,17 @@ describe("a router", () => {
       });
       router.initialize();
 
+      let fetcherData;
+      router.subscribe((state) => {
+        if (state.fetchers.get("key")?.data) {
+          fetcherData = state.fetchers.get("key")?.data;
+        }
+      });
+
       let key = "key";
       router.fetch(key, "root", "/foo");
       await fooDfd.resolve("FOO");
-      expect(router.state.fetchers.get("key")?.data).toBe("FOO");
+      expect(fetcherData).toBe("FOO");
 
       let rootDfd2 = createDeferred();
       let newRoutes: AgnosticDataRouteObject[] = [
@@ -2615,10 +2622,17 @@ describe("a router", () => {
       });
       router.initialize();
 
+      let fetcherData;
+      router.subscribe((state) => {
+        if (state.fetchers.get("key")?.data) {
+          fetcherData = state.fetchers.get("key")?.data;
+        }
+      });
+
       let key = "key";
       router.fetch(key, "root", "/foo");
       await fooDfd.resolve("FOO");
-      expect(router.state.fetchers.get("key")?.data).toBe("FOO");
+      expect(fetcherData).toBe("FOO");
 
       let rootDfd2 = createDeferred();
       let newRoutes: AgnosticDataRouteObject[] = [
@@ -2659,7 +2673,7 @@ describe("a router", () => {
       expect(router.state.loaderData).toEqual({
         root: "ROOT*",
       });
-      // Fetcher should have been revalidated but theown a 404 wince the route was removed
+      // Fetcher should have been revalidated but thrown a 404 since the route was removed
       expect(router.state.fetchers.get("key")?.data).toBe(undefined);
       expect(router.state.errors).toEqual({
         root: new ErrorResponseImpl(

--- a/packages/router/__tests__/should-revalidate-test.ts
+++ b/packages/router/__tests__/should-revalidate-test.ts
@@ -541,12 +541,18 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch");
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(shouldRevalidate.mock.calls.length).toBe(0);
 
     // Normal navigations should trigger fetcher shouldRevalidate with
@@ -561,10 +567,8 @@ describe("shouldRevalidate", () => {
       nextUrl: expect.urlMatch("http://localhost/child"),
       defaultShouldRevalidate: false,
     });
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
 
     router.navigate("/");
     await tick();
@@ -576,10 +580,8 @@ describe("shouldRevalidate", () => {
       nextUrl: expect.urlMatch("http://localhost/"),
       defaultShouldRevalidate: false,
     });
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
 
     // Submission navigations should trigger fetcher shouldRevalidate with
     // defaultShouldRevalidate=true
@@ -588,10 +590,8 @@ describe("shouldRevalidate", () => {
       formData: createFormData({}),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(shouldRevalidate.mock.calls.length).toBe(3);
     expect(shouldRevalidate.mock.calls[2][0]).toMatchObject({
       currentParams: {},
@@ -639,15 +639,21 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH");
 
     let arg = shouldRevalidate.mock.calls[0][0];
     expect(arg).toMatchInlineSnapshot(`
@@ -702,15 +708,20 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: undefined,
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe(undefined);
 
     let arg = shouldRevalidate.mock.calls[0][0];
     expect(arg).toMatchInlineSnapshot(`
@@ -817,16 +828,20 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
 
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(router.state.loaderData).toMatchObject({
       index: "INDEX",
     });
@@ -836,10 +851,8 @@ describe("shouldRevalidate", () => {
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 2",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 2");
     expect(router.state.loaderData).toMatchObject({
       index: "INDEX",
     });

--- a/packages/router/__tests__/utils/data-router-setup.ts
+++ b/packages/router/__tests__/utils/data-router-setup.ts
@@ -16,6 +16,7 @@ import {
   matchRoutes,
   redirect,
   parsePath,
+  IDLE_FETCHER,
 } from "../../index";
 
 // Private API
@@ -320,6 +321,15 @@ export function setup({
     window: testWindow,
   }).initialize();
 
+  let fetcherData = new Map<string, any>();
+  currentRouter.subscribe((state) => {
+    state.fetchers.forEach((fetcher, key) => {
+      if (fetcher.data) {
+        fetcherData.set(key, fetcher.data);
+      }
+    });
+  });
+
   function getRouteHelpers(
     routeId: string,
     navigationId: number,
@@ -489,7 +499,11 @@ export function setup({
         navigationId,
         get fetcher() {
           invariant(currentRouter, "No currentRouter available");
-          return currentRouter.getFetcher(key);
+          let fetcher = currentRouter.state.fetchers.get(key) || IDLE_FETCHER;
+          return {
+            ...fetcher,
+            data: fetcherData.get(key),
+          };
         },
         lazy: {},
         loaders: {},
@@ -544,7 +558,11 @@ export function setup({
       navigationId,
       get fetcher() {
         invariant(currentRouter, "No currentRouter available");
-        return currentRouter.getFetcher(key);
+        let fetcher = currentRouter.state.fetchers.get(key) || IDLE_FETCHER;
+        return {
+          ...fetcher,
+          data: fetcherData.get(key),
+        };
       },
       lazy: lazyHelpers,
       loaders: loaderHelpers,
@@ -727,6 +745,7 @@ export function setup({
     window: testWindow,
     history,
     router: currentRouter,
+    fetcherData,
     navigate,
     fetch,
     revalidate,

--- a/packages/router/__tests__/utils/utils.ts
+++ b/packages/router/__tests__/utils/utils.ts
@@ -28,11 +28,11 @@ export function isRedirect(result: any) {
   );
 }
 
-export function createDeferred() {
+export function createDeferred<T = any>() {
   let resolve: (val?: any) => Promise<void>;
   let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
+  let promise = new Promise<T>((res, rej) => {
+    resolve = async (val: T) => {
       res(val);
       try {
         await promise;

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -872,6 +872,8 @@ export function createRouter(init: RouterInit): Router {
   let fetchControllers = new Map<string, AbortController>();
 
   // Keys for persisted fetchers
+  // - `false` means it was submitted with `persist:true`
+  // - `true` value means a deletion was requested during submission
   let persistedFetchers = new Map<string, boolean>();
 
   // Track loads based on the order in which they started


### PR DESCRIPTION
Implementation for https://github.com/remix-run/remix/discussions/7698

* Users can provide their own fetcher keys via `useFetcher({ key: "abc" })`, allowing you to access the same fetcher instance from hook invocations in separate parts of your app.  Current internal keys are incrementing values (`"1"`, `"2"`, etc.) so they've been updated with a `__` prefix to avoid potential collisions with user-specific values (`"__1"`, `"__2"`, etc.).  
  * Maybe it's time to turn these keys into symbols?
* Fetcher persistence is available for **submitting fetchers only**.  `useFetcher({ persist: true })` will cause the fetcher to persist beyond it's component unmount **if and only if** it was non-idle at the time of unmount.  It will delay cleanup until it returns to an idle state.