### PR TITLE
Add fetcherKey APIs and update fetcher persistence architecture

### DIFF
--- a/.changeset/fetcher-key.md
+++ b/.changeset/fetcher-key.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Add support for manual fetcher key specification via `useFetcher({ key: string })` so you can access the same fetcher instance from different components in your application without prop-drilling ([RFC](https://github.com/remix-run/remix/discussions/7698))

--- a/.changeset/fetcher-persist-router
+++ b/.changeset/fetcher-persist-router
@@ -1,5 +1,0 @@
----
-"@remix-run/router": minor
----
-
-Add a new `opts.persist` option for `router.fetch` submission calls that will delay the cleanup of the fetcher until it returns to an `idle` state

--- a/.changeset/fetcher-persist-router
+++ b/.changeset/fetcher-persist-router
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Add a new `opts.persist` option for `router.fetch` submission calls that will delay the cleanup of the fetcher until it returns to an `idle` state

--- a/.changeset/fetcher-persist.md
+++ b/.changeset/fetcher-persist.md
@@ -1,0 +1,8 @@
+---
+"react-router-dom": minor
+---
+
+Add support for submitting fetcher persistence via `useFetcher({ persist: true })` ([RFC](https://github.com/remix-run/remix/discussions/7698))
+
+- When `persist` is specified, if the submitting fetcher is unmounted while it is active, it will persist via `useFetchers()` until it returns back to an `idle` state
+- This allows you to accessing pending/optimistic UI data via `useFetchers()` for fetchers whose components have since unmounted

--- a/.changeset/fetcher-persist.md
+++ b/.changeset/fetcher-persist.md
@@ -1,8 +1,0 @@
----
-"react-router-dom": minor
----
-
-Add support for submitting fetcher persistence via `useFetcher({ persist: true })` ([RFC](https://github.com/remix-run/remix/discussions/7698))
-
-- When `persist` is specified, if the submitting fetcher is unmounted while it is active, it will persist via `useFetchers()` until it returns back to an `idle` state
-- This allows you to accessing pending/optimistic UI data via `useFetchers()` for fetchers whose components have since unmounted

--- a/.changeset/fetcher-persistence.md
+++ b/.changeset/fetcher-persistence.md
@@ -6,9 +6,10 @@
 Fix the persistence behavior of fetchers so that they don't get cleaned up on `fetcher` unmount, but instead get cleaned up on fetcher completion (which may be after the fetcher unmounts in the UI) ([RFC](https://github.com/remix-run/remix/discussions/7698))
 
 - This is a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetcher information for pending/optimistic UI
-- It was not intended to reflect fetcher data or hang onto fetchers after they returned to an idle state
+- It was not intended to reflect fetcher data or hang onto fetchers after they returned to an `idle` state
 - To do this we've re-architected things a bit and now it's the `react-router-dom` layer that holds stateful fetcher data to expose via `useFetcher()`
 - The `router` now only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed when it returns to `idle` (and the data is handed off to the React layer)
-- **Warning:** This has two potential "breaking bug" side-effects for your application:
-  - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to `idle`. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.
+- **Warning:** This has a few potential "breaking bug" side-effects for your application:
+  - `useFetchers()` longer exposes the `data` field because it now only represents in-flight fetchers, and thus it does not reflect fetchers that have completed and have data
+  - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to an `idle` state. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.
   - Fetchers that complete while still mounted will no longer appear in `useFetchers()` - they served effectively no purpose in there since you can access the data via `useFetcher().data`)

--- a/.changeset/fetcher-persistence.md
+++ b/.changeset/fetcher-persistence.md
@@ -5,8 +5,9 @@
 
 Fix the persistence behavior of fetchers so that they don't get cleaned up on `fetcher` unmount, but instead get cleaned up on fetcher completion (which may be after the fetcher unmounts in the UI) ([RFC](https://github.com/remix-run/remix/discussions/7698))
 
-- This is a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetchers.
-- To do this we've re-architected things a bit and now it's the `react-router-dom` layer that holds stateful fetcher data
+- This is a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetcher information for pending/optimistic UI
+- It was not intended to reflect fetcher data or hang onto fetchers after they returned to an idle state
+- To do this we've re-architected things a bit and now it's the `react-router-dom` layer that holds stateful fetcher data to expose via `useFetcher()`
 - The `router` now only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed when it returns to `idle` (and the data is handed off to the React layer)
 - **Warning:** This has two potential "breaking bug" side-effects for your application:
   - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to `idle`. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.

--- a/.changeset/fetcher-persistence.md
+++ b/.changeset/fetcher-persistence.md
@@ -1,0 +1,13 @@
+---
+"react-router-dom": minor
+"@remix-run/router": minor
+---
+
+Fix the persistence behavior of fetchers so that they don't get cleaned up on `fetcher` unmount, but instead get cleaned up on fetcher completion (which may be after the fetcher unmounts in the UI) ([RFC](https://github.com/remix-run/remix/discussions/7698))
+
+- This is a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetchers.
+- To do this we've re-architected things a bit and now it's the `react-router-dom` layer that holds stateful fetcher data
+- The `router` now only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed when it returns to `idle` (and the data is handed off to the React layer)
+- **Warning:** This has two potential "breaking bug" side-effects for your application:
+  - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to `idle`. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.
+  - Fetchers that complete while still mounted will no longer appear in `useFetchers()` - they served effectively no purpose in there since you can access the data via `useFetcher().data`)

--- a/.changeset/fix-type-bug.md
+++ b/.changeset/fix-type-bug.md
@@ -2,5 +2,4 @@
 "@remix-run/router": patch
 ---
 
-- Remove the internal `router.getFetcher` API
-- Fix `router.deleteFetcher` type definition which incorrectly specified `key` as an optional parameter
+Fix `router.deleteFetcher` type definition which incorrectly specified `key` as an optional parameter

--- a/.changeset/fix-type-bug.md
+++ b/.changeset/fix-type-bug.md
@@ -2,4 +2,5 @@
 "@remix-run/router": patch
 ---
 
-Fixed a bug in the `Router` `getFetcher`/`deleteFetcher` type definition which incorrectly specified `key` as an optional parameter
+- Remove the internal `router.getFetcher` API
+- Fix `router.deleteFetcher` type definition which incorrectly specified `key` as an optional parameter

--- a/.changeset/fix-type-bug.md
+++ b/.changeset/fix-type-bug.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fixed a bug in the `Router` `getFetcher`/`deleteFetcher` type definition which incorrectly specified `key` as an optional parameter

--- a/.changeset/remove-get-fetcher.md
+++ b/.changeset/remove-get-fetcher.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": minor
+---
+
+Remove the internal `router.getFetcher` API

--- a/.changeset/submit-navigate-fetcherKey.md
+++ b/.changeset/submit-navigate-fetcherKey.md
@@ -1,0 +1,8 @@
+---
+"react-router-dom": minor
+---
+
+Add `navigate`/`fetcherKey` params/props to `useSumbit`/`Form` to support kicking off a fetcher submission under the hood with an optionally user-specified key
+
+- Invoking a fetcher in this way is ephemeral and stateless
+- If you need to access the state of one of these fetchers, you will need to leverage `useFetcher({ key })` to look it up elsewhere

--- a/package.json
+++ b/package.json
@@ -110,19 +110,19 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "48.6 kB"
+      "none": "48.3 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
-      "none": "13.9 kB"
+      "none": "13.8 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
       "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "15.9 kB"
+      "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.2 kB"
+      "none": "22.5 kB"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -119,10 +119,10 @@
       "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "16.3 kB"
+      "none": "16.4 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.5 kB"
+      "none": "22.6 kB"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "48.3 kB"
+      "none": "48.6 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"
@@ -122,7 +122,7 @@
       "none": "15.9 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.1 kB"
+      "none": "22.2 kB"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -119,10 +119,10 @@
       "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "16.4 kB"
+      "none": "16.5 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.6 kB"
+      "none": "22.7 kB"
     }
   }
 }

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -5862,7 +5862,7 @@ function testDomRouter(
                         navigation.state,
                         data,
                         actionData,
-                        fetchers.map((f) => `${f.state}:${f.data}`),
+                        fetchers.map((f) => f.state),
                       ].join(",")}
                     </pre>
                     <Outlet />
@@ -5937,9 +5937,7 @@ function testDomRouter(
 
         fireEvent.click(screen.getByText("Submit Form"));
         // Fetcher does not trigger useNavigation
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,loading:undefined")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,loading"));
 
         loaderDefer.resolve("LOADER");
         // Fetcher does not change the location key.  Because no useFetcher()
@@ -5954,14 +5952,10 @@ function testDomRouter(
 
         fireEvent.click(screen.getByText("Submit Form"));
         // Fetcher does not trigger useNavigation
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,submitting:undefined")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,submitting"));
 
         actionDefer.resolve("ACTION");
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,loading:ACTION:value")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,loading"));
 
         loaderDefer.resolve("LOADER");
         // Fetcher does not change the location key.  Because no useFetcher()
@@ -5976,9 +5970,7 @@ function testDomRouter(
 
         fireEvent.click(screen.getByText("Submit Form"));
         // Fetcher does not trigger useNavigation
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,loading:undefined")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,loading"));
         expect(getHtml(container)).toMatch("fetcher:loading:undefined");
 
         loaderDefer.resolve("LOADER");
@@ -5999,14 +5991,10 @@ function testDomRouter(
 
         fireEvent.click(screen.getByText("Submit Form"));
         // Fetcher does not trigger useNavigation
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,submitting:undefined")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,submitting"));
 
         actionDefer.resolve("ACTION");
-        await waitFor(() =>
-          screen.getByText("default,idle,INIT,,loading:ACTION:value")
-        );
+        await waitFor(() => screen.getByText("default,idle,INIT,,loading"));
         expect(getHtml(container)).toMatch("fetcher:loading:ACTION:value");
 
         loaderDefer.resolve("LOADER");

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -170,6 +170,16 @@ export interface SubmitOptions {
   encType?: FormEncType;
 
   /**
+   * Indicate a specific fetcherKey to use when using navigate=false
+   */
+  fetcherKey?: string;
+
+  /**
+   * navigate=false will use a fetcher instead of a navigation
+   */
+  navigate?: boolean;
+
+  /**
    * Set `true` to replace the current entry in the browser's history stack
    * instead of creating a new one (i.e. stay on "the same page"). Defaults
    * to `false`.

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1552,7 +1552,7 @@ export function useFetcher<TData = any>({
     `useFetcher can only be used on routes that contain a unique "id"`
   );
 
-  let [_fetcherKey] = React.useState(() => String(++fetcherId));
+  let [_fetcherKey] = React.useState(() => `__${String(++fetcherId)}`);
   let fetcherKey = key ? key : _fetcherKey;
   let [Form] = React.useState(() => {
     invariant(routeId, `No routeId available for fetcher.Form()`);

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1262,7 +1262,6 @@ if (__DEV__) {
 enum DataRouterHook {
   UseScrollRestoration = "useScrollRestoration",
   UseSubmit = "useSubmit",
-  UseSubmitFetcher = "useSubmitFetcher",
   UseFetcher = "useFetcher",
   useViewTransitionState = "useViewTransitionState",
 }
@@ -1661,9 +1660,12 @@ export function useFetcher<TData = any>({
  * Provides all fetchers currently on the page. Useful for layouts and parent
  * routes that need to provide pending/optimistic UI regarding the fetch.
  */
-export function useFetchers(): Fetcher[] {
+export function useFetchers(): Omit<Fetcher, "data">[] {
   let state = useDataRouterState(DataRouterStateHook.UseFetchers);
-  return [...state.fetchers.values()];
+  return [...state.fetchers.values()].map((fetcher) => {
+    let { data, ...rest } = fetcher;
+    return rest;
+  });
 }
 
 const SCROLL_RESTORATION_STORAGE_KEY = "react-router-scroll-positions";

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1506,10 +1506,14 @@ export function useFormAction(
   return createPath(path);
 }
 
-function createFetcherForm(fetcherKey: string, routeId: string) {
+function createFetcherForm(
+  fetcherKey: string,
+  routeId: string,
+  persist: boolean
+) {
   let FetcherForm = React.forwardRef<HTMLFormElement, FetcherFormProps>(
     (props, ref) => {
-      let submit = useSubmitFetcher(fetcherKey, routeId);
+      let submit = useSubmitFetcher(fetcherKey, routeId, persist);
       return <FormImpl {...props} ref={ref} submit={submit} />;
     }
   );
@@ -1552,16 +1556,16 @@ export function useFetcher<TData = any>({
   let fetcherKey = key ? key : _fetcherKey;
   let [Form] = React.useState(() => {
     invariant(routeId, `No routeId available for fetcher.Form()`);
-    return createFetcherForm(fetcherKey, routeId);
+    return createFetcherForm(fetcherKey, routeId, persist === true);
   });
   let [load] = React.useState(() => (href: string) => {
     invariant(router, "No router available for fetcher.load()");
     invariant(routeId, "No routeId available for fetcher.load()");
     router.fetch(fetcherKey, routeId, href);
   });
-  let submit = useSubmitFetcher(fetcherKey, routeId);
+  let submit = useSubmitFetcher(fetcherKey, routeId, persist === true);
 
-  let fetcher = router.getFetcher<TData>(fetcherKey, persist);
+  let fetcher = router.getFetcher<TData>(fetcherKey);
 
   let fetcherWithComponents = React.useMemo(
     () => ({

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -35,6 +35,7 @@ import {
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_ViewTransitionContext as ViewTransitionContext,
+  UNSAFE_FetchersContext as FetchersContext,
 } from "react-router-dom";
 
 export interface StaticRouterProps {
@@ -132,17 +133,25 @@ export function StaticRouterProvider({
     <>
       <DataRouterContext.Provider value={dataRouterContext}>
         <DataRouterStateContext.Provider value={state}>
-          <ViewTransitionContext.Provider value={{ isTransitioning: false }}>
-            <Router
-              basename={dataRouterContext.basename}
-              location={state.location}
-              navigationType={state.historyAction}
-              navigator={dataRouterContext.navigator}
-              static={dataRouterContext.static}
-            >
-              <DataRoutes routes={router.routes} state={state} />
-            </Router>
-          </ViewTransitionContext.Provider>
+          <FetchersContext.Provider
+            value={{
+              fetcherData: new Map<string, any>(),
+              register: () => {},
+              unregister: () => {},
+            }}
+          >
+            <ViewTransitionContext.Provider value={{ isTransitioning: false }}>
+              <Router
+                basename={dataRouterContext.basename}
+                location={state.location}
+                navigationType={state.historyAction}
+                navigator={dataRouterContext.navigator}
+                static={dataRouterContext.static}
+              >
+                <DataRoutes routes={router.routes} state={state} />
+              </Router>
+            </ViewTransitionContext.Provider>
+          </FetchersContext.Provider>
         </DataRouterStateContext.Provider>
       </DataRouterContext.Provider>
       {hydrateScript ? (

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -326,9 +326,6 @@ export function createStaticRouter(
     },
     createHref,
     encodeLocation,
-    getFetcher() {
-      return IDLE_FETCHER;
-    },
     deleteFetcher() {
       throw msg("deleteFetcher");
     },

--- a/packages/router/__tests__/lazy-test.ts
+++ b/packages/router/__tests__/lazy-test.ts
@@ -119,8 +119,8 @@ describe("lazily loaded route modules", () => {
       expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
 
       await loaderDfd.resolve("LAZY LOADER");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER");
     });
 
     it("fetches lazy route modules on fetcher.submit", async () => {
@@ -140,8 +140,8 @@ describe("lazily loaded route modules", () => {
       expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
 
       await actionDfd.resolve("LAZY ACTION");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY ACTION");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY ACTION");
     });
 
     it("fetches lazy route modules on staticHandler.query()", async () => {
@@ -574,8 +574,8 @@ describe("lazily loaded route modules", () => {
       await loaderDfdA.resolve("LAZY LOADER A");
       await loaderDfdB.resolve("LAZY LOADER B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER B");
       expect(lazyLoaderStubA).not.toHaveBeenCalled();
       expect(lazyloaderStubB).toHaveBeenCalledTimes(2);
     });
@@ -615,8 +615,8 @@ describe("lazily loaded route modules", () => {
       await actionDfdA.resolve("LAZY ACTION A");
       await actionDfdB.resolve("LAZY ACTION B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY ACTION B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY ACTION B");
       expect(lazyActionStubA).not.toHaveBeenCalled();
       expect(lazyActionStubB).toHaveBeenCalledTimes(2);
     });
@@ -740,8 +740,8 @@ describe("lazily loaded route modules", () => {
       await loaderDfdA.resolve("LAZY LOADER A");
       await loaderDfdB.resolve("LAZY LOADER B");
 
-      expect(t.router.state.fetchers.get(key)?.state).toBe("idle");
-      expect(t.router.state.fetchers.get(key)?.data).toBe("LAZY LOADER B");
+      expect(t.router.state.fetchers.get(key)).toBeUndefined();
+      expect(t.fetcherData.get(key)).toBe("LAZY LOADER B");
       expect(lazyLoaderStubA).not.toHaveBeenCalled();
       expect(lazyLoaderStubB).toHaveBeenCalledTimes(2);
     });

--- a/packages/router/__tests__/redirects-test.ts
+++ b/packages/router/__tests__/redirects-test.ts
@@ -156,10 +156,7 @@ describe("redirects", () => {
       loaderData: {},
       errors: null,
     });
-    expect(t.router.state.fetchers.get("key")).toMatchObject({
-      state: "idle",
-      data: undefined,
-    });
+    expect(t.router.state.fetchers.get("key")).toBeUndefined();
   });
 
   it("supports relative routing in redirects (from child fetch loader)", async () => {

--- a/packages/router/__tests__/revalidate-test.ts
+++ b/packages/router/__tests__/revalidate-test.ts
@@ -898,17 +898,13 @@ describe("router.revalidate", () => {
     let key = "key";
     let F = await t.fetch("/", key);
     await F.loaders.root.resolve("ROOT_DATA*");
-    expect(t.router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "ROOT_DATA*",
-    });
+    expect(t.router.state.fetchers.get(key)).toBeUndefined();
+    expect(t.fetcherData.get(key)).toBe("ROOT_DATA*");
 
     let R = await t.revalidate();
     await R.loaders.root.resolve("ROOT_DATA**");
     await R.loaders.index.resolve("INDEX_DATA");
-    expect(t.router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "ROOT_DATA**",
-    });
+    expect(t.router.state.fetchers.get(key)).toBeUndefined();
+    expect(t.fetcherData.get(key)).toBe("ROOT_DATA**");
   });
 });

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2511,10 +2511,17 @@ describe("a router", () => {
       });
       router.initialize();
 
+      let fetcherData;
+      router.subscribe((state) => {
+        if (state.fetchers.get("key")?.data) {
+          fetcherData = state.fetchers.get("key")?.data;
+        }
+      });
+
       let key = "key";
       router.fetch(key, "root", "/foo");
       await fooDfd.resolve("FOO");
-      expect(router.state.fetchers.get("key")?.data).toBe("FOO");
+      expect(fetcherData).toBe("FOO");
 
       let rootDfd2 = createDeferred();
       let newRoutes: AgnosticDataRouteObject[] = [
@@ -2615,10 +2622,17 @@ describe("a router", () => {
       });
       router.initialize();
 
+      let fetcherData;
+      router.subscribe((state) => {
+        if (state.fetchers.get("key")?.data) {
+          fetcherData = state.fetchers.get("key")?.data;
+        }
+      });
+
       let key = "key";
       router.fetch(key, "root", "/foo");
       await fooDfd.resolve("FOO");
-      expect(router.state.fetchers.get("key")?.data).toBe("FOO");
+      expect(fetcherData).toBe("FOO");
 
       let rootDfd2 = createDeferred();
       let newRoutes: AgnosticDataRouteObject[] = [
@@ -2659,7 +2673,7 @@ describe("a router", () => {
       expect(router.state.loaderData).toEqual({
         root: "ROOT*",
       });
-      // Fetcher should have been revalidated but theown a 404 wince the route was removed
+      // Fetcher should have been revalidated but thrown a 404 since the route was removed
       expect(router.state.fetchers.get("key")?.data).toBe(undefined);
       expect(router.state.errors).toEqual({
         root: new ErrorResponseImpl(

--- a/packages/router/__tests__/should-revalidate-test.ts
+++ b/packages/router/__tests__/should-revalidate-test.ts
@@ -541,12 +541,18 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch");
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(shouldRevalidate.mock.calls.length).toBe(0);
 
     // Normal navigations should trigger fetcher shouldRevalidate with
@@ -561,10 +567,8 @@ describe("shouldRevalidate", () => {
       nextUrl: expect.urlMatch("http://localhost/child"),
       defaultShouldRevalidate: false,
     });
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
 
     router.navigate("/");
     await tick();
@@ -576,10 +580,8 @@ describe("shouldRevalidate", () => {
       nextUrl: expect.urlMatch("http://localhost/"),
       defaultShouldRevalidate: false,
     });
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
 
     // Submission navigations should trigger fetcher shouldRevalidate with
     // defaultShouldRevalidate=true
@@ -588,10 +590,8 @@ describe("shouldRevalidate", () => {
       formData: createFormData({}),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(shouldRevalidate.mock.calls.length).toBe(3);
     expect(shouldRevalidate.mock.calls[2][0]).toMatchObject({
       currentParams: {},
@@ -639,15 +639,21 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH");
 
     let arg = shouldRevalidate.mock.calls[0][0];
     expect(arg).toMatchInlineSnapshot(`
@@ -702,15 +708,20 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
+
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: undefined,
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe(undefined);
 
     let arg = shouldRevalidate.mock.calls[0][0];
     expect(arg).toMatchInlineSnapshot(`
@@ -817,16 +828,20 @@ describe("shouldRevalidate", () => {
     await tick();
 
     let key = "key";
+    let fetcherData;
+    router.subscribe((state) => {
+      if (state.fetchers.get(key)?.data) {
+        fetcherData = state.fetchers.get(key)?.data;
+      }
+    });
 
     router.fetch(key, "root", "/fetch", {
       formMethod: "post",
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 1",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 1");
     expect(router.state.loaderData).toMatchObject({
       index: "INDEX",
     });
@@ -836,10 +851,8 @@ describe("shouldRevalidate", () => {
       formData: createFormData({ key: "value" }),
     });
     await tick();
-    expect(router.state.fetchers.get(key)).toMatchObject({
-      state: "idle",
-      data: "FETCH 2",
-    });
+    expect(router.state.fetchers.get(key)).toBeUndefined();
+    expect(fetcherData).toBe("FETCH 2");
     expect(router.state.loaderData).toMatchObject({
       index: "INDEX",
     });

--- a/packages/router/__tests__/utils/data-router-setup.ts
+++ b/packages/router/__tests__/utils/data-router-setup.ts
@@ -16,6 +16,7 @@ import {
   matchRoutes,
   redirect,
   parsePath,
+  IDLE_FETCHER,
 } from "../../index";
 
 // Private API
@@ -320,6 +321,15 @@ export function setup({
     window: testWindow,
   }).initialize();
 
+  let fetcherData = new Map<string, any>();
+  currentRouter.subscribe((state) => {
+    state.fetchers.forEach((fetcher, key) => {
+      if (fetcher.data) {
+        fetcherData.set(key, fetcher.data);
+      }
+    });
+  });
+
   function getRouteHelpers(
     routeId: string,
     navigationId: number,
@@ -489,7 +499,11 @@ export function setup({
         navigationId,
         get fetcher() {
           invariant(currentRouter, "No currentRouter available");
-          return currentRouter.getFetcher(key);
+          let fetcher = currentRouter.state.fetchers.get(key) || IDLE_FETCHER;
+          return {
+            ...fetcher,
+            data: fetcherData.get(key),
+          };
         },
         lazy: {},
         loaders: {},
@@ -544,7 +558,11 @@ export function setup({
       navigationId,
       get fetcher() {
         invariant(currentRouter, "No currentRouter available");
-        return currentRouter.getFetcher(key);
+        let fetcher = currentRouter.state.fetchers.get(key) || IDLE_FETCHER;
+        return {
+          ...fetcher,
+          data: fetcherData.get(key),
+        };
       },
       lazy: lazyHelpers,
       loaders: loaderHelpers,
@@ -727,6 +745,7 @@ export function setup({
     window: testWindow,
     history,
     router: currentRouter,
+    fetcherData,
     navigate,
     fetch,
     revalidate,

--- a/packages/router/__tests__/utils/utils.ts
+++ b/packages/router/__tests__/utils/utils.ts
@@ -28,11 +28,11 @@ export function isRedirect(result: any) {
   );
 }
 
-export function createDeferred() {
+export function createDeferred<T = any>() {
   let resolve: (val?: any) => Promise<void>;
   let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
+  let promise = new Promise<T>((res, rej) => {
+    resolve = async (val: T) => {
       res(val);
       try {
         await promise;

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -872,6 +872,8 @@ export function createRouter(init: RouterInit): Router {
   let fetchControllers = new Map<string, AbortController>();
 
   // Keys for persisted fetchers
+  // - `false` means it was submitted with `persist:true`
+  // - `true` value means a deletion was requested during submission
   let persistedFetchers = new Map<string, boolean>();
 
   // Track loads based on the order in which they started


### PR DESCRIPTION
Implements the updated version of https://github.com/remix-run/remix/discussions/7698

Supersedes https://github.com/remix-run/react-router/pull/10945

**Todo:**
* [ ] Should we remove non-idle fetchers from `router.state` entirely?  Right now they remain in there when they return to `idle` for one `subscribe` call so we can hand-off the data to the React layer.  However, would it make sense to remove them before calling subscribers and pass the data in a subsequent argument?  
  ```js
  subscriber(state, { fetcherData, unstable_viewTransitionOpts })
  ```
* [ ] Look into cleanup behavior for fetchers that return `data` but never have a `useFetcher` register to grab it so they never get a ref count
* [ ] Expose fetcher `key` on `useFetchers`
