### PR TITLE
Add future.v7_fetcherPersist flag

### DIFF
--- a/.changeset/fetcher-cleanup.md
+++ b/.changeset/fetcher-cleanup.md
@@ -1,0 +1,11 @@
+---
+"@remix-run/router": minor
+---
+
+Add a new `future.v7_fetcherCleanup` flag to the `@remix-run/router` to change the persistence behavior of fetchers when `router.deleteFetcher` is called. Instead of being immediately cleaned up, fetchers will persist until they return to an `idle` state([RFC](https://github.com/remix-run/remix/discussions/7698))
+
+- This is sort of a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetcher information for pending/optimistic UI -- it was not intended to reflect fetcher data or hang onto fetchers after they returned to an `idle` state
+- With `v7_fetcherCleanup`, the `router` only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed as soon as it returns to `idle` (and the data is handed off to the React layer)
+- Keep an eye out for the following specific behavioral changes when opting into this flag and check your app for compatibility:
+  - Fetchers that complete _while still mounted_ will no longer appear in `useFetchers()`. They served effectively no purpose in there since you can access the data via `useFetcher().data`).
+  - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to an `idle` state. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.

--- a/.changeset/fetcher-cleanup.md
+++ b/.changeset/fetcher-cleanup.md
@@ -2,10 +2,10 @@
 "@remix-run/router": minor
 ---
 
-Add a new `future.v7_fetcherCleanup` flag to the `@remix-run/router` to change the persistence behavior of fetchers when `router.deleteFetcher` is called. Instead of being immediately cleaned up, fetchers will persist until they return to an `idle` state([RFC](https://github.com/remix-run/remix/discussions/7698))
+Add a new `future.v7_fetcherPersist` flag to the `@remix-run/router` to change the persistence behavior of fetchers when `router.deleteFetcher` is called. Instead of being immediately cleaned up, fetchers will persist until they return to an `idle` state([RFC](https://github.com/remix-run/remix/discussions/7698))
 
 - This is sort of a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetcher information for pending/optimistic UI -- it was not intended to reflect fetcher data or hang onto fetchers after they returned to an `idle` state
-- With `v7_fetcherCleanup`, the `router` only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed as soon as it returns to `idle` (and the data is handed off to the React layer)
+- With `v7_fetcherPersist`, the `router` only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed as soon as it returns to `idle` (and the data is handed off to the React layer)
 - Keep an eye out for the following specific behavioral changes when opting into this flag and check your app for compatibility:
   - Fetchers that complete _while still mounted_ will no longer appear in `useFetchers()`. They served effectively no purpose in there since you can access the data via `useFetcher().data`).
   - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to an `idle` state. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.

--- a/.changeset/fix-router-future-prop.md
+++ b/.changeset/fix-router-future-prop.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+Fix the `future`prop on `BrowserRouter`, `HashRouter` and `MemoryRouter` so that it accepts a `Partial<FutureConfig>` instead of requiring all flags to be included.

--- a/docs/guides/api-development-strategy.md
+++ b/docs/guides/api-development-strategy.md
@@ -66,7 +66,7 @@ const router = createBrowserRouter(routes, {
 | Flag                     | Description                                                           |
 | ------------------------ | --------------------------------------------------------------------- |
 | `v7_normalizeFormMethod` | Normalize `useNavigation().formMethod` to be an uppercase HTTP Method |
-| `v7_fetcherCleanup`      | Delay active fetcher cleanup until they return to an `idle` state     |
+| `v7_fetcherPersist`      | Delay active fetcher cleanup until they return to an `idle` state     |
 
 ### React Router Future Flags
 

--- a/docs/guides/api-development-strategy.md
+++ b/docs/guides/api-development-strategy.md
@@ -66,6 +66,7 @@ const router = createBrowserRouter(routes, {
 | Flag                     | Description                                                           |
 | ------------------------ | --------------------------------------------------------------------- |
 | `v7_normalizeFormMethod` | Normalize `useNavigation().formMethod` to be an uppercase HTTP Method |
+| `v7_fetcherCleanup`      | Delay active fetcher cleanup until they return to an `idle` state     |
 
 ### React Router Future Flags
 

--- a/examples/data-router/src/app.tsx
+++ b/examples/data-router/src/app.tsx
@@ -24,38 +24,48 @@ import { addTodo, deleteTodo, getTodos } from "./todos";
 
 import "./index.css";
 
-let router = createBrowserRouter([
-  {
-    path: "/",
-    Component: Layout,
-    children: [
-      {
-        index: true,
-        loader: homeLoader,
-        Component: Home,
+let router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      Component() {
+        let fetchers = useFetchers();
+        return (
+          <>
+            <pre>{JSON.stringify(fetchers)}</pre>
+            <Outlet />
+          </>
+        );
       },
-      {
-        path: "todos",
-        action: todosAction,
-        loader: todosLoader,
-        Component: TodosList,
-        ErrorBoundary: TodosBoundary,
-        children: [
-          {
-            path: ":id",
-            loader: todoLoader,
-            Component: Todo,
+      children: [
+        {
+          index: true,
+          Component() {
+            let fetcher = useFetcher({ key: "a" });
+            let fetcher2 = useFetcher({ key: "a" });
+            return (
+              <div>
+                <button onClick={() => fetcher.load("/fetch")}>Load</button>
+                <button onClick={() => fetcher2.load("/fetch")}>Load</button>
+                <pre>{JSON.stringify(fetcher)}</pre>
+                <pre>{JSON.stringify(fetcher2)}</pre>
+              </div>
+            );
           },
-        ],
-      },
-      {
-        path: "deferred",
-        loader: deferredLoader,
-        Component: DeferredPage,
-      },
-    ],
-  },
-]);
+        },
+      ],
+    },
+    {
+      path: "/fetch",
+      loader: () => new Promise((r) => setTimeout(() => r("FETCH"), 1000)),
+    },
+  ],
+  {
+    future: {
+      v7_fetcherPersist: true,
+    },
+  }
+);
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => router.dispose());
@@ -71,329 +81,4 @@ export function sleep(n: number = 500) {
 
 export function Fallback() {
   return <p>Performing initial data load</p>;
-}
-
-// Layout
-export function Layout() {
-  let navigation = useNavigation();
-  let revalidator = useRevalidator();
-  let fetchers = useFetchers();
-  let fetcherInProgress = fetchers.some((f) =>
-    ["loading", "submitting"].includes(f.state)
-  );
-
-  return (
-    <>
-      <h1>Data Router Example</h1>
-
-      <p>
-        This example demonstrates some of the core features of React Router
-        including nested &lt;Route&gt;s, &lt;Outlet&gt;s, &lt;Link&gt;s, and
-        using a "*" route (aka "splat route") to render a "not found" page when
-        someone visits an unrecognized URL.
-      </p>
-
-      <nav>
-        <ul>
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/todos">Todos</Link>
-          </li>
-          <li>
-            <Link to="/deferred">Deferred</Link>
-          </li>
-          <li>
-            <Link to="/404">404 Link</Link>
-          </li>
-          <li>
-            <button onClick={() => revalidator.revalidate()}>
-              Revalidate Data
-            </button>
-          </li>
-        </ul>
-      </nav>
-      <div style={{ position: "fixed", top: 0, right: 0 }}>
-        {navigation.state !== "idle" && <p>Navigation in progress...</p>}
-        {revalidator.state !== "idle" && <p>Revalidation in progress...</p>}
-        {fetcherInProgress && <p>Fetcher in progress...</p>}
-      </div>
-      <p>
-        Click on over to <Link to="/todos">/todos</Link> and check out these
-        data loading APIs!
-      </p>
-      <p>
-        Or, checkout <Link to="/deferred">/deferred</Link> to see how to
-        separate critical and lazily loaded data in your loaders.
-      </p>
-      <p>
-        We've introduced some fake async-aspects of routing here, so Keep an eye
-        on the top-right hand corner to see when we're actively navigating.
-      </p>
-      <hr />
-      <Outlet />
-    </>
-  );
-}
-
-// Home
-interface HomeLoaderData {
-  date: string;
-}
-
-export async function homeLoader(): Promise<HomeLoaderData> {
-  await sleep();
-  return {
-    date: new Date().toISOString(),
-  };
-}
-
-export function Home() {
-  let data = useLoaderData() as HomeLoaderData;
-  return (
-    <>
-      <h2>Home</h2>
-      <p>Date from loader: {data.date}</p>
-    </>
-  );
-}
-
-// Todos
-export async function todosAction({ request }: ActionFunctionArgs) {
-  await sleep();
-
-  let formData = await request.formData();
-
-  // Deletion via fetcher
-  if (formData.get("action") === "delete") {
-    let id = formData.get("todoId");
-    if (typeof id === "string") {
-      deleteTodo(id);
-      return { ok: true };
-    }
-  }
-
-  // Addition via <Form>
-  let todo = formData.get("todo");
-  if (typeof todo === "string") {
-    addTodo(todo);
-  }
-
-  return new Response(null, {
-    status: 302,
-    headers: { Location: "/todos" },
-  });
-}
-
-export async function todosLoader(): Promise<Todos> {
-  await sleep();
-  return getTodos();
-}
-
-export function TodosList() {
-  let todos = useLoaderData() as Todos;
-  let navigation = useNavigation();
-  let formRef = React.useRef<HTMLFormElement>(null);
-
-  // If we add and then we delete - this will keep isAdding=true until the
-  // fetcher completes it's revalidation
-  let [isAdding, setIsAdding] = React.useState(false);
-  React.useEffect(() => {
-    if (navigation.formData?.get("action") === "add") {
-      setIsAdding(true);
-    } else if (navigation.state === "idle") {
-      setIsAdding(false);
-      formRef.current?.reset();
-    }
-  }, [navigation]);
-
-  return (
-    <>
-      <h2>Todos</h2>
-      <p>
-        This todo app uses a &lt;Form&gt; to submit new todos and a
-        &lt;fetcher.form&gt; to delete todos. Click on a todo item to navigate
-        to the /todos/:id route.
-      </p>
-      <ul>
-        <li>
-          <Link to="/todos/junk">
-            Click this link to force an error in the loader
-          </Link>
-        </li>
-        {Object.entries(todos).map(([id, todo]) => (
-          <li key={id}>
-            <TodoItem id={id} todo={todo} />
-          </li>
-        ))}
-      </ul>
-      <Form method="post" ref={formRef}>
-        <input type="hidden" name="action" value="add" />
-        <input name="todo"></input>
-        <button type="submit" disabled={isAdding}>
-          {isAdding ? "Adding..." : "Add"}
-        </button>
-      </Form>
-      <Outlet />
-    </>
-  );
-}
-
-export function TodosBoundary() {
-  let error = useRouteError() as Error;
-  return (
-    <>
-      <h2>Error 💥</h2>
-      <p>{error.message}</p>
-    </>
-  );
-}
-
-interface TodoItemProps {
-  id: string;
-  todo: string;
-}
-
-export function TodoItem({ id, todo }: TodoItemProps) {
-  let fetcher = useFetcher();
-
-  let isDeleting = fetcher.formData != null;
-  return (
-    <>
-      <Link to={`/todos/${id}`}>{todo}</Link>
-      &nbsp;
-      <fetcher.Form method="post" style={{ display: "inline" }}>
-        <input type="hidden" name="action" value="delete" />
-        <button type="submit" name="todoId" value={id} disabled={isDeleting}>
-          {isDeleting ? "Deleting..." : "Delete"}
-        </button>
-      </fetcher.Form>
-    </>
-  );
-}
-
-// Todo
-export async function todoLoader({
-  params,
-}: LoaderFunctionArgs): Promise<string> {
-  await sleep();
-  let todos = getTodos();
-  if (!params.id) {
-    throw new Error("Expected params.id");
-  }
-  let todo = todos[params.id];
-  if (!todo) {
-    throw new Error(`Uh oh, I couldn't find a todo with id "${params.id}"`);
-  }
-  return todo;
-}
-
-export function Todo() {
-  let params = useParams();
-  let todo = useLoaderData() as string;
-  return (
-    <>
-      <h2>Nested Todo Route:</h2>
-      <p>id: {params.id}</p>
-      <p>todo: {todo}</p>
-    </>
-  );
-}
-
-// Deferred Data
-interface DeferredRouteLoaderData {
-  critical1: string;
-  critical2: string;
-  lazyResolved: Promise<string>;
-  lazy1: Promise<string>;
-  lazy2: Promise<string>;
-  lazy3: Promise<string>;
-  lazyError: Promise<string>;
-}
-
-const rand = () => Math.round(Math.random() * 100);
-const resolve = (d: string, ms: number) =>
-  new Promise((r) => setTimeout(() => r(`${d} - ${rand()}`), ms));
-const reject = (d: Error | string, ms: number) =>
-  new Promise((_, r) =>
-    setTimeout(() => {
-      if (d instanceof Error) {
-        d.message += ` - ${rand()}`;
-      } else {
-        d += ` - ${rand()}`;
-      }
-      r(d);
-    }, ms)
-  );
-
-export async function deferredLoader() {
-  return defer({
-    critical1: await resolve("Critical 1", 250),
-    critical2: await resolve("Critical 2", 500),
-    lazyResolved: Promise.resolve("Lazy Data immediately resolved - " + rand()),
-    lazy1: resolve("Lazy 1", 1000),
-    lazy2: resolve("Lazy 2", 1500),
-    lazy3: resolve("Lazy 3", 2000),
-    lazyError: reject(new Error("Kaboom!"), 2500),
-  });
-}
-
-export function DeferredPage() {
-  let data = useLoaderData() as DeferredRouteLoaderData;
-  return (
-    <div>
-      {/* Critical data renders immediately */}
-      <p>{data.critical1}</p>
-      <p>{data.critical2}</p>
-
-      {/* Pre-resolved deferred data never triggers the fallback */}
-      <React.Suspense fallback={<p>should not see me!</p>}>
-        <Await resolve={data.lazyResolved}>
-          <RenderAwaitedData />
-        </Await>
-      </React.Suspense>
-
-      {/* Deferred data can be rendered using a component + the useAsyncValue() hook */}
-      <React.Suspense fallback={<p>loading 1...</p>}>
-        <Await resolve={data.lazy1}>
-          <RenderAwaitedData />
-        </Await>
-      </React.Suspense>
-
-      <React.Suspense fallback={<p>loading 2...</p>}>
-        <Await resolve={data.lazy2}>
-          <RenderAwaitedData />
-        </Await>
-      </React.Suspense>
-
-      {/* Or you can bypass the hook and use a render function */}
-      <React.Suspense fallback={<p>loading 3...</p>}>
-        <Await resolve={data.lazy3}>{(data: string) => <p>{data}</p>}</Await>
-      </React.Suspense>
-
-      {/* Deferred rejections render using the useAsyncError hook */}
-      <React.Suspense fallback={<p>loading (error)...</p>}>
-        <Await resolve={data.lazyError} errorElement={<RenderAwaitedError />}>
-          <RenderAwaitedData />
-        </Await>
-      </React.Suspense>
-    </div>
-  );
-}
-
-function RenderAwaitedData() {
-  let data = useAsyncValue() as string;
-  return <p>{data}</p>;
-}
-
-function RenderAwaitedError() {
-  let error = useAsyncError() as Error;
-  return (
-    <p style={{ color: "red" }}>
-      Error (errorElement)!
-      <br />
-      {error.message} {error.stack}
-    </p>
-  );
 }

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -5382,7 +5382,7 @@ function testDomRouter(
           });
         });
 
-        describe("v7_fetcherCleanup=true", () => {
+        describe("v7_fetcherPersist=true", () => {
           it("loading fetchers persist until completion", async () => {
             let dfd = createDeferred();
             let router = createTestRouter(
@@ -5424,7 +5424,7 @@ function testDomRouter(
                   loader: () => dfd.promise,
                 },
               ],
-              { window: getWindow("/"), future: { v7_fetcherCleanup: true } }
+              { window: getWindow("/"), future: { v7_fetcherPersist: true } }
             );
             let { container } = render(<RouterProvider router={router} />);
 
@@ -5493,7 +5493,7 @@ function testDomRouter(
                   action: () => dfd.promise,
                 },
               ],
-              { window: getWindow("/"), future: { v7_fetcherCleanup: true } }
+              { window: getWindow("/"), future: { v7_fetcherPersist: true } }
             );
             let { container } = render(<RouterProvider router={router} />);
 
@@ -5566,7 +5566,7 @@ function testDomRouter(
                   action: () => dfd.promise,
                 },
               ],
-              { window: getWindow("/"), future: { v7_fetcherCleanup: true } }
+              { window: getWindow("/"), future: { v7_fetcherPersist: true } }
             );
             let { container } = render(<RouterProvider router={router} />);
 
@@ -5640,7 +5640,7 @@ function testDomRouter(
                   action: () => dfd.promise,
                 },
               ],
-              { window: getWindow("/"), future: { v7_fetcherCleanup: true } }
+              { window: getWindow("/"), future: { v7_fetcherPersist: true } }
             );
             let { container } = render(<RouterProvider router={router} />);
 
@@ -5705,7 +5705,7 @@ function testDomRouter(
                   action: () => dfd.promise,
                 },
               ],
-              { window: getWindow("/"), future: { v7_fetcherCleanup: true } }
+              { window: getWindow("/"), future: { v7_fetcherPersist: true } }
             );
             let { container } = render(<RouterProvider router={router} />);
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -644,7 +644,7 @@ function DataRoutes({
 export interface BrowserRouterProps {
   basename?: string;
   children?: React.ReactNode;
-  future?: FutureConfig;
+  future?: Partial<FutureConfig>;
   window?: Window;
 }
 
@@ -693,7 +693,7 @@ export function BrowserRouter({
 export interface HashRouterProps {
   basename?: string;
   children?: React.ReactNode;
-  future?: FutureConfig;
+  future?: Partial<FutureConfig>;
   window?: Window;
 }
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -185,7 +185,7 @@ export interface MemoryRouterProps {
   children?: React.ReactNode;
   initialEntries?: InitialEntry[];
   initialIndex?: number;
-  future?: FutureConfig;
+  future?: Partial<FutureConfig>;
 }
 
 /**

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -343,7 +343,7 @@ export type HydrationState = Partial<
  * Future flags to toggle new feature behavior
  */
 export interface FutureConfig {
-  v7_fetcherCleanup: boolean;
+  v7_fetcherPersist: boolean;
   v7_normalizeFormMethod: boolean;
   v7_prependBasename: boolean;
 }
@@ -764,7 +764,7 @@ export function createRouter(init: RouterInit): Router {
   let basename = init.basename || "/";
   // Config driven behavior flags
   let future: FutureConfig = {
-    v7_fetcherCleanup: false,
+    v7_fetcherPersist: false,
     v7_normalizeFormMethod: false,
     v7_prependBasename: false,
     ...init.future,
@@ -887,7 +887,7 @@ export function createRouter(init: RouterInit): Router {
   // Most recent href/match for fetcher.load calls for fetchers
   let fetchLoadMatches = new Map<string, FetchLoadMatch>();
 
-  // Fetchers that have requested a delete when using v7_fetcherCleanup,
+  // Fetchers that have requested a delete when using v7_fetcherPersist,
   // they'll be officially removed after they return to idle
   let deletedFetchers = new Set<string>();
 
@@ -1025,7 +1025,7 @@ export function createRouter(init: RouterInit): Router {
     );
 
     // Remove idle fetchers from state since we only care about in-flight fetchers.
-    if (future.v7_fetcherCleanup) {
+    if (future.v7_fetcherPersist) {
       state.fetchers.forEach((fetcher, key) => {
         if (fetcher.state === "idle") {
           if (deletedFetchers.has(key)) {
@@ -2403,7 +2403,7 @@ export function createRouter(init: RouterInit): Router {
   }
 
   function deleteFetcherAndUpdateState(key: string): void {
-    if (future.v7_fetcherCleanup) {
+    if (future.v7_fetcherPersist) {
       deletedFetchers.add(key);
     } else {
       deleteFetcher(key);


### PR DESCRIPTION
Dependent on https://github.com/remix-run/react-router/pull/10961

Implemented the new fetcher persist/cleanup behavior behind a new `future.v7_fetcherPersist` flag in the router.

* Implements the updated version of https://github.com/remix-run/remix/discussions/7698
* 3rd and final PR to supersede https://github.com/remix-run/react-router/pull/10945
