### PR TITLE
Revert "Ensure Form contains splat portion of pathname when no action is specified (#10933)"

### DIFF
--- a/.changeset/splat-form-action.md
+++ b/.changeset/splat-form-action.md
@@ -1,5 +1,0 @@
----
-"react-router-dom": patch
----
-
-Ensure `<Form>` default action contains splat portion of pathname when no `action` is specified

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -2894,7 +2894,7 @@ function testDomRouter(
           let { container } = render(<RouterProvider router={router} />);
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo/bar?a=1"
+            "/foo?a=1"
           );
         });
 
@@ -2935,44 +2935,6 @@ function testDomRouter(
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
             "/foo"
-          );
-        });
-
-        it("includes splat portion of path when no action is specified (inline splat)", async () => {
-          let router = createTestRouter(
-            createRoutesFromElements(
-              <Route path="/">
-                <Route path="foo">
-                  <Route path="*" element={<NoActionComponent />} />
-                </Route>
-              </Route>
-            ),
-            {
-              window: getWindow("/foo/bar/baz"),
-            }
-          );
-          let { container } = render(<RouterProvider router={router} />);
-
-          expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo/bar/baz"
-          );
-        });
-
-        it("includes splat portion of path when no action is specified (nested splat)", async () => {
-          let router = createTestRouter(
-            createRoutesFromElements(
-              <Route path="/">
-                <Route path="foo/*" element={<NoActionComponent />} />
-              </Route>
-            ),
-            {
-              window: getWindow("/foo/bar/baz"),
-            }
-          );
-          let { container } = render(<RouterProvider router={router} />);
-
-          expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo/bar/baz"
           );
         });
       });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1457,20 +1457,18 @@ export function useFormAction(
   let { basename } = React.useContext(NavigationContext);
   let routeContext = React.useContext(RouteContext);
   invariant(routeContext, "useFormAction must be used inside a RouteContext");
-  let location = useLocation();
 
   let [match] = routeContext.matches.slice(-1);
   // Shallow clone path so we can modify it below, otherwise we modify the
   // object referenced by useMemo inside useResolvedPath
-  let path = {
-    ...useResolvedPath(action != null ? action : location.pathname, {
-      relative,
-    }),
-  };
+  let path = { ...useResolvedPath(action ? action : ".", { relative }) };
 
-  // If no action was specified, browsers will persist current search params
-  // when determining the path, so match that behavior
+  // Previously we set the default action to ".". The problem with this is that
+  // `useResolvedPath(".")` excludes search params of the resolved URL. This is
+  // the intended behavior of when "." is specifically provided as
+  // the form action, but inconsistent w/ browsers when the action is omitted.
   // https://github.com/remix-run/remix/issues/927
+  let location = useLocation();
   if (action == null) {
     // Safe to write to this directly here since if action was undefined, we
     // would have called useResolvedPath(".") which will never include a search


### PR DESCRIPTION
Reverting because this had some unintended impacts on `useFormAction` behavior from a layout route when using dynamic params.  Will re-open a new PR with a proper fix.

This reverts #10933 (commit 908a40a25382612b869638664e19a4aa7a977e53)

Reopens: #10922