### PR TITLE
Updates for v7_fetcherPersist post-processing logic

### DIFF
--- a/.changeset/fetcher-cleanup.md
+++ b/.changeset/fetcher-cleanup.md
@@ -2,10 +2,9 @@
 "@remix-run/router": minor
 ---
 
-Add a new `future.v7_fetcherPersist` flag to the `@remix-run/router` to change the persistence behavior of fetchers when `router.deleteFetcher` is called. Instead of being immediately cleaned up, fetchers will persist until they return to an `idle` state([RFC](https://github.com/remix-run/remix/discussions/7698))
+Add a new `future.v7_fetcherPersist` flag to the `@remix-run/router` to change the persistence behavior of fetchers when `router.deleteFetcher` is called. Instead of being immediately cleaned up, fetchers will persist until they return to an `idle` state ([RFC](https://github.com/remix-run/remix/discussions/7698))
 
 - This is sort of a long-standing bug fix as the `useFetchers()` API was always supposed to only reflect **in-flight** fetcher information for pending/optimistic UI -- it was not intended to reflect fetcher data or hang onto fetchers after they returned to an `idle` state
-- With `v7_fetcherPersist`, the `router` only knows about in-flight fetchers - they do not exist in `state.fetchers` until a `fetch()` call is made, and they are removed as soon as it returns to `idle` (and the data is handed off to the React layer)
 - Keep an eye out for the following specific behavioral changes when opting into this flag and check your app for compatibility:
   - Fetchers that complete _while still mounted_ will no longer appear in `useFetchers()`. They served effectively no purpose in there since you can access the data via `useFetcher().data`).
   - Fetchers that previously unmounted _while in-flight_ will not be immediately aborted and will instead be cleaned up once they return to an `idle` state. They will remain exposed via `useFetchers` while in-flight so you can still access pending/optimistic data after unmount.

--- a/.changeset/fetcher-ref-count.md
+++ b/.changeset/fetcher-ref-count.md
@@ -1,0 +1,8 @@
+---
+"@remix-run/router": minor
+---
+
+When `v7_fetcherPersist` is enabled, the router now performs ref-counting on fetcher keys via `getFetcher`/`deleteFetcher` so it knows when a given fetcher is totally unmounted from the UI
+
+- Once a fetcher has been totally unmounted, we can ignore post-processing of a persisted fetcher result such as a redirect or an error
+- The router will also pass a new `deletedFetchers` array to the subscriber callbacks so that the UI layer can remove associated fetcher data

--- a/.changeset/fix-router-future-prop.md
+++ b/.changeset/fix-router-future-prop.md
@@ -3,4 +3,4 @@
 "react-router-dom": patch
 ---
 
-Fix the `future`prop on `BrowserRouter`, `HashRouter` and `MemoryRouter` so that it accepts a `Partial<FutureConfig>` instead of requiring all flags to be included.
+Fix the `future` prop on `BrowserRouter`, `HashRouter` and `MemoryRouter` so that it accepts a `Partial<FutureConfig>` instead of requiring all flags to be included.

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "filesize": {
     "packages/router/dist/router.umd.min.js": {
-      "none": "48.7 kB"
+      "none": "49.0 kB"
     },
     "packages/react-router/dist/react-router.production.min.js": {
       "none": "13.9 kB"
@@ -119,10 +119,10 @@
       "none": "16.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "16.5 kB"
+      "none": "16.1 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "22.7 kB"
+      "none": "22.3 kB"
     }
   }
 }

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -111,6 +111,8 @@ export function StaticRouterProvider({
     basename: context.basename || "/",
   };
 
+  let fetchersContext = new Map();
+
   let hydrateScript = "";
 
   if (hydrate !== false) {
@@ -133,13 +135,7 @@ export function StaticRouterProvider({
     <>
       <DataRouterContext.Provider value={dataRouterContext}>
         <DataRouterStateContext.Provider value={state}>
-          <FetchersContext.Provider
-            value={{
-              fetcherData: new Map<string, any>(),
-              register: () => {},
-              unregister: () => {},
-            }}
-          >
+          <FetchersContext.Provider value={fetchersContext}>
             <ViewTransitionContext.Provider value={{ isTransitioning: false }}>
               <Router
                 basename={dataRouterContext.basename}

--- a/packages/router/__tests__/view-transition-test.ts
+++ b/packages/router/__tests__/view-transition-test.ts
@@ -19,7 +19,7 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/a" }),
       }),
-      { unstable_viewTransitionOpts: undefined }
+      expect.objectContaining({ unstable_viewTransitionOpts: undefined })
     );
 
     // PUSH /a -> /b - w/ transition
@@ -29,12 +29,12 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/b" }),
       }),
-      {
+      expect.objectContaining({
         unstable_viewTransitionOpts: {
           currentLocation: expect.objectContaining({ pathname: "/a" }),
           nextLocation: expect.objectContaining({ pathname: "/b" }),
         },
-      }
+      })
     );
 
     // POP /b -> /a - w/ transition (cached from above)
@@ -44,13 +44,13 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/a" }),
       }),
-      {
+      expect.objectContaining({
         unstable_viewTransitionOpts: {
           // Args reversed on POP so same hooks apply
           currentLocation: expect.objectContaining({ pathname: "/a" }),
           nextLocation: expect.objectContaining({ pathname: "/b" }),
         },
-      }
+      })
     );
 
     // POP /a -> / - No transition
@@ -60,7 +60,7 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/" }),
       }),
-      { unstable_viewTransitionOpts: undefined }
+      expect.objectContaining({ unstable_viewTransitionOpts: undefined })
     );
 
     unsubscribe();


### PR DESCRIPTION
When `v7_fetcherPersist` is enabled we open up some new code flows for fetcher result processing that we need to consider.

* Previously, when fetchers were aborted on unmount, we would end up ignoring all results from those unmounted fetchers via `if (request.signal.aborted)`
* Now that we don't abort the fetchers immediately (when the flag is enabled) we need to determine if we should process the fetcher result or not

We do this by lifting the ref counting up into the router so it knows if any instances of a given fetcher key are still mounted in the UI. 

* If no instances are mounted at the time the fetcher completes, we don't process the result - like same as before when we aborted on unmount
* If _some_ instances are still mounted (meaning some other new component picked up the fetcher via `useFetcher({ key })`, then we _do_ process the result
