### PR TITLE
Fix issues with useFormAction/useResolvedPath for dot paths in param/splat routes

### DIFF
--- a/.changeset/fix-resolve-path.md
+++ b/.changeset/fix-resolve-path.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a param or splat route to lose the params/splat portion of the URL path
+Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a splat route to lose the splat portion of the URL path

--- a/.changeset/fix-resolve-path.md
+++ b/.changeset/fix-resolve-path.md
@@ -3,3 +3,5 @@
 ---
 
 Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a splat route to lose the splat portion of the URL path.
+
+- ⚠️ This fixes a quite long-standing bug specifically for `"."` paths inside a splat route which incorrectly dropped the splat portion of the URL. If you are relative routing via `"."` inside a splat route in your application you should double check that your logic is not relying on this buggy behavior and update accordingly.

--- a/.changeset/fix-resolve-path.md
+++ b/.changeset/fix-resolve-path.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a param or splat route to lose the params/splat portion of the URL path

--- a/.changeset/fix-resolve-path.md
+++ b/.changeset/fix-resolve-path.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a splat route to lose the splat portion of the URL path
+Fix bug in `useResolvedPath` that would cause `useResolvedPath(".")` in a splat route to lose the splat portion of the URL path.

--- a/.changeset/splat-form-action.md
+++ b/.changeset/splat-form-action.md
@@ -1,5 +1,0 @@
----
-"react-router-dom": patch
----
-
-Ensure `<Form>` default action contains splat portion of pathname when no `action` is specified

--- a/.changeset/splat-form-action.md
+++ b/.changeset/splat-form-action.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Ensure `<Form>` default action contains splat portion of pathname when no `action` is specified

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -2916,6 +2916,44 @@ function testDomRouter(
             "/foo/bar"
           );
         });
+
+        it("includes param portion of path when no action is specified (inline splat)", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo">
+                  <Route path=":param" element={<NoActionComponent />} />
+                </Route>
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo/bar"
+          );
+        });
+
+        it("includes splat portion of path when no action is specified (nested splat)", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo/:param" element={<NoActionComponent />} />
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo/bar"
+          );
+        });
       });
 
       describe("splat routes", () => {

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -3021,26 +3021,6 @@ function testDomRouter(
           let router = createTestRouter(
             createRoutesFromElements(
               <Route path="/">
-                <Route path="foo">
-                  <Route path="*" element={<NoActionComponent />} />
-                </Route>
-              </Route>
-            ),
-            {
-              window: getWindow("/foo/bar/baz"),
-            }
-          );
-          let { container } = render(<RouterProvider router={router} />);
-
-          expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo/bar/baz"
-          );
-        });
-
-        it("includes splat portion of path when no action is specified (nested splat)", async () => {
-          let router = createTestRouter(
-            createRoutesFromElements(
-              <Route path="/">
                 <Route path="foo/*" element={<NoActionComponent />} />
               </Route>
             ),

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -2653,6 +2653,46 @@ function testDomRouter(
             "/foo/bar"
           );
         });
+
+        it("does not include dynamic parameters from a parent layout route", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo" element={<ActionEmptyComponent />}>
+                  <Route path=":param" element={<h1>Param</h1>} />
+                </Route>
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo"
+          );
+        });
+
+        it("does not include splat parameters from a parent layout route", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo" element={<ActionEmptyComponent />}>
+                  <Route path="*" element={<h1>Splat</h1>} />
+                </Route>
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar/baz/qux"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo"
+          );
+        });
       });
 
       describe("index routes", () => {
@@ -2895,7 +2935,7 @@ function testDomRouter(
           let { container } = render(<RouterProvider router={router} />);
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo?a=1"
+            "/foo/bar?a=1"
           );
         });
 
@@ -2915,7 +2955,7 @@ function testDomRouter(
           let { container } = render(<RouterProvider router={router} />);
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo"
+            "/foo/bar"
           );
         });
 
@@ -2935,7 +2975,45 @@ function testDomRouter(
           let { container } = render(<RouterProvider router={router} />);
 
           expect(container.querySelector("form")?.getAttribute("action")).toBe(
-            "/foo"
+            "/foo/bar"
+          );
+        });
+
+        it("includes splat portion of path when no action is specified (inline splat)", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo">
+                  <Route path="*" element={<NoActionComponent />} />
+                </Route>
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar/baz"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo/bar/baz"
+          );
+        });
+
+        it("includes splat portion of path when no action is specified (nested splat)", async () => {
+          let router = createTestRouter(
+            createRoutesFromElements(
+              <Route path="/">
+                <Route path="foo/*" element={<NoActionComponent />} />
+              </Route>
+            ),
+            {
+              window: getWindow("/foo/bar/baz"),
+            }
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/foo/bar/baz"
           );
         });
       });

--- a/packages/react-router-dom/__tests__/link-href-test.tsx
+++ b/packages/react-router-dom/__tests__/link-href-test.tsx
@@ -530,7 +530,7 @@ describe("<Link> href", () => {
       });
 
       expect(renderer.root.findByType("a").props.href).toEqual(
-        "/inbox/messages"
+        "/inbox/messages/abc"
       );
     });
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1466,10 +1466,7 @@ export function useFormAction(
   let [match] = routeContext.matches.slice(-1);
   // Shallow clone path so we can modify it below, otherwise we modify the
   // object referenced by useMemo inside useResolvedPath
-  let currentPath = match.pathname.replace(/\/$/, "");
-  let path = {
-    ...useResolvedPath(action ? action : currentPath, { relative }),
-  };
+  let path = { ...useResolvedPath(action ? action : ".", { relative }) };
 
   // If no action was specified, browsers will persist current search params
   // when determining the path, so match that behavior

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1466,12 +1466,13 @@ export function useFormAction(
   let [match] = routeContext.matches.slice(-1);
   // Shallow clone path so we can modify it below, otherwise we modify the
   // object referenced by useMemo inside useResolvedPath
-  let path = { ...useResolvedPath(action ? action : ".", { relative }) };
+  let currentPath = match.pathname.replace(/\/$/, "");
+  let path = {
+    ...useResolvedPath(action ? action : currentPath, { relative }),
+  };
 
-  // Previously we set the default action to ".". The problem with this is that
-  // `useResolvedPath(".")` excludes search params of the resolved URL. This is
-  // the intended behavior of when "." is specifically provided as
-  // the form action, but inconsistent w/ browsers when the action is omitted.
+  // If no action was specified, browsers will persist current search params
+  // when determining the path, so match that behavior
   // https://github.com/remix-run/remix/issues/927
   let location = useLocation();
   if (action == null) {

--- a/packages/react-router/__tests__/useResolvedPath-test.tsx
+++ b/packages/react-router/__tests__/useResolvedPath-test.tsx
@@ -101,7 +101,33 @@ describe("useResolvedPath", () => {
 
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <pre>
-          {"pathname":"/users","search":"","hash":""}
+          {"pathname":"/users/mj","search":"","hash":""}
+        </pre>
+      `);
+    });
+  });
+
+  describe("in a param route", () => {
+    it("resolves . to the route path", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route
+                  path=":username"
+                  element={<ShowResolvedPath path="." />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users/mj","search":"","hash":""}
         </pre>
       `);
     });

--- a/packages/react-router/__tests__/useResolvedPath-test.tsx
+++ b/packages/react-router/__tests__/useResolvedPath-test.tsx
@@ -85,7 +85,7 @@ describe("useResolvedPath", () => {
   });
 
   describe("in a splat route", () => {
-    it("resolves . to the route path", () => {
+    it("resolves . to the route path (nested splat)", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(
@@ -105,18 +105,123 @@ describe("useResolvedPath", () => {
         </pre>
       `);
     });
-  });
 
-  describe("in a param route", () => {
-    it("resolves . to the route path", () => {
+    it("resolves .. to the route path (nested splat)", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(
           <MemoryRouter initialEntries={["/users/mj"]}>
             <Routes>
               <Route path="/users">
+                <Route path="*" element={<ShowResolvedPath path=".." />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves . to the route path (inline splat)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/name/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route path="name/*" element={<ShowResolvedPath path="." />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users/name/mj","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves .. to the route path (inline splat)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/name/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route path="name/*" element={<ShowResolvedPath path=".." />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users","search":"","hash":""}
+        </pre>
+      `);
+    });
+  });
+
+  describe("in a param route", () => {
+    it("resolves . to the route path (nested param)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route path=":name" element={<ShowResolvedPath path="." />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users/mj","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves .. to the parent route (nested param)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route path=":name" element={<ShowResolvedPath path=".." />} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves . to the route path (inline param)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/name/mj"]}>
+            <Routes>
+              <Route path="/users">
                 <Route
-                  path=":username"
+                  path="name/:name"
                   element={<ShowResolvedPath path="." />}
                 />
               </Route>
@@ -127,7 +232,31 @@ describe("useResolvedPath", () => {
 
       expect(renderer.toJSON()).toMatchInlineSnapshot(`
         <pre>
-          {"pathname":"/users/mj","search":"","hash":""}
+          {"pathname":"/users/name/mj","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves .. to the parent route (inline param)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/name/mj"]}>
+            <Routes>
+              <Route path="/users">
+                <Route
+                  path="name/:name"
+                  element={<ShowResolvedPath path=".." />}
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users","search":"","hash":""}
         </pre>
       `);
     });

--- a/packages/react-router/__tests__/useResolvedPath-test.tsx
+++ b/packages/react-router/__tests__/useResolvedPath-test.tsx
@@ -106,7 +106,7 @@ describe("useResolvedPath", () => {
       `);
     });
 
-    it("resolves .. to the route path (nested splat)", () => {
+    it("resolves .. to the parent route path (nested splat)", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(
@@ -148,7 +148,7 @@ describe("useResolvedPath", () => {
       `);
     });
 
-    it("resolves .. to the route path (inline splat)", () => {
+    it("resolves .. to the parent route path (inline splat)", () => {
       let renderer: TestRenderer.ReactTestRenderer;
       TestRenderer.act(() => {
         renderer = TestRenderer.create(
@@ -157,6 +157,58 @@ describe("useResolvedPath", () => {
               <Route path="/users">
                 <Route path="name/*" element={<ShowResolvedPath path=".." />} />
               </Route>
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves . to the route path (descendant route)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/mj"]}>
+            <Routes>
+              <Route
+                path="/users/*"
+                element={
+                  <Routes>
+                    <Route path="mj" element={<ShowResolvedPath path="." />} />
+                  </Routes>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        );
+      });
+
+      expect(renderer.toJSON()).toMatchInlineSnapshot(`
+        <pre>
+          {"pathname":"/users/mj","search":"","hash":""}
+        </pre>
+      `);
+    });
+
+    it("resolves .. to the parent route path (descendant route)", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <MemoryRouter initialEntries={["/users/mj"]}>
+            <Routes>
+              <Route
+                path="/users/*"
+                element={
+                  <Routes>
+                    <Route path="mj" element={<ShowResolvedPath path=".." />} />
+                  </Routes>
+                }
+              />
             </Routes>
           </MemoryRouter>
         );

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -312,6 +312,8 @@ export function useResolvedPath(
   let { matches } = React.useContext(RouteContext);
   let { pathname: locationPathname } = useLocation();
 
+  // Use the full pathname for the leaf match so we include splat values
+  // for "." links
   let routePathnamesJson = JSON.stringify(
     getPathContributingMatches(matches).map((match, idx) =>
       idx === matches.length - 1 ? match.pathname : match.pathnameBase

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -313,7 +313,9 @@ export function useResolvedPath(
   let { pathname: locationPathname } = useLocation();
 
   let routePathnamesJson = JSON.stringify(
-    getPathContributingMatches(matches).map((match) => match.pathnameBase)
+    getPathContributingMatches(matches).map((match, idx) =>
+      idx === matches.length - 1 ? match.pathname : match.pathnameBase
+    )
   );
 
   return React.useMemo(


### PR DESCRIPTION
Second shot at a fix for #10922

Originally fixed in #10933 and reverted in #10965 due to issues.

The main issue seems to boil down to `useResolvedPath`'s longstanding behavior of using `pathnameBase` to construct the current route hierarchy.  `pathnameBase` never contains the splat - but `pathname` does.

This breaks a few existing uni tests that rely on the existing behavior - need to review with @mjackson.
