### PR TITLE
feat: add custom response decoding option

### DIFF
--- a/.changeset/decode-response.md
+++ b/.changeset/decode-response.md
@@ -1,0 +1,7 @@
+---
+"react-router-dom": minor
+"react-router": minor
+"@remix-run/router": minor
+---
+
+add decodeResponse option to createStaticHandler, createStaticRouter, createBrowserRouter, and createHashRouter

--- a/docs/routers/create-browser-router.md
+++ b/docs/routers/create-browser-router.md
@@ -101,6 +101,10 @@ createBrowserRouter(routes, {
 <Link to="/" />; // results in <a href="/app/" />
 ```
 
+## `decodeResponse`
+
+An optional hook to implement custom response decoding logic. This is where you could hook up libraries such as `super-json` or `turbo-stream`.
+
 ## `future`
 
 An optional set of [Future Flags][api-development-strategy] to enable for this Router. We recommend opting into newly released future flags sooner rather than later to ease your eventual migration to v7.

--- a/docs/routers/create-static-handler.md
+++ b/docs/routers/create-static-handler.md
@@ -82,6 +82,10 @@ interface StaticHandler {
 
 These are the same `routes`/`basename` you would pass to [`createBrowserRouter`][createbrowserrouter]
 
+## `decodeResponse`
+
+This is the same you would pass to [`createBrowserRouter`][createbrowserrouter]
+
 ## `handler.query(request, opts)`
 
 The `handler.query()` method takes in a Fetch request, performs route matching, and executes all relevant route action/loader methods depending on the request. The return `context` value contains all of the information required to render the HTML document for the request (route-level `actionData`, `loaderData`, `errors`, etc.). If any of the matched routes return or throw a redirect response, then `query()` will return that redirect in the form of Fetch `Response`.

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -730,6 +730,109 @@ function testDomRouter(
         `);
     });
 
+    it("executes route loaders on navigation with decodeRoute", async () => {
+      let barDefer = createDeferred();
+
+      let router = createTestRouter(
+        createRoutesFromElements(
+          <Route path="/" element={<Layout />}>
+            <Route path="foo" element={<Foo />} />
+            <Route
+              path="bar"
+              loader={() => barDefer.promise}
+              element={<Bar />}
+            />
+          </Route>
+        ),
+        {
+          window: getWindow("/foo"),
+          async decodeResponse(response, defaultDecode) {
+            let contentType = response.headers.get("Content-Type");
+            if (contentType === "text/custom") {
+              const text = await response.text();
+              switch (text) {
+                case "bar":
+                  return { message: "Bar Loader" };
+                default:
+                  return text;
+              }
+            }
+
+            return defaultDecode();
+          },
+        }
+      );
+      let { container } = render(<RouterProvider router={router} />);
+
+      function Layout() {
+        let navigation = useNavigation();
+        return (
+          <div>
+            <Link to="/bar">Link to Bar</Link>
+            <div id="output">
+              <p>{navigation.state}</p>
+              <Outlet />
+            </div>
+          </div>
+        );
+      }
+
+      function Foo() {
+        return <h1>Foo</h1>;
+      }
+      function Bar() {
+        let data = useLoaderData() as { message: string };
+        return <h1>{data.message}</h1>;
+      }
+
+      expect(getHtml(container.querySelector("#output")!))
+        .toMatchInlineSnapshot(`
+          "<div
+            id="output"
+          >
+            <p>
+              idle
+            </p>
+            <h1>
+              Foo
+            </h1>
+          </div>"
+        `);
+
+      fireEvent.click(screen.getByText("Link to Bar"));
+      expect(getHtml(container.querySelector("#output")!))
+        .toMatchInlineSnapshot(`
+          "<div
+            id="output"
+          >
+            <p>
+              loading
+            </p>
+            <h1>
+              Foo
+            </h1>
+          </div>"
+        `);
+
+      barDefer.resolve(
+        new Response("bar", { headers: { "Content-Type": "text/custom" } })
+      );
+      await waitFor(() => screen.getByText("idle"));
+      expect(getHtml(container.querySelector("#output")!))
+        .toMatchInlineSnapshot(`
+          "<div
+            id="output"
+          >
+            <p>
+              idle
+            </p>
+            <h1>
+              Bar Loader
+            </h1>
+          </div>"
+        `);
+    });
+
     it("executes lazy route loaders on navigation", async () => {
       let barDefer = createDeferred();
 

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -36,6 +36,7 @@ import {
 } from "react-router";
 import type {
   BrowserHistory,
+  DecodeResponseFunction,
   Fetcher,
   FormEncType,
   FormMethod,
@@ -231,6 +232,7 @@ interface DOMRouterOpts {
   future?: Partial<Omit<RouterFutureConfig, "v7_prependBasename">>;
   hydrationData?: HydrationState;
   window?: Window;
+  decodeResponse?: DecodeResponseFunction;
 }
 
 export function createBrowserRouter(
@@ -248,6 +250,7 @@ export function createBrowserRouter(
     routes,
     mapRouteProperties,
     window: opts?.window,
+    decodeResponse: opts?.decodeResponse,
   }).initialize();
 }
 
@@ -266,6 +269,7 @@ export function createHashRouter(
     routes,
     mapRouteProperties,
     window: opts?.window,
+    decodeResponse: opts?.decodeResponse,
   }).initialize();
 }
 

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -4,6 +4,7 @@ import type {
   ActionFunctionArgs,
   Blocker,
   BlockerFunction,
+  DecodeResponseFunction,
   ErrorResponse,
   Fetcher,
   HydrationState,
@@ -272,6 +273,7 @@ export function createMemoryRouter(
     hydrationData?: HydrationState;
     initialEntries?: InitialEntry[];
     initialIndex?: number;
+    decodeResponse?: DecodeResponseFunction;
   }
 ): RemixRouter {
   return createRouter({
@@ -287,6 +289,7 @@ export function createMemoryRouter(
     hydrationData: opts?.hydrationData,
     routes,
     mapRouteProperties,
+    decodeResponse: opts?.decodeResponse,
   }).initialize();
 }
 

--- a/packages/router/__tests__/router-test.ts
+++ b/packages/router/__tests__/router-test.ts
@@ -2790,7 +2790,7 @@ describe("a router", () => {
       expect(t.router.state.loaderData.test.toString()).toBe("a=1&b=2");
     });
 
-    it("handles errors thrown from unwrapResponse at the proper boundary", async () => {
+    it("handles errors thrown from decodeResponse at the proper boundary", async () => {
       let t = setup({
         routes: [
           {

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -9,6 +9,7 @@ export type {
   AgnosticNonIndexRouteObject,
   AgnosticRouteMatch,
   AgnosticRouteObject,
+  DecodeResponseFunction,
   ErrorResponse,
   FormEncType,
   FormMethod,

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -4015,9 +4015,14 @@ async function callLoaderOrAction(
       }
     };
 
-    let data = await (decodeResponse
-      ? decodeResponse(result, defaultDecode)
-      : defaultDecode());
+    let data: unknown;
+    try {
+      data = await (decodeResponse
+        ? decodeResponse(result, defaultDecode)
+        : defaultDecode());
+    } catch (e) {
+      return { type: ResultType.error, error: e };
+    }
 
     if (resultType === ResultType.error) {
       return {

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -233,6 +233,10 @@ export interface MapRoutePropertiesFunction {
   } & Record<string, any>;
 }
 
+export interface DecodeResponseFunction {
+  (response: Response, defaultDecode: () => Promise<unknown>): Promise<unknown>;
+}
+
 /**
  * Keys we cannot change from within a lazy() function. We spread all other keys
  * onto the route. Either they're meaningful to the router, or they'll get


### PR DESCRIPTION
This pull request introduces the feature to define custom response decoding logic through the `decodeResponse` option. This way, users have the flexibility to parse and manipulate API responses according to their specific needs before the data is further processed or consumed by the application.

The implementation was carried out by adding the `decodeResponse` option, which can be a function that takes the raw response and returns the decoded data. This feature provides more control over data handling, especially for APIs that return non-standard response structures that require custom parsing logic. It's especially useful in SSR scenarios where you wish to integrate a transport format such as `super-json`.