### PR TITLE
feat: add replace option to loader redirect function

### DIFF
--- a/.changeset/five-bottles-press.md
+++ b/.changeset/five-bottles-press.md
@@ -1,0 +1,11 @@
+---
+"@remix-run/router": minor
+---
+
+`redirect` now accepts a `replace` option in the same way as `navigate`.
+
+```ts
+loader: () => {
+  return redirect("/", { replace: true });
+};
+```

--- a/contributors.yml
+++ b/contributors.yml
@@ -34,6 +34,7 @@
 - bhbs
 - bilalk711
 - bobziroll
+- Brendonovich
 - BrianT1414
 - brockross
 - brookslybrand

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -1796,7 +1796,9 @@ export function createRouter(init: RouterInit): Router {
           revalidatingFetchers[redirect.idx - matchesToLoad.length].key;
         fetchRedirectIds.add(fetcherKey);
       }
-      await startRedirectNavigation(state, redirect.result, { replace });
+      await startRedirectNavigation(state, redirect.result, {
+        replace: replace || redirect.result.replace,
+      });
       return { shortCircuited: true };
     }
 
@@ -2118,7 +2120,9 @@ export function createRouter(init: RouterInit): Router {
           revalidatingFetchers[redirect.idx - matchesToLoad.length].key;
         fetchRedirectIds.add(fetcherKey);
       }
-      return startRedirectNavigation(state, redirect.result);
+      return startRedirectNavigation(state, redirect.result, {
+        replace: redirect.result.replace,
+      });
     }
 
     // Process and commit output from loaders
@@ -4066,6 +4070,7 @@ async function callLoaderOrAction(
         type: ResultType.redirect,
         status,
         location,
+        replace: result.headers.get("X-Remix-Redirect-Replace") !== null,
         revalidate: result.headers.get("X-Remix-Revalidate") !== null,
         reloadDocument: result.headers.get("X-Remix-Reload-Document") !== null,
       };

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -44,6 +44,7 @@ export interface RedirectResult {
   location: string;
   revalidate: boolean;
   reloadDocument?: boolean;
+  replace?: boolean;
 }
 
 /**
@@ -1543,7 +1544,7 @@ export const defer: DeferFunction = (data, init = {}) => {
 
 export type RedirectFunction = (
   url: string,
-  init?: number | ResponseInit
+  init?: number | (ResponseInit & { replace?: boolean })
 ) => Response;
 
 /**
@@ -1560,6 +1561,9 @@ export const redirect: RedirectFunction = (url, init = 302) => {
 
   let headers = new Headers(responseInit.headers);
   headers.set("Location", url);
+
+  if (typeof init === "object" && init.replace)
+    headers.set("X-Remix-Redirect-Replace", "true");
 
   return new Response(null, {
     ...responseInit,


### PR DESCRIPTION
This PR adds the ability to `REPLACE` the current history entry rather than always using `POP` when redirecting in route loaders.

This is useful for how we manage navigation in [Spacedrive](https://github.com/spacedriveapp/spacedrive):
- Our desktop app supports having multiple tabs, with each tab being its own `MemoryRouter` instance and history stack
- `index` routes contain loaders for going from `/` to `/{libraryId}` to `/{libraryId}/{defaultSegment}`, where `libraryId` is loaded asynchronously and `defaultSegment` is determined based on the result of another asynchronous operation
  - loaders are used so we can rely on `Suspense` to show the current tab until the new tab's redirects are complete, since loaders + their redirects all run in a single transition
- The traversal of those `index` routes shouldn't append to the history stack, so that `/{libraryId}/{defaultSegment}` is the 0th history entry
- Each new tab starts at `/{libraryId}`, so one loader run + one redirect is guaranteed to happen
- Currently, each tab automatically has a history stack of length 2 since the redirect that happens is a `PUSH`, not a `REPLACE`
- Our in-app back button can't disable itself properly as history stack length is always > 1

Allowing loader redirects to `REPLACE` rather than `PUSH` easily fixes our navigation button problem