### PR TITLE
doc edited for unstable_useViewTransitionState

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -63,6 +63,7 @@
 - dokeet
 - Drishtantr
 - edwin177
+- eiffelwong1
 - ek9
 - ekaansharora
 - elanis

--- a/docs/hooks/use-view-transition-state.md
+++ b/docs/hooks/use-view-transition-state.md
@@ -30,15 +30,15 @@ Consider clicking on an image in a list that you need to expand into the hero im
 
 ```jsx
 function NavImage({ src, alt, id }) {
-  let to = `/images/${idx}`;
-  let vt = unstable_useViewTransitionState(href);
+  const to = `/images/${id}`;
+  const isTransitioning = unstable_useViewTransitionState(to);
   return (
     <Link to={to} unstable_viewTransition>
       <img
         src={src}
         alt={alt}
         style={{
-          viewTransitionName: vt ? "image-expand" : "",
+          viewTransitionName: isTransitioning ? "image-expand" : "",
         }}
       />
     </Link>


### PR DESCRIPTION
# Summary

edited the `unstable_useViewTransitionState` document page for better correctness (correcting missing href and idx) of code and align closer with the examples under Components -> link -> unstable_viewtransition

link document referring to: https://remix.run/docs/en/main/components/link#unstable_viewtransition

somewhat new to open source contribution, let me know if I have done anything incorrectly