### PR TITLE
useLocation state generic type

### DIFF
--- a/.changeset/calm-items-listen.md
+++ b/.changeset/calm-items-listen.md
@@ -3,12 +3,18 @@
 "@remix-run/router": patch
 ---
 
-`useLocation` hook now accepts a state as generic.
+`useLocation` hook now accepts a state as a generic parameter.
 
-So, you are able to define
+Thus, if you've defined a state you want to send with navigate
+
+```ts
+navigate('thepath', { state: { from: 'Your message' } }) // string | boolean | number
+```
+
+you can retrieve this state in your target component like this:
 
 ```ts
 const location = useLocation<{from?: string}>();
 
-console.log(location.state?.from) // string | null | undefined
+console.log(location.state?.from) // "Your message" -> string | null | undefined
 ```

--- a/.changeset/calm-items-listen.md
+++ b/.changeset/calm-items-listen.md
@@ -1,0 +1,14 @@
+---
+"react-router": patch
+"@remix-run/router": patch
+---
+
+`useLocation` hook now accepts a state as generic.
+
+So, you are able to define
+
+```ts
+const location = useLocation<{from?: string}>();
+
+console.log(location.state?.from) // string | null | undefined
+```

--- a/contributors.yml
+++ b/contributors.yml
@@ -34,6 +34,7 @@
 - bhbs
 - bilalk711
 - bobziroll
+- boonya
 - BrianT1414
 - brockross
 - brookslybrand

--- a/docs/components/link-native.md
+++ b/docs/components/link-native.md
@@ -16,7 +16,7 @@ interface LinkProps extends TouchableHighlightProps {
   children?: React.ReactNode;
   onPress?(event: GestureResponderEvent): void;
   replace?: boolean;
-  state?: any;
+  state?: unknown;
   to: To;
 }
 ```

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -143,7 +143,9 @@ The `state` property can be used to set a stateful value for the new location wh
 You can access this state value while on the "new-path" route:
 
 ```ts
-let { state } = useLocation<{some?: string}>();
+const location = useLocation<{some?: string}>();
+
+location.state?.some //=> "value"
 ```
 
 ## `reloadDocument`

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -22,7 +22,7 @@ interface LinkProps
   relative?: "route" | "path";
   reloadDocument?: boolean;
   replace?: boolean;
-  state?: any;
+  state?: unknown;
   unstable_viewTransition?: boolean;
 }
 
@@ -143,7 +143,7 @@ The `state` property can be used to set a stateful value for the new location wh
 You can access this state value while on the "new-path" route:
 
 ```ts
-let { state } = useLocation();
+let { state } = useLocation<{some?: string}>();
 ```
 
 ## `reloadDocument`

--- a/docs/components/navigate.md
+++ b/docs/components/navigate.md
@@ -13,7 +13,7 @@ declare function Navigate(props: NavigateProps): null;
 interface NavigateProps {
   to: To;
   replace?: boolean;
-  state?: any;
+  state?: unknown;
   relative?: RelativeRoutingType;
 }
 ```

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -8,9 +8,9 @@ title: useLocation
   <summary>Type declaration</summary>
 
 ```tsx
-declare function useLocation(): Location;
+declare function useLocation<State = unknown>(): Location<State | null>;
 
-interface Location<State = any> extends Path {
+interface Location<State = null> extends Path {
   state: State;
   key: string;
 }

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -68,6 +68,14 @@ You may include an optional `state` value to store in [history state][history-st
 navigate("/new-route", { state: { key: "value" } });
 ```
 
+you can retrieve this state in your target component like this:
+
+```ts
+const location = useLocation<{key?: string}>();
+
+location.state?.key //=> "value"
+```
+
 ## `options.preventScrollReset`
 
 When using the [`<ScrollRestoration>`][scrollrestoration] component, you can disable resetting the scroll to the top of the page via `options.preventScrollReset`

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -17,7 +17,7 @@ interface NavigateFunction {
 
 interface NavigateOptions {
   replace?: boolean;
-  state?: any;
+  state?: unknown;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   unstable_flushSync?: boolean;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -100,7 +100,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/hooks/use-location
  */
-export function useLocation(): Location {
+export function useLocation<State = unknown>(): Location<State | null> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -56,7 +56,7 @@ export interface Path {
  * An entry in a history stack. A location contains information about the
  * URL path, as well as possibly some arbitrary state and a key.
  */
-export interface Location<State = any> extends Path {
+export interface Location<State = unknown> extends Path {
   /**
    * A value of arbitrary data associated with this location.
    */


### PR DESCRIPTION
`useLocation` hook now accepts a state as a generic parameter.

Thus, if you've defined a state you want to send with navigate

```ts
navigate('thepath', { state: { from: 'Your message' } }) // string | boolean | number
```

you can retrieve this state in your target component like this:

```ts
const location = useLocation<{from?: string}>();

console.log(location.state?.from) // "Your message" -> string | null | undefined
```

**P.S.** I think my PR is related to the issue https://github.com/remix-run/react-router/issues/10441