### PR TITLE
Fix Headers constructor with undefined

### DIFF
--- a/.changeset/chatty-buckets-lay.md
+++ b/.changeset/chatty-buckets-lay.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fixes error relating to `TypeError: Failed to construct 'Headers': No matching constructor signature` on certain versions of Tizen and Samsung Internet

--- a/contributors.yml
+++ b/contributors.yml
@@ -214,6 +214,7 @@
 - stasundr
 - stmtk1
 - swalker326
+- tacheometry
 - tanayv
 - thecode00
 - theostavrides

--- a/packages/router/__tests__/utils/custom-matchers.ts
+++ b/packages/router/__tests__/utils/custom-matchers.ts
@@ -45,13 +45,13 @@ export function deferredData(received, done, status = 200, headers = {}) {
       `instead got done=${String(deferredData.done)}/status=${
         deferredData.init!.status || 200
       }/headers=${JSON.stringify(
-        Object.fromEntries(new Headers(deferredData.init!.headers).entries())
+        Object.fromEntries(new Headers(deferredData.init!.headers ?? {}).entries())
       )}`,
     pass:
       deferredData.done === done &&
       (deferredData.init!.status || 200) === status &&
       JSON.stringify(
-        Object.fromEntries(new Headers(deferredData.init!.headers).entries())
+        Object.fromEntries(new Headers(deferredData.init!.headers ?? {}).entries())
       ) === JSON.stringify(headers),
   };
 }

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1300,7 +1300,7 @@ export type JsonFunction = <Data>(
 export const json: JsonFunction = (data, init = {}) => {
   let responseInit = typeof init === "number" ? { status: init } : init;
 
-  let headers = new Headers(responseInit.headers);
+  let headers = new Headers(responseInit.headers ?? {});
   if (!headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json; charset=utf-8");
   }
@@ -1535,7 +1535,7 @@ export const redirect: RedirectFunction = (url, init = 302) => {
     responseInit.status = 302;
   }
 
-  let headers = new Headers(responseInit.headers);
+  let headers = new Headers(responseInit.headers ?? {});
   headers.set("Location", url);
 
   return new Response(null, {


### PR DESCRIPTION
## Issue description

A friend was having issues with Jellyfin on his Samsung Smart TV. Running the program, this is what he got:

![TypeError: Failed to construct 'Headers': No matching constructor signature.](https://github.com/remix-run/react-router/assets/39647014/6b79abc8-d8a5-4b04-b272-cc35b1d71c4f)

It reads out: `TypeError: Failed to construct 'Headers': No matching constructor signature.`

Tracking this down, it is due to some `react-router` code. Turns out, this is due to a bug in Samsung's JavaScript implementation. `new Headers(undefined)` should be a valid constructor, but running this on Samsung, this errors. I suggested updating the browser, but this was not possible, as the version was locked.

## Fix

Thus, like in other projects I've seen, I've implemented the fix of running the constructor with an empty object (`new Headers({})`) instead of `undefined` or `null` (~~`new Headers(undefined)`~~).

This is inspired from the following work:
- https://github.com/GoogleChrome/workbox/issues/1461 with the fix of https://github.com/GoogleChrome/workbox/pull/1463
- https://github.com/connectrpc/connect-es/issues/231 with the fix of https://github.com/connectrpc/connect-es/pull/232
- https://github.com/whatwg/fetch/issues/185

These changes increase compatibility, making it possible to run `react-router` on older browser implementations, and introduce no breaking changes.

After building using this fork of React Router, the program was no longer crashing on my friend's Tizen system.