### PR TITLE
documentation fix: "Server-Side Rendering" link in loader.md redirecting to 404

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -248,3 +248,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- KaranRandhir

--- a/docs/route/loader.md
+++ b/docs/route/loader.md
@@ -178,5 +178,5 @@ For more details, read the [`errorElement`][errorelement] documentation.
 [json]: ../fetch/json
 [errorelement]: ./error-element
 [pickingarouter]: ../routers/picking-a-router
-[ssr]: ../guides/ssr.md
+[ssr]: ../guides/ssr
 [partialhydration]: ../routers/create-browser-router#partial-hydration-data


### PR DESCRIPTION
hyperlink on the text "Server-Side Rendering" is redirecting to not found page. Removing .md from the link redirects to the correct route.