### PR TITLE
Leverage useId for internal fetcher keys when available

### DIFF
--- a/.changeset/fetcher-key-useid.md
+++ b/.changeset/fetcher-key-useid.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+Leverage `useId` for internal fetcher keys when available

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -5368,9 +5368,11 @@ function testDomRouter(
             { window: getWindow("/") }
           );
           let { container } = render(<RouterProvider router={router} />);
-          expect(container.innerHTML).not.toMatch(/__\d+__,my-key/);
+          expect(container.innerHTML).not.toMatch(/my-key/);
           await waitFor(() =>
-            expect(container.innerHTML).toMatch(/__\d+__,my-key/)
+            // React `useId()` results in either `:r2a:` or `:rp:` depending on
+            // `DataBrowserRouter`/`DataHashRouter`
+            expect(container.innerHTML).toMatch(/(:r2a:|:rp:),my-key/)
           );
         });
       });

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -396,6 +396,8 @@ const START_TRANSITION = "startTransition";
 const startTransitionImpl = React[START_TRANSITION];
 const FLUSH_SYNC = "flushSync";
 const flushSyncImpl = ReactDOM[FLUSH_SYNC];
+const USE_ID = "useId";
+const useIdImpl = React[USE_ID];
 
 function startTransitionSafe(cb: () => void) {
   if (startTransitionImpl) {
@@ -1634,10 +1636,14 @@ export function useFetcher<TData = any>({
   );
 
   // Fetcher key handling
-  let [fetcherKey, setFetcherKey] = React.useState<string>(key || "");
+  // OK to call conditionally to feature detect `useId`
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  let defaultKey = useIdImpl ? useIdImpl() : "";
+  let [fetcherKey, setFetcherKey] = React.useState<string>(key || defaultKey);
   if (key && key !== fetcherKey) {
     setFetcherKey(key);
   } else if (!fetcherKey) {
+    // We will only fall through here when `useId` is not available
     setFetcherKey(getUniqueFetcherId());
   }
 


### PR DESCRIPTION
Still digging but for some reason the `setState` during render of `useFetcher` to assign the internal unique incrementing `key` causes `useId` to return unstable values on client and server.  The "proper" fix for React 18 is to use `useId` to generate fetcher keys and avoid the incrementing key hack, but we need to support React 17 in React Router as well. 

We can feature detect `useId` and use it when available, and fall back on the current approach for React 17 and below.
 
Closes https://github.com/remix-run/remix/issues/8393