### PR TITLE
URL param validation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -239,6 +239,7 @@
 - vishwast03
 - vonagam
 - WalkAlone0325
+- wille
 - willemarcel
 - williamsdyyz
 - willsawyerrrr

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -27,6 +27,10 @@ const router = createBrowserRouter([
       );
     },
 
+    validateParams: ({ teamId }) => {
+      return !isNaN(Number(teamId));
+    }
+
     // performing this mutation when data is submitted to it
     action: async ({ request }) => {
       return updateFakeTeam(await request.formData());

--- a/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
+++ b/packages/react-router/__tests__/createRoutesFromChildren-test.tsx
@@ -39,6 +39,7 @@ describe("creating routes from JSX", () => {
               "loader": undefined,
               "path": "home",
               "shouldRevalidate": undefined,
+              "validateParams": undefined,
             },
             {
               "Component": undefined,
@@ -57,6 +58,7 @@ describe("creating routes from JSX", () => {
               "loader": undefined,
               "path": "about",
               "shouldRevalidate": undefined,
+              "validateParams": undefined,
             },
             {
               "Component": undefined,
@@ -81,6 +83,7 @@ describe("creating routes from JSX", () => {
                   "loader": undefined,
                   "path": undefined,
                   "shouldRevalidate": undefined,
+                  "validateParams": undefined,
                 },
                 {
                   "Component": undefined,
@@ -99,6 +102,7 @@ describe("creating routes from JSX", () => {
                   "loader": undefined,
                   "path": ":id",
                   "shouldRevalidate": undefined,
+                  "validateParams": undefined,
                 },
               ],
               "element": undefined,
@@ -111,6 +115,7 @@ describe("creating routes from JSX", () => {
               "loader": undefined,
               "path": "users",
               "shouldRevalidate": undefined,
+              "validateParams": undefined,
             },
           ],
           "element": undefined,
@@ -123,6 +128,7 @@ describe("creating routes from JSX", () => {
           "loader": undefined,
           "path": "/",
           "shouldRevalidate": undefined,
+          "validateParams": undefined,
         },
       ]
     `);
@@ -173,6 +179,7 @@ describe("creating routes from JSX", () => {
               "loader": [Function],
               "path": "home",
               "shouldRevalidate": [Function],
+              "validateParams": undefined,
             },
             {
               "Component": undefined,
@@ -197,6 +204,7 @@ describe("creating routes from JSX", () => {
                   "loader": undefined,
                   "path": undefined,
                   "shouldRevalidate": undefined,
+                  "validateParams": undefined,
                 },
               ],
               "element": undefined,
@@ -209,6 +217,7 @@ describe("creating routes from JSX", () => {
               "loader": undefined,
               "path": "users",
               "shouldRevalidate": undefined,
+              "validateParams": undefined,
             },
           ],
           "element": undefined,
@@ -223,6 +232,7 @@ describe("creating routes from JSX", () => {
           "loader": undefined,
           "path": "/",
           "shouldRevalidate": undefined,
+          "validateParams": undefined,
         },
       ]
     `);

--- a/packages/react-router/__tests__/path-matching-test.tsx
+++ b/packages/react-router/__tests__/path-matching-test.tsx
@@ -1,5 +1,5 @@
 import type { RouteObject } from "react-router";
-import { matchRoutes } from "react-router";
+import { matchPath, matchRoutes } from "react-router";
 
 function pickPaths(routes: RouteObject[], pathname: string): string[] | null {
   let matches = matchRoutes(routes, pathname);
@@ -330,6 +330,30 @@ describe("path matching with splats", () => {
     `);
 
     consoleWarn.mockRestore();
+  });
+});
+
+describe("path matching with param validation", () => {
+  test("optional static segment at the start of the path", () => {
+    let routes = [
+      {
+        path: "/test/:param?",
+        validateParams: (params) => {
+          return params.param === "hi";
+        },
+      },
+    ];
+
+    expect(matchRoutes(routes, "/test/hi")).toMatchObject([
+      {
+        pathname: "/test/hi",
+        params: {
+          param: "hi",
+        },
+      },
+    ]);
+
+    expect(matchRoutes(routes, '/test/not-hi')).toBeNull();
   });
 });
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -342,6 +342,7 @@ export interface PathRouteProps {
   action?: NonIndexRouteObject["action"];
   hasErrorBoundary?: NonIndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: NonIndexRouteObject["shouldRevalidate"];
+  validateParams?: NonIndexRouteObject["validateParams"];
   handle?: NonIndexRouteObject["handle"];
   index?: false;
   children?: React.ReactNode;

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -365,6 +365,7 @@ export interface IndexRouteProps {
   action?: IndexRouteObject["action"];
   hasErrorBoundary?: IndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: IndexRouteObject["shouldRevalidate"];
+  validateParams?: IndexRouteObject["validateParams"];
   handle?: IndexRouteObject["handle"];
   index: true;
   children?: undefined;
@@ -708,6 +709,7 @@ export function createRoutesFromChildren(
       action: element.props.action,
       errorElement: element.props.errorElement,
       ErrorBoundary: element.props.ErrorBoundary,
+      validateParams: element.props.validateParams,
       hasErrorBoundary:
         element.props.ErrorBoundary != null ||
         element.props.errorElement != null,

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -24,6 +24,7 @@ export interface IndexRouteObject {
   action?: AgnosticIndexRouteObject["action"];
   hasErrorBoundary?: AgnosticIndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: AgnosticIndexRouteObject["shouldRevalidate"];
+  validateParams?: AgnosticIndexRouteObject["validateParams"];
   handle?: AgnosticIndexRouteObject["handle"];
   index: true;
   children?: undefined;
@@ -44,6 +45,7 @@ export interface NonIndexRouteObject {
   action?: AgnosticNonIndexRouteObject["action"];
   hasErrorBoundary?: AgnosticNonIndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: AgnosticNonIndexRouteObject["shouldRevalidate"];
+  validateParams?: AgnosticNonIndexRouteObject["validateParams"];
   handle?: AgnosticNonIndexRouteObject["handle"];
   index?: false;
   children?: RouteObject[];

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -270,12 +270,15 @@ export interface LazyRouteFunction<R extends AgnosticRouteObject> {
   (): Promise<RequireOne<Omit<R, ImmutableRouteKey>>>;
 }
 
+export type ValidateParamsFunction = (params: Params) => boolean;
+
 /**
  * Base RouteObject with common props shared by all types of routes
  */
 type AgnosticBaseRouteObject = {
   caseSensitive?: boolean;
   path?: string;
+  validateParams?: ValidateParamsFunction;
   id?: string;
   loader?: LoaderFunction;
   action?: ActionFunction;
@@ -760,6 +763,12 @@ function matchRouteBranch<
     if (!match) return null;
 
     Object.assign(matchedParams, match.params);
+
+    if (meta.route.validateParams) {
+      if (!meta.route.validateParams(matchedParams)) {
+        return null;
+      }
+    }
 
     let route = meta.route;
 


### PR DESCRIPTION
Introduces a `validateParams` prop on `<Route />` and `matchPath`

Previously discussed here https://github.com/remix-run/react-router/discussions/8125#discussioncomment-1616128

My use case is having lots of similar route patterns with dynamic parameters that does different things.

Of course I could have a splash route that matches everything and then do the validation in the component but that would be another layer of self made routing and since I'm using `matchRoutes` on the server to decide if it's a valid page or not, I cannot quickly decide if its a valid page because matchRoutes would still return a match for a wildcard that I decide is not valid further down in my own routing code.

Right now to implement something similar, you need to do something like this, I'm highlighting the drawbacks below in some sample code
```js
const reactRoutes = (
  <Route element={<Root />}>
    <Route path="/something"/>
    <Route path="/somethingelse"/>
    
    {/*
    Problem 1: I cannot use layout routes here because the routing happens in my own component
    */}
    <Route path="*" element={<MyRouter />}/>
  </Route>
/>
)

const customRoutes = [
  ['/:country/:language?/:category/:subcategory?', ProductListingPage],
  ['/:country/:language?/:productId', ProductPage]
];
function customMatchRoutes(pathname) {
  for (const [pattern, Component] of customRoutes) {
    // Using matchPath to see if it's a match or not, and then validating the params, and if the params aren't valid, continue to the next pattern
    const match = matchPath(pattern, pathname);
    if (match) {
      if (!isValidCountry(match.params.country)) continue;
      if (!isValidLanguage(match.params.language)) continue;
      if (!isValidCategory(match.params.category)) continue;
      // etc
  
      // Problem 2: useParams() will not work since matching happened outside of the router context
      return <Component params={match.params} />;
    }
  }
  return null;
}
function MyRouter() {
  const { pathname } = useLocation();
  const element = customMatchRoutes(customRoutes, pathname);
  return element;
}

// express
express.get('*', (req, res, next) => {
  const matches = matchRoutes(reactRoutes, req.path);

  if (!matches) {
    return res.sendStatus(404)
  }

  let element;

  // Problem 3: I cannot rely on matchRoutes because it will always match the splat route
  // I will have to check if the match is a splat, then run my own route validation here as well
  if (matches.some(match => match.route.path === '*')) {
    element = customMatchRoutes(req.path);
    if (!match) {
      return res.sendStatus(404)
    }
  } else {
    element = renderMatches(matches);
  }

  const html = ReactDOM.renderToString(
    <StaticRouter location={req.path}>
      {element}
    </StaticRouter>
  )
  res.write(html)
})
```

Building this functionality directly into react-router would allow us to just do this

```js
// Page to view product listings
// Valid links are
// /us/fast-cars
// /us/fast-cars/ferrari
// /us/es/fast-cars
// /us/es/fast-cars/ferrari
<Route
  path="/:country/:language?/:category/:subcategory?"
  validateParams={({ country, language, category, subcategory }) => {
    if (!['us', 'en', 'se', 'de'].includes(country)) {
      return false
    }
    if (language && !['en', 'es'].includes(language)) {
      return false
    }
    if (category !== 'fast-cars') {
      return false
    }
    // etc, this goes on
    return true
  }}
/>


// Page to view a product
// One of
// /us/ferrari-f90
// /us/es/ferrari-f90
<Route
  path="/:country?/:language?/:productId"
  validateParams={({ country, language, productId }) => {
    if (country && !['us', 'en', 'se', 'de'].includes(country)) {
      return false
    }
    if (language && !['en', 'es'].includes(language)) {
      return false
    }
    // Don't know the product IDs in advance
    return true
  }}
/>

// express
express.get('*', (req, res, next) => {
  // Can rely on matchRoutes
  const matches = matchRoutes(reactRoutes, req.path);

  if (!matches) {
    return res.sendStatus(404)
  }
})
```

This would allow us to use layout routes and have all the routing centralized.