### PR TITLE
Strongly Typed state in useLocation() hook

### DIFF
--- a/.changeset/lemon-cars-roll.md
+++ b/.changeset/lemon-cars-roll.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Strongly typed `State` in useLocation() hook

--- a/contributors.yml
+++ b/contributors.yml
@@ -181,6 +181,7 @@
 - Obi-Dann
 - omar-moquete
 - p13i
+- pankaj-ch
 - parched
 - parveen232
 - paulsmithkc

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -8,7 +8,7 @@ title: useLocation
   <summary>Type declaration</summary>
 
 ```tsx
-declare function useLocation(): Location;
+declare function useLocation<State = unknown>(): Location<State | null>;
 
 interface Location<State = any> extends Path {
   state: State;

--- a/docs/hooks/use-location.md
+++ b/docs/hooks/use-location.md
@@ -8,7 +8,7 @@ title: useLocation
   <summary>Type declaration</summary>
 
 ```tsx
-declare function useLocation<State = unknown>(): Location<State | null>;
+declare function useLocation<State = any>(): Location<State | null>;
 
 interface Location<State = any> extends Path {
   state: State;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -100,7 +100,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/hooks/use-location
  */
-export function useLocation<T = unknown>(): Location<T | null> {
+export function useLocation<State = any>(): Location<State | null> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -100,7 +100,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/hooks/use-location
  */
-export function useLocation(): Location {
+export function useLocation<T = unknown>(): Location<T | null> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the

--- a/packages/router/__tests__/navigation-test.ts
+++ b/packages/router/__tests__/navigation-test.ts
@@ -171,7 +171,7 @@ describe("navigations", () => {
       expect(t.router.state.loaderData).toEqual({});
       expect(t.router.state.errors).toMatchInlineSnapshot(`
         {
-          "foo": [SyntaxError: Unexpected token } in JSON at position 15],
+          "foo": [SyntaxError: Unexpected non-whitespace character after JSON at position 15],
         }
       `);
     });
@@ -206,7 +206,7 @@ describe("navigations", () => {
       expect(t.router.state.loaderData).toEqual({});
       expect(t.router.state.errors).toMatchInlineSnapshot(`
         {
-          "root": [SyntaxError: Unexpected token } in JSON at position 15],
+          "root": [SyntaxError: Unexpected non-whitespace character after JSON at position 15],
         }
       `);
     });


### PR DESCRIPTION
## What got changed?

- Pass `State` generic to `Location<any>` type. This will enable us to strongly type the location state in the useLocation() hook. Just like we used to in react-router-dom v5 with the help of `@types/react-router-dom` pkg.
- Update failing jest snapshot


Usage Example:
```tsx
const { state } = useLocation<{from?: string}>();
```

Current workaround: Include this in your .d.ts file

```.d.ts
import 'react-router-dom';
import { Path } from 'react-router-dom';

interface Location<State = any> extends Path {
  state: State;
  key: string;
}

declare module 'react-router-dom' {
  declare function useLocation<State = any>(): Location<State | null>;
}
```