### PR TITLE
Respect the ErrorResponse status code if passed to getStaticContextFromError

### DIFF
--- a/.changeset/static-context-error-status-code.md
+++ b/.changeset/static-context-error-status-code.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Respect the `ErrorResponse` status code if passed to `getStaticContextFormError`

--- a/packages/router/__tests__/ssr-test.ts
+++ b/packages/router/__tests__/ssr-test.ts
@@ -1,5 +1,9 @@
 import type { StaticHandler, StaticHandlerContext } from "../router";
-import { UNSAFE_DEFERRED_SYMBOL, createStaticHandler } from "../router";
+import {
+  UNSAFE_DEFERRED_SYMBOL,
+  createStaticHandler,
+  getStaticContextFromError,
+} from "../router";
 import {
   ErrorResponseImpl,
   defer,
@@ -9,7 +13,7 @@ import {
 } from "../utils";
 import { deferredData, trackedPromise } from "./utils/custom-matchers";
 import { createDeferred } from "./utils/data-router-setup";
-import { createRequest, createSubmitRequest } from "./utils/utils";
+import { createRequest, createSubmitRequest, invariant } from "./utils/utils";
 
 interface CustomMatchers<R = jest.Expect> {
   trackedPromise(data?: any, error?: any, aborted?: boolean): R;
@@ -1279,6 +1283,58 @@ describe("ssr", () => {
         expect(Array.from(context.actionHeaders.child.entries())).toEqual([
           ["one", "1"],
         ]);
+      });
+    });
+
+    describe("getStaticContextFromError", () => {
+      it("should provide a context for a second-pass render for a thrown error", async () => {
+        let { query } = createStaticHandler(SSR_ROUTES);
+        let context = await query(createRequest("/"));
+        expect(context).toMatchObject({
+          errors: null,
+          loaderData: {
+            index: "INDEX LOADER",
+          },
+          statusCode: 200,
+        });
+
+        let error = new Error("💥");
+        invariant(!(context instanceof Response), "Uh oh");
+        context = getStaticContextFromError(SSR_ROUTES, context, error);
+        expect(context).toMatchObject({
+          errors: {
+            index: error,
+          },
+          loaderData: {
+            index: "INDEX LOADER",
+          },
+          statusCode: 500,
+        });
+      });
+
+      it("should accept a thrown response from entry.server", async () => {
+        let { query } = createStaticHandler(SSR_ROUTES);
+        let context = await query(createRequest("/"));
+        expect(context).toMatchObject({
+          errors: null,
+          loaderData: {
+            index: "INDEX LOADER",
+          },
+          statusCode: 200,
+        });
+
+        let errorResponse = new ErrorResponseImpl(400, "Bad Request", "Oops!");
+        invariant(!(context instanceof Response), "Uh oh");
+        context = getStaticContextFromError(SSR_ROUTES, context, errorResponse);
+        expect(context).toMatchObject({
+          errors: {
+            index: errorResponse,
+          },
+          loaderData: {
+            index: "INDEX LOADER",
+          },
+          statusCode: 400,
+        });
       });
     });
   });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3372,7 +3372,7 @@ export function getStaticContextFromError(
 ) {
   let newContext: StaticHandlerContext = {
     ...context,
-    statusCode: 500,
+    statusCode: isRouteErrorResponse(error) ? error.status : 500,
     errors: {
       [context._deepestRenderedBoundaryId || routes[0].id]: error,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3644,9 +3644,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001517:
-  version "1.0.30001518"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz#b3ca93904cb4699c01218246c4d77a71dbe97150"
-  integrity sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==
+  version "1.0.30001579"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz"
+  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
 
 ccount@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This will allow us to respect status codes from thrown `Response`'s in Remix `entry.server`