### PR TITLE
fix: memoize useFetchers

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -101,6 +101,7 @@
 - Ivanrenes
 - JackPriceBurns
 - jacob-ebey
+- jacobparis
 - JaffParker
 - jakkku
 - JakubDrozd

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1738,10 +1738,14 @@ export function useFetcher<TData = any>({
  */
 export function useFetchers(): (Fetcher & { key: string })[] {
   let state = useDataRouterState(DataRouterStateHook.UseFetchers);
-  return Array.from(state.fetchers.entries()).map(([key, fetcher]) => ({
-    ...fetcher,
-    key,
-  }));
+  return React.useMemo(
+    () =>
+      Array.from(state.fetchers.entries()).map(([key, fetcher]) => ({
+        ...fetcher,
+        key,
+      })),
+    [state.fetchers]
+  );
 }
 
 const SCROLL_RESTORATION_STORAGE_KEY = "react-router-scroll-positions";


### PR DESCRIPTION
useFetchers currently returns a new array on every render. This PR memoizes it based on the internal useDataRouterState which appears to be stable as long as the fetchers aren't actually changing. 

The included test fails before the fix with `fetchers count: 3` and passes after the fix