### PR TITLE
Update context provider link to point to React's new documentation site

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -220,6 +220,7 @@
 - swalker326
 - tanayv
 - thecode00
+- thepedroferrari
 - theostavrides
 - thisiskartik
 - thomasverleye

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -15,7 +15,7 @@ declare function useOutletContext<
 
 </details>
 
-Often parent routes manage state or other values you want shared with child routes. You can create your own [context provider](https://react.dev/reference/react/createContext) if you like, but this is such a common situation that it's built-into `<Outlet />`:
+Often parent routes manage state or other values you want shared with child routes. You can create your own [context provider](https://react.dev/learn/passing-data-deeply-with-context) if you like, but this is such a common situation that it's built-into `<Outlet />`:
 
 ```tsx lines=[3]
 function Parent() {

--- a/docs/hooks/use-outlet-context.md
+++ b/docs/hooks/use-outlet-context.md
@@ -15,7 +15,7 @@ declare function useOutletContext<
 
 </details>
 
-Often parent routes manage state or other values you want shared with child routes. You can create your own [context provider](https://reactjs.org/docs/context.html) if you like, but this is such a common situation that it's built-into `<Outlet />`:
+Often parent routes manage state or other values you want shared with child routes. You can create your own [context provider](https://react.dev/reference/react/createContext) if you like, but this is such a common situation that it's built-into `<Outlet />`:
 
 ```tsx lines=[3]
 function Parent() {


### PR DESCRIPTION
Docs: Update context provider link in useOutletContext section

This change updates the markdown link for the context provider reference to point directly to the `createContext` documentation on React's new site, ensuring users have access to the latest information.

Let me know if you prefer an update to another of theirs URL, I felt that the createContext was more direct connected to what the docs meant, but it could also be https://react.dev/learn/passing-data-deeply-with-context if you prefer to go to a more generic context page.