### PR TITLE
Don't run loaders below the boundary during partial hydration

### DIFF
--- a/.changeset/partial-hydration-bubbled-error.md
+++ b/.changeset/partial-hydration-bubbled-error.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix a `future.v7_partialHydration` bug that would re-run loaders below the boundary on hydration if SSR loader errors bubbled to a parent boundary

--- a/packages/router/__tests__/route-fallback-test.ts
+++ b/packages/router/__tests__/route-fallback-test.ts
@@ -401,7 +401,7 @@ describe("future.v7_partialHydration", () => {
       });
     });
 
-    it("does not kick off initial data load if errors exist", async () => {
+    it("does not kick off initial data load if errors exist (parent error)", async () => {
       let consoleWarnSpy = jest
         .spyOn(console, "warn")
         .mockImplementation(() => {});
@@ -451,6 +451,63 @@ describe("future.v7_partialHydration", () => {
         },
         loaderData: {
           "0-0": "CHILD_DATA",
+        },
+      });
+
+      router.dispose();
+      consoleWarnSpy.mockReset();
+    });
+
+    it("does not kick off initial data load if errors exist (bubbled child error)", async () => {
+      let consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      let parentDfd = createDeferred();
+      let parentSpy = jest.fn(() => parentDfd.promise);
+      let childDfd = createDeferred();
+      let childSpy = jest.fn(() => childDfd.promise);
+      let router = createRouter({
+        history: createMemoryHistory({ initialEntries: ["/child"] }),
+        routes: [
+          {
+            path: "/",
+            loader: parentSpy,
+            children: [
+              {
+                path: "child",
+                loader: childSpy,
+              },
+            ],
+          },
+        ],
+        future: {
+          v7_partialHydration: true,
+        },
+        hydrationData: {
+          errors: {
+            "0": "CHILD ERROR",
+          },
+          loaderData: {
+            "0": "PARENT DATA",
+          },
+        },
+      });
+      router.initialize();
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(parentSpy).not.toHaveBeenCalled();
+      expect(childSpy).not.toHaveBeenCalled();
+      expect(router.state).toMatchObject({
+        historyAction: "POP",
+        location: expect.objectContaining({ pathname: "/child" }),
+        matches: [{ route: { path: "/" } }, { route: { path: "child" } }],
+        initialized: true,
+        navigation: IDLE_NAVIGATION,
+        errors: {
+          "0": "CHILD ERROR",
+        },
+        loaderData: {
+          "0": "PARENT DATA",
         },
       });
 


### PR DESCRIPTION
Came across this during the single fetch work, where if a child loader threw on SSR and bubbled to the parent, we'd see that the child route had a loader and no `loaderData`/`errors` on the client and think we needed to re-run it