### PR TITLE
docs: Fix use-navigate.md example output in section on using useLocation with the URL constructor

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,6 +3,7 @@
 - abeadam
 - abhi-kr-2100
 - AchThomas
+- acusti
 - adamdotjs
 - adil62
 - adriananin

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -109,7 +109,7 @@ new URL("..", window.origin + location.pathname);
 
 // With trailing slashes:
 new URL(".", window.origin + location.pathname + "/");
-// 'https://remix.run/docs/en/main/start/future-flags/'
+// 'https://remix.run/docs/en/main/start/quickstart/'
 new URL("..", window.origin + location.pathname + "/");
 // 'https://remix.run/docs/en/main/start/'
 ```


### PR DESCRIPTION
the top of the code block specifies
```js
// Assume the current URL is https://remix.run/docs/en/main/start/quickstart
```

but the expected output is based on the current URL being `https://remix.run/docs/en/main/start/future-flags`.