### PR TITLE
docs:add changelog doc

### DIFF
--- a/docs/start/changelog.md
+++ b/docs/start/changelog.md
@@ -1,0 +1,9 @@
+---
+title: Changelog
+---
+
+# Changelog
+
+See the detailed changelog for each release on [GitHub][changelog].
+
+[changelog]: https://github.com/remix-run/react-router/blob/main/CHANGELOG.md


### PR DESCRIPTION
Just like the Remix docs have a changelog, now so will the react router docs!

Note: this is just a placeholder, [we'll render the actual CHANGELOG file](https://github.com/remix-run/react-router-website/issues/94)