### PR TITLE
Remove flags

### DIFF
--- a/.changeset/funny-tips-beg.md
+++ b/.changeset/funny-tips-beg.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+[REMOVE] Remove staticHandler.query flags that we can implement in dataStrategy

--- a/.changeset/slow-flies-help.md
+++ b/.changeset/slow-flies-help.md
@@ -3,4 +3,3 @@
 ---
 
 - Move `unstable_dataStrategy` from `createStaticHandler` to `staticHandler.query` so it can be request-specific for use with the `ResponseStub` approach in Remix. It's not really applicable to `queryRoute` for now since that's a singular handler call anyway so any pre-processing/post/processing could be done there manually.
-- Added a new `skipLoaders` flag to `staticHandler.query` for calling only the action in Remix Single Fetch

--- a/.changeset/static-query-flags.md
+++ b/.changeset/static-query-flags.md
@@ -2,7 +2,4 @@
 "@remix-run/router": minor
 ---
 
-Added 2 new options to the `staticHandler.query` method for use in Remix's Single Fetch implementation:
-
-- `loadRouteIds`: An optional array of route IDs to load if you wish to load a subset of the matched routes (useful for fine-grained revalidation)
-- `skipLoaderErrorBubbling`: Disable error bubbling on loader executions for single-fetch scenarios where the client-side router will handle the bubbling
+Added a `skipLoaderErrorBubbling` flag to `staticHandler.query` to disable error bubbling on loader executions for single-fetch scenarios where the client-side router will handle the bubbling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,10 +202,7 @@ With this flag enabled, `action`'s that return/throw a `4xx`/`5xx` response stat
 
 - Add a new `unstable_dataStrategy` configuration option ([#11098](https://github.com/remix-run/react-router/pull/11098), ([#11377](https://github.com/remix-run/react-router/pull/11377)))
 - `@remix-run/router` - Add a new `future.unstable_skipActionRevalidation` future flag ([#11098](https://github.com/remix-run/react-router/pull/11098))
-- `@remix-run/router` - SSR: Added 3 new options to the `staticHandler.query` method for use in Remix's Single Fetch implementation: ([#11098](https://github.com/remix-run/react-router/pull/11098), ([#11377](https://github.com/remix-run/react-router/pull/11377)))
-  - `loadRouteIds`: Optional array of route IDs to load a subset of the matched routes
-  - `skipLoaderErrorBubbling`: Disable error bubbling by the static handler
-  - `skipLoaders`: Only call the action on POST requests, don't call all of the loaders afterwards
+- `@remix-run/router` - SSR: Added a new `skipLoaderErrorBubbling` options to the `staticHandler.query` method to disable error bubbling by the static handler for use in Remix's Single Fetch implementation ([#11098](https://github.com/remix-run/react-router/pull/11098), ([#11377](https://github.com/remix-run/react-router/pull/11377)))
 
 **Full Changelog**: [`v6.22.3...v6.23.0`](https://github.com/remix-run/react-router/compare/react-router@6.22.3...react-router@6.23.0)
 

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "none": "14.8 kB"
     },
     "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "17.2 kB"
+      "none": "17.21 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
       "none": "17.1 kB"

--- a/packages/router/__tests__/ssr-test.ts
+++ b/packages/router/__tests__/ssr-test.ts
@@ -1090,56 +1090,6 @@ describe("ssr", () => {
       expect(arg(childStub).context.sessionId).toBe("12345");
     });
 
-    it("should support a loadRouteIds parameter for granular loads", async () => {
-      let rootStub = jest.fn(() => "ROOT");
-      let childStub = jest.fn(() => "CHILD");
-      let actionStub = jest.fn(() => "CHILD ACTION");
-      let { query } = createStaticHandler([
-        {
-          id: "root",
-          path: "/",
-          loader: rootStub,
-          children: [
-            {
-              id: "child",
-              path: "child",
-              action: actionStub,
-              loader: childStub,
-            },
-          ],
-        },
-      ]);
-
-      let ctx = await query(createRequest("/child"), {
-        loadRouteIds: ["child"],
-      });
-      expect(rootStub).not.toHaveBeenCalled();
-      expect(childStub).toHaveBeenCalled();
-      expect(ctx).toMatchObject({
-        loaderData: {
-          child: "CHILD",
-        },
-      });
-
-      actionStub.mockClear();
-      rootStub.mockClear();
-      childStub.mockClear();
-
-      ctx = await query(createSubmitRequest("/child"), {
-        loadRouteIds: ["child"],
-      });
-      expect(rootStub).not.toHaveBeenCalled();
-      expect(childStub).toHaveBeenCalled();
-      expect(ctx).toMatchObject({
-        actionData: {
-          child: "CHILD ACTION",
-        },
-        loaderData: {
-          child: "CHILD",
-        },
-      });
-    });
-
     describe("deferred", () => {
       let { query } = createStaticHandler(SSR_ROUTES);
 


### PR DESCRIPTION
We can implement this behavior in Remix's `dataStrategy` implementation now that it's request specific