### PR TITLE
Fix `error-sanitization-test`

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -6,7 +6,6 @@ const config: PlaywrightTestConfig = {
   testMatch: ["**/*-test.ts"],
   // TODO: Temporary!  Remove from this list as we get each suite passing
   testIgnore: [
-    "**/error-sanitization-test.ts",
     "**/file-uploads-test.ts",
     "**/vite-basename-test.ts",
     "**/vite-build-test.ts",

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -595,9 +595,7 @@ function deserializeErrors(
           try {
             // @ts-expect-error
             let error = new ErrorConstructor(val.message);
-            // Wipe away the client-side stack trace.  Nothing to fill it in with
-            // because we don't serialize SSR stack traces for security reasons
-            error.stack = "";
+            error.stack = val.stack;
             serialized[key] = error;
           } catch (e) {
             // no-op - fall through and create a normal Error
@@ -607,9 +605,7 @@ function deserializeErrors(
 
       if (serialized[key] == null) {
         let error = new Error(val.message);
-        // Wipe away the client-side stack trace.  Nothing to fill it in with
-        // because we don't serialize SSR stack traces for security reasons
-        error.stack = "";
+        error.stack = val.stack;
         serialized[key] = error;
       }
     } else {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -595,7 +595,8 @@ function deserializeErrors(
           try {
             // @ts-expect-error
             let error = new ErrorConstructor(val.message);
-            error.stack = val.stack;
+            error.stack =
+              process.env.NODE_ENV === "development" ? val.stack : "";
             serialized[key] = error;
           } catch (e) {
             // no-op - fall through and create a normal Error
@@ -605,7 +606,7 @@ function deserializeErrors(
 
       if (serialized[key] == null) {
         let error = new Error(val.message);
-        error.stack = val.stack;
+        error.stack = process.env.NODE_ENV === "development" ? val.stack : "";
         serialized[key] = error;
       }
     } else {

--- a/packages/react-router-dom/ssr/errors.ts
+++ b/packages/react-router-dom/ssr/errors.ts
@@ -25,7 +25,8 @@ export function deserializeErrors(
           try {
             // @ts-expect-error
             let error = new ErrorConstructor(val.message);
-            error.stack = val.stack;
+            error.stack =
+              process.env.NODE_ENV === "development" ? val.stack : "";
             serialized[key] = error;
           } catch (e) {
             // no-op - fall through and create a normal Error
@@ -35,7 +36,7 @@ export function deserializeErrors(
 
       if (serialized[key] == null) {
         let error = new Error(val.message);
-        error.stack = val.stack;
+        error.stack = process.env.NODE_ENV === "development" ? val.stack : "";
         serialized[key] = error;
       }
     } else {


### PR DESCRIPTION
Turns out the logic differed slightly between `react-router-dom` and `@remix-run/react` and that Remix serializes stack traces in development mode, so we need to ensure that stack traces are picked up when deserializing errors.