### PR TITLE
Fix `file-uploads-test`

### DIFF
--- a/integration/file-uploads-test.ts
+++ b/integration/file-uploads-test.ts
@@ -17,7 +17,6 @@ test.describe.skip("file-uploads", () => {
 
   test.beforeAll(async () => {
     fixture = await createFixture({
-      useReactRouterServe: true, // To support usage of process.cwd() in fileUploadHandler.ts
       files: {
         "app/fileUploadHandler.ts": js`
           import * as path from "node:path";
@@ -28,9 +27,10 @@ test.describe.skip("file-uploads", () => {
             unstable_createMemoryUploadHandler as createMemoryUploadHandler,
           } from "@remix-run/node";
 
+          const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
           export let uploadHandler = composeUploadHandlers(
             createFileUploadHandler({
-              directory: path.resolve(process.cwd(), "uploads"),
+              directory: path.resolve(__dirname, "..", "..", "uploads"),
               maxPartSize: 10_000, // 10kb
               // you probably want to avoid conflicts in production
               // do not set to false or passthrough filename in real
@@ -117,7 +117,9 @@ test.describe.skip("file-uploads", () => {
 >`);
 
     let written = await fs.readFile(
-      url.pathToFileURL(path.join(process.cwd(), "uploads/underLimit.txt")),
+      url.pathToFileURL(
+        path.join(fixture.projectDir, "uploads/underLimit.txt")
+      ),
       "utf8"
     );
     expect(written).toBe(uploadData);
@@ -164,9 +166,10 @@ test.describe("single fetch", () => {
               unstable_createMemoryUploadHandler as createMemoryUploadHandler,
             } from "@remix-run/node";
 
+            const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
             export let uploadHandler = composeUploadHandlers(
               createFileUploadHandler({
-                directory: path.resolve(process.cwd(), "uploads"),
+                directory: path.resolve(__dirname, "..", "..", "uploads"),
                 maxPartSize: 10_000, // 10kb
                 // you probably want to avoid conflicts in production
                 // do not set to false or passthrough filename in real
@@ -253,7 +256,9 @@ test.describe("single fetch", () => {
 >`);
 
       let written = await fs.readFile(
-        url.pathToFileURL(path.join(process.cwd(), "uploads/underLimit.txt")),
+        url.pathToFileURL(
+          path.join(fixture.projectDir, "uploads/underLimit.txt")
+        ),
         "utf8"
       );
       expect(written).toBe(uploadData);

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -7,7 +7,6 @@ const config: PlaywrightTestConfig = {
   // TODO: Temporary!  Remove from this list as we get each suite passing
   testIgnore: [
     "**/error-sanitization-test.ts",
-    "**/file-uploads-test.ts",
     "**/vite-basename-test.ts",
     "**/vite-build-test.ts",
     "**/vite-cloudflare-test.ts",


### PR DESCRIPTION
This test has been passing since #11419 but the usage of `process.cwd()` in the test was causing temp files to be written outside of the `.tmp` directory. This re-instates the original usage of `__dirname` via `import.meta.url`, but fixes the relative path when calling `createFileUploadHandler`.