### PR TITLE
Fix `vite-css-test`

### DIFF
--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -5,11 +5,7 @@ const config: PlaywrightTestConfig = {
   testDir: ".",
   testMatch: ["**/*-test.ts"],
   // TODO: Temporary!  Remove from this list as we get each suite passing
-  testIgnore: [
-    "**/vite-cloudflare-test.ts",
-    "**/vite-css-test.ts",
-    "**/vite-dot-server-test.ts",
-  ],
+  testIgnore: ["**/vite-cloudflare-test.ts", "**/vite-dot-server-test.ts"],
   /* Maximum time one test can run for. */
   timeout: process.platform === "win32" ? 60_000 : 30_000,
   fullyParallel: true,

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -156,7 +156,12 @@ const VITE_CONFIG = async (port: number) => dedent`
 
   export default {
     ${await viteConfig.server({ port })}
-    plugins: [reactRouter(), vanillaExtractPlugin()],
+    plugins: [
+      reactRouter(),
+      vanillaExtractPlugin({
+        emitCssInSsr: true,
+      }),
+    ],
   }
 `;
 


### PR DESCRIPTION
Vanilla Extract internally has checks for the `remix` Vite plugin. Until that's updated, we need to manually enable the `emitCssInSsr` option which is normally enabled internally when the `remix` plugin is detected. Once Vanilla Extract is patched, we can update to the latest version and remove the `emitCssInSsr` option since it's now the default behaviour and no longer configurable.