### PR TITLE
Update tutorial.md to clarify react-router required dependencies

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -255,3 +255,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- PathToLife

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -15,11 +15,13 @@ The rest is just there for your information and deeper understanding. Let's get 
 
 ## Setup
 
-<docs-info>If you're not going to follow along in your own app, you can skip this section</docs-info>
+<docs-info>This section is a tutorial that creates a mini application. If you would like to use react-router in your own app, you can skip this section</docs-info>
 
 We'll be using [Vite][vite] for our bundler and dev server for this tutorial. You'll need [Node.js][node] installed for the `npm` command line tool.
 
 👉️ **Open up your terminal and bootstrap a new React app with Vite:**
+
+Note react-router does not need `localforage match-sorter sort-by` to function, only `npm install react-router-dom`.
 
 ```sh
 npm create vite@latest name-of-your-project -- --template react


### PR DESCRIPTION
On the tutorial page the initial `npm install` command near the top of the page list `localforage, match-sorter, sort-by` as packages to be installed when getting started.

This tutorial page is a common page visited by developers whom are already familiar with react-router.

This PR addresses the common question does `react-router` require `localforage, match-sorter, sort-by`?

Fixes #11099