### PR TITLE
Update error sanitization logic

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -595,8 +595,9 @@ function deserializeErrors(
           try {
             // @ts-expect-error
             let error = new ErrorConstructor(val.message);
-            error.stack =
-              process.env.NODE_ENV === "development" ? val.stack : "";
+            // Wipe away the client-side stack trace.  Nothing to fill it in with
+            // because we don't serialize SSR stack traces for security reasons
+            error.stack = "";
             serialized[key] = error;
           } catch (e) {
             // no-op - fall through and create a normal Error
@@ -606,7 +607,9 @@ function deserializeErrors(
 
       if (serialized[key] == null) {
         let error = new Error(val.message);
-        error.stack = process.env.NODE_ENV === "development" ? val.stack : "";
+        // Wipe away the client-side stack trace.  Nothing to fill it in with
+        // because we don't serialize SSR stack traces for security reasons
+        error.stack = "";
         serialized[key] = error;
       }
     } else {

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -93,6 +93,7 @@ import type {
   AssetsManifest,
   FutureConfig as RemixFutureConfig,
 } from "./ssr/entry";
+import { deserializeErrors as deserializeErrorsRemix } from "./ssr/errors";
 import { RemixErrorBoundary } from "./ssr/errorBoundaries";
 import type { RouteModules } from "./ssr/routeModules";
 import {
@@ -847,7 +848,9 @@ export function RouterProvider({
       }
 
       if (hydrationData && hydrationData.errors) {
-        hydrationData.errors = deserializeErrors(hydrationData.errors);
+        // TODO: De-dup this or remove entirely in v7 where single fetch is the
+        // only approach and we have already serialized or deserialized on the server
+        hydrationData.errors = deserializeErrorsRemix(hydrationData.errors);
       }
     }
 

--- a/packages/react-router-dom/ssr/errors.ts
+++ b/packages/react-router-dom/ssr/errors.ts
@@ -25,8 +25,7 @@ export function deserializeErrors(
           try {
             // @ts-expect-error
             let error = new ErrorConstructor(val.message);
-            error.stack =
-              process.env.NODE_ENV === "development" ? val.stack : "";
+            error.stack = val.stack;
             serialized[key] = error;
           } catch (e) {
             // no-op - fall through and create a normal Error
@@ -36,7 +35,7 @@ export function deserializeErrors(
 
       if (serialized[key] == null) {
         let error = new Error(val.message);
-        error.stack = process.env.NODE_ENV === "development" ? val.stack : "";
+        error.stack = val.stack;
         serialized[key] = error;
       }
     } else {


### PR DESCRIPTION
Revert the `process.env` check from https://github.com/remix-run/react-router/pull/11420 since we don't 100% handle those in our current build configs and just use the Remix implementation directly for the Remix codepath.  Eventually I hope the Remix implementation goes away in a single-fetch only world...