### PR TITLE
Fix Windows Rollup build

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "remark-stringify": "^10.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-extensions": "^0.1.0",
     "rollup-plugin-prettier": "^2.3.0",
     "rollup-plugin-terser": "^7.0.2",
     "semver": "^7.5.4",

--- a/packages/react-router-dom-v5-compat/rollup.config.js
+++ b/packages/react-router-dom-v5-compat/rollup.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const babel = require("@rollup/plugin-babel").default;
 const copy = require("rollup-plugin-copy");
-const extensions = require("rollup-plugin-extensions");
+const nodeResolve = require("@rollup/plugin-node-resolve").default;
 const prettier = require("rollup-plugin-prettier");
 const replace = require("@rollup/plugin-replace");
 const { terser } = require("rollup-plugin-terser");
@@ -17,8 +17,8 @@ const {
 const { name, version } = require("./package.json");
 
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
-  const RR_DOM_DIR = path.join(ROOT_DIR, "packages", "react-router-dom");
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
+  const RR_DOM_DIR = "packages/react-router-dom";
 
   // JS modules for bundlers
   let modules = [
@@ -35,19 +35,19 @@ module.exports = function rollup() {
         copy({
           targets: [
             {
-              src: path.join(RR_DOM_DIR, "(index|dom|server).ts*"),
-              dest: path.join(SOURCE_DIR, "react-router-dom"),
+              src: `${RR_DOM_DIR}/(index|dom|server).ts*`,
+              dest: `${SOURCE_DIR}/react-router-dom`,
             },
             {
-              src: [path.join(RR_DOM_DIR, "ssr", "*.ts*")],
-              dest: path.join(SOURCE_DIR, "react-router-dom", "ssr"),
+              src: `${RR_DOM_DIR}/ssr/*.ts*`,
+              dest: `${SOURCE_DIR}/react-router-dom/ssr`,
             },
           ],
           // buildStart is not soon enough to run before the typescript plugin :/
           hook: "options",
           verbose: true,
         }),
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -68,9 +68,7 @@ module.exports = function rollup() {
           noEmitOnError: true,
         }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
           verbose: true,
         }),
         validateReplacedVersion(),
@@ -98,7 +96,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -138,7 +136,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const babel = require("@rollup/plugin-babel").default;
 const copy = require("rollup-plugin-copy");
-const extensions = require("rollup-plugin-extensions");
+const nodeResolve = require("@rollup/plugin-node-resolve").default;
 const prettier = require("rollup-plugin-prettier");
 const replace = require("@rollup/plugin-replace");
 const { terser } = require("rollup-plugin-terser");
@@ -17,7 +17,7 @@ const {
 const { name, version } = require("./package.json");
 
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
 
   // JS modules for bundlers
   const modules = [
@@ -31,7 +31,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -52,9 +52,7 @@ module.exports = function rollup() {
           noEmitOnError: true,
         }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
           verbose: true,
         }),
         validateReplacedVersion(),
@@ -76,7 +74,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -108,7 +106,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -163,7 +161,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -201,7 +199,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -253,7 +251,7 @@ module.exports = function rollup() {
       ],
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -293,7 +291,7 @@ module.exports = function rollup() {
       ],
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".ts", ".tsx"] }),
+        nodeResolve({ extensions: [".ts", ".tsx"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,

--- a/packages/react-router-native/rollup.config.js
+++ b/packages/react-router-native/rollup.config.js
@@ -12,7 +12,7 @@ const {
 const { name, version } = require("./package.json");
 
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
 
   const modules = [
     {
@@ -47,9 +47,7 @@ module.exports = function rollup() {
           noEmitOnError: true,
         }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
           verbose: true,
         }),
       ].concat(PRETTY ? prettier({ parser: "babel" }) : []),

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const babel = require("@rollup/plugin-babel").default;
 const copy = require("rollup-plugin-copy");
-const extensions = require("rollup-plugin-extensions");
+const nodeResolve = require("@rollup/plugin-node-resolve").default;
 const prettier = require("rollup-plugin-prettier");
 const replace = require("@rollup/plugin-replace");
 const { terser } = require("rollup-plugin-terser");
@@ -15,7 +15,7 @@ const {
 const { name, version } = require("./package.json");
 
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(name);
 
   // JS modules for bundlers
   const modules = [
@@ -29,7 +29,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -42,9 +42,7 @@ module.exports = function rollup() {
           extensions: [".ts", ".tsx"],
         }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
           verbose: true,
         }),
       ].concat(PRETTY ? prettier({ parser: "babel" }) : []),
@@ -63,7 +61,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -96,7 +94,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -147,7 +145,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,
@@ -180,7 +178,7 @@ module.exports = function rollup() {
       },
       external: (id) => isBareModuleId(id),
       plugins: [
-        extensions({ extensions: [".tsx", ".ts"] }),
+        nodeResolve({ extensions: [".tsx", ".ts"] }),
         babel({
           babelHelpers: "bundled",
           exclude: /node_modules/,

--- a/packages/remix-dev/rollup.config.js
+++ b/packages/remix-dev/rollup.config.js
@@ -14,7 +14,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-dev"
@@ -53,7 +53,7 @@ module.exports = function rollup() {
         nodeResolve({ extensions: [".ts"] }),
         copy({
           targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
+            { src: "LICENSE.md", dest: SOURCE_DIR },
             { src: `${SOURCE_DIR}/vite/static`, dest: `${OUTPUT_DIR}/vite` },
             {
               src: `${SOURCE_DIR}/config/defaults`,

--- a/packages/remix-express/rollup.config.js
+++ b/packages/remix-express/rollup.config.js
@@ -14,7 +14,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-express"
@@ -45,9 +45,7 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts", ".tsx"] }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
         }),
       ],
     },

--- a/packages/remix-node/rollup.config.js
+++ b/packages/remix-node/rollup.config.js
@@ -14,7 +14,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-node"
@@ -45,9 +45,7 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts", ".tsx"] }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
         }),
       ],
     },

--- a/packages/remix-serve/rollup.config.js
+++ b/packages/remix-serve/rollup.config.js
@@ -13,7 +13,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-serve"
@@ -44,9 +44,7 @@ module.exports = function rollup() {
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
         }),
         {
           name: "dynamic-import-polyfill",

--- a/packages/remix-server-runtime/rollup.config.js
+++ b/packages/remix-server-runtime/rollup.config.js
@@ -15,7 +15,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-server-runtime"
@@ -47,9 +47,7 @@ module.exports = function rollup() {
           noEmitOnError: true,
         }),
         copy({
-          targets: [
-            { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-          ],
+          targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
         }),
       ],
     },

--- a/packages/remix-testing/rollup.config.js
+++ b/packages/remix-testing/rollup.config.js
@@ -14,7 +14,7 @@ const { name, version } = require("./package.json");
 
 /** @returns {import("rollup").RollupOptions[]} */
 module.exports = function rollup() {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "remix-testing"
@@ -33,7 +33,7 @@ module.exports = function rollup() {
   /** @type {import("rollup").RollupOptions} */
   let remixTestingCJS = {
     external: (id) => isBareModuleId(id),
-    input: path.join(SOURCE_DIR, "index.ts"),
+    input: `${SOURCE_DIR}/index.ts`,
     output: {
       banner: createBanner(name, version),
       dir: OUTPUT_DIR,
@@ -49,7 +49,7 @@ module.exports = function rollup() {
         noEmitOnError: true,
       }),
       copy({
-        targets: [{ src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR }],
+        targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
       }),
     ],
   };
@@ -58,10 +58,10 @@ module.exports = function rollup() {
   /** @type {import("rollup").RollupOptions} */
   let remixTestingESM = {
     external: (id) => isBareModuleId(id),
-    input: path.join(SOURCE_DIR, "index.ts"),
+    input: `${SOURCE_DIR}/index.ts`,
     output: {
       banner: createBanner(name, version),
-      dir: path.join(OUTPUT_DIR, "esm"),
+      dir: `${OUTPUT_DIR}/esm`,
       format: "esm",
       preserveModules: true,
     },

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -3,7 +3,7 @@ const path = require("path");
 const babel = require("@rollup/plugin-babel").default;
 const typescript = require("@rollup/plugin-typescript");
 const copy = require("rollup-plugin-copy");
-const extensions = require("rollup-plugin-extensions");
+const nodeResolve = require("@rollup/plugin-node-resolve").default;
 const prettier = require("rollup-plugin-prettier");
 const { terser } = require("rollup-plugin-terser");
 
@@ -19,7 +19,7 @@ function getRollupConfig(
   filename,
   { includeTypesAndCopy, minify } = {}
 ) {
-  const { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
+  const { SOURCE_DIR, OUTPUT_DIR } = getBuildDirectories(
     name,
     // We don't live in a folder matching our package name
     "router"
@@ -35,7 +35,7 @@ function getRollupConfig(
       ...(format === "umd" ? { name: "RemixRouter" } : {}),
     },
     plugins: [
-      extensions({ extensions: [".ts"] }),
+      nodeResolve({ extensions: [".ts"] }),
       babel({
         babelHelpers: "bundled",
         exclude: /node_modules/,
@@ -53,9 +53,7 @@ function getRollupConfig(
               noEmitOnError: true,
             }),
             copy({
-              targets: [
-                { src: path.join(ROOT_DIR, "LICENSE.md"), dest: SOURCE_DIR },
-              ],
+              targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
               verbose: true,
             }),
           ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,6 @@ importers:
       rollup-plugin-copy:
         specifier: ^3.4.0
         version: 3.4.0
-      rollup-plugin-extensions:
-        specifier: ^0.1.0
-        version: 0.1.0(rollup@2.79.1)
       rollup-plugin-prettier:
         specifier: ^2.3.0
         version: 2.3.0(prettier@2.8.8)(rollup@2.79.1)
@@ -14686,14 +14683,6 @@ packages:
       fs-extra: 8.1.0
       globby: 10.0.1
       is-plain-object: 3.0.1
-    dev: false
-
-  /rollup-plugin-extensions@0.1.0(rollup@2.79.1):
-    resolution: {integrity: sha512-d7RzW7iiiHNYRsqe3W2GTz9bClIVm9J3mbHQqetsCZHpPPgDfo/OpXmwiziyMhm3bgiJTswxqw4QNr6qX4NfHA==}
-    peerDependencies:
-      rollup: ^1.4.1
-    dependencies:
-      rollup: 2.79.1
     dev: false
 
   /rollup-plugin-inject@3.0.2:

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -7,9 +7,8 @@ const PRETTY = !!process.env.PRETTY;
 
 /**
  * Determine the relevant directories for a rollup build, relative to the
- * current working directory and taking LOCAL_BUILD_DIRECTORY into account
+ * root directory and taking LOCAL_BUILD_DIRECTORY into account
  *
- * ROOT_DIR     Root directory for the react-router repo
  * SOURCE_DIR   Source package directory we will read input files from
  * OUTPUT_DIR   Destination directory to write rollup output to
  *
@@ -17,18 +16,11 @@ const PRETTY = !!process.env.PRETTY;
  * @param {string} [folderName] folder name (i.e., router). Defaults to package name
  */
 function getBuildDirectories(packageName, folderName) {
-  let ROOT_DIR = __dirname;
   let SOURCE_DIR = folderName
-    ? path.join(__dirname, "packages", folderName)
-    : path.join(__dirname, "packages", ...packageName.split("/"));
+    ? path.posix.join("packages", folderName)
+    : path.posix.join("packages", ...packageName.split("/"));
 
-  // Update if we're not running from root
-  if (process.cwd() !== __dirname) {
-    ROOT_DIR = path.dirname(path.dirname(process.cwd()));
-    SOURCE_DIR = process.cwd();
-  }
-
-  let OUTPUT_DIR = path.join(SOURCE_DIR, "dist");
+  let OUTPUT_DIR = path.posix.join(SOURCE_DIR, "dist");
 
   if (process.env.LOCAL_BUILD_DIRECTORY) {
     try {
@@ -48,7 +40,7 @@ function getBuildDirectories(packageName, folderName) {
     }
   }
 
-  return { ROOT_DIR, SOURCE_DIR, OUTPUT_DIR };
+  return { SOURCE_DIR, OUTPUT_DIR };
 }
 
 function createBanner(packageName, version, { executable = false } = {}) {


### PR DESCRIPTION
This addresses a couple of issues in the Rollup build on Windows:
- `rollup-plugin-extensions` doesn't resolve paths correctly on Windows, so we need to replace it with `@rollup/plugin-node-resolve`.
- `rollup-plugin-copy` doesn't support absolute paths on Windows.