### PR TITLE
Handle TypeScript errors in watch mode

### DIFF
--- a/packages/react-router-dom-v5-compat/rollup.config.js
+++ b/packages/react-router-dom-v5-compat/rollup.config.js
@@ -13,6 +13,7 @@ const {
   getBuildDirectories,
   validateReplacedVersion,
   PRETTY,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -65,7 +66,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         copy({
           targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -13,6 +13,7 @@ const {
   validateReplacedVersion,
   isBareModuleId,
   PRETTY,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -49,7 +50,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         copy({
           targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],
@@ -270,7 +271,7 @@ module.exports = function rollup() {
           tsconfig: path.join(__dirname, "tsconfig.json"),
           include: ["server.tsx"],
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         validateReplacedVersion(),
       ].concat(PRETTY ? prettier({ parser: "babel" }) : []),

--- a/packages/react-router-native/rollup.config.js
+++ b/packages/react-router-native/rollup.config.js
@@ -8,6 +8,7 @@ const {
   isBareModuleId,
   getBuildDirectories,
   PRETTY,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -44,7 +45,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         copy({
           targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],

--- a/packages/react-router/rollup.config.js
+++ b/packages/react-router/rollup.config.js
@@ -11,6 +11,7 @@ const {
   isBareModuleId,
   getBuildDirectories,
   PRETTY,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -76,7 +77,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         replace({
           preventAssignment: true,

--- a/packages/remix-dev/rollup.config.js
+++ b/packages/remix-dev/rollup.config.js
@@ -9,6 +9,7 @@ const {
   isBareModuleId,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -48,7 +49,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({

--- a/packages/remix-express/rollup.config.js
+++ b/packages/remix-express/rollup.config.js
@@ -9,6 +9,7 @@ const {
   createBanner,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -41,7 +42,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         nodeResolve({ extensions: [".ts", ".tsx"] }),
         copy({

--- a/packages/remix-node/rollup.config.js
+++ b/packages/remix-node/rollup.config.js
@@ -9,6 +9,7 @@ const {
   createBanner,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -41,7 +42,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         nodeResolve({ extensions: [".ts", ".tsx"] }),
         copy({

--- a/packages/remix-serve/rollup.config.js
+++ b/packages/remix-serve/rollup.config.js
@@ -8,6 +8,7 @@ const {
   createBanner,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -40,7 +41,7 @@ module.exports = function rollup() {
         typescript({
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         nodeResolve({ extensions: [".ts"] }),
         copy({

--- a/packages/remix-server-runtime/rollup.config.js
+++ b/packages/remix-server-runtime/rollup.config.js
@@ -10,6 +10,7 @@ const {
   createBanner,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -44,7 +45,7 @@ module.exports = function rollup() {
           // eslint-disable-next-line no-restricted-globals
           tsconfig: path.join(__dirname, "tsconfig.json"),
           exclude: ["__tests__"],
-          noEmitOnError: true,
+          noEmitOnError: !WATCH,
         }),
         copy({
           targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],

--- a/packages/remix-testing/rollup.config.js
+++ b/packages/remix-testing/rollup.config.js
@@ -9,6 +9,7 @@ const {
   createBanner,
   getBuildDirectories,
   remixBabelConfig,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -46,7 +47,7 @@ module.exports = function rollup() {
       typescript({
         tsconfig: path.join(__dirname, "tsconfig.json"),
         exclude: ["__tests__"],
-        noEmitOnError: true,
+        noEmitOnError: !WATCH,
       }),
       copy({
         targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -11,6 +11,7 @@ const {
   createBanner,
   getBuildDirectories,
   PRETTY,
+  WATCH,
 } = require("../../rollup.utils");
 const { name, version } = require("./package.json");
 
@@ -50,7 +51,7 @@ function getRollupConfig(
             typescript({
               tsconfig: path.join(__dirname, "tsconfig.json"),
               exclude: ["__tests__"],
-              noEmitOnError: true,
+              noEmitOnError: !WATCH,
             }),
             copy({
               targets: [{ src: "LICENSE.md", dest: SOURCE_DIR }],

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -4,6 +4,7 @@ const { version } = require("./packages/react-router/package.json");
 const majorVersion = version.split(".").shift();
 
 const PRETTY = !!process.env.PRETTY;
+const WATCH = !!process.env.ROLLUP_WATCH;
 
 /**
  * Determine the relevant directories for a rollup build, relative to the
@@ -171,4 +172,5 @@ module.exports = {
   isBareModuleId,
   remixBabelConfig,
   PRETTY,
+  WATCH,
 };


### PR DESCRIPTION
When running `pnpm watch`, the Rollup process exits whenever there's a syntax or type error. Turns out this is due to the TypeScript plugin's `noEmitOnError` option being enabled. We still want this enabled when running `pnpm build`, so I'm using the Rollup's `ROLLUP_WATCH` environment variable to disable `noEmitOnError` whenever we're in watch mode.