### PR TITLE
Fix raw hash link scrolling behavior

### DIFF
--- a/.changeset/hash-double-click.md
+++ b/.changeset/hash-double-click.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Fix scroll issue with popstate events from <a href="#hash"> clicks

--- a/packages/router/history.ts
+++ b/packages/router/history.ts
@@ -626,6 +626,17 @@ function getUrlBasedHistory(
   }
 
   function handlePop() {
+    let { key, idx } = globalHistory.state || {};
+    if (key == null && idx == null) {
+      // If we `popstate` to a location we don't know about, don't handle it.
+      // It's an <a href="#hash"> click so we'll just let the browser do the
+      // hash scrolling as it normally would.
+      // - If we pop to our initial location, we won't have a key, but will have idx=0
+      // - If we pop to any subsequent location, we'll have both a key and an idx
+      // - if we pop out of our app it won't be a popstate since we'll load a new document
+      return;
+    }
+
     action = Action.Pop;
     let nextIndex = getIndex();
     let delta = nextIndex == null ? null : nextIndex - index;


### PR DESCRIPTION
Potential solution for [#7573](https://github.com/remix-run/remix/issues/7573)

The tl;dr; is that if you're in a React Router SPA, clicking an `<a href="#hash">` link triggers a `popstate` event so we sort of think we're navigating forwards/backwards in the history stack - when in reality it's a new entry on the stack that RR doesn't know about so it doesn't have a `key`.  This causes it to inherit the `default` key value because it thinks it's the first page of a new session - and that causes all sorts of weird behavior with scroll restoration.

This also likely causes issues with any `useBlocker` stuff because we won't have an `idx` on these locations either.

I think we have three choices:

**Option 1 - Implemented in this PR** - Totally ignore these events since they're not `<Link>`'s and thus are not intended to be "enhanced" and go through RR.  The downsides of this approach are:
* Back navigations from these unknown locations won't quite behave correctly.  We won't save the current scroll position on the hash link click if we totally ignore it, so we won't restore clicking back from the hash. 
  * `/page -> /page#hash` will scroll to the hash via default browser behavior, but it will not persist off the current `/page` scroll position
  * back button to `/page` will try to restore to any _prior_ `/page` position if it had one, but not the position it was at prior to the hash click.  So `/page -> /whatever -> /page -> /page#hash -> BACK` would restore to the first `/page` scroll position incorrectly
* The browser will not properly restore on back clicks through subsequent hashes
  * `/page -> /page#a` will scroll to the `#a` hash via default browser behavior
  * `/page#a -> /page#b` will scroll to the `#b` hash via default browser behavior
  * back button to `/page#a` will not scroll back to `#a` because we've set `window.history.scrollRestoration = "manual"`

**Option 2** - Try to enhance `<a href="#hash">` link clicks into RR `<Link>` clicks.  This gets tricky since we'd need to mess with the current `history.state` and give it a proper incremented `idx`, and we'd also probably need to send the `popstate` through a `router.replace` (not a push because the `popstate` has already put us to a new location with an empty `history.state`) so it was created as a normal navigation and did the correct saving of scroll position, etc.

**Option 3** - Do nothing.  If users want proper behavior of hash scrolling for `<a>` links in an RR SPA, then they can enhance the links on their own in userland using a [delegated approach](https://github.com/remix-run/react-router-website/blob/main/app/ui/delegate-markdown-links.ts).  Since they call `e.preventDefault()` on these link clicks, then the issue presented above never happens because the `popstate` event never fires.

I vote Option 3 since the simpler option 1 has weird side effects, and I don't like option 2 because RR has no business messing with plain `<a>` tags at all.  