### PR TITLE
[docs] update `edit` page in getting-started

### DIFF
--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -768,14 +768,14 @@ export default function EditContact() {
           aria-label="First name"
           type="text"
           name="first"
-          defaultValue={contact.first}
+          defaultValue={contact?.first}
         />
         <input
           placeholder="Last"
           aria-label="Last name"
           type="text"
           name="last"
-          defaultValue={contact.last}
+          defaultValue={contact?.last}
         />
       </p>
       <label>
@@ -784,7 +784,7 @@ export default function EditContact() {
           type="text"
           name="twitter"
           placeholder="@jack"
-          defaultValue={contact.twitter}
+          defaultValue={contact?.twitter}
         />
       </label>
       <label>
@@ -794,14 +794,14 @@ export default function EditContact() {
           aria-label="Avatar URL"
           type="text"
           name="avatar"
-          defaultValue={contact.avatar}
+          defaultValue={contact?.avatar}
         />
       </label>
       <label>
         <span>Notes</span>
         <textarea
           name="notes"
-          defaultValue={contact.notes}
+          defaultValue={contact?.notes}
           rows={6}
         />
       </label>


### PR DESCRIPTION
Update to prevent breaking `edit` page when following getting-started

See comment: https://gist.github.com/ryanflorence/1e7f5d3344c0db4a8394292c157cd305