### PR TITLE
Fix `router` prop type on `RouterProvider`

### DIFF
--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -740,7 +740,7 @@ class Deferred<T> {
 
 // When using a DOM RouterProvider with SSR you don't have to specify a router
 // and it can be constructed via `__remixManifest`/`__remixContext` etc.
-export type RouterProviderProps = MemoryRouterProviderProps & {
+export type RouterProviderProps = Omit<MemoryRouterProviderProps, "router"> & {
   router?: RemixRouter;
 };
 


### PR DESCRIPTION
The `router` prop was still being marked as required.