### PR TITLE
Extract remix logic out of RouterProvider into HydratedRouter

### DIFF
--- a/.changeset/create-remix-router.md
+++ b/.changeset/create-remix-router.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": major
+---
+
+Use `createRemixRouter`/`RouterProvider` in `entry.client` instead of `RemixBrowser`

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -45,7 +45,7 @@ const files = {
   "app/entry.client.tsx": js`
     import "./entry.client.css";
 
-    import { RouterProvider } from "react-router-dom";
+    import { HydratedRouter } from "react-router-dom";
     import { startTransition, StrictMode } from "react";
     import { hydrateRoot } from "react-dom/client";
 
@@ -53,7 +53,7 @@ const files = {
       hydrateRoot(
         document,
         <StrictMode>
-          <RouterProvider />
+          <HydratedRouter />
         </StrictMode>
       );
     });

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -323,7 +323,7 @@ test.describe("SPA Mode", () => {
             </html>
           `,
           "app/entry.client.tsx": js`
-            import { RouterProvider } from "react-router-dom";
+            import { HydratedRouter } from "react-router-dom";
             import { startTransition, StrictMode } from "react";
             import { hydrateRoot } from "react-dom/client";
 
@@ -331,7 +331,7 @@ test.describe("SPA Mode", () => {
               hydrateRoot(
                 document.querySelector("#app"),
                 <StrictMode>
-                  <RouterProvider />
+                  <HydratedRouter />
                 </StrictMode>
               );
             });

--- a/packages/react-router-dom/__tests__/ssr/components-test.tsx
+++ b/packages/react-router-dom/__tests__/ssr/components-test.tsx
@@ -9,6 +9,7 @@ import {
   Outlet,
   RouterProvider,
 } from "../../index";
+import { HydratedRouter } from "../../ssr/browser";
 import { RemixContext } from "../../ssr/components";
 import invariant from "../../ssr/invariant";
 import { RemixServer } from "../../ssr/server";
@@ -214,7 +215,7 @@ describe("<RemixServer>", () => {
   });
 });
 
-describe("<RemixBrowser>", () => {
+describe("<HydratedRouter>", () => {
   it("handles empty default export objects from the compiler", () => {
     window.__remixContext = {
       url: "/",
@@ -263,7 +264,7 @@ describe("<RemixBrowser>", () => {
 
     jest.spyOn(console, "error");
 
-    let { container } = render(<RouterProvider />);
+    let { container } = render(<HydratedRouter />);
 
     expect(console.error).not.toHaveBeenCalled();
     expect(container.innerHTML).toMatch("<h1>Root</h1>");

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -81,8 +81,6 @@ import {
   shouldProcessLinkClick,
 } from "./dom";
 
-import type { SSRInfo } from "./ssr/browser";
-import { HydratedRouter } from "./ssr/browser";
 import type { PrefetchBehavior, ScriptProps, UIMatch } from "./ssr/components";
 import {
   PrefetchPageLinks,
@@ -265,14 +263,13 @@ export { decodeViaTurboStream as UNSAFE_decodeViaTurboStream } from "./ssr/singl
 ////////////////////////////////////////////////////////////////////////////////
 
 declare global {
+  // TODO: v7 - Can this go away in favor of "just use remix"?
+  var __staticRouterHydrationData: HydrationState | undefined;
+  // v6 SPA info
+  var __reactRouterVersion: string;
   interface Document {
     startViewTransition(cb: () => Promise<void> | void): ViewTransition;
   }
-
-  // v6 SPA info
-  var __reactRouterVersion: string;
-  // TODO: v7 - Can this go away in favor of "just use remix"?
-  var __staticRouterHydrationData: HydrationState | undefined;
 }
 
 // HEY YOU! DON'T TOUCH THIS VARIABLE!
@@ -407,7 +404,7 @@ function deserializeErrors(
 //#region Contexts
 ////////////////////////////////////////////////////////////////////////////////
 
-export type ViewTransitionContextObject =
+type ViewTransitionContextObject =
   | {
       isTransitioning: false;
     }

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -13,7 +13,7 @@ import type {
   Navigator,
   RelativeRoutingType,
   RouteObject,
-  RouterProviderProps as MemoryRouterProviderProps,
+  RouterProviderProps,
   To,
 } from "react-router";
 import {
@@ -65,7 +65,6 @@ import {
   UNSAFE_warning as warning,
   matchPath,
   IDLE_FETCHER,
-  matchRoutes,
 } from "@remix-run/router";
 
 import type {
@@ -82,6 +81,8 @@ import {
   shouldProcessLinkClick,
 } from "./dom";
 
+import type { SSRInfo } from "./ssr/browser";
+import { HydratedRouter } from "./ssr/browser";
 import type { PrefetchBehavior, ScriptProps, UIMatch } from "./ssr/components";
 import {
   PrefetchPageLinks,
@@ -89,22 +90,6 @@ import {
   mergeRefs,
   usePrefetchBehavior,
 } from "./ssr/components";
-import type {
-  AssetsManifest,
-  FutureConfig as RemixFutureConfig,
-} from "./ssr/entry";
-import { deserializeErrors as deserializeErrorsRemix } from "./ssr/errors";
-import { RemixErrorBoundary } from "./ssr/errorBoundaries";
-import type { RouteModules } from "./ssr/routeModules";
-import {
-  createClientRoutes,
-  createClientRoutesWithHMRRevalidationOptOut,
-  shouldHydrateRouteLoader,
-} from "./ssr/routes";
-import {
-  decodeViaTurboStream,
-  getSingleFetchDataStrategy,
-} from "./ssr/single-fetch";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Re-exports
@@ -167,6 +152,7 @@ export type {
   RouteObject,
   RouteProps,
   RouterProps,
+  RouterProviderProps,
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
@@ -223,8 +209,8 @@ export {
   useRoutes,
 } from "react-router";
 
+export { HydratedRouter } from "./ssr/browser";
 export { Meta, Links, Scripts, PrefetchPageLinks } from "./ssr/components";
-
 export type { HtmlLinkDescriptor } from "./ssr/links";
 export type {
   ClientActionFunction,
@@ -235,7 +221,6 @@ export type {
   MetaDescriptor,
   MetaFunction,
 } from "./ssr/routeModules";
-
 export type { RemixServerProps } from "./ssr/server";
 export { RemixServer } from "./ssr/server";
 
@@ -279,23 +264,6 @@ export { decodeViaTurboStream as UNSAFE_decodeViaTurboStream } from "./ssr/singl
 //#region Global Stuff
 ////////////////////////////////////////////////////////////////////////////////
 
-type WindowRemixContext = {
-  url: string;
-  basename?: string;
-  state: HydrationState;
-  criticalCss?: string;
-  future: RemixFutureConfig;
-  isSpaMode: boolean;
-  stream: ReadableStream<Uint8Array> | undefined;
-  streamController: ReadableStreamDefaultController<Uint8Array>;
-  // The number of active deferred keys rendered on the server
-  a?: number;
-  dev?: {
-    port?: number;
-    hmrRuntime?: string;
-  };
-};
-
 declare global {
   interface Document {
     startViewTransition(cb: () => Promise<void> | void): ViewTransition;
@@ -305,20 +273,6 @@ declare global {
   var __reactRouterVersion: string;
   // TODO: v7 - Can this go away in favor of "just use remix"?
   var __staticRouterHydrationData: HydrationState | undefined;
-
-  // v7 SSR Info
-  // TODO: v7 - Once this is all working, rename these global variables to __reactRouter*
-  var __remixContext: WindowRemixContext | undefined;
-  var __remixManifest: AssetsManifest | undefined;
-  var __remixRouteModules: RouteModules | undefined;
-  var __remixRouter: RemixRouter | undefined;
-  var __remixRevalidation: number | undefined;
-  var __remixClearCriticalCss: (() => void) | undefined;
-  var $RefreshRuntime$:
-    | {
-        performReactRefresh: () => void;
-      }
-    | undefined;
 }
 
 // HEY YOU! DON'T TOUCH THIS VARIABLE!
@@ -335,179 +289,6 @@ try {
   window.__reactRouterVersion = REACT_ROUTER_VERSION;
 } catch (e) {
   // no-op
-}
-
-type SSRInfo = {
-  context: WindowRemixContext;
-  routeModules: RouteModules;
-  manifest: AssetsManifest;
-  stateDecodingPromise:
-    | (Promise<void> & {
-        value?: unknown;
-        error?: unknown;
-      })
-    | undefined;
-  router: RemixRouter | undefined;
-  routerInitialized: boolean;
-};
-
-let ssrInfo: SSRInfo | null = null;
-
-function initSsrInfo(): void {
-  if (
-    !ssrInfo &&
-    window.__remixContext &&
-    window.__remixManifest &&
-    window.__remixRouteModules
-  ) {
-    ssrInfo = {
-      context: window.__remixContext,
-      manifest: window.__remixManifest,
-      routeModules: window.__remixRouteModules,
-      stateDecodingPromise: undefined,
-      router: undefined,
-      routerInitialized: false,
-    };
-  }
-}
-
-export type HmrInfo = {
-  abortController: AbortController | undefined;
-  routerReadyResolve: (router: RemixRouter) => void;
-  routerReadyPromise: Promise<RemixRouter>;
-};
-
-let hmrInfo: HmrInfo | null = null;
-
-if (
-  import.meta &&
-  // @ts-expect-error
-  import.meta.hot &&
-  window.__remixManifest
-) {
-  let resolve: (router: RemixRouter) => void;
-  let routerReadyPromise = new Promise((r) => {
-    resolve = r;
-  }).catch(() => {
-    // This is a noop catch handler to avoid unhandled promise rejection warnings
-    // in the console. The promise is never rejected.
-    return undefined;
-  }) as Promise<RemixRouter>;
-
-  hmrInfo = {
-    abortController: undefined,
-    routerReadyResolve: resolve!,
-    // There's a race condition with HMR where the remix:manifest is signaled before
-    // the router is assigned in the RemixBrowser component. This promise gates the
-    // HMR handler until the router is ready
-    routerReadyPromise,
-  };
-
-  // @ts-expect-error
-  import.meta.hot.accept(
-    "remix:manifest",
-    async ({
-      assetsManifest,
-      needsRevalidation,
-    }: {
-      assetsManifest: AssetsManifest;
-      needsRevalidation: Set<string>;
-    }) => {
-      let router = await hmrInfo!.routerReadyPromise;
-      // This should never happen, but just in case...
-      if (!router || !ssrInfo || !hmrInfo) {
-        console.error(
-          "Failed to accept HMR update because the router/ssrInfo was not ready."
-        );
-        return;
-      }
-
-      let routeIds = [
-        ...new Set(
-          router.state.matches
-            .map((m) => m.route.id)
-            .concat(Object.keys(ssrInfo!.routeModules))
-        ),
-      ];
-
-      hmrInfo.abortController?.abort();
-      hmrInfo.abortController = new AbortController();
-      let signal = hmrInfo.abortController.signal;
-
-      // Load new route modules that we've seen.
-      let newRouteModules = Object.assign(
-        {},
-        ssrInfo.routeModules,
-        Object.fromEntries(
-          (
-            await Promise.all(
-              routeIds.map(async (id) => {
-                if (!assetsManifest.routes[id]) {
-                  return null;
-                }
-                let imported = await import(
-                  assetsManifest.routes[id].module +
-                    `?t=${assetsManifest.hmr?.timestamp}`
-                );
-                invariant(ssrInfo, "ssrInfo unavailable for HMR update");
-                return [
-                  id,
-                  {
-                    ...imported,
-                    // react-refresh takes care of updating these in-place,
-                    // if we don't preserve existing values we'll loose state.
-                    default: imported.default
-                      ? ssrInfo.routeModules[id]?.default || imported.default
-                      : imported.default,
-                    ErrorBoundary: imported.ErrorBoundary
-                      ? ssrInfo.routeModules[id]?.ErrorBoundary ||
-                        imported.ErrorBoundary
-                      : imported.ErrorBoundary,
-                    HydrateFallback: imported.HydrateFallback
-                      ? ssrInfo.routeModules[id]?.HydrateFallback ||
-                        imported.HydrateFallback
-                      : imported.HydrateFallback,
-                  },
-                ];
-              })
-            )
-          ).filter(Boolean) as [string, RouteModules[string]][]
-        )
-      );
-
-      Object.assign(ssrInfo.routeModules, newRouteModules);
-      // Create new routes
-      let routes = createClientRoutesWithHMRRevalidationOptOut(
-        needsRevalidation,
-        assetsManifest.routes,
-        ssrInfo.routeModules,
-        ssrInfo.context.state,
-        ssrInfo.context.future,
-        ssrInfo.context.isSpaMode
-      );
-
-      // This is temporary API and will be more granular before release
-      router._internalSetRoutes(routes);
-
-      // Wait for router to be idle before updating the manifest and route modules
-      // and triggering a react-refresh
-      let unsub = router.subscribe((state) => {
-        if (state.revalidation === "idle") {
-          unsub();
-          // Abort if a new update comes in while we're waiting for the
-          // router to be idle.
-          if (signal.aborted) return;
-          // Ensure RouterProvider setState has flushed before re-rendering
-          setTimeout(() => {
-            Object.assign(ssrInfo!.manifest, assetsManifest);
-            window.$RefreshRuntime$!.performReactRefresh();
-          }, 1);
-        }
-      });
-      window.__remixRevalidation = (window.__remixRevalidation || 0) + 1;
-      router.revalidate();
-    }
-  );
 }
 //#endregion
 
@@ -626,7 +407,7 @@ function deserializeErrors(
 //#region Contexts
 ////////////////////////////////////////////////////////////////////////////////
 
-type ViewTransitionContextObject =
+export type ViewTransitionContextObject =
   | {
       isTransitioning: false;
     }
@@ -738,201 +519,14 @@ class Deferred<T> {
   }
 }
 
-// When using a DOM RouterProvider with SSR you don't have to specify a router
-// and it can be constructed via `__remixManifest`/`__remixContext` etc.
-export type RouterProviderProps = Omit<MemoryRouterProviderProps, "router"> & {
-  router?: RemixRouter;
-};
-
 /**
  * Given a Remix Router instance, render the appropriate UI
  */
 export function RouterProvider({
   fallbackElement,
-  router: propRouter,
+  router,
   future,
 }: RouterProviderProps): React.ReactElement {
-  let router = propRouter || ssrInfo?.router;
-
-  if (!router) {
-    initSsrInfo();
-
-    if (!ssrInfo) {
-      throw new Error(
-        "You must be using the SSR features of React Router in order to skip " +
-          "passing a `router` prop to `<RouterProvider>`"
-      );
-    }
-
-    // TODO: Do some testing to confirm it's OK to skip the hard reload check
-    // now that all route.lazy stuff is wired up
-
-    // When single fetch is enabled, we need to suspend until the initial state
-    // snapshot is decoded into window.__remixContext.state
-    if (ssrInfo.context.future.unstable_singleFetch) {
-      let localSsrInfo = ssrInfo;
-      // Note: `stateDecodingPromise` is not coupled to `router` - we'll reach this
-      // code potentially many times waiting for our state to arrive, but we'll
-      // then only get past here and create the `router` one time
-      if (!ssrInfo.stateDecodingPromise) {
-        let stream = ssrInfo.context.stream;
-        invariant(stream, "No stream found for single fetch decoding");
-        ssrInfo.context.stream = undefined;
-        ssrInfo.stateDecodingPromise = decodeViaTurboStream(stream, window)
-          .then((value) => {
-            ssrInfo!.context.state =
-              value.value as typeof localSsrInfo.context.state;
-            localSsrInfo.stateDecodingPromise!.value = true;
-          })
-          .catch((e) => {
-            localSsrInfo.stateDecodingPromise!.error = e;
-          });
-      }
-      if (ssrInfo.stateDecodingPromise.error) {
-        throw ssrInfo.stateDecodingPromise.error;
-      }
-      if (!ssrInfo.stateDecodingPromise.value) {
-        throw ssrInfo.stateDecodingPromise;
-      }
-    }
-
-    let routes = createClientRoutes(
-      ssrInfo.manifest.routes,
-      ssrInfo.routeModules,
-      ssrInfo.context.state,
-      ssrInfo.context.future,
-      ssrInfo.context.isSpaMode
-    );
-
-    let hydrationData = undefined;
-    if (!ssrInfo.context.isSpaMode) {
-      // Create a shallow clone of `loaderData` we can mutate for partial hydration.
-      // When a route exports a `clientLoader` and a `HydrateFallback`, the SSR will
-      // render the fallback so we need the client to do the same for hydration.
-      // The server loader data has already been exposed to these route `clientLoader`'s
-      // in `createClientRoutes` above, so we need to clear out the version we pass to
-      // `createBrowserRouter` so it initializes and runs the client loaders.
-      hydrationData = {
-        ...ssrInfo.context.state,
-        loaderData: { ...ssrInfo.context.state.loaderData },
-      };
-      let initialMatches = matchRoutes(routes, window.location);
-      if (initialMatches) {
-        for (let match of initialMatches) {
-          let routeId = match.route.id;
-          let route = ssrInfo.routeModules[routeId];
-          let manifestRoute = ssrInfo.manifest.routes[routeId];
-          // Clear out the loaderData to avoid rendering the route component when the
-          // route opted into clientLoader hydration and either:
-          // * gave us a HydrateFallback
-          // * or doesn't have a server loader and we have no data to render
-          if (
-            route &&
-            shouldHydrateRouteLoader(
-              manifestRoute,
-              route,
-              ssrInfo.context.isSpaMode
-            ) &&
-            (route.HydrateFallback || !manifestRoute.hasLoader)
-          ) {
-            hydrationData.loaderData[routeId] = undefined;
-          } else if (manifestRoute && !manifestRoute.hasLoader) {
-            // Since every Remix route gets a `loader` on the client side to load
-            // the route JS module, we need to add a `null` value to `loaderData`
-            // for any routes that don't have server loaders so our partial
-            // hydration logic doesn't kick off the route module loaders during
-            // hydration
-            hydrationData.loaderData[routeId] = null;
-          }
-        }
-      }
-
-      if (hydrationData && hydrationData.errors) {
-        // TODO: De-dup this or remove entirely in v7 where single fetch is the
-        // only approach and we have already serialized or deserialized on the server
-        hydrationData.errors = deserializeErrorsRemix(hydrationData.errors);
-      }
-    }
-
-    // We don't use createBrowserRouter here because we need fine-grained control
-    // over initialization to support synchronous `clientLoader` flows.
-    ssrInfo.router = router = createRouter({
-      routes,
-      history: createBrowserHistory(),
-      basename: ssrInfo.context.basename,
-      future: {
-        v7_normalizeFormMethod: true,
-        v7_fetcherPersist: ssrInfo.context.future.v3_fetcherPersist,
-        v7_partialHydration: true,
-        v7_prependBasename: true,
-        v7_relativeSplatPath: ssrInfo.context.future.v3_relativeSplatPath,
-        // Single fetch enables this underlying behavior
-        unstable_skipActionErrorRevalidation:
-          ssrInfo.context.future.unstable_singleFetch === true,
-      },
-      hydrationData,
-      mapRouteProperties,
-      unstable_dataStrategy: ssrInfo.context.future.unstable_singleFetch
-        ? getSingleFetchDataStrategy(ssrInfo.manifest, ssrInfo.routeModules)
-        : undefined,
-    });
-
-    // We can call initialize() immediately if the router doesn't have any
-    // loaders to run on hydration
-    if (router.state.initialized) {
-      ssrInfo.routerInitialized = true;
-      router.initialize();
-    }
-
-    // @ts-ignore
-    router.createRoutesForHMR = createClientRoutesWithHMRRevalidationOptOut;
-    window.__remixRouter = router;
-
-    // Notify that the router is ready for HMR
-    hmrInfo?.routerReadyResolve(router);
-  }
-
-  // SSR State
-
-  // Critical CSS can become stale after code changes, e.g. styles might be
-  // removed from a component, but the styles will still be present in the
-  // server HTML. This allows our HMR logic to clear the critical CSS state.
-  let [criticalCss, setCriticalCss] = React.useState(
-    process.env.NODE_ENV === "development"
-      ? ssrInfo?.context.criticalCss
-      : undefined
-  );
-  if (process.env.NODE_ENV === "development") {
-    if (ssrInfo) {
-      window.__remixClearCriticalCss = () => setCriticalCss(undefined);
-    }
-  }
-
-  // This is due to the short circuit return above when the pathname doesn't
-  // match and we force a hard reload.  This is an exceptional scenario in which
-  // we can't hydrate anyway.
-  let [location, setLocation] = React.useState(router.state.location);
-
-  React.useLayoutEffect(() => {
-    // If we had to run clientLoaders on hydration, we delay initialization until
-    // after we've hydrated to avoid hydration issues from synchronous client loaders
-    if (ssrInfo && ssrInfo.router && !ssrInfo.routerInitialized) {
-      ssrInfo.routerInitialized = true;
-      ssrInfo.router.initialize();
-    }
-  }, []);
-
-  React.useLayoutEffect(() => {
-    if (ssrInfo && ssrInfo.router) {
-      return ssrInfo.router.subscribe((newState) => {
-        if (newState.location !== location) {
-          setLocation(newState.location);
-        }
-      });
-    }
-  }, [location]);
-
-  // SPA State
   let [state, setStateImpl] = React.useState(router.state);
   let [pendingState, setPendingState] = React.useState<RouterState>();
   let [vtContext, setVtContext] = React.useState<ViewTransitionContextObject>({
@@ -1158,7 +752,7 @@ export function RouterProvider({
   // useId relies on the component tree structure to generate deterministic id's
   // so we need to ensure it remains the same on the client even though
   // we don't need the <script> tag
-  let app = (
+  return (
     <>
       <DataRouterContext.Provider value={dataRouterContext}>
         <DataRouterStateContext.Provider value={state}>
@@ -1190,37 +784,6 @@ export function RouterProvider({
       {null}
     </>
   );
-
-  if (ssrInfo && !propRouter) {
-    // We need to include a wrapper RemixErrorBoundary here in case the root error
-    // boundary also throws and we need to bubble up outside of the router entirely.
-    // Then we need a stateful location here so the user can back-button navigate
-    // out of there
-    return (
-      // This fragment is important to ensure we match the <RemixServer> JSX
-      // structure so that useId values hydrate correctly
-      <>
-        <RemixContext.Provider
-          value={{
-            manifest: ssrInfo.manifest,
-            routeModules: ssrInfo.routeModules,
-            future: ssrInfo.context.future,
-            criticalCss,
-            isSpaMode: ssrInfo.context.isSpaMode,
-          }}
-        >
-          <RemixErrorBoundary location={location}>{app}</RemixErrorBoundary>
-        </RemixContext.Provider>
-        {/*
-          This fragment is important to ensure we match the <RemixServer> JSX
-          structure so that useId values hydrate correctly
-        */}
-        {ssrInfo.context.future.unstable_singleFetch ? <></> : null}
-      </>
-    );
-  } else {
-    return app;
-  }
 }
 
 function DataRoutes({

--- a/packages/react-router-dom/ssr/browser.tsx
+++ b/packages/react-router-dom/ssr/browser.tsx
@@ -65,7 +65,7 @@ declare global {
     | undefined;
 }
 
-export type SSRInfo = {
+type SSRInfo = {
   context: WindowRemixContext;
   routeModules: RouteModules;
   manifest: AssetsManifest;
@@ -100,7 +100,7 @@ function initSsrInfo(): void {
   }
 }
 
-export type HmrInfo = {
+type HmrInfo = {
   abortController: AbortController | undefined;
   routerReadyResolve: (router: RemixRouter) => void;
   routerReadyPromise: Promise<RemixRouter>;

--- a/packages/react-router-dom/ssr/browser.tsx
+++ b/packages/react-router-dom/ssr/browser.tsx
@@ -1,19 +1,13 @@
 import * as React from "react";
-import type {
-  HydrationState,
-  Location,
-  Router as RemixRouter,
-} from "@remix-run/router";
+import type { HydrationState, Router as RemixRouter } from "@remix-run/router";
 import {
   createBrowserHistory,
   createRouter,
   matchRoutes,
 } from "@remix-run/router";
-import {
-  RouterProvider,
-  UNSAFE_mapRouteProperties as mapRouteProperties,
-} from "react-router";
+import { UNSAFE_mapRouteProperties as mapRouteProperties } from "react-router";
 
+import { RouterProvider } from "../index";
 import type {
   AssetsManifest,
   FutureConfig as RemixFutureConfig,

--- a/packages/react-router-dom/ssr/browser.tsx
+++ b/packages/react-router-dom/ssr/browser.tsx
@@ -1,0 +1,453 @@
+import * as React from "react";
+import type {
+  HydrationState,
+  Location,
+  Router as RemixRouter,
+} from "@remix-run/router";
+import {
+  createBrowserHistory,
+  createRouter,
+  matchRoutes,
+} from "@remix-run/router";
+import {
+  RouterProvider,
+  UNSAFE_mapRouteProperties as mapRouteProperties,
+} from "react-router";
+
+import type {
+  AssetsManifest,
+  FutureConfig as RemixFutureConfig,
+} from "./entry";
+import { deserializeErrors } from "./errors";
+import type { RouteModules } from "./routeModules";
+import invariant from "./invariant";
+import {
+  createClientRoutes,
+  createClientRoutesWithHMRRevalidationOptOut,
+  shouldHydrateRouteLoader,
+} from "./routes";
+import {
+  decodeViaTurboStream,
+  getSingleFetchDataStrategy,
+} from "./single-fetch";
+import { RemixContext } from "./components";
+import { RemixErrorBoundary } from "./errorBoundaries";
+
+type WindowRemixContext = {
+  url: string;
+  basename?: string;
+  state: HydrationState;
+  criticalCss?: string;
+  future: RemixFutureConfig;
+  isSpaMode: boolean;
+  stream: ReadableStream<Uint8Array> | undefined;
+  streamController: ReadableStreamDefaultController<Uint8Array>;
+  // The number of active deferred keys rendered on the server
+  a?: number;
+  dev?: {
+    port?: number;
+    hmrRuntime?: string;
+  };
+};
+
+declare global {
+  // TODO: v7 - Once this is all working, rename these global variables to __reactRouter*
+  var __remixContext: WindowRemixContext | undefined;
+  var __remixManifest: AssetsManifest | undefined;
+  var __remixRouteModules: RouteModules | undefined;
+  var __remixRouter: RemixRouter | undefined;
+  var __remixRevalidation: number | undefined;
+  var __remixClearCriticalCss: (() => void) | undefined;
+  var $RefreshRuntime$:
+    | {
+        performReactRefresh: () => void;
+      }
+    | undefined;
+}
+
+export type SSRInfo = {
+  context: WindowRemixContext;
+  routeModules: RouteModules;
+  manifest: AssetsManifest;
+  stateDecodingPromise:
+    | (Promise<void> & {
+        value?: unknown;
+        error?: unknown;
+      })
+    | undefined;
+  router: RemixRouter | undefined;
+  routerInitialized: boolean;
+};
+
+let ssrInfo: SSRInfo | null = null;
+let router: RemixRouter | null = null;
+
+function initSsrInfo(): void {
+  if (
+    !ssrInfo &&
+    window.__remixContext &&
+    window.__remixManifest &&
+    window.__remixRouteModules
+  ) {
+    ssrInfo = {
+      context: window.__remixContext,
+      manifest: window.__remixManifest,
+      routeModules: window.__remixRouteModules,
+      stateDecodingPromise: undefined,
+      router: undefined,
+      routerInitialized: false,
+    };
+  }
+}
+
+export type HmrInfo = {
+  abortController: AbortController | undefined;
+  routerReadyResolve: (router: RemixRouter) => void;
+  routerReadyPromise: Promise<RemixRouter>;
+};
+
+let hmrInfo: HmrInfo | null = null;
+
+if (
+  import.meta &&
+  // @ts-expect-error
+  import.meta.hot &&
+  window.__remixManifest
+) {
+  let resolve: (router: RemixRouter) => void;
+  let routerReadyPromise = new Promise((r) => {
+    resolve = r;
+  }).catch(() => {
+    // This is a noop catch handler to avoid unhandled promise rejection warnings
+    // in the console. The promise is never rejected.
+    return undefined;
+  }) as Promise<RemixRouter>;
+
+  hmrInfo = {
+    abortController: undefined,
+    routerReadyResolve: resolve!,
+    // There's a race condition with HMR where the remix:manifest is signaled before
+    // the router is assigned in the RemixBrowser component. This promise gates the
+    // HMR handler until the router is ready
+    routerReadyPromise,
+  };
+
+  // @ts-expect-error
+  import.meta.hot.accept(
+    "remix:manifest",
+    async ({
+      assetsManifest,
+      needsRevalidation,
+    }: {
+      assetsManifest: AssetsManifest;
+      needsRevalidation: Set<string>;
+    }) => {
+      let router = await hmrInfo!.routerReadyPromise;
+      // This should never happen, but just in case...
+      if (!router || !ssrInfo || !hmrInfo) {
+        console.error(
+          "Failed to accept HMR update because the router/ssrInfo was not ready."
+        );
+        return;
+      }
+
+      let routeIds = [
+        ...new Set(
+          router.state.matches
+            .map((m) => m.route.id)
+            .concat(Object.keys(ssrInfo!.routeModules))
+        ),
+      ];
+
+      hmrInfo.abortController?.abort();
+      hmrInfo.abortController = new AbortController();
+      let signal = hmrInfo.abortController.signal;
+
+      // Load new route modules that we've seen.
+      let newRouteModules = Object.assign(
+        {},
+        ssrInfo.routeModules,
+        Object.fromEntries(
+          (
+            await Promise.all(
+              routeIds.map(async (id) => {
+                if (!assetsManifest.routes[id]) {
+                  return null;
+                }
+                let imported = await import(
+                  assetsManifest.routes[id].module +
+                    `?t=${assetsManifest.hmr?.timestamp}`
+                );
+                invariant(ssrInfo, "ssrInfo unavailable for HMR update");
+                return [
+                  id,
+                  {
+                    ...imported,
+                    // react-refresh takes care of updating these in-place,
+                    // if we don't preserve existing values we'll loose state.
+                    default: imported.default
+                      ? ssrInfo.routeModules[id]?.default || imported.default
+                      : imported.default,
+                    ErrorBoundary: imported.ErrorBoundary
+                      ? ssrInfo.routeModules[id]?.ErrorBoundary ||
+                        imported.ErrorBoundary
+                      : imported.ErrorBoundary,
+                    HydrateFallback: imported.HydrateFallback
+                      ? ssrInfo.routeModules[id]?.HydrateFallback ||
+                        imported.HydrateFallback
+                      : imported.HydrateFallback,
+                  },
+                ];
+              })
+            )
+          ).filter(Boolean) as [string, RouteModules[string]][]
+        )
+      );
+
+      Object.assign(ssrInfo.routeModules, newRouteModules);
+      // Create new routes
+      let routes = createClientRoutesWithHMRRevalidationOptOut(
+        needsRevalidation,
+        assetsManifest.routes,
+        ssrInfo.routeModules,
+        ssrInfo.context.state,
+        ssrInfo.context.future,
+        ssrInfo.context.isSpaMode
+      );
+
+      // This is temporary API and will be more granular before release
+      router._internalSetRoutes(routes);
+
+      // Wait for router to be idle before updating the manifest and route modules
+      // and triggering a react-refresh
+      let unsub = router.subscribe((state) => {
+        if (state.revalidation === "idle") {
+          unsub();
+          // Abort if a new update comes in while we're waiting for the
+          // router to be idle.
+          if (signal.aborted) return;
+          // Ensure RouterProvider setState has flushed before re-rendering
+          setTimeout(() => {
+            Object.assign(ssrInfo!.manifest, assetsManifest);
+            window.$RefreshRuntime$!.performReactRefresh();
+          }, 1);
+        }
+      });
+      window.__remixRevalidation = (window.__remixRevalidation || 0) + 1;
+      router.revalidate();
+    }
+  );
+}
+
+function createHydratedRouter(): RemixRouter {
+  initSsrInfo();
+
+  if (!ssrInfo) {
+    throw new Error(
+      "You must be using the SSR features of React Router in order to skip " +
+        "passing a `router` prop to `<RouterProvider>`"
+    );
+  }
+
+  // TODO: Do some testing to confirm it's OK to skip the hard reload check
+  // now that all route.lazy stuff is wired up
+
+  // When single fetch is enabled, we need to suspend until the initial state
+  // snapshot is decoded into window.__remixContext.state
+  if (ssrInfo.context.future.unstable_singleFetch) {
+    let localSsrInfo = ssrInfo;
+    // Note: `stateDecodingPromise` is not coupled to `router` - we'll reach this
+    // code potentially many times waiting for our state to arrive, but we'll
+    // then only get past here and create the `router` one time
+    if (!ssrInfo.stateDecodingPromise) {
+      let stream = ssrInfo.context.stream;
+      invariant(stream, "No stream found for single fetch decoding");
+      ssrInfo.context.stream = undefined;
+      ssrInfo.stateDecodingPromise = decodeViaTurboStream(stream, window)
+        .then((value) => {
+          ssrInfo!.context.state =
+            value.value as typeof localSsrInfo.context.state;
+          localSsrInfo.stateDecodingPromise!.value = true;
+        })
+        .catch((e) => {
+          localSsrInfo.stateDecodingPromise!.error = e;
+        });
+    }
+    if (ssrInfo.stateDecodingPromise.error) {
+      throw ssrInfo.stateDecodingPromise.error;
+    }
+    if (!ssrInfo.stateDecodingPromise.value) {
+      throw ssrInfo.stateDecodingPromise;
+    }
+  }
+
+  let routes = createClientRoutes(
+    ssrInfo.manifest.routes,
+    ssrInfo.routeModules,
+    ssrInfo.context.state,
+    ssrInfo.context.future,
+    ssrInfo.context.isSpaMode
+  );
+
+  let hydrationData: HydrationState | undefined = undefined;
+  if (!ssrInfo.context.isSpaMode) {
+    // Create a shallow clone of `loaderData` we can mutate for partial hydration.
+    // When a route exports a `clientLoader` and a `HydrateFallback`, the SSR will
+    // render the fallback so we need the client to do the same for hydration.
+    // The server loader data has already been exposed to these route `clientLoader`'s
+    // in `createClientRoutes` above, so we need to clear out the version we pass to
+    // `createBrowserRouter` so it initializes and runs the client loaders.
+    hydrationData = {
+      ...ssrInfo.context.state,
+      loaderData: { ...ssrInfo.context.state.loaderData },
+    };
+    let initialMatches = matchRoutes(routes, window.location);
+    if (initialMatches) {
+      for (let match of initialMatches) {
+        let routeId = match.route.id;
+        let route = ssrInfo.routeModules[routeId];
+        let manifestRoute = ssrInfo.manifest.routes[routeId];
+        // Clear out the loaderData to avoid rendering the route component when the
+        // route opted into clientLoader hydration and either:
+        // * gave us a HydrateFallback
+        // * or doesn't have a server loader and we have no data to render
+        if (
+          route &&
+          shouldHydrateRouteLoader(
+            manifestRoute,
+            route,
+            ssrInfo.context.isSpaMode
+          ) &&
+          (route.HydrateFallback || !manifestRoute.hasLoader)
+        ) {
+          hydrationData.loaderData![routeId] = undefined;
+        } else if (manifestRoute && !manifestRoute.hasLoader) {
+          // Since every Remix route gets a `loader` on the client side to load
+          // the route JS module, we need to add a `null` value to `loaderData`
+          // for any routes that don't have server loaders so our partial
+          // hydration logic doesn't kick off the route module loaders during
+          // hydration
+          hydrationData.loaderData![routeId] = null;
+        }
+      }
+    }
+
+    if (hydrationData && hydrationData.errors) {
+      // TODO: De-dup this or remove entirely in v7 where single fetch is the
+      // only approach and we have already serialized or deserialized on the server
+      hydrationData.errors = deserializeErrors(hydrationData.errors);
+    }
+  }
+
+  // We don't use createBrowserRouter here because we need fine-grained control
+  // over initialization to support synchronous `clientLoader` flows.
+  let router = createRouter({
+    routes,
+    history: createBrowserHistory(),
+    basename: ssrInfo.context.basename,
+    future: {
+      v7_normalizeFormMethod: true,
+      v7_fetcherPersist: ssrInfo.context.future.v3_fetcherPersist,
+      v7_partialHydration: true,
+      v7_prependBasename: true,
+      v7_relativeSplatPath: ssrInfo.context.future.v3_relativeSplatPath,
+      // Single fetch enables this underlying behavior
+      unstable_skipActionErrorRevalidation:
+        ssrInfo.context.future.unstable_singleFetch === true,
+    },
+    hydrationData,
+    mapRouteProperties,
+    unstable_dataStrategy: ssrInfo.context.future.unstable_singleFetch
+      ? getSingleFetchDataStrategy(ssrInfo.manifest, ssrInfo.routeModules)
+      : undefined,
+  });
+  ssrInfo.router = router;
+
+  // We can call initialize() immediately if the router doesn't have any
+  // loaders to run on hydration
+  if (router.state.initialized) {
+    ssrInfo.routerInitialized = true;
+    router.initialize();
+  }
+
+  // @ts-ignore
+  router.createRoutesForHMR = createClientRoutesWithHMRRevalidationOptOut;
+  window.__remixRouter = router;
+
+  // Notify that the router is ready for HMR
+  hmrInfo?.routerReadyResolve(router);
+
+  return router;
+}
+
+export function HydratedRouter() {
+  if (!router) {
+    router = createHydratedRouter();
+  }
+
+  // Critical CSS can become stale after code changes, e.g. styles might be
+  // removed from a component, but the styles will still be present in the
+  // server HTML. This allows our HMR logic to clear the critical CSS state.
+  let [criticalCss, setCriticalCss] = React.useState(
+    process.env.NODE_ENV === "development"
+      ? ssrInfo?.context.criticalCss
+      : undefined
+  );
+  if (process.env.NODE_ENV === "development") {
+    if (ssrInfo) {
+      window.__remixClearCriticalCss = () => setCriticalCss(undefined);
+    }
+  }
+
+  let [location, setLocation] = React.useState(router.state.location);
+
+  React.useLayoutEffect(() => {
+    // If we had to run clientLoaders on hydration, we delay initialization until
+    // after we've hydrated to avoid hydration issues from synchronous client loaders
+    if (ssrInfo && ssrInfo.router && !ssrInfo.routerInitialized) {
+      ssrInfo.routerInitialized = true;
+      ssrInfo.router.initialize();
+    }
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (ssrInfo && ssrInfo.router) {
+      return ssrInfo.router.subscribe((newState) => {
+        if (newState.location !== location) {
+          setLocation(newState.location);
+        }
+      });
+    }
+  }, [location]);
+
+  invariant(ssrInfo, "ssrInfo unavailable for HydratedRouter");
+
+  // We need to include a wrapper RemixErrorBoundary here in case the root error
+  // boundary also throws and we need to bubble up outside of the router entirely.
+  // Then we need a stateful location here so the user can back-button navigate
+  // out of there
+  return (
+    // This fragment is important to ensure we match the <RemixServer> JSX
+    // structure so that useId values hydrate correctly
+    <>
+      <RemixContext.Provider
+        value={{
+          manifest: ssrInfo.manifest,
+          routeModules: ssrInfo.routeModules,
+          future: ssrInfo.context.future,
+          criticalCss,
+          isSpaMode: ssrInfo.context.isSpaMode,
+        }}
+      >
+        <RemixErrorBoundary location={location}>
+          <RouterProvider router={router} />
+        </RemixErrorBoundary>
+      </RemixContext.Provider>
+      {/*
+          This fragment is important to ensure we match the <RemixServer> JSX
+          structure so that useId values hydrate correctly
+        */}
+      {ssrInfo.context.future.unstable_singleFetch ? <></> : null}
+    </>
+  );
+}

--- a/packages/remix-dev/config/defaults/entry.client.tsx
+++ b/packages/remix-dev/config/defaults/entry.client.tsx
@@ -1,12 +1,12 @@
-import { RouterProvider } from "react-router-dom";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router-dom";
 
 startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <RouterProvider />
+      <HydratedRouter />
     </StrictMode>
   );
 });

--- a/playground/compiler-express/app/entry.client.tsx
+++ b/playground/compiler-express/app/entry.client.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from "react-router-dom";
+import { HydratedRouter } from "react-router-dom";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
@@ -6,7 +6,7 @@ startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <RouterProvider />
+      <HydratedRouter />
     </StrictMode>
   );
 });

--- a/playground/compiler-spa/app/entry.client.tsx
+++ b/playground/compiler-spa/app/entry.client.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from "react-router-dom";
+import { HydratedRouter } from "react-router-dom";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
@@ -6,7 +6,7 @@ startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <RouterProvider />
+      <HydratedRouter />
     </StrictMode>
   );
 });

--- a/playground/compiler/app/entry.client.tsx
+++ b/playground/compiler/app/entry.client.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from "react-router-dom";
+import { HydratedRouter } from "react-router-dom";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 
@@ -6,7 +6,7 @@ startTransition(() => {
   hydrateRoot(
     document,
     <StrictMode>
-      <RouterProvider />
+      <HydratedRouter />
     </StrictMode>
   );
 });


### PR DESCRIPTION
Avoid bundle bloat by reversing our idea of just doing all the auto-hydration in `RouterProvider`, since that means folks using `RouterProvider` in a RR SPA are paying the cost for all the Remix hydration code.  Instead this is now effectively going back to the RemixBrowser approach and calling it `HydratedRouter` (name not final 😉 )