### PR TITLE
Changesets Setup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,7 +24,7 @@
   "baseBranch": "dev",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
-  "ignore": ["integration", "integration-*"],
+  "ignore": ["integration", "integration-*", "playground-*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/packages/remix-dev/package.json
+++ b/packages/remix-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/dev",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Dev tools and CLI for Remix",
   "homepage": "https://remix.run",
   "bugs": {

--- a/packages/remix-express/package.json
+++ b/packages/remix-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/express",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Express server request handler for Remix",
   "bugs": {
     "url": "https://github.com/remix-run/remix/issues"

--- a/packages/remix-node/package.json
+++ b/packages/remix-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/node",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Node.js platform abstractions for Remix",
   "bugs": {
     "url": "https://github.com/remix-run/remix/issues"

--- a/packages/remix-serve/package.json
+++ b/packages/remix-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/serve",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Production application server for Remix",
   "bugs": {
     "url": "https://github.com/remix-run/remix/issues"

--- a/packages/remix-server-runtime/package.json
+++ b/packages/remix-server-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/server-runtime",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Server runtime for Remix",
   "bugs": {
     "url": "https://github.com/remix-run/remix/issues"

--- a/packages/remix-testing/package.json
+++ b/packages/remix-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/testing",
-  "version": "2.9.0-pre.0",
+  "version": "6.22.3",
   "description": "Testing utilities for Remix apps",
   "homepage": "https://remix.run",
   "bugs": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remix-run/router",
-  "version": "1.15.3",
+  "version": "6.22.3",
   "description": "Nested/Data-driven/Framework-agnostic Routing",
   "keywords": [
     "remix",

--- a/playground/compiler-express/package.json
+++ b/playground/compiler-express/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "playground-compiler-express",
+  "version": "0.0.0",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/playground/compiler-spa/package.json
+++ b/playground/compiler-spa/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "playground-compiler-spa",
+  "version": "0.0.0",
   "private": true,
   "sideEffects": false,
   "type": "module",

--- a/playground/compiler/package.json
+++ b/playground/compiler/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "playground-compiler",
+  "version": "0.0.0",
   "private": true,
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
Minor updates to do some local testing of the changesets flow.  With these changes you can:

```sh
# Enter prerelease mode and commit changes
pnpm exec changeset pre enter pre
git add .
git commit -a -m "Enter prerelease mode"

# Run version command to bump to 7.0.0-pre.0 and add entries to CHANGELOG's
export GITHUB_TOKEN="....."
pnpm exec changeset version
git add .
git commit -m "Prerelease"

# Run a dry publish run to see what would be published to npm
pnpm -r publish --dry-run --publish-branch brophdawg11/changesets
```

Everything looks good to me in that flow, so with these changes I think we'll be in good shape when it comes time to do a prerelease