### PR TITLE
Apply patches from remix 2.9.0

### DIFF
--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -409,12 +409,7 @@ test.describe("single fetch", () => {
         let app = new PlaywrightFixture(appFixture, page);
         await app.goto("/parent");
         await app.clickLink("/parent/child-with-boundary");
-        await waitForAndAssert(
-          page,
-          app,
-          "#child-error",
-          "Unable to decode turbo-stream response from URL"
-        );
+        await waitForAndAssert(page, app, "#child-error", "CDN Error");
       });
     });
 

--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -409,7 +409,12 @@ test.describe("single fetch", () => {
         let app = new PlaywrightFixture(appFixture, page);
         await app.goto("/parent");
         await app.clickLink("/parent/child-with-boundary");
-        await waitForAndAssert(page, app, "#child-error", "CDN Error!");
+        await waitForAndAssert(
+          page,
+          app,
+          "#child-error",
+          "Unable to decode turbo-stream response from URL"
+        );
       });
     });
 

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -148,7 +148,7 @@ test.describe("Vite / route / server-only module referenced by client", () => {
 
         `  But other route exports in 'app/routes/_index.tsx' depend on '${specifier}'.`,
 
-        "  See https://remix.run/docs/en/main/future/vite#splitting-up-client-and-server-code",
+        "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
       ].forEach(expect(stderr).toMatch);
     });
   }
@@ -208,7 +208,7 @@ test.describe("Vite / non-route / server-only module referenced by client", () =
 
         `    '${specifier}' imported by 'app/reexport-server-only.ts'`,
 
-        "  See https://remix.run/docs/en/main/future/vite#splitting-up-client-and-server-code",
+        "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
       ].forEach(expect(stderr).toMatch);
     });
   }

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -44,7 +44,7 @@ test.describe("SPA Mode", () => {
         let stderr = result.stderr.toString("utf8");
         expect(stderr).toMatch(
           "SPA Mode: 3 invalid route export(s) in `routes/invalid-exports.tsx`: " +
-            "`headers`, `loader`, `action`. See https://remix.run/future/spa-mode " +
+            "`headers`, `loader`, `action`. See https://remix.run/guides/spa-mode " +
             "for more information."
         );
       });
@@ -74,7 +74,7 @@ test.describe("SPA Mode", () => {
         expect(stderr).toMatch(
           "SPA Mode: Invalid `HydrateFallback` export found in `routes/invalid-exports.tsx`. " +
             "`HydrateFallback` is only permitted on the root route in SPA Mode. " +
-            "See https://remix.run/future/spa-mode for more information."
+            "See https://remix.run/guides/spa-mode for more information."
         );
       });
 

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.4`
+  - `@remix-run/node@2.9.0-pre.4`
+
 ## 2.9.0-pre.3
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.5`
+  - `@remix-run/server-runtime@2.9.0-pre.5`
+
 ## 2.9.0-pre.4
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.7`
+  - `@remix-run/server-runtime@2.9.0-pre.7`
+
 ## 2.9.0-pre.6
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.2
+
+### Patch Changes
+
+- Update links printed to the console by the Remix CLI/Dev Server to point to updated docs locations ([#9176](https://github.com/remix-run/remix/pull/9176))
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.2`
+  - `@remix-run/server-runtime@2.9.0-pre.2`
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.3`
+  - `@remix-run/server-runtime@2.9.0-pre.3`
+
 ## 2.9.0-pre.2
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.1`
+  - `@remix-run/node@2.9.0-pre.1`
+
 ## 2.9.0-pre.0
 
 ### Minor Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,71 +1,6 @@
 # `@remix-run/dev`
 
-## 2.9.0-pre.8
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.8`
-  - `@remix-run/server-runtime@2.9.0-pre.8`
-
-## 2.9.0-pre.7
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.7`
-  - `@remix-run/server-runtime@2.9.0-pre.7`
-
-## 2.9.0-pre.6
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.6`
-  - `@remix-run/server-runtime@2.9.0-pre.6`
-
-## 2.9.0-pre.5
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.5`
-  - `@remix-run/server-runtime@2.9.0-pre.5`
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.4`
-  - `@remix-run/node@2.9.0-pre.4`
-
-## 2.9.0-pre.3
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.3`
-  - `@remix-run/server-runtime@2.9.0-pre.3`
-
-## 2.9.0-pre.2
-
-### Patch Changes
-
-- Update links printed to the console by the Remix CLI/Dev Server to point to updated docs locations ([#9176](https://github.com/remix-run/remix/pull/9176))
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.2`
-  - `@remix-run/server-runtime@2.9.0-pre.2`
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.1`
-  - `@remix-run/node@2.9.0-pre.1`
-
-## 2.9.0-pre.0
+## 2.9.0
 
 ### Minor Changes
 
@@ -83,11 +18,10 @@
 - Improve `getDependenciesToBundle` resolution in monorepos ([#8848](https://github.com/remix-run/remix/pull/8848))
 - Fix SPA mode when single fetch is enabled by using streaming entry.server ([#9063](https://github.com/remix-run/remix/pull/9063))
 - Vite: added sourcemap support for transformed routes ([#8970](https://github.com/remix-run/remix/pull/8970))
+- Update links printed to the console by the Remix CLI/Dev Server to point to updated docs locations ([#9176](https://github.com/remix-run/remix/pull/9176))
 - Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.0`
-  - `@remix-run/server-runtime@2.9.0-pre.0`
-  - `@remix-run/react@2.9.0-pre.0`
-  - `@remix-run/serve@2.9.0-pre.0`
+  - `@remix-run/node@2.9.0`
+  - `@remix-run/server-runtime@2.9.0`
 
 ## 2.8.1
 

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.8`
+  - `@remix-run/server-runtime@2.9.0-pre.8`
+
 ## 2.9.0-pre.7
 
 ### Patch Changes

--- a/packages/remix-dev/CHANGELOG.md
+++ b/packages/remix-dev/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/dev`
 
+## 2.9.0-pre.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.6`
+  - `@remix-run/server-runtime@2.9.0-pre.6`
+
 ## 2.9.0-pre.5
 
 ### Patch Changes

--- a/packages/remix-dev/vite/plugin.ts
+++ b/packages/remix-dev/vite/plugin.ts
@@ -1554,7 +1554,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
               "",
               `  But other route exports in '${importerShort}' depend on '${id}'.`,
               "",
-              "  See https://remix.run/docs/en/main/future/vite#splitting-up-client-and-server-code",
+              "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
               "",
             ].join("\n")
           );
@@ -1566,7 +1566,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
             "",
             `    '${id}' imported by '${importerShort}'`,
             "",
-            "  See https://remix.run/docs/en/main/future/vite#splitting-up-client-and-server-code",
+            "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
             "",
           ].join("\n")
         );
@@ -1609,7 +1609,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
             let str = serverOnlyExports.map((e) => `\`${e}\``).join(", ");
             let message =
               `SPA Mode: ${serverOnlyExports.length} invalid route export(s) in ` +
-              `\`${route.file}\`: ${str}. See https://remix.run/future/spa-mode ` +
+              `\`${route.file}\`: ${str}. See https://remix.run/guides/spa-mode ` +
               `for more information.`;
             throw Error(message);
           }
@@ -1622,7 +1622,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
               let message =
                 `SPA Mode: Invalid \`HydrateFallback\` export found in ` +
                 `\`${route.file}\`. \`HydrateFallback\` is only permitted on ` +
-                `the root route in SPA Mode. See https://remix.run/future/spa-mode ` +
+                `the root route in SPA Mode. See https://remix.run/guides/spa-mode ` +
                 `for more information.`;
               throw Error(message);
             }

--- a/packages/remix-dev/vite/styles.ts
+++ b/packages/remix-dev/vite/styles.ts
@@ -198,7 +198,7 @@ export const getStylesForUrl = async ({
   let appPath = path.relative(process.cwd(), reactRouterConfig.appDirectory);
   let documentRouteFiles =
     matchRoutes(routes, url, build.basename)?.map((match) =>
-      path.join(appPath, reactRouterConfig.routes[match.route.id].file)
+      path.resolve(appPath, reactRouterConfig.routes[match.route.id].file)
     ) ?? [];
 
   let styles = await getStylesForFiles({

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.5`
+
 ## 2.9.0-pre.4
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.4`
+
 ## 2.9.0-pre.3
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.3`
+
 ## 2.9.0-pre.2
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.2`
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,67 +1,11 @@
 # `@remix-run/express`
 
-## 2.9.0-pre.8
+## 2.9.0
 
 ### Patch Changes
 
 - Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.8`
-
-## 2.9.0-pre.7
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.7`
-
-## 2.9.0-pre.6
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.6`
-
-## 2.9.0-pre.5
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.5`
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.4`
-
-## 2.9.0-pre.3
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.3`
-
-## 2.9.0-pre.2
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.2`
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.1`
-
-## 2.9.0-pre.0
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.0`
+  - `@remix-run/node@2.9.0`
 
 ## 2.8.1
 

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.6`
+
 ## 2.9.0-pre.5
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.7`
+
 ## 2.9.0-pre.6
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.8`
+
 ## 2.9.0-pre.7
 
 ### Patch Changes

--- a/packages/remix-express/CHANGELOG.md
+++ b/packages/remix-express/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/express`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.1`
+
 ## 2.9.0-pre.0
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.3
+
+### Patch Changes
+
+- - Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
+  - `remix-serve` will default to using `undici` for the fetch polyfill if `future._unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
+    - Any users opting into Single Fetch and managing their own polfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.3`
+
 ## 2.9.0-pre.2
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.1`
+
 ## 2.9.0-pre.0
 
 ### Minor Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.8`
+
 ## 2.9.0-pre.7
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.6`
+
 ## 2.9.0-pre.5
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.2`
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.7`
+
 ## 2.9.0-pre.6
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.4`
+
 ## 2.9.0-pre.3
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@remix-run/node`
 
+## 2.9.0-pre.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/server-runtime@2.9.0-pre.5`
+
 ## 2.9.0-pre.4
 
 ### Patch Changes

--- a/packages/remix-node/CHANGELOG.md
+++ b/packages/remix-node/CHANGELOG.md
@@ -1,74 +1,18 @@
 # `@remix-run/node`
 
-## 2.9.0-pre.8
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.8`
-
-## 2.9.0-pre.7
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.7`
-
-## 2.9.0-pre.6
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.6`
-
-## 2.9.0-pre.5
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.5`
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.4`
-
-## 2.9.0-pre.3
-
-### Patch Changes
-
-- - Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
-  - `remix-serve` will default to using `undici` for the fetch polyfill if `future._unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
-    - Any users opting into Single Fetch and managing their own polfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.3`
-
-## 2.9.0-pre.2
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.2`
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.1`
-
-## 2.9.0-pre.0
+## 2.9.0
 
 ### Minor Changes
 
-- Use undici as our fetch polyfill going forward. #9106 ([#9111](https://github.com/remix-run/remix/pull/9111))
+- Use undici as our fetch polyfill going forward ([#9106](https://github.com/remix-run/remix/pull/9106), [#9111](https://github.com/remix-run/remix/pull/9111))
+- Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
+  - `remix-serve` will default to using `undici` for the fetch polyfill if `future._unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
+    - Any users opting into Single Fetch and managing their own polfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
 
 ### Patch Changes
 
 - Updated dependencies:
-  - `@remix-run/server-runtime@2.9.0-pre.0`
+  - `@remix-run/server-runtime@2.9.0`
 
 ## 2.8.1
 

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/express@2.9.0-pre.2`
+  - `@remix-run/node@2.9.0-pre.2`
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.1`
+  - `@remix-run/express@2.9.0-pre.1`
+
 ## 2.9.0-pre.0
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,16 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.3
+
+### Patch Changes
+
+- - Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
+  - `remix-serve` will default to using `undici` for the fetch polyfill if `future._unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
+    - Any users opting into Single Fetch and managing their own polfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.3`
+  - `@remix-run/express@2.9.0-pre.3`
+
 ## 2.9.0-pre.2
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/express@2.9.0-pre.6`
+  - `@remix-run/node@2.9.0-pre.6`
+
 ## 2.9.0-pre.5
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.4`
+  - `@remix-run/express@2.9.0-pre.4`
+
 ## 2.9.0-pre.3
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/express@2.9.0-pre.7`
+  - `@remix-run/node@2.9.0-pre.7`
+
 ## 2.9.0-pre.6
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,79 +1,18 @@
 # `@remix-run/serve`
 
-## 2.9.0-pre.8
+## 2.9.0
+
+### Minor Changes
+
+- Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
+  - `remix-serve` will default to using `undici` for the fetch polyfill if `future.unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
+  - Any users opting into Single Fetch and managing their own polyfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
 
 ### Patch Changes
 
 - Updated dependencies:
-  - `@remix-run/express@2.9.0-pre.8`
-  - `@remix-run/node@2.9.0-pre.8`
-
-## 2.9.0-pre.7
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/express@2.9.0-pre.7`
-  - `@remix-run/node@2.9.0-pre.7`
-
-## 2.9.0-pre.6
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/express@2.9.0-pre.6`
-  - `@remix-run/node@2.9.0-pre.6`
-
-## 2.9.0-pre.5
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/express@2.9.0-pre.5`
-  - `@remix-run/node@2.9.0-pre.5`
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.4`
-  - `@remix-run/express@2.9.0-pre.4`
-
-## 2.9.0-pre.3
-
-### Patch Changes
-
-- - Put `undici` fetch polyfill behind a new `installGlobals({ nativeFetch: true })` parameter ([#9198](https://github.com/remix-run/remix/pull/9198))
-  - `remix-serve` will default to using `undici` for the fetch polyfill if `future._unstable_singleFetch` is enabled because the single fetch implementation relies on the `undici` polyfill
-    - Any users opting into Single Fetch and managing their own polfill will need to pass the flag to `installGlobals` on their own to avoid runtime errors with Single Fetch
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.3`
-  - `@remix-run/express@2.9.0-pre.3`
-
-## 2.9.0-pre.2
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/express@2.9.0-pre.2`
-  - `@remix-run/node@2.9.0-pre.2`
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.1`
-  - `@remix-run/express@2.9.0-pre.1`
-
-## 2.9.0-pre.0
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.0`
-  - `@remix-run/express@2.9.0-pre.0`
+  - `@remix-run/node@2.9.0`
+  - `@remix-run/express@2.9.0`
 
 ## 2.8.1
 

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/express@2.9.0-pre.5`
+  - `@remix-run/node@2.9.0-pre.5`
+
 ## 2.9.0-pre.4
 
 ### Patch Changes

--- a/packages/remix-serve/CHANGELOG.md
+++ b/packages/remix-serve/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/serve`
 
+## 2.9.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/express@2.9.0-pre.8`
+  - `@remix-run/node@2.9.0-pre.8`
+
 ## 2.9.0-pre.7
 
 ### Patch Changes

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.5
+
 ## 2.9.0-pre.4
 
 ### Patch Changes

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- [REMOVE] Remove RR flags and implement via dataStrategy ([#9157](https://github.com/remix-run/remix/pull/9157))
+
 ## 2.9.0-pre.0
 
 ### Minor Changes

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.2
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,47 +1,17 @@
 # `@remix-run/server-runtime`
 
-## 2.9.0-pre.8
-
-## 2.9.0-pre.7
-
-## 2.9.0-pre.6
-
-## 2.9.0-pre.5
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- [REMOVE] Fix typings for response in LoaderFunctonArgs/ActionFunctionArgs ([#9254](https://github.com/remix-run/remix/pull/9254))
-
-## 2.9.0-pre.3
-
-## 2.9.0-pre.2
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- [REMOVE] Remove RR flags and implement via dataStrategy ([#9157](https://github.com/remix-run/remix/pull/9157))
-
-## 2.9.0-pre.0
+## 2.9.0
 
 ### Minor Changes
 
 - New `future.unstable_singleFetch` flag ([#8773](https://github.com/remix-run/remix/pull/8773))
-
   - Naked objects returned from loaders/actions are no longer automatically converted to JSON responses. They'll be streamed as-is via `turbo-stream` so `Date`'s will become `Date` through `useLoaderData()`
   - You can return naked objects with `Promise`'s without needing to use `defer()` - including nested `Promise`'s
     - If you need to return a custom status code or custom response headers, you can still use the `defer` utility
   - `<RemixServer abortDelay>` is no longer used. Instead, you should `export const streamTimeout` from `entry.server.tsx` and the remix server runtime will use that as the delay to abort the streamed response
     - If you export your own streamTimeout, you should decouple that from aborting the react `renderToPipeableStream`. You should always ensure that react is aborted _afer_ the stream is aborted so that abort rejections can be flushed down
   - Actions no longer automatically revalidate on 4xx/5xx responses (via RR `future.unstable_skipActionErrorRevalidation` flag) - you can return a 2xx to opt-into revalidation or use `shouldRevalidate`
-
-### Patch Changes
-
-- handle net new redirects created by handleDataRequest ([#9104](https://github.com/remix-run/remix/pull/9104))
 - Add `ResponseStub` header interface for single fetch and deprecate the `headers` export ([#9142](https://github.com/remix-run/remix/pull/9142))
-
   - The `headers` export is no longer used when single fetch is enabled
   - `loader`/`action` functions now receive a mutable `response` parameter
     - `type ResponseStub = { status: numbers | undefined, headers: Headers }`
@@ -61,6 +31,10 @@
   - Because single fetch supports naked object returns, and you no longer need to return a `Response` instance to set status/headers, the `json`/`redirect`/`redirectDocument`/`defer` utilities are considered deprecated when using Single Fetch
   - You may still continue returning normal `Response` instances and they'll apply status codes in the same way, and will apply all headers via `headers.set` - overwriting any same-named header values from parents
     - If you need to append, you will need to switch from returning a `Response` instance to using the new `response` parameter
+
+### Patch Changes
+
+- Handle net new redirects created by handleDataRequest ([#9104](https://github.com/remix-run/remix/pull/9104))
 
 ## 2.8.1
 

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.3
+
 ## 2.9.0-pre.2
 
 ## 2.9.0-pre.1

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.6
+
 ## 2.9.0-pre.5
 
 ## 2.9.0-pre.4

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.7
+
 ## 2.9.0-pre.6
 
 ## 2.9.0-pre.5

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- [REMOVE] Fix typings for response in LoaderFunctonArgs/ActionFunctionArgs ([#9254](https://github.com/remix-run/remix/pull/9254))
+
 ## 2.9.0-pre.3
 
 ## 2.9.0-pre.2

--- a/packages/remix-server-runtime/CHANGELOG.md
+++ b/packages/remix-server-runtime/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `@remix-run/server-runtime`
 
+## 2.9.0-pre.8
+
 ## 2.9.0-pre.7
 
 ## 2.9.0-pre.6

--- a/packages/remix-server-runtime/routeModules.ts
+++ b/packages/remix-server-runtime/routeModules.ts
@@ -40,6 +40,9 @@ export type ResponseStubOperation = [
 export type ResponseStub = {
   status: number | undefined;
   headers: Headers;
+};
+
+export type ResponseStubImpl = ResponseStub & {
   [ResponseStubOperationsSymbol]: ResponseStubOperation[];
 };
 

--- a/packages/remix-server-runtime/routes.ts
+++ b/packages/remix-server-runtime/routes.ts
@@ -6,7 +6,8 @@ import type {
 
 import { callRouteAction, callRouteLoader } from "./data";
 import type { FutureConfig } from "./entry";
-import type { ResponseStub, ServerRouteModule } from "./routeModules";
+import type { ServerRouteModule } from "./routeModules";
+import type { DataStrategyCtx } from "./single-fetch";
 
 export interface RouteManifest<Route> {
   [routeId: string]: Route;
@@ -100,9 +101,8 @@ export function createStaticHandlerDataRoutes(
               loader: route.module.loader!,
               routeId: route.id,
               singleFetch: future.unstable_singleFetch === true,
-              response: (
-                dataStrategyCtx as unknown as { response: ResponseStub }
-              )?.response,
+              response: (dataStrategyCtx as DataStrategyCtx | undefined)
+                ?.response,
             })
         : undefined,
       action: route.module.action
@@ -114,9 +114,8 @@ export function createStaticHandlerDataRoutes(
               action: route.module.action!,
               routeId: route.id,
               singleFetch: future.unstable_singleFetch === true,
-              response: (
-                dataStrategyCtx as unknown as { response: ResponseStub }
-              )?.response,
+              response: (dataStrategyCtx as DataStrategyCtx | undefined)
+                ?.response,
             })
         : undefined,
       handle: route.module.handle,

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.3
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.3`
+  - `@remix-run/react@2.9.0-pre.3`
+
 ## 2.9.0-pre.2
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/react@2.9.0-pre.8`
+  - `@remix-run/node@2.9.0-pre.8`
+
 ## 2.9.0-pre.7
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.6
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/react@2.9.0-pre.6`
+  - `@remix-run/node@2.9.0-pre.6`
+
 ## 2.9.0-pre.5
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,70 +1,6 @@
 # `@remix-run/testing`
 
-## 2.9.0-pre.8
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/react@2.9.0-pre.8`
-  - `@remix-run/node@2.9.0-pre.8`
-
-## 2.9.0-pre.7
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/react@2.9.0-pre.7`
-  - `@remix-run/node@2.9.0-pre.7`
-
-## 2.9.0-pre.6
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/react@2.9.0-pre.6`
-  - `@remix-run/node@2.9.0-pre.6`
-
-## 2.9.0-pre.5
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/react@2.9.0-pre.5`
-  - `@remix-run/node@2.9.0-pre.5`
-
-## 2.9.0-pre.4
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.4`
-  - `@remix-run/react@2.9.0-pre.4`
-
-## 2.9.0-pre.3
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.3`
-  - `@remix-run/react@2.9.0-pre.3`
-
-## 2.9.0-pre.2
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.2`
-  - `@remix-run/react@2.9.0-pre.2`
-
-## 2.9.0-pre.1
-
-### Patch Changes
-
-- Updated dependencies:
-  - `@remix-run/react@2.9.0-pre.1`
-  - `@remix-run/node@2.9.0-pre.1`
-
-## 2.9.0-pre.0
+## 2.9.0
 
 ### Minor Changes
 
@@ -80,8 +16,8 @@
 ### Patch Changes
 
 - Updated dependencies:
-  - `@remix-run/node@2.9.0-pre.0`
-  - `@remix-run/react@2.9.0-pre.0`
+  - `@remix-run/node@2.9.0`
+  - `@remix-run/react@2.9.0`
 
 ## 2.8.1
 

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.4
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.4`
+  - `@remix-run/react@2.9.0-pre.4`
+
 ## 2.9.0-pre.3
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.7
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/react@2.9.0-pre.7`
+  - `@remix-run/node@2.9.0-pre.7`
+
 ## 2.9.0-pre.6
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/node@2.9.0-pre.2`
+  - `@remix-run/react@2.9.0-pre.2`
+
 ## 2.9.0-pre.1
 
 ### Patch Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/react@2.9.0-pre.1`
+  - `@remix-run/node@2.9.0-pre.1`
+
 ## 2.9.0-pre.0
 
 ### Minor Changes

--- a/packages/remix-testing/CHANGELOG.md
+++ b/packages/remix-testing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@remix-run/testing`
 
+## 2.9.0-pre.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - `@remix-run/react@2.9.0-pre.5`
+  - `@remix-run/node@2.9.0-pre.5`
+
 ## 2.9.0-pre.4
 
 ### Patch Changes


### PR DESCRIPTION
We originally migrated remix packages to the `v7` as of `remix@2.9.0-pre.0`.  Now that `2.9.0` is released and merged into `dev` this brings over all subsequent changes up to the merge commit of `release-next -> dev` (SHA 470bb1c2e4e6e15cbcddc689b857f19cdd03bca8).

Patches generated via (on the `dev` branch):

```sh
git format-patch remix@2.9.0-pre.0..HEAD -o ~/Desktop/patches integration packages/remix-dev packages/remix-express packages/remix-node packages/remix-serve packages/remix-server-runtime packages/remix-testing ':!*/package.json'
```

And applied via:

```sh
git am ~/Desktop/patches/*.patch
```
A few patches required manual intervention:

**Vite critical CSS resolution**

I made this change manually in this branch.

Fix Vite critical CSS resolution for route files with absolute paths ([#9194](https://github.com/remix-run/remix/pull/9194))

**The naive fetch flag changes will need to be-applied manually**

chore(remix-node): put native fetch behind config option ([#9198](https://github.com/remix-run/remix/pull/9198))

**Playwright Hanging Fix**

This was skipped because it has already been changed in RR.
Fix Playwright hanging in Node 20.5.2+ ([#9232](https://github.com/remix-run/remix/pull/9232))

**Babel/react-refresh change**

This was skipped because it has already been changed in RR.
Applying: Ignore Babel config for `react-refresh` transform ([#9241](https://github.com/remix-run/remix/pull/9241))


