### PR TITLE
Fix useLocation to receive 0 instead of null when state is set to 0

### DIFF
--- a/.changeset/smooth-sloths-exist.md
+++ b/.changeset/smooth-sloths-exist.md
@@ -1,0 +1,6 @@
+---
+"react-router-dom": patch
+"react-router-dom-v5-compat": patch
+---
+
+useLocation retains a non-null state when state passed explicitly

--- a/.changeset/smooth-sloths-exist.md
+++ b/.changeset/smooth-sloths-exist.md
@@ -3,4 +3,4 @@
 "react-router-dom-v5-compat": patch
 ---
 
-useLocation retains a non-null state when state passed explicitly
+Allow falsy `location.state` values passed to `<StaticRouter>`

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,3 +253,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- jungwoo3490

--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -86,7 +86,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state ?? null,
+    state: locationProp.state != null ? locationProp.state : null,
     key: locationProp.key || "default",
   };
 

--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
 import type { Location, To } from "history";
 import { Action, createPath, parsePath } from "history";
+import * as React from "react";
 
 // Get useHistory from react-router-dom v5 (peer dep).
 // @ts-expect-error
-import { useHistory, Route as RouteV5 } from "react-router-dom";
+import { Route as RouteV5, useHistory } from "react-router-dom";
 
 // We are a wrapper around react-router-dom v6, so bring it in
 // and bundle it because an app can't have two versions of
 // react-router-dom in its package.json.
-import { Router, Routes, Route } from "../react-router-dom";
+import { Route, Router, Routes } from "../react-router-dom";
 
 // v5 isn't in TypeScript, they'll also lose the @types/react-router with this
 // but not worried about that for now.
@@ -86,7 +86,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state || null,
+    state: locationProp.state ? locationProp.state === 0 ? 0 : locationProp.state : null,
     key: locationProp.key || "default",
   };
 

--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -86,7 +86,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state ? locationProp.state === 0 ? 0 : locationProp.state : null,
+    state: locationProp.state ?? null,
     key: locationProp.key || "default",
   };
 

--- a/packages/react-router-dom-v5-compat/lib/components.tsx
+++ b/packages/react-router-dom-v5-compat/lib/components.tsx
@@ -1,15 +1,15 @@
+import * as React from "react";
 import type { Location, To } from "history";
 import { Action, createPath, parsePath } from "history";
-import * as React from "react";
 
 // Get useHistory from react-router-dom v5 (peer dep).
 // @ts-expect-error
-import { Route as RouteV5, useHistory } from "react-router-dom";
+import { useHistory, Route as RouteV5 } from "react-router-dom";
 
 // We are a wrapper around react-router-dom v6, so bring it in
 // and bundle it because an app can't have two versions of
 // react-router-dom in its package.json.
-import { Route, Router, Routes } from "../react-router-dom";
+import { Router, Routes, Route } from "../react-router-dom";
 
 // v5 isn't in TypeScript, they'll also lose the @types/react-router with this
 // but not worried about that for now.

--- a/packages/react-router-dom/__tests__/static-location-test.tsx
+++ b/packages/react-router-dom/__tests__/static-location-test.tsx
@@ -56,5 +56,31 @@ describe("A <StaticRouter>", () => {
         key: expect.any(String),
       });
     });
+
+    it("retains a non-null state when passed explicitly", () => {
+      let location!: ReturnType<typeof useLocation>;
+      function LocationChecker() {
+        location = useLocation();
+        return null;
+      }
+
+      ReactDOMServer.renderToStaticMarkup(
+        <StaticRouter
+          location={{ pathname: "/the/path", search: "?the=query", state: 0 }}
+        >
+          <Routes>
+            <Route path="/the/path" element={<LocationChecker />} />
+          </Routes>
+        </StaticRouter>
+      );
+
+      expect(location).toEqual({
+        pathname: "/the/path",
+        search: "?the=query",
+        hash: "",
+        state: 0,
+        key: expect.any(String),
+      });
+    });
   });
 });

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -29,7 +29,7 @@ import type {
   Location,
   RouteObject,
   To,
-} from "react-router-dom";
+} from "./index";
 import {
   createPath,
   parsePath,
@@ -38,7 +38,7 @@ import {
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_FetchersContext as FetchersContext,
   UNSAFE_ViewTransitionContext as ViewTransitionContext,
-} from "react-router-dom";
+} from "./index";
 
 export interface StaticRouterProps {
   basename?: string;
@@ -315,6 +315,7 @@ export function createStaticRouter(
         v7_partialHydration: opts.future?.v7_partialHydration === true,
         v7_prependBasename: false,
         v7_relativeSplatPath: opts.future?.v7_relativeSplatPath === true,
+        unstable_skipActionErrorRevalidation: false,
       };
     },
     get state() {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -66,7 +66,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state ? locationProp.state === 0 ? 0 : locationProp.state : null,
+    state: locationProp.state ?? null,
     key: locationProp.key || "default",
   };
 

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -1,24 +1,24 @@
-import * as React from "react";
 import type {
   Path,
-  RevalidationState,
   Router as RemixRouter,
-  StaticHandlerContext,
-  CreateStaticHandlerOptions as RouterCreateStaticHandlerOptions,
+  RevalidationState,
   UNSAFE_RouteManifest as RouteManifest,
-  RouterState,
+  CreateStaticHandlerOptions as RouterCreateStaticHandlerOptions,
   FutureConfig as RouterFutureConfig,
+  RouterState,
+  StaticHandlerContext,
 } from "@remix-run/router";
 import {
+  Action,
   IDLE_BLOCKER,
   IDLE_FETCHER,
   IDLE_NAVIGATION,
-  Action,
+  UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
   UNSAFE_invariant as invariant,
   isRouteErrorResponse,
   createStaticHandler as routerCreateStaticHandler,
-  UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
 } from "@remix-run/router";
+import * as React from "react";
 import {
   UNSAFE_mapRouteProperties as mapRouteProperties,
   UNSAFE_useRoutesImpl as useRoutesImpl,
@@ -31,13 +31,13 @@ import type {
   To,
 } from "./index";
 import {
-  createPath,
-  parsePath,
-  Router,
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_FetchersContext as FetchersContext,
+  Router,
   UNSAFE_ViewTransitionContext as ViewTransitionContext,
+  createPath,
+  parsePath,
 } from "./index";
 
 export interface StaticRouterProps {
@@ -66,7 +66,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state || null,
+    state: locationProp.state ? locationProp.state === 0 ? 0 : locationProp.state : null,
     key: locationProp.key || "default",
   };
 

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -1,24 +1,24 @@
+import * as React from "react";
 import type {
   Path,
-  Router as RemixRouter,
   RevalidationState,
-  UNSAFE_RouteManifest as RouteManifest,
-  CreateStaticHandlerOptions as RouterCreateStaticHandlerOptions,
-  FutureConfig as RouterFutureConfig,
-  RouterState,
+  Router as RemixRouter,
   StaticHandlerContext,
+  CreateStaticHandlerOptions as RouterCreateStaticHandlerOptions,
+  UNSAFE_RouteManifest as RouteManifest,
+  RouterState,
+  FutureConfig as RouterFutureConfig,
 } from "@remix-run/router";
 import {
-  Action,
   IDLE_BLOCKER,
   IDLE_FETCHER,
   IDLE_NAVIGATION,
-  UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
+  Action,
   UNSAFE_invariant as invariant,
   isRouteErrorResponse,
   createStaticHandler as routerCreateStaticHandler,
+  UNSAFE_convertRoutesToDataRoutes as convertRoutesToDataRoutes,
 } from "@remix-run/router";
-import * as React from "react";
 import {
   UNSAFE_mapRouteProperties as mapRouteProperties,
   UNSAFE_useRoutesImpl as useRoutesImpl,
@@ -29,16 +29,16 @@ import type {
   Location,
   RouteObject,
   To,
-} from "./index";
+} from "react-router-dom";
 import {
+  createPath,
+  parsePath,
+  Router,
   UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   UNSAFE_FetchersContext as FetchersContext,
-  Router,
   UNSAFE_ViewTransitionContext as ViewTransitionContext,
-  createPath,
-  parsePath,
-} from "./index";
+} from "react-router-dom";
 
 export interface StaticRouterProps {
   basename?: string;
@@ -315,7 +315,6 @@ export function createStaticRouter(
         v7_partialHydration: opts.future?.v7_partialHydration === true,
         v7_prependBasename: false,
         v7_relativeSplatPath: opts.future?.v7_relativeSplatPath === true,
-        unstable_skipActionErrorRevalidation: false,
       };
     },
     get state() {

--- a/packages/react-router-dom/server.tsx
+++ b/packages/react-router-dom/server.tsx
@@ -66,7 +66,7 @@ export function StaticRouter({
     pathname: locationProp.pathname || "/",
     search: locationProp.search || "",
     hash: locationProp.hash || "",
-    state: locationProp.state ?? null,
+    state: locationProp.state != null ? locationProp.state : null,
     key: locationProp.key || "default",
   };
 


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/11448

I fixed location's state property value like this.

```ts
let location: Location = {
  pathname: locationProp.pathname || "/",
  search: locationProp.search || "",
  hash: locationProp.hash || "",
  state: locationProp.state ?? null, // fixed
  key: locationProp.key || "default",
};
```

Now, useLocation receive 0 instead of null when state is set to 0.