### PR TITLE
Support unstable_dataStrategy on staticHandler.queryRoute

### DIFF
--- a/.changeset/clever-pumas-arrive.md
+++ b/.changeset/clever-pumas-arrive.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Support `unstable_dataStrategy` on `staticHandler.queryRoute`

--- a/packages/router/__tests__/ssr-test.ts
+++ b/packages/router/__tests__/ssr-test.ts
@@ -2628,5 +2628,18 @@ describe("ssr", () => {
 
       /* eslint-enable jest/no-conditional-expect */
     });
+
+    describe("router dataStrategy", () => {
+      it("should apply a custom data strategy", async () => {
+        let { queryRoute } = createStaticHandler(SSR_ROUTES);
+        let data;
+
+        data = await queryRoute(createRequest("/custom"), {
+          unstable_dataStrategy: urlDataStrategy,
+        });
+        expect(data).toBeInstanceOf(URLSearchParams);
+        expect((data as URLSearchParams).get("foo")).toBe("bar");
+      });
+    });
   });
 });

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -412,7 +412,11 @@ export interface StaticHandler {
   ): Promise<StaticHandlerContext | Response>;
   queryRoute(
     request: Request,
-    opts?: { routeId?: string; requestContext?: unknown }
+    opts?: {
+      routeId?: string;
+      requestContext?: unknown;
+      unstable_dataStrategy?: DataStrategyFunction;
+    }
   ): Promise<any>;
 }
 
@@ -3099,7 +3103,12 @@ export function createStaticHandler(
     {
       routeId,
       requestContext,
-    }: { requestContext?: unknown; routeId?: string } = {}
+      unstable_dataStrategy,
+    }: {
+      requestContext?: unknown;
+      routeId?: string;
+      unstable_dataStrategy?: DataStrategyFunction;
+    } = {}
   ): Promise<any> {
     let url = new URL(request.url);
     let method = request.method;
@@ -3132,7 +3141,7 @@ export function createStaticHandler(
       location,
       matches,
       requestContext,
-      null,
+      unstable_dataStrategy || null,
       false,
       match
     );


### PR DESCRIPTION
Needed so we can make `response` non-optional for resource routes in https://github.com/remix-run/remix/issues/9314