### PR TITLE
Check for `document` existence when checking `startViewTransition`

### DIFF
--- a/.changeset/good-donkeys-kiss.md
+++ b/.changeset/good-donkeys-kiss.md
@@ -1,5 +1,4 @@
 ---
-"react-router": patch
 "react-router-dom": patch
 ---
 

--- a/.changeset/good-donkeys-kiss.md
+++ b/.changeset/good-donkeys-kiss.md
@@ -1,0 +1,6 @@
+---
+"react-router": patch
+"react-router-dom": patch
+---
+
+Check for `document` existence when checking `startViewTransition`

--- a/contributors.yml
+++ b/contributors.yml
@@ -241,6 +241,7 @@
 - tlinhart
 - tom-sherman
 - tomasr8
+- TooTallNate
 - triangularcube
 - trungpv1601
 - turansky

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -526,6 +526,7 @@ export function RouterProvider({
 
       let isViewTransitionUnavailable =
         router.window == null ||
+        router.window.document == null ||
         typeof router.window.document.startViewTransition !== "function";
 
       // If this isn't a view transition or it's not available in this browser,


### PR DESCRIPTION
My non-browser environment has `window`, but does not have `document`. Checking for `document` existence here makes React Router work for me.