### PR TITLE
feat: export type NavLinkRenderProps

### DIFF
--- a/.changeset/six-pianos-serve.md
+++ b/.changeset/six-pianos-serve.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": major
+---
+
+Exported NavLinkRenderProps type. Usefull when typing custom NavLink callback.

--- a/.changeset/six-pianos-serve.md
+++ b/.changeset/six-pianos-serve.md
@@ -2,4 +2,4 @@
 "react-router-dom": patch
 ---
 
-Exported NavLinkRenderProps type. Usefull when typing custom NavLink callback.
+Export `NavLinkRenderProps` type for easier typing of custom `NavLink` callback

--- a/.changeset/six-pianos-serve.md
+++ b/.changeset/six-pianos-serve.md
@@ -1,5 +1,5 @@
 ---
-"react-router-dom": major
+"react-router-dom": patch
 ---
 
 Exported NavLinkRenderProps type. Usefull when typing custom NavLink callback.

--- a/contributors.yml
+++ b/contributors.yml
@@ -265,3 +265,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- zeromask1337

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1024,7 +1024,7 @@ if (__DEV__) {
   Link.displayName = "Link";
 }
 
-type NavLinkRenderProps = {
+export type NavLinkRenderProps = {
   isActive: boolean;
   isPending: boolean;
   isTransitioning: boolean;


### PR DESCRIPTION
Documentation tells us we can use callbacks to utilize various NavLink states

```js
import { NavLink } from "react-router-dom";

<NavLink
  to="/messages"
  className={({ isActive, isPending }) =>
    isPending ? "pending" : isActive ? "active" : ""
  }
>
  Messages
</NavLink>;
```

But then restricts us by not letting use type annotation for it

```js
import { NavLink } from 'react-router-dom';
import { useCallback } from 'react';

export const Header = () => {
  const navLinkClassName = useCallback(
    ({ isActive, isPending }: NavLinkRenderProps) => // this is impossible right now because type is not exported
      isPending ? 'text-gray-500' : isActive ? 'text-orange-800' : '',
    [],
  );
  return (
    <>
      <header className='h-10 w-full bg-amber-100'>
        <nav className='p-2'>
          <ul className='flex items-center gap-5'>
            <li>
              <NavLink to='/home' className={navLinkClassName}>
                Home
              </NavLink>
            </li>
            <li>
              <NavLink to='/search' className={navLinkClassName}>
                Search
              </NavLink>
            </li>
          </ul>
        </nav>
      </header>
    </>
  );
};

```

You might say that we can just map over array of links, as usual, but that again restricts us from building more complex and type safe logic