### PR TITLE
docs: Replace `.` typo with `;`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -205,6 +205,7 @@
 - rimian
 - robbtraister
 - RobHannay
+- robinvdvleuten
 - rtmann
 - rubeonline
 - ryanflorence

--- a/docs/routers/create-browser-router.md
+++ b/docs/routers/create-browser-router.md
@@ -259,7 +259,7 @@ let router = createBrowserRouter(routes, {
         // Don't override anything - just resolve route.lazy + call loader
         let result = await match.resolve();
         console.log(`Done processing route ${match.route.id}`);
-        return result.
+        return result;
       })
     )
   },


### PR DESCRIPTION
Replaced a small typo I noticed while copy pasting the example.