### PR TITLE
Fix prerender test on Windows

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -123,7 +123,7 @@ test.describe("Prerendering", () => {
     appFixture = await createAppFixture(fixture);
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
-    expect(fs.readdirSync(clientDir)).toEqual([
+    expect(fs.readdirSync(clientDir).sort()).toEqual([
       "_root.data",
       "about",
       "about.data",
@@ -175,7 +175,7 @@ test.describe("Prerendering", () => {
     appFixture = await createAppFixture(fixture);
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
-    expect(fs.readdirSync(clientDir)).toEqual([
+    expect(fs.readdirSync(clientDir).sort()).toEqual([
       "_root.data",
       "about",
       "about.data",


### PR DESCRIPTION
The order of the array returned by `fs.readdirSync` differs on Windows, so we need to sort it before asserting its contents.