### PR TITLE
Clean build manifest output

### DIFF
--- a/.changeset/remove-manifest-option.md
+++ b/.changeset/remove-manifest-option.md
@@ -1,0 +1,28 @@
+---
+"@react-router/dev": major
+---
+
+For Remix consumers migrating to React Router, the Vite plugin's `manifest` option has been removed.
+
+The `manifest` option been superseded by the more powerful `buildEnd` hook since it's passed the `buildManifest` argument. You can still write the build manifest to disk if needed, but you'll most likely find it more convenient to write any logic depending on the build manifest within the `buildEnd` hook itself.
+
+If you were using the `manifest` option, you can replace it with a `buildEnd` hook that writes the manifest to disk like this:
+
+```js
+import { vitePlugin as reactRouter } from "@react-router/dev";
+import { writeFile } from "node:fs/promises";
+
+export default {
+  plugins: [
+    reactRouter({
+      async buildEnd({ buildManifest }) {
+        await writeFile(
+          "build/manifest.json",
+          JSON.stringify(buildManifest, null, 2),
+          "utf-8"
+        );
+      },
+    }),
+  ],
+};
+```

--- a/.changeset/vite-manifest-location.md
+++ b/.changeset/vite-manifest-location.md
@@ -1,0 +1,7 @@
+---
+"@react-router/dev": major
+---
+
+For Remix consumers migrating to React Router, Vite manifests (i.e. `.vite/manifest.json`) are now written within each build subdirectory, e.g. `build/client/.vite/manifest.json` and `build/server/.vite/manifest.json` instead of `build/.vite/client-manifest.json` and `build/.vite/server-manifest.json`. This means that the build output is now much closer to what you'd expect from a typical Vite project.
+
+Originally the Remix Vite plugin moved all Vite manifests to a root-level `build/.vite` directory to avoid accidentally serving them in production, particularly from the client build. This was later improved with additional logic that deleted these Vite manifest files at the end of the build process unless Vite's `build.manifest` had been enabled within the app's Vite config. This greatly reduced the risk of accidentally serving the Vite manifests in production since they're only present when explicitly asked for. As a result, we can now assume that consumers will know that they need to manage these additional files themselves, and React Router can safely generate a more standard Vite build output.

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -6,24 +6,10 @@ import dedent from "dedent";
 
 import { createProject, build, viteConfig } from "./helpers/vite.js";
 
-function createRoute(path: string) {
-  return {
-    [`app/routes/${path}`]: `
-      export default function Route() {
-        return <p>Path: ${path}</p>;
-      }
-    `,
-  };
-}
-
-const TEST_ROUTES = [
-  "_index.tsx",
-  "parent-route.tsx",
-  "parent-route.child-route.tsx",
-];
+const js = String.raw;
 
 const files = {
-  "app/root.tsx": `
+  "app/root.tsx": js`
     import { Links, Meta, Outlet, Scripts } from "react-router-dom";
 
     export default function Root() {
@@ -41,7 +27,11 @@ const files = {
       );
     }
   `,
-  ...Object.assign({}, ...TEST_ROUTES.map(createRoute)),
+  "app/routes/_index.tsx": js`
+    export default function Route() {
+      return <p>Hello world</p>;
+    }
+  `,
 };
 
 test.describe(() => {
@@ -54,7 +44,7 @@ test.describe(() => {
 
         export default {
           build: { manifest: true },
-          plugins: [reactRouter({ manifest: true })],
+          plugins: [reactRouter()],
         }
       `,
       ...files,
@@ -64,48 +54,15 @@ test.describe(() => {
   });
 
   test("Vite / manifests enabled / Vite manifests", () => {
-    let viteManifestFiles = fs.readdirSync(path.join(cwd, "build", ".vite"));
-
-    expect(viteManifestFiles).toEqual([
-      "client-manifest.json",
-      "server-manifest.json",
-    ]);
-  });
-
-  test("Vite / manifests enabled / React Router build manifest", async () => {
-    let manifestPath = path.join(
-      cwd,
-      "build",
-      ".react-router",
-      "manifest.json"
+    let viteManifestFilesClient = fs.readdirSync(
+      path.join(cwd, "build", "client", ".vite")
     );
-    expect(JSON.parse(fs.readFileSync(manifestPath, "utf8"))).toEqual({
-      routes: {
-        root: {
-          file: "root.tsx",
-          id: "root",
-          path: "",
-        },
-        "routes/_index": {
-          file: "routes/_index.tsx",
-          id: "routes/_index",
-          index: true,
-          parentId: "root",
-        },
-        "routes/parent-route": {
-          file: "routes/parent-route.tsx",
-          id: "routes/parent-route",
-          parentId: "root",
-          path: "parent-route",
-        },
-        "routes/parent-route.child-route": {
-          file: "routes/parent-route.child-route.tsx",
-          id: "routes/parent-route.child-route",
-          parentId: "routes/parent-route",
-          path: "child-route",
-        },
-      },
-    });
+    expect(viteManifestFilesClient).toEqual(["manifest.json"]);
+
+    let viteManifestFilesServer = fs.readdirSync(
+      path.join(cwd, "build", "server", ".vite")
+    );
+    expect(viteManifestFilesServer).toEqual(["manifest.json"]);
   });
 });
 
@@ -122,12 +79,10 @@ test.describe(() => {
   });
 
   test("Vite / manifest disabled / Vite manifests", () => {
-    let manifestDir = path.join(cwd, "build", ".vite");
-    expect(fs.existsSync(manifestDir)).toBe(false);
-  });
+    let manifestDirClient = path.join(cwd, "build", "client", ".vite");
+    expect(fs.existsSync(manifestDirClient)).toBe(false);
 
-  test("Vite / manifest disabled / React Router build manifest doesn't exist", async () => {
-    let manifestDir = path.join(cwd, "build", ".react-router");
-    expect(fs.existsSync(manifestDir)).toBe(false);
+    let manifestDirServer = path.join(cwd, "build", "server", ".vite");
+    expect(fs.existsSync(manifestDirServer)).toBe(false);
   });
 });

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -124,6 +124,7 @@ test.describe("Prerendering", () => {
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
     expect(fs.readdirSync(clientDir).sort()).toEqual([
+      ".vite",
       "_root.data",
       "about",
       "about.data",
@@ -176,6 +177,7 @@ test.describe("Prerendering", () => {
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
     expect(fs.readdirSync(clientDir).sort()).toEqual([
+      ".vite",
       "_root.data",
       "about",
       "about.data",

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -213,7 +213,6 @@ test("Vite / presets", async () => {
     "buildDirectory",
     "buildEnd",
     "future",
-    "manifest",
     "prerender",
     "publicPath",
     "routes",

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -964,10 +964,10 @@ test.describe("SPA Mode", () => {
 
     test("only generates client Vite manifest", () => {
       let viteManifestFiles = fs.readdirSync(
-        path.join(fixture.projectDir, "build", ".vite")
+        path.join(fixture.projectDir, "build", "client", ".vite")
       );
 
-      expect(viteManifestFiles).toEqual(["client-manifest.json"]);
+      expect(viteManifestFiles).toEqual(["manifest.json"]);
     });
   });
 });

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -138,11 +138,6 @@ export type VitePluginConfig = {
    */
   buildEnd?: BuildEndHook;
   /**
-   * Whether to write a `"manifest.json"` file to the build directory.`
-   * Defaults to `false`.
-   */
-  manifest?: boolean;
-  /**
    * An array of URLs to prerender to HTML files at build time.  Can also be a
    * function returning an array to dynamically generate URLs.
    */
@@ -194,11 +189,6 @@ export type ResolvedVitePluginConfig = Readonly<{
    * Enabled future flags
    */
   future: FutureConfig;
-  /**
-   * Whether to write a `"manifest.json"` file to the build directory.`
-   * Defaults to `false`.
-   */
-  manifest: boolean;
   /**
    * An array of URLs to prerender to HTML files at build time.
    */
@@ -363,7 +353,6 @@ export async function resolveReactRouterConfig({
   let defaults = {
     basename: "/",
     buildDirectory: "build",
-    manifest: false,
     serverBuildFile: "index.js",
     serverModuleFormat: "esm",
     ssr: true,
@@ -376,7 +365,6 @@ export async function resolveReactRouterConfig({
     buildEnd,
     future: userFuture,
     ignoredRouteFiles,
-    manifest,
     routes: userRoutesFunction,
     prerender: prerenderConfig,
     serverBuildFile,
@@ -464,7 +452,6 @@ export async function resolveReactRouterConfig({
     buildDirectory,
     buildEnd,
     future,
-    manifest,
     prerender,
     publicPath,
     routes,


### PR DESCRIPTION
This simplifies the build output and makes it closer to your standard Vite output by making a couple of changes:

1) We now leave Vite manifests in their default location, e.g. `build/client/.vite/manifest.json` and `build/server/.vite/manifest.json` instead of `build/.vite/client-manifest.json` and `build/.vite/server-manifest.json`. Note that these Vite manifests are deleted unless consumers explicitly enable them via `build: { manifest: true }` in their Vite config. This means that the build output is now much closer to what you'd expect from a typical Vite project.

2) We no longer have a `manifest` option to write a React Router build manifest to disk under `build/.react-router/manifest.json`. This option was originally added in Remix for Vercel so that they could enable it in their preset but then was superseded by the more powerful `buildEnd` hook which has access to the build manifest in memory. Since the RRv7 migration is a major release, it's a good opportunity to streamline the plugin API and remove the unnecessary `manifest` option.