### PR TITLE
Remove `publicPath` from resolved config

### DIFF
--- a/.changeset/remove-build-end-public-path.md
+++ b/.changeset/remove-build-end-public-path.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": major
+---
+
+For Remix consumers migrating to React Router who used the Vite plugin's `buildEnd` hook, the resolved `reactRouterConfig` object no longer contains a `publicPath` property since this belongs to Vite, not React Router.

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -215,7 +215,6 @@ test("Vite / presets", async () => {
     "future",
     "manifest",
     "prerender",
-    "publicPath",
     "routes",
     "serverBuildFile",
     "serverBundles",

--- a/packages/remix-dev/config.ts
+++ b/packages/remix-dev/config.ts
@@ -204,10 +204,6 @@ export type ResolvedVitePluginConfig = Readonly<{
    */
   prerender: Array<string> | null;
   /**
-   * Derived from Vite's `base` config
-   * */
-  publicPath: string;
-  /**
    * An object of all available routes, keyed by route id.
    */
   routes: RouteManifest;
@@ -324,6 +320,10 @@ let deepFreeze = (o: any) => {
   return o;
 };
 
+export function resolvePublicPath(viteUserConfig: Vite.UserConfig) {
+  return viteUserConfig.base ?? "/";
+}
+
 export async function resolveReactRouterConfig({
   rootDirectory,
   reactRouterUserConfig,
@@ -416,7 +416,7 @@ export async function resolveReactRouterConfig({
 
   let appDirectory = path.resolve(rootDirectory, userAppDirectory || "app");
   let buildDirectory = path.resolve(rootDirectory, userBuildDirectory);
-  let publicPath = viteUserConfig.base ?? "/";
+  let publicPath = resolvePublicPath(viteUserConfig);
 
   if (
     basename !== "/" &&
@@ -466,7 +466,6 @@ export async function resolveReactRouterConfig({
     future,
     manifest,
     prerender,
-    publicPath,
     routes,
     serverBuildFile,
     serverBundles,


### PR DESCRIPTION
The resolved `reactRouterConfig` object passed to the `buildEnd` hook should only contain properties present on the user-provided React Router config object, whereas the `publicPath` property is a Vite concern. This is just a minor tidy up to keep this API scoped to React Router. If anyone needs the public path in the build end hook, we should instead be passing in the resolved Vite config rather than individual properties.