### PR TITLE
fix: keep setSearchParams reference equal

### DIFF
--- a/.changeset/young-eggs-act.md
+++ b/.changeset/young-eggs-act.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": patch
+---
+
+keep setSearchParams reference equal

--- a/contributors.yml
+++ b/contributors.yml
@@ -265,3 +265,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- le0nik

--- a/packages/react-router-dom/__tests__/search-params-test.tsx
+++ b/packages/react-router-dom/__tests__/search-params-test.tsx
@@ -126,6 +126,54 @@ describe("useSearchParams", () => {
     expect(node.innerHTML).toMatch(/The new query is "Ryan Florence"/);
   });
 
+  it("keeps setSearchParams reference equal", () => {
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams({ "q": "0" });
+      let query = searchParams.get("q")!;
+
+      const initialSetSearchParamsRef = React.useRef(setSearchParams);
+
+      function handleClick() {
+        setSearchParams((cur) => {
+          cur.set("q", `${Number(cur.get("q")) + 1}`);
+          return cur;
+        });
+      }
+
+      const hasRefChanged = setSearchParams !== initialSetSearchParamsRef.current;
+
+      return (
+        <div>
+          <p>The current query is "{query}".</p>
+          <p>setSearchParams ref has {hasRefChanged ? "changed" : "not changed"}.</p>
+          <button type="button" onClick={handleClick}>Click me</button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search?q=0"]}>
+          <Routes>
+            <Route path="search" element={<SearchPage />} />
+          </Routes>
+        </MemoryRouter>
+      );
+    });
+
+    const button = node.querySelector("button")!;
+
+    expect(node.innerHTML).toMatch(/The current query is "0"/);
+    expect(node.innerHTML).toMatch(/setSearchParams ref has not changed/);
+
+    act(() => {
+       button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(node.innerHTML).toMatch(/The current query is "1"/);
+    expect(node.innerHTML).toMatch(/setSearchParams ref has not changed/);
+  });
+
   it("allows removal of search params when a default is provided", () => {
     function SearchPage() {
       let [searchParams, setSearchParams] = useSearchParams({

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1471,16 +1471,22 @@ export function useSearchParams(
     [location.search]
   );
 
+  let searchParamsRef = React.useRef(searchParams);
+
+  React.useEffect(() => {
+    searchParamsRef.current = searchParams;
+  }, [searchParams]);
+
   let navigate = useNavigate();
   let setSearchParams = React.useCallback<SetURLSearchParams>(
     (nextInit, navigateOptions) => {
       const newSearchParams = createSearchParams(
-        typeof nextInit === "function" ? nextInit(searchParams) : nextInit
+        typeof nextInit === "function" ? nextInit(searchParamsRef.current) : nextInit
       );
       hasSetSearchParamsRef.current = true;
       navigate("?" + newSearchParams, navigateOptions);
     },
-    [navigate, searchParams]
+    [navigate]
   );
 
   return [searchParams, setSearchParams];


### PR DESCRIPTION
Hello,

Currently, there is an issue where the `setSearchParams` reference changes each time `searchParams` are updated. This makes functional updates less useful because adding `setSearchParams` to `useEffect` dependencies results in `useEffect` re-executing every time search params change.

This PR addresses the issue and makes `setSearchParams` behave like `setState`, maintaining reference equality.