### PR TITLE
Fix useMatches usage of UIMatch generics to type data and handle properties

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -265,3 +265,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- felquis

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -912,7 +912,7 @@ export function useRevalidator() {
  * Returns the active route matches, useful for accessing loaderData for
  * parent/child routes or the route "handle" property
  */
-export function useMatches(): UIMatch[] {
+export function useMatches<D = unknown, H = unknown>(): UIMatch<D, H>[] {
   let { matches, loaderData } = useDataRouterState(
     DataRouterStateHook.UseMatches
   );

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -538,10 +538,10 @@ export interface UIMatch<Data = unknown, Handle = unknown> {
   handle: Handle;
 }
 
-export function convertRouteMatchToUiMatch(
+export function convertRouteMatchToUiMatch<D = unknown, H = unknown>(
   match: AgnosticDataRouteMatch,
   loaderData: RouteData
-): UIMatch {
+): UIMatch<D, H> {
   let { route, pathname, params } = match;
   return {
     id: route.id,


### PR DESCRIPTION
Hi everyone, I'm creating the [breadcrumb tutorial](https://remix.run/docs/en/main/guides/breadcrumbs#defining-the-breadcrumbs-for-routes) and I couldn't find documentation on how to define the type returned at data and handle attributes from useMatches.

I tried something like this, and it returned TS errors:
```ts
const matches = useMatches<UIMatch<{ breadcrumb?: string }, unknown>>()
```

I figured although UIMatch interface uses generic types, it doesn't apply it on the `useMatches` and `convertRouteMatchToUiMatch` functions.

Here's an example of what's possible with this PR: it defines the type for the data attribute returned in the array.

Only type the data attribute:
```ts
const matches = useMatches<{ breadcrumb?: string }>()
```

Only type the handle attribute:
```ts
const matches2 = useMatches<{},{ breadcrumb?: string }>();
```

Example:
```ts
export function CustomBreadCrumb() {
  const matches = useMatches<{ breadcrumb?: string }>();
  const matches2 = useMatches<{},{ breadcrumb?: string }>();

  console.log(matches[0].data.breadcrumb);
  console.log(matches2[0].handle.breadcrumb);
}
```

<img width="521" alt="Screenshot 2024-05-26 at 19 38 50" src="https://github.com/remix-run/react-router/assets/736728/1a06d170-578d-4e07-bfda-a6e27b2a80de">

----

I managed to run `pnpm build` on my local env, but couldn't get other commands running successfully, but it looks like it's working and I'm hopping the CI here will help.

----

More context from Twitter: https://twitter.com/imfelquis/status/1794491410495733927

The typescript error I'm trying to avoid:
![image](https://github.com/remix-run/react-router/assets/736728/035052a2-b5c4-466c-a1e7-297ba40907c3)

Here is a codesandbox setup with remix demonstrating the type error (it only show up on editor mode) - [link](https://codesandbox.io/p/devbox/breadcrumbs-demo-vvfxnx?file=%2Fapp%2Froot.tsx%3A26%2C49)