### PR TITLE
docs: added useBlocker to the data apis

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -268,3 +268,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- Geist5000

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -134,6 +134,7 @@ The following APIs are introduced in React Router 6.4 and will only work when us
 [useactiondata]: ../hooks/use-action-data
 [useasyncerror]: ../hooks/use-async-error
 [useasyncvalue]: ../hooks/use-async-value
+[useblocker]: ../hooks/use-blocker
 [usefetcher]: ../hooks/use-fetcher
 [usefetchers]: ../hooks/use-fetchers
 [useloaderdata]: ../hooks/use-loader-data


### PR DESCRIPTION
the useBlocker hook only works with a data route, so the hook should be present in this list.