### PR TITLE
Fixed a typo in concepts.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -268,3 +268,4 @@
 - yracnet
 - yuleicul
 - zheng-chuang
+- OlegDev1

--- a/docs/start/concepts.md
+++ b/docs/start/concepts.md
@@ -568,7 +568,7 @@ The `Outlet` component will always render the next match. That means `<Teams>` a
 If the URL were `/contact-us`, the element tree would change to:
 
 ```jsx
-<ContactForm />
+<Contact />
 ```
 
 Because the contact form is not under the main `<App>` route.


### PR DESCRIPTION
In the entry app, Rendering section (lines 513-536) <Contact /> component is used. But on the line 571, <ContactForm /> component is used, for the same path. It is a typo, so i have changed it to <Contact />