### PR TITLE
feat: Add OpenTelemetry

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -121,6 +121,7 @@
 - JesusTheHun
 - jimniels
 - jmargeta
+- joaquin-diaz
 - johnpangalos
 - jonkoops
 - jrakotoharisoa

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,0 +1,41 @@
+---
+title: OpenTelemetry
+new: true
+---
+
+# OpenTelemetry
+
+React-router is instrumented to track routing events using OpenTelemetry. This allows you to automatically see them in your observability platform. For each route transition, a span named `route-change` is created with the following attributes:
+* `react_router.current.url.path` - the path of the current URL
+* `react_router.current.url.query` - the query string of the current URL
+* `react_router.next.url.path` - the path of the next URL
+* `react_router.next.url.query` - the query string of the next URL
+* `react_router.history_action.path` - type of change in the history stack (push, replace, pop)
+
+## Providing Span Context
+
+Context is important to understand the relationship between spans. To provide context, you can set up a `spanContext` in the location state. This context will be attached to the span created for the route change. Here is an example of how you can set up the context:
+
+```jsx
+import { useNavigate } from 'react-router-dom';
+
+const MyComponent = () => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/new-route', { state: { spanContext: { traceId: '1234', spanId: '5678' } } });
+  }
+
+  return <button onClick={handleClick}>Go to new route</button>;
+}
+```
+
+or directly in the `Link` component:
+
+```jsx
+import { Link } from 'react-router-dom';
+
+const MyComponent = () => {
+  return <Link to="/new-route" state={{ spanContext: { traceId: '1234', spanId: '5678' }}}>Go to new route</Link>;
+}
+```

--- a/packages/react-router-dom-v5-compat/package.json
+++ b/packages/react-router-dom-v5-compat/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
+    "@opentelemetry/api": "^1.8.0",
     "@remix-run/router": "workspace:*",
     "history": "^5.3.0",
     "react-router": "workspace:*"

--- a/packages/react-router-dom/__tests__/otel-test.tsx
+++ b/packages/react-router-dom/__tests__/otel-test.tsx
@@ -1,0 +1,237 @@
+import * as React from "react";
+import {
+  Route,
+  Link,
+  createBrowserRouter,
+  createRoutesFromElements,
+  RouterProvider,
+  useNavigate,
+} from "react-router-dom";
+import type { Tracer } from "@opentelemetry/api";
+import { context } from "@opentelemetry/api";
+import { trace } from "@opentelemetry/api";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { JSDOM } from "jsdom";
+
+function getWindowImpl(initialUrl: string, isHash = false): Window {
+  // Need to use our own custom DOM in order to get a working history
+  const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
+  dom.window.history.replaceState(null, "", (isHash ? "#" : "") + initialUrl);
+  return dom.window as unknown as Window;
+}
+
+describe("OpenTelemetry", () => {
+  let getTracerSpy: jest.SpyInstance;
+  let activeContextSpy: jest.SpyInstance;
+  let contextWithSpy: jest.SpyInstance;
+  let setSpanContextSpy: jest.SpyInstance;
+  const mockTracer = {
+    startSpan: jest.fn().mockReturnValue({
+      setAttributes: jest.fn(),
+      end: jest.fn(),
+    }),
+  };
+  const mockSpan = mockTracer.startSpan();
+  const activeContext = context.active();
+
+  beforeEach(() => {
+    getTracerSpy = jest
+      .spyOn(trace, "getTracer")
+      .mockReturnValue(mockTracer as unknown as Tracer);
+    activeContextSpy = jest
+      .spyOn(context, "active")
+      .mockReturnValue(activeContext);
+    contextWithSpy = jest.spyOn(context, "with");
+    setSpanContextSpy = jest.spyOn(trace, "setSpanContext");
+  });
+
+  afterEach(() => {
+    getTracerSpy.mockRestore();
+    activeContextSpy.mockRestore();
+    contextWithSpy.mockRestore();
+    setSpanContextSpy.mockRestore();
+
+    jest.clearAllMocks();
+  });
+
+  it("creates a span without a context when navigating using a <Link /> component without state", async () => {
+    function Home() {
+      return (
+        <div>
+          <h1>Home</h1>
+          <Link to="about">About</Link>
+        </div>
+      );
+    }
+
+    const router = createBrowserRouter(
+      createRoutesFromElements(
+        <>
+          <Route path="/" element={<Home />} />
+          <Route path="about" element={<h1>About</h1>} />
+        </>
+      ),
+      { window: getWindowImpl("/") }
+    );
+
+    const screen = render(<RouterProvider router={router} />);
+
+    const anchor = screen.getByRole("link");
+    expect(anchor).not.toBeNull();
+
+    fireEvent.click(anchor);
+
+    const h1 = screen.getByText("About");
+    expect(h1).not.toBeNull();
+    expect(h1?.textContent).toEqual("About");
+
+    expect(contextWithSpy).toHaveBeenCalledWith(
+      activeContext,
+      expect.any(Function)
+    );
+    expect(getTracerSpy).toHaveBeenCalledWith("react-router");
+    expect(mockTracer.startSpan).toHaveBeenCalledWith("route-change");
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+      "react_router.current.url.path": "/",
+      "react_router.current.url.query": "",
+      "react_router.history_action": "PUSH",
+      "react_router.next.url.path": "/about",
+      "react_router.next.url.query": "",
+    });
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a span without a context when navigating programmatically without state", async () => {
+    function Home() {
+      const navigate = useNavigate();
+
+      return (
+        <div>
+          <h1>Home</h1>
+          <button onClick={() => navigate("about")}>Navigate</button>
+        </div>
+      );
+    }
+
+    const router = createBrowserRouter(
+      createRoutesFromElements(
+        <>
+          <Route path="/" element={<Home />} />
+          <Route path="about" element={<h1>About</h1>} />
+        </>
+      ),
+      { window: getWindowImpl("/") }
+    );
+
+    const screen = render(<RouterProvider router={router} />);
+
+    const button = screen.getByRole("button");
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button);
+    await waitFor(() => screen.getByText("About"));
+
+    expect(contextWithSpy).toHaveBeenCalledWith(
+      activeContext,
+      expect.any(Function)
+    );
+    expect(getTracerSpy).toHaveBeenCalledWith("react-router");
+    expect(mockTracer.startSpan).toHaveBeenCalledWith("route-change");
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+      "react_router.current.url.path": "/",
+      "react_router.current.url.query": "",
+      "react_router.history_action": "PUSH",
+      "react_router.next.url.path": "/about",
+      "react_router.next.url.query": "",
+    });
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a span with span context when navigating using a <Link /> component with state", async () => {
+    function Home() {
+      return (
+        <div>
+          <h1>Home</h1>
+          <Link to="about" state={{ spanContext: { traceId: "123" } }}>
+            About
+          </Link>
+        </div>
+      );
+    }
+
+    const router = createBrowserRouter(
+      createRoutesFromElements(
+        <>
+          <Route path="/" element={<Home />} />
+          <Route path="about" element={<h1>About</h1>} />
+        </>
+      ),
+      { window: getWindowImpl("/") }
+    );
+
+    const screen = render(<RouterProvider router={router} />);
+
+    const anchor = screen.getByRole("link");
+    expect(anchor).not.toBeNull();
+
+    fireEvent.click(anchor);
+
+    const h1 = screen.getByText("About");
+    expect(h1).not.toBeNull();
+    expect(h1?.textContent).toEqual("About");
+
+    expect(setSpanContextSpy).toHaveBeenCalledWith(activeContext, {
+      traceId: "123",
+    });
+  });
+
+  it("creates a span with span context when navigating programmatically with state", async () => {
+    function Home() {
+      const navigate = useNavigate();
+
+      return (
+        <div>
+          <h1>Home</h1>
+          <button
+            onClick={() =>
+              navigate("about", {
+                state: {
+                  spanContext: {
+                    traceId: "123",
+                  },
+                },
+              })
+            }
+          >
+            Navigate
+          </button>
+        </div>
+      );
+    }
+
+    const router = createBrowserRouter(
+      createRoutesFromElements(
+        <>
+          <Route path="/" element={<Home />} />
+          <Route path="about" element={<h1>About</h1>} />
+        </>
+      ),
+      { window: getWindowImpl("/") }
+    );
+
+    const screen = render(<RouterProvider router={router} />);
+
+    const button = screen.getByRole("button");
+    expect(button).not.toBeNull();
+
+    fireEvent.click(button);
+
+    const h1 = screen.getByText("About");
+    expect(h1).not.toBeNull();
+    expect(h1?.textContent).toEqual("About");
+
+    expect(setSpanContextSpy).toHaveBeenCalledWith(activeContext, {
+      traceId: "123",
+    });
+  });
+});

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "dependencies": {
+    "@opentelemetry/api": "^1.8.0",
     "@remix-run/router": "workspace:*",
     "react-router": "workspace:*"
   },

--- a/packages/react-router-dom/rollup.config.js
+++ b/packages/react-router-dom/rollup.config.js
@@ -28,7 +28,7 @@ module.exports = function rollup() {
         sourcemap: !PRETTY,
         banner: createBanner("React Router DOM", version),
       },
-      external: ["react", "react-dom", "react-router", "@remix-run/router"],
+      external: ["react", "react-dom", "react-router", "@remix-run/router", "@opentelemetry/api"],
       plugins: [
         extensions({ extensions: [".ts", ".tsx"] }),
         babel({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
 
   packages/react-router-dom:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@remix-run/router':
         specifier: workspace:*
         version: link:../router
@@ -248,6 +251,9 @@ importers:
 
   packages/react-router-dom-v5-compat:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@remix-run/router':
         specifier: workspace:*
         version: link:../router
@@ -2474,6 +2480,11 @@ packages:
     resolution: {integrity: sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==}
     dependencies:
       '@octokit/openapi-types': 18.0.0
+    dev: false
+
+  /@opentelemetry/api@1.8.0:
+    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
+    engines: {node: '>=8.0.0'}
     dev: false
 
   /@react-native-community/cli-clean@8.0.4:


### PR DESCRIPTION
Hi! In my company, we use [OpenTelemetry](https://opentelemetry.io/docs/demo/services/frontend/#browser-instrumentation) for RUM (Real User Monitoring) by hooking into react-router's listeners, and we thought it might be useful for other users to have this built-in.

For those of you who are not familiar with OpenTelemetry, OpenTelemetry is an [Observability](https://opentelemetry.io/docs/concepts/observability-primer/#what-is-observability) framework and toolkit designed to create and manage telemetry data such as [traces](https://opentelemetry.io/docs/concepts/signals/traces/), [metrics](https://opentelemetry.io/docs/concepts/signals/metrics/), and [logs](https://opentelemetry.io/docs/concepts/signals/logs/). You can read more about it in their [docs](https://opentelemetry.io/docs/what-is-opentelemetry/).

Essentially, what I'm adding is an event tracking when a user navigates to another route, with a couple of attributes showing the current and next path. I'm following the OpenTelemetry [Instrumentation](https://opentelemetry.io/docs/concepts/instrumentation/libraries/#opentelemetry-api) docs, and I think it's worth mentioning that **all these API calls are no-op for users without the OpenTelemetry SDK integrated into their apps**. Meaning, this will not affect users without OpenTelemetry, although they'll get the `5.4kB` extra size in the bundle (minified, and gzipped).

This is my first contribution to react-router, so please let me know if there's anything I need to change. Also, any feedback on how this event (or possible others) can be instrumented is welcome.

Thanks!