### PR TITLE
Fix type definition of `Route.children`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -67,6 +67,7 @@
 - DigitalNaut
 - dmitrytarassov
 - dokeet
+- doytch
 - Drishtantr
 - edwin177
 - eiffelwong1

--- a/docs/route/route.md
+++ b/docs/route/route.md
@@ -70,7 +70,7 @@ Neither style is discouraged and behavior is identical. For the majority of this
 interface RouteObject {
   path?: string;
   index?: boolean;
-  children?: React.ReactNode;
+  children?: RouteObject[];
   caseSensitive?: boolean;
   id?: string;
   loader?: LoaderFunction;


### PR DESCRIPTION
In the docs, the type of `RouteObject.children` appears to be incorrect [based on the TS definition](https://github.com/remix-run/react-router/blob/5d66dbdbc8edf1d9c3a4d9c9d84073d046b5785b/packages/react-router/lib/context.ts#L49). This fixes that.