### PR TITLE
Remove duplicate RouterProvider implementations

### DIFF
--- a/.changeset/thin-nails-turn.md
+++ b/.changeset/thin-nails-turn.md
@@ -1,0 +1,5 @@
+---
+"react-router": minor
+---
+
+Remove duplicate `RouterProvider` impliementations

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -40,7 +40,6 @@ import urlDataStrategy from "./router/utils/urlDataStrategy";
 import { createDeferred } from "./router/utils/utils";
 import MemoryNavigate from "./utils/MemoryNavigate";
 import getHtml from "./utils/getHtml";
-import { RouterProvider as DomRouterProvider } from "../lib/dom/lib";
 
 describe("createMemoryRouter", () => {
   let consoleWarn: jest.SpyInstance;
@@ -1193,9 +1192,7 @@ describe("createMemoryRouter", () => {
       },
     ]);
 
-    // TODO: Fetchers only supported in DomRouterProvider at the moment, but
-    // that should be fixed once we align the two
-    render(<DomRouterProvider router={router} />);
+    render(<RouterProvider router={router} />);
 
     await waitFor(() => screen.getByText("Fetch (1, empty)"));
     fireEvent.click(screen.getByText("Fetch (1, empty)"));
@@ -1251,9 +1248,7 @@ describe("createMemoryRouter", () => {
       },
     ]);
 
-    // TODO: Fetchers only supported in DomRouterProvider at the moment, but
-    // that should be fixed once we align the two
-    render(<DomRouterProvider router={router} />);
+    render(<RouterProvider router={router} />);
 
     await waitFor(() => screen.getByText("Fetch (1, empty)"));
     fireEvent.click(screen.getByText("Fetch (1, empty)"));
@@ -3371,7 +3366,6 @@ describe("createMemoryRouter", () => {
         </React.Suspense>
       );
 
-      console.log(getHtml(container));
       expect(getHtml(container)).toMatchInlineSnapshot(`
         "<div>
           <p>

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -57,7 +57,6 @@ import type {
   PathRouteProps,
   RouteProps,
   RouterProps,
-  RouterProviderProps,
   RoutesProps,
 } from "./lib/components";
 import {
@@ -67,7 +66,6 @@ import {
   Outlet,
   Route,
   Router,
-  RouterProvider,
   Routes,
   createRoutesFromChildren,
   renderMatches,
@@ -168,7 +166,6 @@ export type {
   RouteObject,
   RouteProps,
   RouterProps,
-  RouterProviderProps,
   RoutesProps,
   Search,
   ShouldRevalidateFunction,
@@ -188,7 +185,6 @@ export {
   Outlet,
   Route,
   Router,
-  RouterProvider,
   Routes,
   createMemoryRouter,
   createPath,
@@ -279,6 +275,7 @@ export type {
   SubmitFunction,
   FetcherSubmitFunction,
   FetcherWithComponents,
+  RouterProviderProps,
 } from "./lib/dom/lib";
 export {
   createBrowserRouter,
@@ -293,6 +290,7 @@ export {
   unstable_HistoryRouter,
   NavLink,
   Form,
+  RouterProvider,
   ScrollRestoration,
   useLinkClickHandler,
   useSearchParams,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -28,7 +28,6 @@ import {
 import * as React from "react";
 
 import type {
-  DataRouteObject,
   IndexRouteObject,
   Navigator,
   NonIndexRouteObject,
@@ -37,8 +36,6 @@ import type {
 } from "./context";
 import {
   AwaitContext,
-  DataRouterContext,
-  DataRouterStateContext,
   LocationContext,
   NavigationContext,
   RouteContext,
@@ -51,8 +48,8 @@ import {
   useNavigate,
   useOutlet,
   useRoutes,
-  useRoutesImpl,
 } from "./hooks";
+import { startTransitionSafe } from "./dom/lib";
 
 // TODO: Let's get this back to using an import map and development/production
 // condition once we get the rollup build replaced
@@ -161,158 +158,6 @@ export function createMemoryRouter(
 /**
  * @category Types
  */
-export interface RouterProviderProps {
-  fallbackElement?: React.ReactNode;
-  router: RemixRouter;
-  // Only accept future flags relevant to rendering behavior
-  // routing flags should be accessed via router.future
-  future?: Partial<Pick<FutureConfig, "v7_startTransition">>;
-}
-
-/**
-  Webpack + React 17 fails to compile on any of the following because webpack
-  complains that `startTransition` doesn't exist in `React`:
-  * import { startTransition } from "react"
-  * import * as React from from "react";
-    "startTransition" in React ? React.startTransition(() => setState()) : setState()
-  * import * as React from from "react";
-    "startTransition" in React ? React["startTransition"](() => setState()) : setState()
-
-  Moving it to a constant such as the following solves the Webpack/React 17 issue:
-  * import * as React from from "react";
-    const START_TRANSITION = "startTransition";
-    START_TRANSITION in React ? React[START_TRANSITION](() => setState()) : setState()
-
-  However, that introduces webpack/terser minification issues in production builds
-  in React 18 where minification/obfuscation ends up removing the call of
-  React.startTransition entirely from the first half of the ternary.  Grabbing
-  this exported reference once up front resolves that issue.
-
-  See https://github.com/remix-run/react-router/issues/10579
-*/
-const START_TRANSITION = "startTransition";
-const startTransitionImpl = React[START_TRANSITION];
-
-/**
- * Given a Remix Router instance, render the appropriate UI
- *
- * @category Router Components
- */
-export function RouterProvider({
-  fallbackElement,
-  router,
-  future,
-}: RouterProviderProps): React.ReactElement {
-  let [state, setStateImpl] = React.useState(router.state);
-  let { v7_startTransition } = future || {};
-
-  let setState = React.useCallback<RouterSubscriber>(
-    (newState: RouterState) => {
-      if (v7_startTransition && startTransitionImpl) {
-        startTransitionImpl(() => setStateImpl(newState));
-      } else {
-        setStateImpl(newState);
-      }
-    },
-    [setStateImpl, v7_startTransition]
-  );
-
-  // Need to use a layout effect here so we are subscribed early enough to
-  // pick up on any render-driven redirects/navigations (useEffect/<Navigate>)
-  React.useLayoutEffect(() => router.subscribe(setState), [router, setState]);
-
-  React.useEffect(() => {
-    warning(
-      fallbackElement == null || !router.future.v7_partialHydration,
-      "`<RouterProvider fallbackElement>` is deprecated when using " +
-        "`v7_partialHydration`, use a `HydrateFallback` component instead"
-    );
-    // Only log this once on initial mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  let navigator = React.useMemo((): Navigator => {
-    return {
-      createHref: router.createHref,
-      encodeLocation: router.encodeLocation,
-      go: (n) => router.navigate(n),
-      push: (to, state, opts) =>
-        router.navigate(to, {
-          state,
-          preventScrollReset: opts?.preventScrollReset,
-        }),
-      replace: (to, state, opts) =>
-        router.navigate(to, {
-          replace: true,
-          state,
-          preventScrollReset: opts?.preventScrollReset,
-        }),
-    };
-  }, [router]);
-
-  let basename = router.basename || "/";
-
-  let dataRouterContext = React.useMemo(
-    () => ({
-      router,
-      navigator,
-      static: false,
-      basename,
-    }),
-    [router, navigator, basename]
-  );
-
-  // The fragment and {null} here are important!  We need them to keep React 18's
-  // useId happy when we are server-rendering since we may have a <script> here
-  // containing the hydrated server-side staticContext (from StaticRouterProvider).
-  // useId relies on the component tree structure to generate deterministic id's
-  // so we need to ensure it remains the same on the client even though
-  // we don't need the <script> tag
-  return (
-    <>
-      <DataRouterContext.Provider value={dataRouterContext}>
-        <DataRouterStateContext.Provider value={state}>
-          <Router
-            basename={basename}
-            location={state.location}
-            navigationType={state.historyAction}
-            navigator={navigator}
-            future={{
-              v7_relativeSplatPath: router.future.v7_relativeSplatPath,
-            }}
-          >
-            {state.initialized || router.future.v7_partialHydration ? (
-              <DataRoutes
-                routes={router.routes}
-                future={router.future}
-                state={state}
-              />
-            ) : (
-              fallbackElement
-            )}
-          </Router>
-        </DataRouterStateContext.Provider>
-      </DataRouterContext.Provider>
-      {null}
-    </>
-  );
-}
-
-function DataRoutes({
-  routes,
-  future,
-  state,
-}: {
-  routes: DataRouteObject[];
-  future: RemixRouter["future"];
-  state: RouterState;
-}): React.ReactElement | null {
-  return useRoutesImpl(routes, undefined, state, future);
-}
-
-/**
- * @category Types
- */
 export interface MemoryRouterProps {
   basename?: string;
   children?: React.ReactNode;
@@ -350,8 +195,8 @@ export function MemoryRouter({
   let { v7_startTransition } = future || {};
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      v7_startTransition && startTransitionImpl
-        ? startTransitionImpl(() => setStateImpl(newState))
+      v7_startTransition
+        ? startTransitionSafe(() => setStateImpl(newState))
         : setStateImpl(newState);
     },
     [setStateImpl, v7_startTransition]

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -7,8 +7,6 @@ import type {
   MemoryHistory,
   RelativeRoutingType,
   Router as RemixRouter,
-  RouterState,
-  RouterSubscriber,
   To,
   TrackedPromise,
   unstable_DataStrategyFunction,

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1,4 +1,11 @@
 import * as React from "react";
+
+// TODO: This static import doesn't allow us to work quite right in a pure-react
+// app that doesn't even have react-dom as a dependency.  Let's look into using
+// an export map for `react-router/dom   that would provide the `flushSync` method
+// to the memory `<RouterProvider>` via a prop.  And then
+// `import { RouterProvider } from 'react-router/memory'` // memory use case
+// `import { RouterProvider } from 'react-router/dom'` // DOM use case
 import * as ReactDOM from "react-dom";
 import type {
   BrowserHistory,

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -53,7 +53,7 @@ import {
   usePrefetchBehavior,
 } from "./ssr/components";
 import type {
-  RouterProviderProps,
+  FutureConfig,
   FutureConfig as RenderFutureConfig,
 } from "../components";
 import { Router, mapRouteProperties } from "../components";
@@ -290,7 +290,7 @@ const flushSyncImpl = ReactDOM[FLUSH_SYNC];
 const USE_ID = "useId";
 const useIdImpl = React[USE_ID];
 
-function startTransitionSafe(cb: () => void) {
+export function startTransitionSafe(cb: () => void) {
   if (startTransitionImpl) {
     startTransitionImpl(cb);
   } else {
@@ -336,6 +336,14 @@ class Deferred<T> {
       };
     });
   }
+}
+
+export interface RouterProviderProps {
+  fallbackElement?: React.ReactNode;
+  router: RemixRouter;
+  // Only accept future flags relevant to rendering behavior
+  // routing flags should be accessed via router.future
+  future?: Partial<Pick<FutureConfig, "v7_startTransition">>;
 }
 
 /**

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1173,7 +1173,7 @@ export interface NavLinkProps
 
 /**
   Wraps {@link Link | `<Link>`} with additional props for styling active and pending states.
-  
+
   - Automatically applies classes to the link based on its active and pending states, see {@link NavLinkProps.className}.
   - Automatically applies `aria-current="page"` to the link when the link is active. See [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) on MDN.
 
@@ -1910,15 +1910,6 @@ export interface FetcherSubmitFunction {
   ): Promise<void>;
 }
 
-function validateClientSideSubmission() {
-  if (typeof document === "undefined") {
-    throw new Error(
-      "You are calling submit during the server render. " +
-        "Try calling submit within a `useEffect` or callback instead."
-    );
-  }
-}
-
 let fetcherId = 0;
 let getUniqueFetcherId = () => `__${String(++fetcherId)}__`;
 
@@ -1949,8 +1940,6 @@ export function useSubmit(): SubmitFunction {
 
   return React.useCallback<SubmitFunction>(
     async (target, options = {}) => {
-      validateClientSideSubmission();
-
       let { action, method, encType, formData, body } = getFormSubmissionInfo(
         target,
         basename
@@ -2132,7 +2121,7 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
 
   /**
     Loads data from a route. Useful for loading data imperatively inside of user events outside of a normal button or form, like a combobox or search input.
-      
+
     ```tsx
     let fetcher = useFetcher()
 
@@ -2159,7 +2148,7 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
 
 /**
   Useful for creating complex, dynamic user interfaces that require multiple, concurrent data interactions without causing a navigation.
-  
+
   Fetchers track their own, independent state and can be used to load data, submit forms, and generally interact with loaders and actions.
 
   ```tsx

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -789,7 +789,6 @@ export function createRouter(init: RouterInit): Router {
     typeof routerWindow !== "undefined" &&
     typeof routerWindow.document !== "undefined" &&
     typeof routerWindow.document.createElement !== "undefined";
-  const isServer = !isBrowser;
 
   invariant(
     init.routes.length > 0,
@@ -1973,14 +1972,6 @@ export function createRouter(init: RouterInit): Router {
     href: string | null,
     opts?: RouterFetchOptions
   ) {
-    if (isServer) {
-      throw new Error(
-        "router.fetch() was called during the server render, but it shouldn't be. " +
-          "You are likely calling a useFetcher() method in the body of your component. " +
-          "Try moving it to a useEffect or a callback."
-      );
-    }
-
     if (fetchControllers.has(key)) abortFetcher(key);
     let flushSync = (opts && opts.unstable_flushSync) === true;
 


### PR DESCRIPTION
We used to have 2 of these since we kept DOM-specifics in `react-router-dom` (`document.startViewTransition`, `ReactDOM.flushSync`) but now we just need the one and it can be defensive against the lack of `window`/`document`