### PR TITLE
defineRoute: type helpers for `meta({matches})` and `useMatches`

### DIFF
--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -347,7 +347,11 @@ export type { ServerRouterProps } from "./lib/dom/ssr/server";
 export { ServerRouter } from "./lib/dom/ssr/server";
 export type { RoutesTestStubProps } from "./lib/dom/ssr/routes-test-stub";
 export { createRoutesStub } from "./lib/dom/ssr/routes-test-stub";
-export { defineRoute } from "./lib/router/define-route";
+export {
+  defineRoute,
+  type Match,
+  type MetaMatch,
+} from "./lib/router/define-route";
 
 ///////////////////////////////////////////////////////////////////////////////
 // DANGER! PLEASE READ ME!

--- a/packages/react-router/lib/router/define-route.ts
+++ b/packages/react-router/lib/router/define-route.ts
@@ -1,8 +1,12 @@
 import type { ReactNode } from "react";
 
-import type { MetaDescriptor, MetaMatch } from "../dom/ssr/routeModules";
+import type {
+  MetaDescriptor,
+  MetaMatch as _MetaMatch,
+} from "../dom/ssr/routeModules";
 import type { LinkDescriptor } from "../dom/ssr/links";
 import type { Location } from "./history";
+import type { UIMatch } from "./utils";
 
 // TODO: allow widest type (branded type: NOT_SET)
 
@@ -150,7 +154,7 @@ type Route<
       ClientLoaderHydrate,
       HydrateFallback
     >;
-    matches?: Array<MetaMatch>;
+    matches?: Array<_MetaMatch>;
   }) => MetaDescriptor[];
 
   Component?: (args: {
@@ -237,6 +241,30 @@ export function defineRootRoute<
 ): T {
   return route;
 }
+
+type LoaderDataFromRoute<R> = R extends Route<
+  any,
+  infer ServerLoaderData,
+  infer ClientLoaderData,
+  infer ClientLoaderHydrate,
+  infer HydrateFallback,
+  any,
+  any
+>
+  ? LoaderData<
+      ServerLoaderData,
+      ClientLoaderData,
+      ClientLoaderHydrate,
+      HydrateFallback
+    >
+  : never;
+
+export type MetaMatch<R extends Route<any, any, any, any, any, any, any>> =
+  _MetaMatch<string, LoaderDataFromRoute<R>>;
+
+export type Match<R extends Route<any, any, any, any, any, any, any>> = Pretty<
+  UIMatch<LoaderDataFromRoute<R>>
+>;
 
 // === TESTS ===
 


### PR DESCRIPTION
All types for parent route matches have been type cases under-the-hood. Previous attempts let you provide types for `matches` array, but then you'd have to pluck out a specific item from that and do more type casts. So instead, now `matches` is a wide type (array of matches each with `unknown` data) and we provide `Match` and `MetaMatch` type helpers to narrow down the type once you've found the match you wanted.

```ts
import { defineRoute, MetaMatch } from "react-router"

import type blahRoute from "./blah"

export default defineRoute({
  meta({ matches }) {
    let match = matches.find(id === "routes/blah") as MetaMatch<typeof blahRoute>
    console.log(match.data)
    //                ^? types inferred from `routes/blah`'s loader
  }
})
```