### PR TITLE
Migrate `react-router-dom` test usage

### DIFF
--- a/integration/abort-signal-test.ts
+++ b/integration/abort-signal-test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { json } from "@react-router/node";
-        import { useActionData, useLoaderData, Form } from "react-router-dom";
+        import { useActionData, useLoaderData, Form } from "react-router";
 
         export async function action ({ request }) {
           // New event loop causes express request to close

--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -23,7 +23,7 @@ test.describe("actions", () => {
     fixture = await createFixture({
       files: {
         "app/routes/urlencoded.tsx": js`
-          import { Form, useActionData } from "react-router-dom";
+          import { Form, useActionData } from "react-router";
 
           export let action = async ({ request }) => {
             let formData = await request.formData();
@@ -48,7 +48,7 @@ test.describe("actions", () => {
         `,
 
         "app/routes/request-text.tsx": js`
-          import { Form, useActionData } from "react-router-dom";
+          import { Form, useActionData } from "react-router";
 
           export let action = async ({ request }) => {
             let text = await request.text();
@@ -75,7 +75,7 @@ test.describe("actions", () => {
 
         [`app/routes/${THROWS_REDIRECT}.jsx`]: js`
           import { redirect } from "@react-router/node";
-          import { Form } from "react-router-dom";
+          import { Form } from "react-router";
 
           export function action() {
             throw redirect("/${REDIRECT_TARGET}")
@@ -97,7 +97,7 @@ test.describe("actions", () => {
         `,
 
         "app/routes/no-action.tsx": js`
-          import { Form } from "react-router-dom";
+          import { Form } from "react-router";
 
           export default function Component() {
             return (

--- a/integration/browser-entry-test.ts
+++ b/integration/browser-entry-test.ts
@@ -15,7 +15,7 @@ test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
       "app/routes/_index.tsx": js`
-        import { Link } from "react-router-dom";
+        import { Link } from "react-router";
 
         export default function Index() {
           return (

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -60,7 +60,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { json } from "@react-router/node";
-        import { useLoaderData, Link } from "react-router-dom";
+        import { useLoaderData, Link } from "react-router";
 
         export function loader() {
           return json("pizza");

--- a/integration/catch-boundary-data-test.ts
+++ b/integration/catch-boundary-data-test.ts
@@ -48,7 +48,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
             Scripts,
             useLoaderData,
             useMatches,
-          } from "react-router-dom";
+          } from "react-router";
 
           export const loader = () => json("${ROOT_DATA}");
 
@@ -88,7 +88,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
         `,
 
         "app/routes/_index.tsx": js`
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
           export default function Index() {
             return (
               <div>
@@ -110,7 +110,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
         `,
 
         [`app/routes${HAS_BOUNDARY_LAYOUT_NESTED_LOADER_FILE}.jsx`]: js`
-          import { useMatches } from "react-router-dom";
+          import { useMatches } from "react-router";
           export function loader() {
             return "${LAYOUT_DATA}";
           }
@@ -140,7 +140,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
         `,
 
         [`app/routes${HAS_BOUNDARY_NESTED_LOADER_FILE}.jsx`]: js`
-          import { Outlet, useLoaderData } from "react-router-dom";
+          import { Outlet, useLoaderData } from "react-router";
           export function loader() {
             return "${LAYOUT_DATA}";
           }

--- a/integration/catch-boundary-test.ts
+++ b/integration/catch-boundary-test.ts
@@ -31,7 +31,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
       files: {
         "app/root.tsx": js`
             import { json } from "@react-router/node";
-            import { Links, Meta, Outlet, Scripts, useMatches } from "react-router-dom";
+            import { Links, Meta, Outlet, Scripts, useMatches } from "react-router";
 
             export function loader() {
               return json({ data: "ROOT LOADER" });
@@ -68,7 +68,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         "app/routes/_index.tsx": js`
-            import { Link, Form } from "react-router-dom";
+            import { Link, Form } from "react-router";
             export default function() {
               return (
                 <div>
@@ -94,7 +94,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         [`app/routes${HAS_BOUNDARY_ACTION_FILE}.jsx`]: js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export async function action() {
               throw new Response("", { status: 401 })
             }
@@ -113,7 +113,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         [`app/routes${NO_BOUNDARY_ACTION_FILE}.jsx`]: js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export function action() {
               throw new Response("", { status: 401 })
             }
@@ -129,7 +129,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         [`app/routes${HAS_BOUNDARY_LOADER_FILE}.jsx`]: js`
-            import { useRouteError } from "react-router-dom";
+            import { useRouteError } from "react-router";
             export function loader() {
               throw new Response("", { status: 401 })
             }
@@ -166,7 +166,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         "app/routes/action.tsx": js`
-            import { Outlet, useLoaderData } from "react-router-dom";
+            import { Outlet, useLoaderData } from "react-router";
 
             export function loader() {
               return "PARENT";
@@ -183,7 +183,7 @@ test.describe("ErrorBoundary (thrown responses)", () => {
           `,
 
         "app/routes/action.child-catch.tsx": js`
-            import { Form, useLoaderData, useRouteError } from "react-router-dom";
+            import { Form, useLoaderData, useRouteError } from "react-router";
 
             export function loader() {
               return "CHILD";

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -26,7 +26,7 @@ function getFiles({
 }) {
   return {
     "app/root.tsx": js`
-      import { Outlet, Scripts } from "react-router-dom"
+      import { Outlet, Scripts } from "react-router"
 
       export default function Root() {
         return (
@@ -43,14 +43,14 @@ function getFiles({
       }
     `,
     "app/routes/_index.tsx": js`
-      import { Link } from "react-router-dom"
+      import { Link } from "react-router"
       export default function Component() {
         return <Link to="/parent/child">Go to /parent/child</Link>
       }
     `,
     "app/routes/parent.tsx": js`
       import { json } from '@react-router/node'
-      import { Outlet, useLoaderData } from "react-router-dom"
+      import { Outlet, useLoaderData } from "react-router"
       export function loader() {
         return json({ message: 'Parent Server Loader'});
       }
@@ -90,7 +90,7 @@ function getFiles({
     `,
     "app/routes/parent.child.tsx": js`
       import { json } from '@react-router/node'
-      import { Form, Outlet, useActionData, useLoaderData } from "react-router-dom"
+      import { Form, Outlet, useActionData, useLoaderData } from "react-router"
       export function loader() {
         return json({ message: 'Child Server Loader'});
       }
@@ -319,7 +319,7 @@ test.describe("Client Data", () => {
           "app/routes/parent.child.tsx": js`
             import * as React from 'react';
             import { defer, json } from '@react-router/node'
-            import { Await, useLoaderData } from "react-router-dom"
+            import { Await, useLoaderData } from "react-router"
             export function loader() {
               return defer({
                 message: 'Child Server Loader',
@@ -418,7 +418,7 @@ test.describe("Client Data", () => {
           "app/routes/parent.child.tsx": js`
             import * as React from 'react';
             import { json } from '@react-router/node';
-            import { useLoaderData } from "react-router-dom";
+            import { useLoaderData } from "react-router";
             export function loader() {
               return json({
                 message: "Child Server Loader Data",
@@ -471,7 +471,7 @@ test.describe("Client Data", () => {
             }),
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
-              import { useLoaderData } from "react-router-dom";
+              import { useLoaderData } from "react-router";
               // Even without setting hydrate=true, this should run on hydration
               export async function clientLoader({ serverLoader }) {
                 await new Promise(r => setTimeout(r, 100));
@@ -514,7 +514,7 @@ test.describe("Client Data", () => {
             }),
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
-              import { useLoaderData } from "react-router-dom";
+              import { useLoaderData } from "react-router";
               // Even without setting hydrate=true, this should run on hydration
               export async function clientLoader({ serverLoader }) {
                 await new Promise(r => setTimeout(r, 100));
@@ -557,7 +557,7 @@ test.describe("Client Data", () => {
             }),
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
-              import { useLoaderData, useRouteError } from "react-router-dom";
+              import { useLoaderData, useRouteError } from "react-router";
               export async function clientLoader({ serverLoader }) {
                 return await serverLoader();
               }
@@ -601,7 +601,7 @@ test.describe("Client Data", () => {
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
               import { json } from '@react-router/node';
-              import { useLoaderData, useRevalidator } from "react-router-dom";
+              import { useLoaderData, useRevalidator } from "react-router";
               let isFirstCall = true;
               export async function loader({ serverLoader }) {
                 if (isFirstCall) {
@@ -666,7 +666,7 @@ test.describe("Client Data", () => {
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
               import { json } from '@react-router/node';
-              import { useLoaderData, useRevalidator } from "react-router-dom";
+              import { useLoaderData, useRevalidator } from "react-router";
               let isFirstCall = true;
               export async function loader({ serverLoader }) {
                 if (isFirstCall) {
@@ -742,7 +742,7 @@ test.describe("Client Data", () => {
                 childClientLoaderHydrate: false,
               }),
               "app/routes/parent.child.tsx": js`
-                import { ClientLoaderFunctionArgs, useRouteError } from "react-router-dom";
+                import { ClientLoaderFunctionArgs, useRouteError } from "react-router";
 
                 export function loader() {
                   throw new Error("Broken!")
@@ -882,7 +882,7 @@ test.describe("Client Data", () => {
             }),
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
-              import { useLoaderData, useRouteError } from "react-router-dom";
+              import { useLoaderData, useRouteError } from "react-router";
               export async function clientLoader({ serverLoader }) {
                 return await serverLoader();
               }
@@ -1095,7 +1095,7 @@ test.describe("Client Data", () => {
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
               import { json } from '@react-router/node';
-              import { Form, useRouteError } from "react-router-dom";
+              import { Form, useRouteError } from "react-router";
               export async function clientAction({ serverAction }) {
                 return await serverAction();
               }
@@ -1312,7 +1312,7 @@ test.describe("Client Data", () => {
             "app/routes/parent.child.tsx": js`
               import * as React from 'react';
               import { json } from '@react-router/node';
-              import { Form, useRouteError } from "react-router-dom";
+              import { Form, useRouteError } from "react-router";
               export async function clientAction({ serverAction }) {
                 return await serverAction();
               }

--- a/integration/custom-entry-server-test.ts
+++ b/integration/custom-entry-server-test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
     files: {
       "app/entry.server.tsx": js`
         import * as React from "react";
-        import { ServerRouter } from "react-router-dom";
+        import { ServerRouter } from "react-router";
         import { renderToString } from "react-dom/server";
 
         export default function handleRequest(

--- a/integration/defer-loader-test.ts
+++ b/integration/defer-loader-test.ts
@@ -16,7 +16,7 @@ test.describe("deferred loaders", () => {
     fixture = await createFixture({
       files: {
         "app/routes/_index.tsx": js`
-          import { useLoaderData, Link } from "react-router-dom";
+          import { useLoaderData, Link } from "react-router";
           export default function Index() {
             return (
               <div>
@@ -38,7 +38,7 @@ test.describe("deferred loaders", () => {
         "app/routes/direct-promise-access.tsx": js`
           import * as React from "react";
           import { defer } from "@react-router/node";
-          import { useLoaderData, Link, Await } from "react-router-dom";
+          import { useLoaderData, Link, Await } from "react-router";
           export function loader() {
             return defer({
               bar: new Promise(async (resolve, reject) => {

--- a/integration/defer-test.ts
+++ b/integration/defer-test.ts
@@ -76,7 +76,7 @@ test.describe("non-aborted", () => {
         `,
         "app/root.tsx": js`
           import { defer } from "@react-router/node";
-          import { Links, Meta, Outlet, Scripts, useLoaderData } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
           import Interactive from "~/components/interactive";
 
@@ -117,7 +117,7 @@ test.describe("non-aborted", () => {
 
         "app/routes/_index.tsx": js`
           import { defer } from "@react-router/node";
-          import { Link, useLoaderData } from "react-router-dom";
+          import { Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -149,7 +149,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-noscript-resolved.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -184,7 +184,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-noscript-unresolved.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -223,7 +223,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-resolved.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -259,7 +259,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-unresolved.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -303,7 +303,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-rejected.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -344,7 +344,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-unrejected.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -410,7 +410,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-rejected-no-error-element.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -454,7 +454,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-script-unrejected-no-error-element.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -502,7 +502,7 @@ test.describe("non-aborted", () => {
         "app/routes/deferred-manual-resolve.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -998,7 +998,7 @@ test.describe("aborted", () => {
           import { PassThrough } from "node:stream";
           import type { AppLoadContext, EntryContext } from "@react-router/node";
           import { createReadableStreamFromReadable } from "@react-router/node";
-          import { ServerRouter } from "react-router-dom";
+          import { ServerRouter } from "react-router";
           import { isbot } from "isbot";
           import { renderToPipeableStream } from "react-dom/server";
 
@@ -1143,7 +1143,7 @@ test.describe("aborted", () => {
         `,
         "app/root.tsx": js`
           import { defer } from "@react-router/node";
-          import { Links, Meta, Outlet, Scripts, useLoaderData } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
           import Interactive from "~/components/interactive";
 
@@ -1185,7 +1185,7 @@ test.describe("aborted", () => {
         "app/routes/deferred-server-aborted.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {
@@ -1230,7 +1230,7 @@ test.describe("aborted", () => {
         "app/routes/deferred-server-aborted-no-error-element.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, Link, useLoaderData } from "react-router-dom";
+          import { Await, Link, useLoaderData } from "react-router";
           import Counter from "~/components/counter";
 
           export function loader() {

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -48,7 +48,7 @@ test.describe("ErrorBoundary", () => {
       {
         files: {
           "app/root.tsx": js`
-              import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+              import { Links, Meta, Outlet, Scripts } from "react-router";
 
               export default function Root() {
                 return (
@@ -83,7 +83,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/_index.tsx": js`
-              import { Link, Form } from "react-router-dom";
+              import { Link, Form } from "react-router";
               export default function () {
                 return (
                   <div>
@@ -122,7 +122,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           [`app/routes${HAS_BOUNDARY_ACTION_FILE}.jsx`]: js`
-              import { Form } from "react-router-dom";
+              import { Form } from "react-router";
               export async function action() {
                 throw new Error("Kaboom!")
               }
@@ -141,7 +141,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           [`app/routes${NO_BOUNDARY_ACTION_FILE}.jsx`]: js`
-              import { Form } from "react-router-dom";
+              import { Form } from "react-router";
               export function action() {
                 throw new Error("Kaboom!")
               }
@@ -211,7 +211,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/fetcher-boundary.tsx": js`
-              import { useFetcher } from "react-router-dom";
+              import { useFetcher } from "react-router";
               export function ErrorBoundary() {
                 return <p id="fetcher-boundary">${OWN_BOUNDARY_TEXT}</p>
               }
@@ -229,7 +229,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/fetcher-no-boundary.tsx": js`
-              import { useFetcher } from "react-router-dom";
+              import { useFetcher } from "react-router";
               export default function() {
                 let fetcher = useFetcher();
 
@@ -246,7 +246,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/action.tsx": js`
-              import { Outlet, useLoaderData } from "react-router-dom";
+              import { Outlet, useLoaderData } from "react-router";
 
               export function loader() {
                 return "PARENT";
@@ -263,7 +263,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/action.child-error.tsx": js`
-              import { Form, useLoaderData, useRouteError } from "react-router-dom";
+              import { Form, useLoaderData, useRouteError } from "react-router";
 
               export function loader() {
                 return "CHILD";
@@ -500,7 +500,7 @@ test.describe("ErrorBoundary", () => {
       fixture = await createFixture({
         files: {
           "app/root.tsx": js`
-              import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+              import { Links, Meta, Outlet, Scripts } from "react-router";
 
               export default function Root() {
                 return (
@@ -519,7 +519,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           "app/routes/_index.tsx": js`
-              import { Link, Form } from "react-router-dom";
+              import { Link, Form } from "react-router";
 
               export default function () {
                 return (
@@ -568,7 +568,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           [`app/routes${NO_ROOT_BOUNDARY_LOADER_RETURN}.jsx`]: js`
-              import { useLoaderData } from "react-router-dom";
+              import { useLoaderData } from "react-router";
 
               export async function loader() {}
 
@@ -583,7 +583,7 @@ test.describe("ErrorBoundary", () => {
             `,
 
           [`app/routes${NO_ROOT_BOUNDARY_ACTION_RETURN}.jsx`]: js`
-              import { useActionData } from "react-router-dom";
+              import { useActionData } from "react-router";
 
               export async function action() {}
 
@@ -665,7 +665,7 @@ test.describe("loaderData in ErrorBoundary", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-            import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+            import { Links, Meta, Outlet, Scripts } from "react-router";
 
             export default function Root() {
               return (
@@ -686,7 +686,7 @@ test.describe("loaderData in ErrorBoundary", () => {
           `,
 
         "app/routes/parent.tsx": js`
-            import { Outlet, useLoaderData, useMatches, useRouteError } from "react-router-dom";
+            import { Outlet, useLoaderData, useMatches, useRouteError } from "react-router";
 
             export function loader() {
               return "PARENT";
@@ -716,7 +716,7 @@ test.describe("loaderData in ErrorBoundary", () => {
           `,
 
         "app/routes/parent.child-with-boundary.tsx": js`
-            import { Form, useLoaderData, useRouteError } from "react-router-dom";
+            import { Form, useLoaderData, useRouteError } from "react-router";
 
             export function loader() {
               return "CHILD";
@@ -751,7 +751,7 @@ test.describe("loaderData in ErrorBoundary", () => {
           `,
 
         "app/routes/parent.child-without-boundary.tsx": js`
-            import { Form, useLoaderData } from "react-router-dom";
+            import { Form, useLoaderData } from "react-router";
 
             export function loader() {
               return "CHILD";
@@ -955,7 +955,7 @@ test.describe("Default ErrorBoundary", () => {
 
     return {
       "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts, useRouteError } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts, useRouteError } from "react-router";
 
           export default function Root() {
             return (
@@ -978,7 +978,7 @@ test.describe("Default ErrorBoundary", () => {
         `,
 
       "app/routes/_index.tsx": js`
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
           export default function () {
             return (
               <div>
@@ -1243,7 +1243,7 @@ test("Allows back-button out of an error boundary after a hard reload", async ({
   let fixture = await createFixture({
     files: {
       "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts, useRouteError } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts, useRouteError } from "react-router";
 
           export default function App() {
             return (
@@ -1278,7 +1278,7 @@ test("Allows back-button out of an error boundary after a hard reload", async ({
           }
         `,
       "app/routes/_index.tsx": js`
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
 
           export default function Index() {
             return (

--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -19,7 +19,7 @@ test.describe("ErrorBoundary", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (
@@ -46,7 +46,7 @@ test.describe("ErrorBoundary", () => {
             isRouteErrorResponse,
             useLoaderData,
             useRouteError,
-          } from "react-router-dom";
+          } from "react-router";
 
           export function loader() {
             return "PARENT LOADER";
@@ -86,7 +86,7 @@ test.describe("ErrorBoundary", () => {
             useLoaderData,
             useLocation,
             useRouteError,
-          } from "react-router-dom";
+          } from "react-router";
 
           export function loader({ request }) {
             let errorType = new URL(request.url).searchParams.get('type');
@@ -115,7 +115,7 @@ test.describe("ErrorBoundary", () => {
         `,
 
         "app/routes/parent.child-without-boundary.tsx": js`
-          import { useLoaderData, useLocation } from "react-router-dom";
+          import { useLoaderData, useLocation } from "react-router";
 
           export function loader({ request }) {
             let errorType = new URL(request.url).searchParams.get('type');

--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -21,7 +21,7 @@ test.describe("ErrorBoundary", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (
@@ -40,7 +40,7 @@ test.describe("ErrorBoundary", () => {
         `,
 
         "app/routes/_index.tsx": js`
-          import { Link, Form } from "react-router-dom";
+          import { Link, Form } from "react-router";
 
           export default function () {
             return <h1>Index</h1>

--- a/integration/error-sanitization-test.ts
+++ b/integration/error-sanitization-test.ts
@@ -12,7 +12,7 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
 
 const routeFiles = {
   "app/root.tsx": js`
-    import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+    import { Links, Meta, Outlet, Scripts } from "react-router";
 
     export default function Root() {
       return (
@@ -33,7 +33,7 @@ const routeFiles = {
   `,
 
   "app/routes/_index.tsx": js`
-    import { useLoaderData, useLocation, useRouteError } from "react-router-dom";
+    import { useLoaderData, useLocation, useRouteError } from "react-router";
 
     export function loader({ request }) {
       if (new URL(request.url).searchParams.has('loader')) {
@@ -78,7 +78,7 @@ const routeFiles = {
   "app/routes/defer.tsx": js`
     import * as React from 'react';
     import { defer } from "@react-router/server-runtime";
-    import { Await, useAsyncError, useLoaderData, useRouteError  } from "react-router-dom";
+    import { Await, useAsyncError, useLoaderData, useRouteError  } from "react-router";
 
     export function loader({ request }) {
       if (new URL(request.url).searchParams.has('loader')) {
@@ -493,7 +493,7 @@ test.describe("Error Sanitization", () => {
               import { PassThrough } from "node:stream";
 
               import { createReadableStreamFromReadable } from "@react-router/node";
-              import { ServerRouter, isRouteErrorResponse } from "react-router-dom";
+              import { ServerRouter, isRouteErrorResponse } from "react-router";
               import { renderToPipeableStream } from "react-dom/server";
 
               const ABORT_DELAY = 5_000;

--- a/integration/fetch-globals-test.ts
+++ b/integration/fetch-globals-test.ts
@@ -15,7 +15,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { json } from "@react-router/node";
-        import { useLoaderData } from "react-router-dom";
+        import { useLoaderData } from "react-router";
         export async function loader() {
           const resp = await fetch('https://reqres.in/api/users?page=2');
           return (resp instanceof Response) ? 'is an instance of global Response' : 'is not an instance of global Response';

--- a/integration/fetcher-layout-test.ts
+++ b/integration/fetcher-layout-test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/layout-action.tsx": js`
         import { json } from "@react-router/node";
-        import { Outlet, useFetcher, useFormAction } from "react-router-dom";
+        import { Outlet, useFetcher, useFormAction } from "react-router";
 
         export let action = ({ params }) => json("layout action data");
 
@@ -45,7 +45,7 @@ test.beforeAll(async () => {
           useFetcher,
           useFormAction,
           useLoaderData,
-        } from "react-router-dom";
+        } from "react-router";
 
         export let loader = ({ params }) => json("index data");
 
@@ -76,7 +76,7 @@ test.beforeAll(async () => {
           useFetcher,
           useFormAction,
           useLoaderData,
-        } from "react-router-dom";
+        } from "react-router";
 
         export let loader = ({ params }) => json(params.param);
 
@@ -103,7 +103,7 @@ test.beforeAll(async () => {
 
       "app/routes/layout-loader.tsx": js`
         import { json } from "@react-router/node";
-        import { Outlet, useFetcher, useFormAction } from "react-router-dom";
+        import { Outlet, useFetcher, useFormAction } from "react-router";
 
         export let loader = () => json("layout loader data");
 
@@ -132,7 +132,7 @@ test.beforeAll(async () => {
           useFetcher,
           useFormAction,
           useLoaderData,
-        } from "react-router-dom";
+        } from "react-router";
 
         export let loader = ({ params }) => json("index data");
 
@@ -159,7 +159,7 @@ test.beforeAll(async () => {
           useFetcher,
           useFormAction,
           useLoaderData,
-        } from "react-router-dom";
+        } from "react-router";
 
         export let loader = ({ params }) => json(params.param);
 

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -30,7 +30,7 @@ test.describe("useFetcher", () => {
         `,
 
         "app/routes/fetcher-action-only-call.tsx": js`
-          import { useFetcher } from "react-router-dom";
+          import { useFetcher } from "react-router";
 
           export default function FetcherActionOnlyCall() {
             let fetcher = useFetcher();
@@ -61,7 +61,7 @@ test.describe("useFetcher", () => {
         `,
 
         "app/routes/_index.tsx": js`
-          import { useFetcher } from "react-router-dom";
+          import { useFetcher } from "react-router";
           export default function Index() {
             let fetcher = useFetcher();
             return (
@@ -90,7 +90,7 @@ test.describe("useFetcher", () => {
         `,
 
         "app/routes/parent.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export function action() {
             return new Response("${PARENT_LAYOUT_ACTION}");
@@ -106,7 +106,7 @@ test.describe("useFetcher", () => {
         `,
 
         "app/routes/parent._index.tsx": js`
-          import { useFetcher } from "react-router-dom";
+          import { useFetcher } from "react-router";
 
           export function action() {
             return new Response("${PARENT_INDEX_ACTION}");
@@ -150,7 +150,7 @@ test.describe("useFetcher", () => {
 
         "app/routes/fetcher-echo.tsx": js`
           import { json } from "@react-router/node";
-          import { useFetcher } from "react-router-dom";
+          import { useFetcher } from "react-router";
 
           export async function action({ request }) {
             await new Promise(r => setTimeout(r, 1000));
@@ -441,7 +441,7 @@ test.describe("fetcher aborts and adjacent forms", () => {
             useFetcher,
             useLoaderData,
             useNavigation
-          } from "react-router-dom";
+          } from "react-router";
 
           export async function loader({ request }) {
             // 1 second timeout on data

--- a/integration/file-uploads-test.ts
+++ b/integration/file-uploads-test.ts
@@ -45,7 +45,7 @@ test.describe("file-uploads", () => {
             import {
               unstable_parseMultipartFormData as parseMultipartFormData,
             } from "@react-router/node";
-            import { Form, useActionData } from "react-router-dom";
+            import { Form, useActionData } from "react-router";
             import { uploadHandler } from "~/fileUploadHandler";
 
             export let action = async ({ request }) => {

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -29,7 +29,7 @@ test.describe("flat routes", () => {
           });
         `,
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (
@@ -89,7 +89,7 @@ test.describe("flat routes", () => {
         `,
 
         "app/routes/dashboard/route.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export default function () {
             return (
@@ -299,7 +299,7 @@ test.describe("pathless routes and route collisions", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Link, Outlet, Scripts, useMatches } from "react-router-dom";
+          import { Link, Outlet, Scripts, useMatches } from "react-router";
 
           export default function App() {
             let matches = 'Number of matches: ' + useMatches().length;
@@ -326,7 +326,7 @@ test.describe("pathless routes and route collisions", () => {
           }
         `,
         "app/routes/nested._pathless.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export default function Layout() {
             return (
@@ -343,7 +343,7 @@ test.describe("pathless routes and route collisions", () => {
           }
         `,
         "app/routes/nested._pathless2.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export default function Layout() {
             return (

--- a/integration/form-test.ts
+++ b/integration/form-test.ts
@@ -62,7 +62,7 @@ test.describe("Forms", () => {
     fixture = await createFixture({
       files: {
         "app/routes/get-submission.tsx": js`
-            import { useLoaderData, Form } from "react-router-dom";
+            import { useLoaderData, Form } from "react-router";
 
             export function loader({ request }) {
               let url = new URL(request.url);
@@ -144,7 +144,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/inbox.tsx": js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export default function() {
               return (
                 <>
@@ -169,7 +169,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/blog.tsx": js`
-            import { Form, Outlet } from "react-router-dom";
+            import { Form, Outlet } from "react-router";
             export default function() {
               return (
                 <>
@@ -196,7 +196,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/blog._index.tsx": js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export function action() {
               return { ok: true };
             }
@@ -230,7 +230,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/blog.$postId.tsx": js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export default function() {
               return (
                 <>
@@ -255,7 +255,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/projects.tsx": js`
-            import { Form, Outlet } from "react-router-dom";
+            import { Form, Outlet } from "react-router";
             export default function() {
               return (
                 <>
@@ -273,7 +273,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/projects.$.tsx": js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
             export default function() {
               return (
                 <>
@@ -299,7 +299,7 @@ test.describe("Forms", () => {
 
         "app/routes/stop-propagation.tsx": js`
             import { json } from "@react-router/node";
-            import { Form, useActionData } from "react-router-dom";
+            import { Form, useActionData } from "react-router";
 
             export async function action({ request }) {
               let formData = await request.formData();
@@ -320,7 +320,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/form-method.tsx": js`
-            import { Form, useActionData, useLoaderData, useSearchParams } from "react-router-dom";
+            import { Form, useActionData, useLoaderData, useSearchParams } from "react-router";
             import { json } from "@react-router/node";
 
             export function action({ request }) {
@@ -351,7 +351,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/submitter.tsx": js`
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
 
             export default function() {
               return (
@@ -374,7 +374,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/file-upload.tsx": js`
-            import { Form, useSearchParams } from "react-router-dom";
+            import { Form, useSearchParams } from "react-router";
 
             export default function() {
               const [params] = useSearchParams();
@@ -395,7 +395,7 @@ test.describe("Forms", () => {
 
         "app/routes/empty-file-upload.tsx": js`
             import { json } from "@react-router/server-runtime";
-            import { Form, useActionData } from "react-router-dom";
+            import { Form, useActionData } from "react-router";
 
             export async function action({ request }) {
               let formData = await request.formData();
@@ -430,7 +430,7 @@ test.describe("Forms", () => {
         //
         // TODO: refactor other tests to use this
         "app/routes/outputFormData.tsx": js`
-            import { useActionData, useSearchParams } from "react-router-dom";
+            import { useActionData, useSearchParams } from "react-router";
 
             export async function action({ request }) {
               const formData = await request.formData();
@@ -455,7 +455,7 @@ test.describe("Forms", () => {
 
         "app/routes/pathless-layout-parent.tsx": js`
             import { json } from '@react-router/server-runtime'
-            import { Form, Outlet, useActionData } from 'react-router-dom'
+            import { Form, Outlet, useActionData } from "react-router"
 
             export async function action({ request }) {
               return json({ submitted: true });
@@ -476,7 +476,7 @@ test.describe("Forms", () => {
           `,
 
         "app/routes/pathless-layout-parent._pathless.nested.tsx": js`
-            import { Outlet } from 'react-router-dom';
+            import { Outlet } from "react-router";
 
             export default function () {
               return (

--- a/integration/headers-test.ts
+++ b/integration/headers-test.ts
@@ -18,7 +18,7 @@ test.describe.skip("headers export", () => {
         files: {
           "app/root.tsx": js`
             import { json } from "@react-router/node";
-            import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+            import { Links, Meta, Outlet, Scripts } from "react-router";
 
             export const loader = () => json({});
 
@@ -160,7 +160,7 @@ test.describe.skip("headers export", () => {
 
           "app/routes/cookie.tsx": js`
             import { json } from "@react-router/server-runtime";
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
 
             export function loader({ request }) {
               if (new URL(request.url).searchParams.has("parent-throw")) {
@@ -221,7 +221,7 @@ test.describe.skip("headers export", () => {
       {
         files: {
           "app/root.tsx": js`
-            import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+            import { Links, Meta, Outlet, Scripts } from "react-router";
 
             export default function Root() {
               return (

--- a/integration/helpers/node-template/package.json
+++ b/integration/helpers/node-template/package.json
@@ -19,8 +19,7 @@
     "isbot": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router": "workspace:*",
-    "react-router-dom": "workspace:*"
+    "react-router": "workspace:*"
   },
   "devDependencies": {
     "@react-router/dev": "workspace:*",

--- a/integration/helpers/vite-template/package.json
+++ b/integration/helpers/vite-template/package.json
@@ -21,7 +21,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "workspace:*",
-    "react-router-dom": "workspace:*",
     "serialize-javascript": "^6.0.1"
   },
   "devDependencies": {

--- a/integration/hook-useSubmit-test.ts
+++ b/integration/hook-useSubmit-test.ts
@@ -16,7 +16,7 @@ test.describe("`useSubmit()` returned function", () => {
     fixture = await createFixture({
       files: {
         "app/routes/_index.tsx": js`
-          import { useLoaderData, useSubmit } from "react-router-dom";
+          import { useLoaderData, useSubmit } from "react-router";
 
           export function loader({ request }) {
             let url = new URL(request.url);
@@ -46,7 +46,7 @@ test.describe("`useSubmit()` returned function", () => {
         `,
         "app/routes/action.tsx": js`
           import { json } from "@react-router/node";
-          import { useActionData, useSubmit } from "react-router-dom";
+          import { useActionData, useSubmit } from "react-router";
 
           export async function action({ request }) {
             let contentType = request.headers.get('Content-Type');

--- a/integration/layout-route-test.ts
+++ b/integration/layout-route-test.ts
@@ -16,7 +16,7 @@ test.describe("pathless layout routes", () => {
       await createFixture({
         files: {
           "app/routes/_layout.tsx": js`
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
 
             export default () => <div data-testid="layout-route"><Outlet /></div>;
           `,
@@ -27,7 +27,7 @@ test.describe("pathless layout routes", () => {
             export default () => <div data-testid="layout-subroute">Layout subroute</div>;
           `,
           "app/routes/sandwiches._pathless.tsx": js`
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
 
             export default () => <div data-testid="sandwiches-pathless-route"><Outlet /></div>;
           `,

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -88,7 +88,7 @@ test.describe("route module link export", () => {
             Scripts,
             useRouteError,
             isRouteErrorResponse
-          } from "react-router-dom";
+          } from "react-router";
           import resetHref from "./reset.css?url";
           import stylesHref from "./app.css?url";
           import favicon from "./favicon.ico";
@@ -193,7 +193,7 @@ test.describe("route module link export", () => {
 
         "app/routes/_index.tsx": js`
           import { useEffect } from "react";
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
 
           export default function Index() {
             return (
@@ -226,7 +226,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/links.tsx": js`
-          import { useLoaderData, Link } from "react-router-dom";
+          import { useLoaderData, Link } from "react-router";
           import redTextHref from "~/redText.css?url";
           import blueTextHref from "~/blueText.css?url";
           import guitar from "~/guitar.jpg";
@@ -275,7 +275,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/responsive-image-preload.tsx": js`
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
           import guitar600 from "~/guitar-600.jpg";
           import guitar900 from "~/guitar-900.jpg";
 
@@ -309,7 +309,7 @@ test.describe("route module link export", () => {
 
         "app/routes/gists.tsx": js`
           import { json } from "@react-router/node";
-          import { Link, Outlet, useLoaderData, useNavigation } from "react-router-dom";
+          import { Link, Outlet, useLoaderData, useNavigation } from "react-router";
           import stylesHref from "~/gists.css?url";
           export function links() {
             return [{ rel: "stylesheet", href: stylesHref }];
@@ -360,7 +360,7 @@ test.describe("route module link export", () => {
 
         "app/routes/gists.$username.tsx": js`
           import { json, redirect } from "@react-router/node";
-          import { Link, useLoaderData, useParams } from "react-router-dom";
+          import { Link, useLoaderData, useParams } from "react-router";
           export async function loader({ params }) {
             let { username } = params;
             if (username === "mjijackson") {
@@ -417,7 +417,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/gists._index.tsx": js`
-          import { useLoaderData } from "react-router-dom";
+          import { useLoaderData } from "react-router";
           export async function loader() {
             return ${JSON.stringify(fakeGists)};
           }
@@ -473,7 +473,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/parent.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export function links() {
             return [
@@ -491,7 +491,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/parent.child.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
 
           export function loader() {
             throw new Response(null, { status: 404 });

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -19,7 +19,7 @@ test.describe("loader", () => {
       files: {
         "app/root.tsx": js`
             import { json } from "@react-router/node";
-            import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+            import { Links, Meta, Outlet, Scripts } from "react-router";
 
             export const loader = () => json("${ROOT_DATA}");
 
@@ -75,7 +75,7 @@ test.describe("loader in an app", () => {
       await createFixture({
         files: {
           "app/root.tsx": js`
-            import { Outlet } from 'react-router-dom'
+            import { Outlet } from "react-router"
 
             export default function Root() {
               return (

--- a/integration/matches-test.ts
+++ b/integration/matches-test.ts
@@ -18,7 +18,7 @@ test.describe("useMatches", () => {
         "app/root.tsx": js`
           import * as React from 'react';
           import { json } from "@react-router/node";
-          import { Link, Links, Meta, Outlet, Scripts, useMatches } from "react-router-dom";
+          import { Link, Links, Meta, Outlet, Scripts, useMatches } from "react-router";
           export const handle = { stuff: "root handle"};
           export const loader = () => json("ROOT");
           export default function Root() {
@@ -69,7 +69,7 @@ test.describe("useMatches", () => {
 
         "app/routes/count.tsx": js`
           import * as React from 'react';
-          import { useMatches } from "react-router-dom";
+          import { useMatches } from "react-router";
           export default function Count() {
             let matches = useMatches();
             let [count, setCount] = React.useState(0);

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -17,7 +17,7 @@ test.describe("pathless layout routes", () => {
         files: {
           "app/routes/_index.tsx": js`
             import { redirect, json } from "@react-router/node";
-            import { Form, useActionData } from "react-router-dom";
+            import { Form, useActionData } from "react-router";
 
             export let loader = async () => {
               let headers = new Headers();

--- a/integration/navigation-state-test.ts
+++ b/integration/navigation-state-test.ts
@@ -38,7 +38,7 @@ test.describe("navigation states", () => {
       files: {
         "app/root.tsx": js`
             import { useMemo, useRef } from "react";
-            import { Outlet, Scripts, useNavigation } from "react-router-dom";
+            import { Outlet, Scripts, useNavigation } from "react-router";
             export default function() {
               const navigation = useNavigation();
               const navigationsRef = useRef();
@@ -68,7 +68,7 @@ test.describe("navigation states", () => {
             }
           `,
         "app/routes/_index.tsx": js`
-            import { Form, Link, useFetcher } from "react-router-dom";
+            import { Form, Link, useFetcher } from "react-router";
             export function loader() { return null; }
             export default function() {
               const fetcher = useFetcher();

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -29,7 +29,7 @@ test.describe.skip("multi fetch", () => {
             Outlet,
             Scripts,
             useLoaderData,
-          } from "react-router-dom";
+          } from "react-router";
 
           export default function Root() {
             const styles =
@@ -285,7 +285,7 @@ test.describe.skip("multi fetch", () => {
       fixture = await createFixture({
         files: {
           "app/routes/_index.tsx": js`
-            import { Link } from "react-router-dom";
+            import { Link } from "react-router";
 
             export default function Component() {
               return (
@@ -359,7 +359,7 @@ test.describe.skip("multi fetch", () => {
       fixture = await createFixture({
         files: {
           "app/root.tsx": js`
-              import { Links, Meta, Scripts, useFetcher } from "react-router-dom";
+              import { Links, Meta, Scripts, useFetcher } from "react-router";
               import globalCss from "./global.css";
 
               export function links() {
@@ -444,7 +444,7 @@ test.describe.skip("multi fetch", () => {
               Outlet,
               Scripts,
               useLoaderData,
-            } from "react-router-dom";
+            } from "react-router";
 
             export default function Root() {
               const styles =
@@ -494,7 +494,7 @@ test.describe.skip("multi fetch", () => {
           `,
 
           "app/routes/with-nested-links.tsx": js`
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
             import globalCss from "../global.css";
 
             export function links() {
@@ -587,7 +587,7 @@ test.describe.skip("single fetch", () => {
             Outlet,
             Scripts,
             useLoaderData,
-          } from "react-router-dom";
+          } from "react-router";
 
           export default function Root() {
             const styles =
@@ -843,7 +843,7 @@ test.describe.skip("single fetch", () => {
       fixture = await createFixture({
         files: {
           "app/routes/_index.tsx": js`
-            import { Link } from "react-router-dom";
+            import { Link } from "react-router";
 
             export default function Component() {
               return (
@@ -917,7 +917,7 @@ test.describe.skip("single fetch", () => {
       fixture = await createFixture({
         files: {
           "app/root.tsx": js`
-              import { Links, Meta, Scripts, useFetcher } from "react-router-dom";
+              import { Links, Meta, Scripts, useFetcher } from "react-router";
               import globalCss from "./global.css";
 
               export function links() {
@@ -1002,7 +1002,7 @@ test.describe.skip("single fetch", () => {
               Outlet,
               Scripts,
               useLoaderData,
-            } from "react-router-dom";
+            } from "react-router";
 
             export default function Root() {
               const styles =
@@ -1052,7 +1052,7 @@ test.describe.skip("single fetch", () => {
           `,
 
           "app/routes/with-nested-links.tsx": js`
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
             import globalCss from "../global.css";
 
             export function links() {

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -17,7 +17,7 @@ test.describe("redirects", () => {
       files: {
         "app/routes/absolute.tsx": js`
             import * as React from 'react';
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
 
             export default function Component() {
               let [count, setCount] = React.useState(0);
@@ -36,7 +36,7 @@ test.describe("redirects", () => {
 
         "app/routes/absolute._index.tsx": js`
             import { redirect } from "@react-router/node";
-            import { Form } from "react-router-dom";
+            import { Form } from "react-router";
 
             export async function action({ request }) {
               return redirect(new URL(request.url).origin + "/absolute/landing");
@@ -66,7 +66,7 @@ test.describe("redirects", () => {
 
         "app/routes/redirect-document.tsx": js`
             import * as React from "react";
-            import { Outlet } from "react-router-dom";
+            import { Outlet } from "react-router";
 
             export default function Component() {
               let [count, setCount] = React.useState(0);
@@ -81,7 +81,7 @@ test.describe("redirects", () => {
           `,
 
         "app/routes/redirect-document._index.tsx": js`
-            import { Link } from "react-router-dom";
+            import { Link } from "react-router";
 
             export default function Component() {
               return <Link to="/redirect-document/a">Link</Link>

--- a/integration/remix-serve-test.ts
+++ b/integration/remix-serve-test.ts
@@ -24,7 +24,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { json } from "@react-router/node";
-        import { useLoaderData, Link } from "react-router-dom";
+        import { useLoaderData, Link } from "react-router";
 
         export function loader() {
           return json("pizza");

--- a/integration/rendering-test.ts
+++ b/integration/rendering-test.ts
@@ -16,7 +16,7 @@ test.describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (

--- a/integration/request-test.ts
+++ b/integration/request-test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { json } from "@react-router/node";
-        import { Form, useLoaderData, useActionData } from "react-router-dom";
+        import { Form, useLoaderData, useActionData } from "react-router";
 
         async function requestToJson(request) {
           let body = null;

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -22,7 +22,7 @@ test.describe("loader in an app", async () => {
     fixture = await createFixture({
       files: {
         "app/routes/_index.tsx": js`
-          import { Form, Link } from "react-router-dom";
+          import { Form, Link } from "react-router";
 
           export default () => (
             <>
@@ -117,7 +117,7 @@ test.describe("loader in an app", async () => {
         `,
         "app/routes/$.tsx": js`
           import { json } from "@react-router/node";
-          import { useRouteError } from "react-router-dom";
+          import { useRouteError } from "react-router";
           export function loader({ request }) {
             throw json({ message: new URL(request.url).pathname + ' not found' }, {
               status: 404
@@ -278,11 +278,11 @@ test.describe("Development server", async () => {
       {
         files: {
           "app/routes/_index.tsx": js`
-            import { Link } from "react-router-dom";
+            import { Link } from "react-router";
             export default () => <Link to="/child">Child</Link>;
           `,
           "app/routes/_main.tsx": js`
-            import { useRouteError } from "react-router-dom";
+            import { useRouteError } from "react-router";
             export function ErrorBoundary() {
               return <pre>{useRouteError().message}</pre>;
             }

--- a/integration/revalidate-test.ts
+++ b/integration/revalidate-test.ts
@@ -16,7 +16,7 @@ test.describe("Revalidation", () => {
       await createFixture({
         files: {
           "app/root.tsx": js`
-              import { Link, Outlet, Scripts, useNavigation } from "react-router-dom";
+              import { Link, Outlet, Scripts, useNavigation } from "react-router";
 
               export default function Component() {
                 let navigation = useNavigation();
@@ -47,7 +47,7 @@ test.describe("Revalidation", () => {
 
           "app/routes/parent.tsx": js`
               import { json } from "@react-router/node";
-              import { Outlet, useLoaderData } from "react-router-dom";
+              import { Outlet, useLoaderData } from "react-router";
 
               export async function loader({ request }) {
                 let header = request.headers.get('Cookie') || '';
@@ -87,7 +87,7 @@ test.describe("Revalidation", () => {
 
           "app/routes/parent.child.tsx": js`
               import { json } from "@react-router/node";
-              import { Form, useLoaderData, useRevalidator } from "react-router-dom";
+              import { Form, useLoaderData, useRevalidator } from "react-router";
 
               export async function action() {
                 return json({ action: 'data' })

--- a/integration/root-route-test.ts
+++ b/integration/root-route-test.ts
@@ -79,7 +79,7 @@ test.describe("root route", () => {
       {
         files: {
           "app/root.tsx": js`
-          import { useRouteError } from "react-router-dom";
+          import { useRouteError } from "react-router";
           export function Layout({ children }) {
             return (
               <html>

--- a/integration/route-collisions-test.ts
+++ b/integration/route-collisions-test.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
 import { createFixture, js } from "./helpers/create-fixture.js";
 
 let ROOT_FILE_CONTENTS = js`
-  import { Outlet, Scripts } from "react-router-dom";
+  import { Outlet, Scripts } from "react-router";
 
   export default function App() {
     return (
@@ -19,7 +19,7 @@ let ROOT_FILE_CONTENTS = js`
 `;
 
 let LAYOUT_FILE_CONTENTS = js`
-  import { Outlet } from "react-router-dom";
+  import { Outlet } from "react-router";
 
   export default function Layout() {
     return <Outlet />

--- a/integration/scroll-test.ts
+++ b/integration/scroll-test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
     files: {
       "app/routes/_index.tsx": js`
         import { redirect } from "@react-router/node";
-        import { Form } from "react-router-dom";
+        import { Form } from "react-router";
 
         export function action() {
           return redirect("/test");
@@ -46,7 +46,7 @@ test.beforeAll(async () => {
       `,
 
       "app/routes/hash.tsx": js`
-        import { Link } from "react-router-dom";
+        import { Link } from "react-router";
 
         export default function Component() {
           return (

--- a/integration/set-cookie-revalidation-test.ts
+++ b/integration/set-cookie-revalidation-test.ts
@@ -40,7 +40,7 @@ test.describe("set-cookie revalidation", () => {
               Outlet,
               Scripts,
               useLoaderData,
-            } from "react-router-dom";
+            } from "react-router";
 
             import { sessionStorage, MESSAGE_KEY } from "~/session.server";
 
@@ -75,7 +75,7 @@ test.describe("set-cookie revalidation", () => {
           `,
 
         "app/routes/_index.tsx": js`
-            import { Link } from "react-router-dom";
+            import { Link } from "react-router";
 
             export default function Index() {
               return (

--- a/integration/splat-routes-test.ts
+++ b/integration/splat-routes-test.ts
@@ -18,7 +18,7 @@ test.describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (
@@ -55,7 +55,7 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/nested.tsx": js`
-          import { Outlet } from "react-router-dom";
+          import { Outlet } from "react-router";
           export default function() {
             return (
               <div>

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -27,7 +27,7 @@ test.describe("rendering", () => {
     fixture = await createFixture({
       files: {
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export function shouldRevalidate() {
             return false;
@@ -52,7 +52,7 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/_index.tsx": js`
-          import { Link } from "react-router-dom";
+          import { Link } from "react-router";
           export default function() {
             return (
               <div>
@@ -66,7 +66,7 @@ test.describe("rendering", () => {
         `,
 
         [`app/routes/${PAGE}.jsx`]: js`
-          import { Outlet, useLoaderData } from "react-router-dom";
+          import { Outlet, useLoaderData } from "react-router";
 
           export function loader() {
             return "${PAGE_TEXT}"
@@ -88,7 +88,7 @@ test.describe("rendering", () => {
         `,
 
         [`app/routes/${PAGE}._index.jsx`]: js`
-          import { useLoaderData, Link } from "react-router-dom";
+          import { useLoaderData, Link } from "react-router";
 
           export function loader() {
             return "${PAGE_INDEX_TEXT}"
@@ -106,7 +106,7 @@ test.describe("rendering", () => {
         `,
 
         [`app/routes/${PAGE}.${CHILD}.jsx`]: js`
-          import { useLoaderData } from "react-router-dom";
+          import { useLoaderData } from "react-router";
 
           export function loader() {
             return "${CHILD_TEXT}"
@@ -140,7 +140,7 @@ test.describe("rendering", () => {
 
         "app/routes/gh-1691.tsx": js`
           import { json, redirect } from "@react-router/node";
-          import { useFetcher} from "react-router-dom";
+          import { useFetcher} from "react-router";
 
           export const action = async ( ) => {
             return redirect("/gh-1691");
@@ -168,7 +168,7 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/parent.tsx": js`
-          import { Outlet, useLoaderData } from "react-router-dom";
+          import { Outlet, useLoaderData } from "react-router";
 
           if (!global.counts) {
             global.count = 0;
@@ -196,7 +196,7 @@ test.describe("rendering", () => {
 
         "app/routes/parent.child.tsx": js`
           import { redirect } from "@react-router/node";
-          import { useFetcher} from "react-router-dom";
+          import { useFetcher} from "react-router";
 
           export const action = async ({ request }) => {
             return redirect("/parent");

--- a/integration/upload-test.ts
+++ b/integration/upload-test.ts
@@ -29,7 +29,7 @@ test.beforeAll(async () => {
           unstable_parseMultipartFormData as parseMultipartFormData,
           MaxPartSizeExceededError,
         } from "@react-router/node";
-        import { Form, useActionData } from "react-router-dom";
+        import { Form, useActionData } from "react-router";
 
         const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
         export let action = async ({ request }) => {
@@ -91,7 +91,7 @@ test.beforeAll(async () => {
           unstable_parseMultipartFormData as parseMultipartFormData,
           MaxPartSizeExceededError,
         } from "@react-router/node";
-        import { Form, useActionData } from "react-router-dom";
+        import { Form, useActionData } from "react-router";
 
         export let action = async ({ request }) => {
           let uploadHandler = createMemoryUploadHandler({
@@ -144,7 +144,7 @@ test.beforeAll(async () => {
           json,
           unstable_parseMultipartFormData as parseMultipartFormData,
         } from "@react-router/node";
-        import { Form, useActionData } from "react-router-dom";
+        import { Form, useActionData } from "react-router";
 
         export let action = async ({ request }) => {
           try {

--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -17,7 +17,7 @@ import { js } from "./helpers/create-fixture.js";
 const files = {
   "app/routes/_index.tsx": String.raw`
     import { useState, useEffect } from "react";
-    import { Link } from "react-router-dom"
+    import { Link } from "react-router"
 
     export default function IndexRoute() {
       const [mounted, setMounted] = useState(false);
@@ -37,7 +37,7 @@ const files = {
     }
   `,
   "app/routes/other.tsx": String.raw`
-    import { useLoaderData } from "react-router-dom";
+    import { useLoaderData } from "react-router";
 
     export const loader = () => {
       return "other-loader";

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -41,7 +41,7 @@ test.beforeAll(async () => {
       });
     `,
     "app/root.tsx": js`
-      import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+      import { Links, Meta, Outlet, Scripts } from "react-router";
 
       export default function Root() {
         return (
@@ -111,7 +111,7 @@ test.beforeAll(async () => {
     "app/routes/mdx.mdx": js`
       import { useEffect, useState } from "react";
       import { json } from "@react-router/node";
-      import { useLoaderData } from "react-router-dom";
+      import { useLoaderData } from "react-router";
 
       import { serverOnly1, serverOnly2 } from "../utils.server";
 
@@ -171,7 +171,7 @@ test.beforeAll(async () => {
     `,
     "app/routes/dotenv.tsx": js`
       import { json } from "@react-router/node";
-      import { useLoaderData } from "react-router-dom";
+      import { useLoaderData } from "react-router";
 
       export const loader = () => {
         return json({
@@ -189,7 +189,7 @@ test.beforeAll(async () => {
     "app/assets/test.txt": "test",
     "app/routes/ssr-only-assets.tsx": js`
       import txtUrl from "../assets/test.txt?url";
-      import { useLoaderData } from "react-router-dom"
+      import { useLoaderData } from "react-router"
 
       export const loader: LoaderFunction = () => {
         return { txtUrl };
@@ -208,7 +208,7 @@ test.beforeAll(async () => {
     "app/assets/test.css": ".test{color:red}",
     "app/routes/ssr-only-css-url-files.tsx": js`
       import cssUrl from "../assets/test.css?url";
-      import { useLoaderData } from "react-router-dom"
+      import { useLoaderData } from "react-router"
 
       export const loader: LoaderFunction = () => {
         return { cssUrl };
@@ -225,7 +225,7 @@ test.beforeAll(async () => {
     `,
 
     "app/routes/ssr-code-split.tsx": js`
-      import { useLoaderData } from "react-router-dom"
+      import { useLoaderData } from "react-router"
 
       export const loader: LoaderFunction = async () => {
         const lib = await import("../ssr-code-split-lib");

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -45,7 +45,7 @@ const files = {
   "app/entry.client.tsx": js`
     import "./entry.client.css";
 
-    import { HydratedRouter } from "react-router-dom";
+    import { HydratedRouter } from "react-router";
     import { startTransition, StrictMode } from "react";
     import { hydrateRoot } from "react-dom/client";
 
@@ -59,7 +59,7 @@ const files = {
     });
   `,
   "app/root.tsx": js`
-    import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+    import { Links, Meta, Outlet, Scripts } from "react-router";
 
     export default function Root() {
       return (

--- a/integration/vite-dev-custom-entry-test.ts
+++ b/integration/vite-dev-custom-entry-test.ts
@@ -35,7 +35,7 @@ test.describe("Vite custom entry dev", () => {
 
           import type { EntryContext } from "@react-router/node";
           import { createReadableStreamFromReadable } from "@react-router/node";
-          import { ServerRouter } from "react-router-dom";
+          import { ServerRouter } from "react-router";
           import { renderToPipeableStream } from "react-dom/server";
 
           const ABORT_DELAY = 5_000;
@@ -94,7 +94,7 @@ test.describe("Vite custom entry dev", () => {
           }
         `,
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -35,7 +35,7 @@ test.describe("Vite dev", () => {
           });
         `,
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+          import { Links, Meta, Outlet, Scripts } from "react-router";
 
           export default function Root() {
             return (
@@ -58,7 +58,7 @@ test.describe("Vite dev", () => {
         "app/routes/_index.tsx": js`
           import { Suspense } from "react";
           import { defer } from "@react-router/node";
-          import { Await, useLoaderData } from "react-router-dom";
+          import { Await, useLoaderData } from "react-router";
 
           export function loader() {
             let deferred = new Promise((resolve) => {
@@ -115,7 +115,7 @@ test.describe("Vite dev", () => {
         `,
         "app/routes/get-cookies.tsx": js`
           import { json, LoaderFunctionArgs } from "@react-router/node";
-          import { useLoaderData } from "react-router-dom"
+          import { useLoaderData } from "react-router"
 
           export const loader = ({ request }: LoaderFunctionArgs) => json({cookies: request.headers.get("Cookie")});
 
@@ -141,7 +141,7 @@ test.describe("Vite dev", () => {
         `,
         "app/routes/mdx.mdx": js`
           import { json } from "@react-router/node";
-          import { useLoaderData } from "react-router-dom";
+          import { useLoaderData } from "react-router";
 
           export const loader = () => {
             return json({
@@ -164,7 +164,7 @@ test.describe("Vite dev", () => {
         "app/routes/dotenv.tsx": js`
           import { useState, useEffect } from "react";
           import { json } from "@react-router/node";
-          import { useLoaderData } from "react-router-dom";
+          import { useLoaderData } from "react-router";
 
           export const loader = () => {
             return json({
@@ -192,7 +192,7 @@ test.describe("Vite dev", () => {
         `,
         "app/routes/error-stacktrace.tsx": js`
           import type { LoaderFunction, MetaFunction } from "@react-router/node";
-          import { Link, useLocation } from "react-router-dom";
+          import { Link, useLocation } from "react-router";
 
           export const loader: LoaderFunction = ({ request }) => {
             if (request.url.includes("crash-loader")) {
@@ -224,7 +224,7 @@ test.describe("Vite dev", () => {
           }
         `,
         "app/routes/known-route-exports.tsx": js`
-          import { useMatches } from "react-router-dom";
+          import { useMatches } from "react-router";
 
           export const meta = () => [{
             title: "HMR meta: 0"

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -46,7 +46,7 @@ test("Vite / dead-code elimination for server exports", async () => {
     "app/routes/remove-server-exports-and-dce.tsx": `
       import fs from "node:fs";
       import { json } from "@react-router/node";
-      import { useLoaderData } from "react-router-dom";
+      import { useLoaderData } from "react-router";
 
       import { serverOnly as serverOnlyFile } from "../utils.server";
       import { serverOnly as serverOnlyDir } from "../.server/utils";

--- a/integration/vite-dotenv-test.ts
+++ b/integration/vite-dotenv-test.ts
@@ -15,7 +15,7 @@ let files = {
   "app/routes/dotenv.tsx": String.raw`
     import { useState, useEffect } from "react";
     import { json } from "@react-router/node";
-    import { useLoaderData } from "react-router-dom";
+    import { useLoaderData } from "react-router";
 
     export const loader = () => {
       return json({

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -162,7 +162,7 @@ async function workflow({
     contents
       .replace(
         "// imports",
-        `// imports\nimport { json } from "@react-router/node";\nimport { useLoaderData } from "react-router-dom"`
+        `// imports\nimport { json } from "@react-router/node";\nimport { useLoaderData } from "react-router"`
       )
       .replace(
         "// loader",

--- a/integration/vite-loader-context-test.ts
+++ b/integration/vite-loader-context-test.ts
@@ -19,7 +19,7 @@ test.beforeAll(async () => {
     "server.mjs": EXPRESS_SERVER({ port, loadContext: { value: "value" } }),
     "app/routes/_index.tsx": String.raw`
       import { json } from "@react-router/node";
-      import { useLoaderData } from "react-router-dom";
+      import { useLoaderData } from "react-router";
 
       export const loader = ({ context }) => {
         return json({ context })

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -26,7 +26,7 @@ const TEST_ROUTES = [
 
 const files = {
   "app/root.tsx": js`
-    import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+    import { Links, Meta, Outlet, Scripts } from "react-router";
 
     export default function Root() {
       return (

--- a/integration/vite-route-added-test.ts
+++ b/integration/vite-route-added-test.ts
@@ -8,7 +8,7 @@ import { createProject, dev, viteConfig } from "./helpers/vite.js";
 const files = {
   "app/routes/_index.tsx": String.raw`
     import { useState, useEffect } from "react";
-    import { Link } from "react-router-dom";
+    import { Link } from "react-router";
 
     export default function IndexRoute() {
       const [mounted, setMounted] = useState(false);

--- a/integration/vite-route-exports-modified-offscreen-test.ts
+++ b/integration/vite-route-exports-modified-offscreen-test.ts
@@ -11,7 +11,7 @@ import {
 const files = {
   "app/routes/_index.tsx": String.raw`
     import { useState, useEffect } from "react";
-    import { Link } from "react-router-dom";
+    import { Link } from "react-router";
 
     export default function IndexRoute() {
       const [mounted, setMounted] = useState(false);
@@ -28,7 +28,7 @@ const files = {
     }
   `,
   "app/routes/other.tsx": String.raw`
-    import { useLoaderData } from "react-router-dom";
+    import { useLoaderData } from "react-router";
 
     export const loader = () => "hello";
 

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -31,7 +31,7 @@ function createRoute(path: string) {
   return {
     [`app/routes/${path}`]: js`
       ${ROUTE_FILE_COMMENT}
-      import { Outlet } from "react-router-dom";
+      import { Outlet } from "react-router";
       import { useState, useEffect } from "react";
 
       export default function Route() {
@@ -77,7 +77,7 @@ const TEST_ROUTES = [
 const files = {
   "app/root.tsx": js`
     ${ROUTE_FILE_COMMENT}
-    import { Links, Meta, Outlet, Scripts } from "react-router-dom";
+    import { Links, Meta, Outlet, Scripts } from "react-router";
 
     export default function Root() {
       return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,9 +402,6 @@ importers:
       react-router:
         specifier: workspace:*
         version: link:../../../packages/react-router
-      react-router-dom:
-        specifier: workspace:*
-        version: link:../../../packages/react-router-dom
     devDependencies:
       '@react-router/dev':
         specifier: workspace:*
@@ -466,9 +463,6 @@ importers:
       react-router:
         specifier: workspace:*
         version: link:../../../packages/react-router
-      react-router-dom:
-        specifier: workspace:*
-        version: link:../../../packages/react-router-dom
       serialize-javascript:
         specifier: ^6.0.1
         version: 6.0.2


### PR DESCRIPTION
This migrates integration test usage of `react-router-dom` to `react-router`.