### PR TITLE
Add `behavior` prop to `<ScrollRestoration />`

### DIFF
--- a/.changeset/little-snails-hide.md
+++ b/.changeset/little-snails-hide.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Add `behavior` prop to `<ScrollRestoration />`

--- a/contributors.yml
+++ b/contributors.yml
@@ -88,6 +88,7 @@
 - gowthamvbhat
 - GraxMonzo
 - GuptaSiddhant
+- h3rmanj
 - haivuw
 - hernanif1
 - holynewbie

--- a/docs/components/scroll-restoration.md
+++ b/docs/components/scroll-restoration.md
@@ -81,6 +81,16 @@ Or you may want to only use the pathname for some paths, and use the normal beha
 />
 ```
 
+## `behavior`
+
+Optional prop that specifies which scroll behavior to use when scrolling to a position.
+
+Possible values: `smooth`, `instant`, `auto`.
+
+Can be useful if you've set `scroll-behavior` globally, but want `<ScrollRestoration />` to use another behavior.
+
+See also: [`scrollTo` behavior option][scroll-behavior]
+
 ## Preventing Scroll Reset
 
 When navigation creates new scroll keys, the scroll position is reset to the top of the page. You can prevent the "scroll to top" behavior from your links and forms:
@@ -102,3 +112,4 @@ Server Rendering frameworks can prevent scroll flashing because they can send a 
 [preventscrollreset]: ../components/link#preventscrollreset
 [form-preventscrollreset]: ../components/form#preventscrollreset
 [pickingarouter]: ../routers/picking-a-router
+[scroll-behavior]: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo#behavior

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       "none": "17.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "17.2 kB"
+      "none": "17.3 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
       "none": "23.6 kB"

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -1330,6 +1330,7 @@ if (__DEV__) {
 export interface ScrollRestorationProps {
   getKey?: GetScrollRestorationKeyFunction;
   storageKey?: string;
+  behavior?: ScrollBehavior;
 }
 
 /**
@@ -1339,8 +1340,9 @@ export interface ScrollRestorationProps {
 export function ScrollRestoration({
   getKey,
   storageKey,
+  behavior,
 }: ScrollRestorationProps) {
-  useScrollRestoration({ getKey, storageKey });
+  useScrollRestoration({ getKey, storageKey, behavior });
   return null;
 }
 
@@ -1780,9 +1782,11 @@ let savedScrollPositions: Record<string, number> = {};
 function useScrollRestoration({
   getKey,
   storageKey,
+  behavior,
 }: {
   getKey?: GetScrollRestorationKeyFunction;
   storageKey?: string;
+  behavior?: ScrollBehavior;
 } = {}) {
   let { router } = useDataRouterContext(DataRouterHook.UseScrollRestoration);
   let { restoreScrollPosition, preventScrollReset } = useDataRouterState(
@@ -1874,7 +1878,7 @@ function useScrollRestoration({
 
       // been here before, scroll to it
       if (typeof restoreScrollPosition === "number") {
-        window.scrollTo(0, restoreScrollPosition);
+        window.scrollTo({ left: 0, top: restoreScrollPosition, behavior });
         return;
       }
 
@@ -1895,8 +1899,8 @@ function useScrollRestoration({
       }
 
       // otherwise go to the top on new locations
-      window.scrollTo(0, 0);
-    }, [location, restoreScrollPosition, preventScrollReset]);
+      window.scrollTo({ left: 0, top: 0, behavior });
+    }, [location, restoreScrollPosition, preventScrollReset, behavior]);
   }
 }
 


### PR DESCRIPTION
Non-breaking continuation of #10318.

Adds an optional `behavior` prop to `<ScrollRestoration />` that are passed through to the `scrollTo` calls. This allows the user to specify a specific behavior for scroll restoration, while setting a different value globally with css.

The original PR was closed due to being breaking, and not going through a proposal for considering more generic behavior. A proposal was opened in #10328, but hasn't received any more activity for a year. Due to the inactivity, I feel the ScrollRestoration works fine other than missing a way to specify behavior, and a generic approach seems unnecessary.