### PR TITLE
Support a callback function for unstable_viewTransition props

### DIFF
--- a/.changeset/chatty-wolves-nail.md
+++ b/.changeset/chatty-wolves-nail.md
@@ -1,0 +1,5 @@
+---
+"react-router-dom": minor
+---
+
+Support a callback function for `Link`/`Form` `unstable_viewTransition` prop

--- a/package.json
+++ b/package.json
@@ -114,10 +114,10 @@
       "none": "17.3 kB"
     },
     "packages/react-router-dom/dist/react-router-dom.production.min.js": {
-      "none": "17.2 kB"
+      "none": "17.4 kB"
     },
     "packages/react-router-dom/dist/umd/react-router-dom.production.min.js": {
-      "none": "23.6 kB"
+      "none": "23.7 kB"
     }
   },
   "pnpm": {

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -7384,7 +7384,7 @@ function testDomRouter(
     });
 
     describe("view transitions", () => {
-      it("applies view transitions to navigations when opted in", async () => {
+      it("applies view transitions to navigations when opted in via boolean prop", async () => {
         let testWindow = getWindow("/");
         let spy = jest.fn((cb) => {
           cb();
@@ -7412,6 +7412,110 @@ function testDomRouter(
                       <button type="submit">/c</button>
                     </Form>
                     <Form action="/d" unstable_viewTransition>
+                      <button type="submit">/d</button>
+                    </Form>
+                    <Outlet />
+                  </div>
+                );
+              },
+              children: [
+                {
+                  index: true,
+                  Component: () => <h1>Home</h1>,
+                },
+                {
+                  path: "a",
+                  Component: () => <h1>A</h1>,
+                },
+                {
+                  path: "b",
+                  Component: () => <h1>B</h1>,
+                },
+                {
+                  path: "c",
+                  action: () => null,
+                  Component: () => <h1>C</h1>,
+                },
+                {
+                  path: "d",
+                  action: () => null,
+                  Component: () => <h1>D</h1>,
+                },
+              ],
+            },
+          ],
+          { window: testWindow }
+        );
+        render(<RouterProvider router={router} />);
+
+        expect(screen.getByText("Home")).toBeDefined();
+        fireEvent.click(screen.getByText("/a"));
+        await waitFor(() => screen.getByText("A"));
+        expect(spy).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByText("/b"));
+        await waitFor(() => screen.getByText("B"));
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByText("/c"));
+        await waitFor(() => screen.getByText("C"));
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByText("/d"));
+        await waitFor(() => screen.getByText("D"));
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+
+      it("applies view transitions to navigations when opted in via function callback", async () => {
+        let testWindow = getWindow("/");
+        let spy = jest.fn((cb) => {
+          cb();
+          return {
+            ready: Promise.resolve(),
+            finished: Promise.resolve(),
+            updateCallbackDone: Promise.resolve(),
+            skipTransition: () => {},
+          };
+        });
+        testWindow.document.startViewTransition = spy;
+
+        let router = createTestRouter(
+          [
+            {
+              path: "/",
+              Component() {
+                return (
+                  <div>
+                    <Link
+                      to="/a"
+                      unstable_viewTransition={({ pathname }) =>
+                        pathname === "/b"
+                      }
+                    >
+                      /a
+                    </Link>
+                    <Link
+                      to="/b"
+                      unstable_viewTransition={({ pathname }) =>
+                        pathname === "/b"
+                      }
+                    >
+                      /b
+                    </Link>
+                    <Form
+                      action="/c"
+                      unstable_viewTransition={({ pathname }) =>
+                        pathname === "/d"
+                      }
+                    >
+                      <button type="submit">/c</button>
+                    </Form>
+                    <Form
+                      action="/d"
+                      unstable_viewTransition={({ pathname }) =>
+                        pathname === "/d"
+                      }
+                    >
                       <button type="submit">/d</button>
                     </Form>
                     <Outlet />


### PR DESCRIPTION
Quick first pass at supporting `<Link to="/path" unstable_viewTransition={fn}>` where `fn` is `(path: Path) => boolean)` - allowing applications to lazily compute the boolean value at click time.  The primary use case is large applications where routes are managed in a central manifest - and they need to look up a route in the manifest to know if view transitions should be enabled.  This can get prohibitively expensive to do path-matching and looking up routes at render time for all rendered links.

I also want to look at supplying `matches` to the callback but that's a bit more involved from an implementation standpoint since we need to move the callback execution down into the guts of the `router` after Fog of War matching has completed.

^ I looked into this and it's totally doable, but it feels a bit odd to do this "use location/matches to determine whether to apply a view transition" at the call-site - that feels far more like a global API.  If you want this "generic" approach you would probably just end up using your own `Link` wrapper to put this callback on every `Link` in the app.  I'm now leaning towards leaving the `Link` prop as a boolean (targeted call-site version) and adding a new top-level function you can use globally if you prefer to operate off a manifest:

```jsx
// I know which paths I want to enable for
<Link to="/path" unstable_viewTransition>

// This feels weird - I give you a specific path but then write a very generic function 
// to determine if the destination route wants view transitions
<Link to="/path" unstable_viewTransition={({ location, matches })} => {
  return enableViewTransition(location, matches);
}}>

// This feels like a more appropriate spot for that API
let router = createBrowserRouter(routes, {
  unstable_viewTransition({ location, matches }) {
    return enableViewTransition(location, matches);
  }
});

// Or, even better - why not just give one generic spot to lazily provide navigation opts:
let router = createBrowserRouter(routes, {
  onNavigation({ location, matches, navigateOpts }) {
    return {
      // Use whatever opts were specified at the call site
      ...navigateOpts,
      // But globally determine view transition behavior
      unstable_viewTransition: enableViewTransition(location, matches),
    };
  }
});
```


