### PR TITLE
Remove bundle size check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,3 @@ jobs:
 
       - name: 🧪 Run tests
         run: pnpm test
-
-      - name: Check bundle size
-        run: pnpm size

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "playground": "node ./scripts/playground.js",
     "prerelease": "pnpm build",
     "release": "changeset publish",
-    "size": "filesize",
     "test": "jest",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest",
     "typecheck": "pnpm run --recursive --parallel typecheck",
@@ -42,7 +41,6 @@
     "jsdom": "22.1.0"
   },
   "dependencies": {
-    "@ampproject/filesize": "^4.3.0",
     "@babel/core": "^7.22.9",
     "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-proposal-optional-chaining": "^7.21.0",
@@ -128,14 +126,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "filesize": {
-    "packages/react-router/dist/react-router.production.min.js": {
-      "none": "124 kB"
-    },
-    "packages/react-router/dist/umd/react-router.production.min.js": {
-      "none": "130 kB"
-    }
   },
   "pnpm": {
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
 
   .:
     dependencies:
-      '@ampproject/filesize':
-        specifier: ^4.3.0
-        version: 4.3.0
       '@babel/core':
         specifier: ^7.22.9
         version: 7.22.9
@@ -260,7 +257,7 @@ importers:
         version: 3.1.1
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3
       vite-env-only:
         specifier: ^2.0.0
         version: 2.2.1
@@ -928,18 +925,6 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  /@ampproject/filesize@4.3.0:
-    resolution: {integrity: sha512-ruXED0Xv1gg7STkhs32k+qKFg4eMnnYLjPZ5PhJbYG5Klf9TvcJlVrjjVpbo17gl3pp5mKLSFxbRrI7Le8vaRQ==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      '@kristoferbaxter/async': 1.0.0
-      '@kristoferbaxter/bytes': 0.1.2
-      '@kristoferbaxter/kleur': 4.0.2
-      fast-glob: 3.2.5
-      mri: 1.1.6
-    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -3207,7 +3192,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.3
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.3)
     dev: false
@@ -3557,7 +3542,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.24.3)
       '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.24.3)
@@ -4382,21 +4367,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
-
-  /@kristoferbaxter/async@1.0.0:
-    resolution: {integrity: sha512-CAQQQ8mUUBKI2P7stYojHwHb+ShdFN8SrC90/96V4m2XlDSctXAA+5PD5CqCICs0o5c/83cYJCeub+FSetKLrw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /@kristoferbaxter/bytes@0.1.2:
-    resolution: {integrity: sha512-jEnik0TVc+nxANari0ZQ+4dZYxxA3HTcK9OVglK8kptsczKpW7I7AVCjKcfujTi8V3qrd9oklr8fJAzA4FjWDA==}
-    engines: {node: '>= 14'}
-    dev: false
-
-  /@kristoferbaxter/kleur@4.0.2:
-    resolution: {integrity: sha512-qZzvfOCXECWaCv3GDOd0uw2iqY+/VqMKvrAu1ufwZNjZEVSMjrFWpeQa+8UnezFOtaBF1FxnzN1Y3u42doK01g==}
-    engines: {node: '>=12'}
-    dev: false
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -8124,18 +8094,6 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.5
 
-  /fast-glob@3.2.5:
-    resolution: {integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
-      picomatch: 2.3.1
-    dev: false
-
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -10933,11 +10891,6 @@ packages:
       - supports-color
     dev: false
 
-  /mri@1.1.6:
-    resolution: {integrity: sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==}
-    engines: {node: '>=4'}
-    dev: false
-
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -13430,10 +13383,44 @@ packages:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.4.5)
-      vite: 5.1.3(@types/node@18.19.26)
+      vite: 5.1.3
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /vite@5.1.3:
+    resolution: {integrity: sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.19.12
+      postcss: 8.4.38
+      rollup: 4.13.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   /vite@5.1.3(@types/node@18.19.26):
     resolution: {integrity: sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==}


### PR DESCRIPTION
This check as it stands is not helpful in the new v7 state of RR since our minified UMD bundles are much larger now that they incorporate the router, the DOM APIs, the Remix APIs etc.  This is just a barrier to merging v7 PRs at the moment.

Once v7 stabilizes a bit more we can consider looking into re-adding a check of this type, but it should not be simply a minified file size check but instead be some form of check against a bundled/treeshaken application.