### PR TITLE
Fix playgrounds not installing binaries

### DIFF
--- a/playground/compiler-express/package.json
+++ b/playground/compiler-express/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "node ./server.js",
+    "setup": "pnpm i react-router@workspace",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },

--- a/playground/compiler-spa/package.json
+++ b/playground/compiler-spa/package.json
@@ -7,6 +7,7 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "preview": "vite preview",
+    "setup": "pnpm i react-router@workspace",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/playground/compiler/package.json
+++ b/playground/compiler/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
+    "setup": "pnpm i @react-router/serve@workspace react-router@workspace",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "tsc"
   },

--- a/scripts/playground.js
+++ b/scripts/playground.js
@@ -43,6 +43,7 @@ async function copyPlayground() {
       chalk.green`To start playground, run:`,
       "",
       `cd ${relativeDestDir}`,
+      "pnpm setup",
       "pnpm dev",
     ].join("\n")
   );


### PR DESCRIPTION
Our playgrounds aren't currently getting the binaries without a specific `pnpm install react-router` step so added that  as an up-front `setup` command