### PR TITLE
Fix local package bins

### DIFF
--- a/packages/react-router-dev/bin.js
+++ b/packages/react-router-dev/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("./dist/cli");

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "bin": {
-    "react-router": "dist/cli.js"
+    "react-router": "bin.js"
   },
   "scripts": {
     "tsc": "tsc"
@@ -91,6 +91,7 @@
   },
   "files": [
     "dist/",
+    "bin.js",
     "CHANGELOG.md",
     "LICENSE.md",
     "README.md"

--- a/packages/react-router-dev/rollup.config.js
+++ b/packages/react-router-dev/rollup.config.js
@@ -81,7 +81,7 @@ module.exports = function rollup() {
       },
       input: `${SOURCE_DIR}/cli.ts`,
       output: {
-        banner: createBanner(name, version, { executable: true }),
+        banner: createBanner(name, version),
         dir: OUTPUT_DIR,
         format: "cjs",
       },

--- a/packages/react-router-serve/bin.js
+++ b/packages/react-router-serve/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("./dist/cli");

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "bin": {
-    "react-router-serve": "dist/cli.js"
+    "react-router-serve": "bin.js"
   },
   "scripts": {
     "tsc": "tsc"
@@ -40,6 +40,7 @@
   },
   "files": [
     "dist/",
+    "bin.js",
     "CHANGELOG.md",
     "LICENSE.md",
     "README.md"

--- a/packages/react-router-serve/rollup.config.js
+++ b/packages/react-router-serve/rollup.config.js
@@ -27,7 +27,7 @@ module.exports = function rollup() {
       },
       input: `${SOURCE_DIR}/cli.ts`,
       output: {
-        banner: createBanner(name, version, { executable: true }),
+        banner: createBanner(name, version),
         dir: OUTPUT_DIR,
         format: "cjs",
       },

--- a/playground/compiler-express/package.json
+++ b/playground/compiler-express/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "react-router build",
     "dev": "node ./server.js",
-    "setup": "pnpm i react-router@workspace",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "tsc"
   },

--- a/playground/compiler-spa/package.json
+++ b/playground/compiler-spa/package.json
@@ -7,7 +7,6 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "preview": "vite preview",
-    "setup": "pnpm i react-router@workspace",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/playground/compiler/package.json
+++ b/playground/compiler/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
-    "setup": "pnpm i @react-router/serve@workspace react-router@workspace",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "tsc"
   },

--- a/rollup.utils.js
+++ b/rollup.utils.js
@@ -44,8 +44,8 @@ function getBuildDirectories(packageName, folderName) {
   return { SOURCE_DIR, OUTPUT_DIR };
 }
 
-function createBanner(packageName, version, { executable = false } = {}) {
-  let banner = `/**
+function createBanner(packageName, version) {
+  return `/**
  * ${packageName} v${version}
  *
  * Copyright (c) Remix Software Inc.
@@ -55,7 +55,6 @@ function createBanner(packageName, version, { executable = false } = {}) {
  *
  * @license MIT
  */`;
-  return executable ? "#!/usr/bin/env node\n" + banner : banner;
 }
 
 // Babel plugin to replace `const REACT_ROUTER_VERSION = "0.0.0";` with the

--- a/scripts/playground.js
+++ b/scripts/playground.js
@@ -43,7 +43,6 @@ async function copyPlayground() {
       chalk.green`To start playground, run:`,
       "",
       `cd ${relativeDestDir}`,
-      "pnpm setup",
       "pnpm dev",
     ].join("\n")
   );


### PR DESCRIPTION
Reverts https://github.com/remix-run/react-router/pull/11747.

When running `pnpm install` within this repo for the first time, you see multiple variations of the following error:

```
 WARN  Failed to create bin at /path/to/react-router/playground/compiler/node_modules/.bin/react-router. ENOENT: no such file or directory, open '/path/to/react-router/packages/react-router-dev/dist/cli.js'
```
 
 This is because pnpm is trying to set up package bins before the build step has been run, so the configured bin files don't exist yet.
 
 One way to fix this is to run the build step in the `postinstall` hook, but this is pretty heavy handed and will slow down CI runs. It'll also incorrectly mark Rollup build errors as a failed install step.
 
Instead, the leaner alternative in this PR is to provide passthrough `bin.js` files that are always present, even if the referenced `dist` directory doesn't exist yet. The package bins won't work until `pnpm build` has been run, but this is already the case when consuming these packages within the repo.