### PR TITLE
Use linked package bins in test templates

### DIFF
--- a/integration/helpers/node-template/package.json
+++ b/integration/helpers/node-template/package.json
@@ -5,9 +5,9 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@react-router/dev/dist/cli.js build",
-    "dev": "node ./node_modules/@react-router/dev/dist/cli.js dev",
-    "start": "node ./node_modules/@react-router/serve/dist/cli.js ./build/index.js",
+    "build": "react-router build",
+    "dev": "react-router dev",
+    "start": "react-router-serve ./build/server/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/integration/helpers/vite-template/package.json
+++ b/integration/helpers/vite-template/package.json
@@ -5,9 +5,9 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "dev": "node ./node_modules/@react-router/dev/dist/cli.js dev",
-    "build": "node ./node_modules/@react-router/dev/dist/cli.js build",
-    "start": "node ./node_modules/@react-router/serve/dist/cli.js ./build/server/index.js",
+    "dev": "react-router dev",
+    "build": "react-router build",
+    "start": "react-router-serve ./build/server/index.js",
     "typecheck": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
This is a minor test clean up in light of https://github.com/remix-run/react-router/pull/11763. Since package bins are always linked, we no longer need to reach into packages to use their bin scripts.