### PR TITLE
Generic for useLocation to allow to provide type for Location State

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -279,3 +279,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- arajg0909

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -100,7 +100,7 @@ export function useInRouterContext(): boolean {
  *
  * @see https://reactrouter.com/hooks/use-location
  */
-export function useLocation(): Location {
+export function useLocation<T>(): Location<T> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the


### PR DESCRIPTION
The current implementation of useLocation does not allow for state type to be passed as a generic to Location return type. By just passing a simple generic we can safely type the state from the location. 