### PR TITLE
Fix failed `optimizeDeps` for react-router-dom

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -574,6 +574,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
     return new Set(filePaths);
   };
 
+  let hasDependency = (name: string) => {
+    try {
+      return Boolean(require.resolve(name, { paths: [ctx.rootDirectory] }));
+    } catch (err) {
+      return false;
+    }
+  };
+
   let getViteManifestAssetPaths = (
     viteManifest: Vite.Manifest
   ): Set<string> => {
@@ -826,8 +834,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
               // Pre-bundle router dependencies to avoid router duplicates.
               // Mismatching routers cause `Error: You must render this element inside a <Remix> element`.
               "react-router",
-              "react-router-dom",
-            ],
+              // Check to avoid "Failed to resolve dependency: react-router-dom, present in 'optimizeDeps.include'"
+              hasDependency("react-router-dom") && "react-router-dom",
+            ].filter(Boolean),
           },
           esbuild: {
             jsx: "automatic",

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -835,8 +835,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
               // Mismatching routers cause `Error: You must render this element inside a <Remix> element`.
               "react-router",
               // Check to avoid "Failed to resolve dependency: react-router-dom, present in 'optimizeDeps.include'"
-              hasDependency("react-router-dom") && "react-router-dom",
-            ].filter(Boolean),
+              ...(hasDependency("react-router-dom")
+                ? ["react-router-dom"]
+                : []),
+            ],
           },
           esbuild: {
             jsx: "automatic",


### PR DESCRIPTION
Now that `react-router-dom` is deprecated, any projects that don't depend on it see the following warning from Vite in the terminal:

> Failed to resolve dependency: react-router-dom, present in 'optimizeDeps.include'

To fix this we now only add react-router-dom to the `optimizeDeps.include` array if it can be resolved from the Vite project root.