### PR TITLE
docs: fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -280,3 +280,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- vitekzach

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -1364,7 +1364,7 @@ If we review the search form, it looks like this:
 </form>
 ```
 
-As we've seen before, browsers can serialize forms by the `name` attribute of it's input elements. The name of this input is `q`, that's why the URL has `?q=`. If we named it `search` the URL would be `?search=`.
+As we've seen before, browsers can serialize forms by the `name` attribute of its input elements. The name of this input is `q`, that's why the URL has `?q=`. If we named it `search` the URL would be `?search=`.
 
 Note that this form is different from the others we've used, it does not have `<form method="post">`. The default `method` is `"get"`. That means when the browser creates the request for the next document, it doesn't put the form data into the request POST body, but into the [`URLSearchParams`][urlsearchparams] of a GET request.
 


### PR DESCRIPTION
Fixing typo in the docs from `it's` to the possessive form `its`.