### PR TITLE
Migrate to babel-dead-code-elimination

### DIFF
--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -39,6 +39,7 @@
     "@npmcli/package-json": "^4.0.1",
     "@react-router/node": "workspace:*",
     "arg": "^5.0.1",
+    "babel-dead-code-elimination": "^1.0.6",
     "chalk": "^4.1.2",
     "es-module-lexer": "^1.3.1",
     "exit-hook": "2.2.1",

--- a/packages/react-router-dev/vite/remove-exports-test.ts
+++ b/packages/react-router-dev/vite/remove-exports-test.ts
@@ -13,9 +13,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = () => {};
-    export const clientExport_2 = () => {};"
-  `);
+      "export const clientExport_1 = () => {};
+      export const clientExport_2 = () => {};"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -41,13 +41,13 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientLib } from 'client-lib';
-    import { sharedLib } from 'shared-lib';
-    const sharedUtil = () => sharedLib();
-    const clientUtil = () => sharedUtil(clientLib());
-    export const clientExport_1 = () => clientUtil();
-    export const clientExport_2 = () => clientUtil();"
-  `);
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = () => clientUtil();
+      export const clientExport_2 = () => clientUtil();"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -63,9 +63,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export function clientExport_1() {}
-    export function clientExport_2() {}"
-  `);
+      "export function clientExport_1() {}
+      export function clientExport_2() {}"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -91,21 +91,21 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientLib } from 'client-lib';
-    import { sharedLib } from 'shared-lib';
-    function sharedUtil() {
-      return sharedLib();
-    }
-    function clientUtil() {
-      return sharedUtil(clientLib());
-    }
-    export function clientExport_1() {
-      return clientUtil();
-    }
-    export function clientExport_2() {
-      return clientUtil();
-    }"
-  `);
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      function sharedUtil() {
+        return sharedLib();
+      }
+      function clientUtil() {
+        return sharedUtil(clientLib());
+      }
+      export function clientExport_1() {
+        return clientUtil();
+      }
+      export function clientExport_2() {
+        return clientUtil();
+      }"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -121,9 +121,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = {};
-    export const clientExport_2 = {};"
-  `);
+      "export const clientExport_1 = {};
+      export const clientExport_2 = {};"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -149,17 +149,79 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientLib } from 'client-lib';
-    import { sharedLib } from 'shared-lib';
-    const sharedUtil = () => sharedLib();
-    const clientUtil = () => sharedUtil(clientLib());
-    export const clientExport_1 = {
-      value: clientUtil()
-    };
-    export const clientExport_2 = {
-      value: clientUtil()
-    };"
-  `);
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = {
+        value: clientUtil()
+      };
+      export const clientExport_2 = {
+        value: clientUtil()
+      };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("class", () => {
+    let result = removeExports(
+      `
+      export class serverExport_1 {}
+      export class serverExport_2 {}
+
+      export class clientExport_1 {}
+      export class clientExport_2 {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export class clientExport_1 {}
+      export class clientExport_2 {}"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("class with dependencies", () => {
+    let result = removeExports(
+      `
+      import { serverLib } from 'server-lib'
+      import { clientLib } from 'client-lib'
+      import { sharedLib } from 'shared-lib'
+
+      const SERVER_STRING = 'SERVER_STRING'
+
+      const sharedUtil = () => sharedLib()
+      const serverUtil = () => sharedUtil(serverLib(SERVER_STRING))
+      const clientUtil = () => sharedUtil(clientLib())
+
+      export class serverExport_1{
+        static util = serverUtil()
+      }
+      export class serverExport_2{
+        static util = serverUtil()
+      }
+
+      export class clientExport_1{
+        static util = clientUtil()
+      }
+      export class clientExport_2{
+        static util = clientUtil()
+      }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export class clientExport_1 {
+        static util = clientUtil();
+      }
+      export class clientExport_2 {
+        static util = clientUtil();
+      }"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -175,9 +237,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = globalFunction();
-    export const clientExport_2 = globalFunction();"
-  `);
+      "export const clientExport_1 = globalFunction();
+      export const clientExport_2 = globalFunction();"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -203,13 +265,13 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientLib } from 'client-lib';
-    import { sharedLib } from 'shared-lib';
-    const sharedUtil = () => sharedLib();
-    const clientUtil = () => sharedUtil(clientLib());
-    export const clientExport_1 = clientUtil();
-    export const clientExport_2 = clientUtil();"
-  `);
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = clientUtil();
+      export const clientExport_2 = clientUtil();"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -225,9 +287,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = (() => {})();
-    export const clientExport_2 = (() => {})();"
-  `);
+      "export const clientExport_1 = (() => {})();
+      export const clientExport_2 = (() => {})();"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -253,14 +315,85 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientLib } from 'client-lib';
-    import { sharedLib } from 'shared-lib';
-    const sharedUtil = () => sharedLib();
-    const clientUtil = () => sharedUtil(clientLib());
-    export const clientExport_1 = (() => clientUtil())();
-    export const clientExport_2 = (() => clientUtil())();"
-  `);
+      "import { clientLib } from 'client-lib';
+      import { sharedLib } from 'shared-lib';
+      const sharedUtil = () => sharedLib();
+      const clientUtil = () => sharedUtil(clientLib());
+      export const clientExport_1 = (() => clientUtil())();
+      export const clientExport_2 = (() => clientUtil())();"
+    `);
     expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export", () => {
+    let result = removeExports(
+      `
+      const serverExport_1 = 123
+      const serverExport_2 = 123
+
+      const clientExport_1 = 123
+      const clientExport_2 = 123
+
+      export { serverExport_1 }
+      export { serverExport_2 }
+
+      export { clientExport_1 }
+      export { clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const clientExport_1 = 123;
+      const clientExport_2 = 123;
+      export { clientExport_1 };
+      export { clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export multiple", () => {
+    let result = removeExports(
+      `
+      const serverExport_1 = 123
+      const serverExport_2 = 123
+
+      const clientExport_1 = 123
+      const clientExport_2 = 123
+
+      export { serverExport_1, serverExport_2 }
+      export { clientExport_1, clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const clientExport_1 = 123;
+      const clientExport_2 = 123;
+      export { clientExport_1, clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("aggregated export multiple mixed", () => {
+    let result = removeExports(
+      `
+      const removeMe_1 = 123
+      const removeMe_2 = 123
+
+      const keepMe_1 = 123
+      const keepMe_2 = 123
+
+      export { removeMe_1, keepMe_1 }
+      export { removeMe_2, keepMe_2 }
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const keepMe_1 = 123;
+      const keepMe_2 = 123;
+      export { keepMe_1 };
+      export { keepMe_2 };"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
   });
 
   test("re-export", () => {
@@ -275,9 +408,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export { clientExport_1 } from './client/1';
-    export { clientExport_2 } from './client/2';"
-  `);
+      "export { clientExport_1 } from './client/1';
+      export { clientExport_2 } from './client/2';"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -285,7 +418,6 @@ describe("removeExports", () => {
     let result = removeExports(
       `
       export { serverExport_1, serverExport_2 } from './server'
-
       export { clientExport_1, clientExport_2 } from './client'
     `,
       ["serverExport_1", "serverExport_2"]
@@ -294,6 +426,21 @@ describe("removeExports", () => {
       "\"export { clientExport_1, clientExport_2 } from './client';\""
     );
     expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export multiple mixed", () => {
+    let result = removeExports(
+      `
+      export { removeMe_1, keepMe_1 } from './1'
+      export { removeMe_2, keepMe_2 } from './2'
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export { keepMe_1 } from './1';
+      export { keepMe_2 } from './2';"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
   });
 
   test("re-export manual", () => {
@@ -313,12 +460,50 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "import { clientExport_1 } from './client/1';
-    import { clientExport_2 } from './client/2';
-    export { clientExport_1 };
-    export { clientExport_2 };"
-  `);
+      "import { clientExport_1 } from './client/1';
+      import { clientExport_2 } from './client/2';
+      export { clientExport_1 };
+      export { clientExport_2 };"
+    `);
     expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export manual multiple", () => {
+    let result = removeExports(
+      `
+      import { serverExport_1, serverExport_2 } from './server'
+      import { clientExport_1, clientExport_2 } from './client'
+
+      export { serverExport_1, serverExport_2 }
+      export { clientExport_1, clientExport_2 }
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { clientExport_1, clientExport_2 } from './client';
+      export { clientExport_1, clientExport_2 };"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("re-export manual multiple mixed", () => {
+    let result = removeExports(
+      `
+      import { removeMe_1, keepMe_1 } from './1'
+      import { removeMe_2, keepMe_2 } from './2'
+
+      export { removeMe_1, keepMe_1 }
+      export { removeMe_2, keepMe_2 }
+    `,
+      ["removeMe_1", "removeMe_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { keepMe_1 } from './1';
+      import { keepMe_2 } from './2';
+      export { keepMe_1 };
+      export { keepMe_2 };"
+    `);
+    expect(result.code).not.toMatch(/removeMe/i);
   });
 
   test("number", () => {
@@ -333,9 +518,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = 123;
-    export const clientExport_2 = 123;"
-  `);
+      "export const clientExport_1 = 123;
+      export const clientExport_2 = 123;"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -351,9 +536,9 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = 'string';
-    export const clientExport_2 = 'string';"
-  `);
+      "export const clientExport_1 = 'string';
+      export const clientExport_2 = 'string';"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -372,10 +557,10 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "const CLIENT_STRING = 'CLIENT_STRING';
-    export const clientExport_1 = CLIENT_STRING;
-    export const clientExport_2 = CLIENT_STRING;"
-  `);
+      "const CLIENT_STRING = 'CLIENT_STRING';
+      export const clientExport_1 = CLIENT_STRING;
+      export const clientExport_2 = CLIENT_STRING;"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 
@@ -391,9 +576,249 @@ describe("removeExports", () => {
       ["serverExport_1", "serverExport_2"]
     );
     expect(result.code).toMatchInlineSnapshot(`
-    "export const clientExport_1 = null;
-    export const clientExport_2 = null;"
-  `);
+      "export const clientExport_1 = null;
+      export const clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("multiple variable declarators", () => {
+    let result = removeExports(
+      `
+      export const serverExport_1 = null,
+        serverExport_2 = null
+
+      export const clientExport_1 = null,
+        clientExport_2 = null
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = null,
+        clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("multiple variable declarators mixed", () => {
+    let result = removeExports(
+      `
+      export const serverExport_1 = null,
+        clientExport_1 = null
+      
+      export const clientExport_2 = null,
+        serverExport_2 = null
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = null;
+      export const clientExport_2 = null;"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("array destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const [serverExport_1, serverExport_2] = [null, null]
+
+        export const [clientExport_1, clientExport_2] = [null, null]
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_1""`
+    );
+  });
+
+  test("array rest destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const [...serverExport_1] = [null, null]
+
+        export const [clientExport_1, clientExport_2] = [null, null]
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_1""`
+    );
+  });
+
+  test("nested array destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const [keepMe_1, [{ nested: [ { nested: [serverExport_2] } ] }] ] = nested;
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_2""`
+    );
+  });
+
+  test("array destructuring works when nothing is removed", () => {
+    let result = removeExports(
+      `
+      export const [clientExport_1, clientExport_2] = [null, null]
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(
+      `"export const [clientExport_1, clientExport_2] = [null, null];"`
+    );
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("object destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const { serverExport_1, serverExport_2 } = {}
+
+        export const { clientExport_1, clientExport_2 } = {}
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_1""`
+    );
+  });
+
+  test("object rest destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const { ...serverExport_1 } = {}
+
+        export const { ...clientExport_1 } = {}
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_1""`
+    );
+  });
+
+  test("nested object destructuring throws on removed export", () => {
+    expect(() =>
+      removeExports(
+        `
+        export const [keepMe_1, [{ nested: [ { nested: { serverExport_2 } } ] }]] = nested;
+      `,
+        ["serverExport_1", "serverExport_2"]
+      )
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot remove destructured export "serverExport_2""`
+    );
+  });
+
+  test("object destructuring works when nothing is removed", () => {
+    let result = removeExports(
+      `
+      export const { clientExport_1, clientExport_2 } = {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const {
+        clientExport_1,
+        clientExport_2
+      } = {};"
+    `);
+    expect(result.code).not.toMatch(/server/i);
+  });
+
+  test("default export", () => {
+    let result = removeExports(
+      `
+      export const keepMe = null;
+
+      const removeMe = null;
+
+      export default removeMe;
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default export aggregated", () => {
+    let result = removeExports(
+      `
+      export const keepMe = null;
+
+      const removeMe = null;
+
+      export { removeMe as default };
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default export aggregated mixed", () => {
+    let result = removeExports(
+      `
+      const keepMe = null;
+
+      const removeMe = null;
+
+      export { removeMe as default, keepMe };
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "const keepMe = null;
+      export { keepMe };"
+    `);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default re-export", () => {
+    let result = removeExports(
+      `
+      export const keepMe = null;
+
+      export { default } from "./module";
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`"export const keepMe = null;"`);
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("default re-export mixed", () => {
+    let result = removeExports(
+      `
+      export { default, keepMe } from "./module";
+    `,
+      ["default"]
+    );
+    expect(result.code).toMatchInlineSnapshot(
+      `"export { keepMe } from "./module";"`
+    );
+    expect(result.code).not.toMatch(/default/i);
+  });
+
+  test("nothing removed", () => {
+    let result = removeExports(
+      `
+      export const clientExport_1 = () => {}
+      export const clientExport_2 = () => {}
+    `,
+      ["serverExport_1", "serverExport_2"]
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "export const clientExport_1 = () => {};
+      export const clientExport_2 = () => {};"
+    `);
     expect(result.code).not.toMatch(/server/i);
   });
 });

--- a/packages/react-router-dev/vite/remove-exports.ts
+++ b/packages/react-router-dev/vite/remove-exports.ts
@@ -1,362 +1,200 @@
-// Adapted from https://github.com/egoist/babel-plugin-eliminator/blob/d29859396b7708b7f7abbacdd951cbbc80902f00/src/index.ts
-// Which was originally adapted from https://github.com/vercel/next.js/blob/574fe0b582d5cc1b13663121fd47a3d82deaaa17/packages/next/build/babel/plugins/next-ssg-transform.ts
 import type { GeneratorOptions } from "@babel/generator";
+import {
+  findReferencedIdentifiers,
+  deadCodeElimination,
+} from "babel-dead-code-elimination";
 
 import type { BabelTypes, NodePath } from "./babel";
-import { parse, traverse, generate, t } from "./babel";
-
-function getIdentifier(
-  path: NodePath<
-    | BabelTypes.FunctionDeclaration
-    | BabelTypes.FunctionExpression
-    | BabelTypes.ArrowFunctionExpression
-  >
-): NodePath<BabelTypes.Identifier> | null {
-  let parentPath = path.parentPath;
-  if (parentPath.type === "VariableDeclarator") {
-    let variablePath = parentPath as NodePath<BabelTypes.VariableDeclarator>;
-    let name = variablePath.get("id");
-    return name.node.type === "Identifier"
-      ? (name as NodePath<BabelTypes.Identifier>)
-      : null;
-  }
-
-  if (parentPath.type === "AssignmentExpression") {
-    let variablePath = parentPath as NodePath<BabelTypes.AssignmentExpression>;
-    let name = variablePath.get("left");
-    return name.node.type === "Identifier"
-      ? (name as NodePath<BabelTypes.Identifier>)
-      : null;
-  }
-
-  if (path.node.type === "ArrowFunctionExpression") {
-    return null;
-  }
-
-  return path.node.id && path.node.id.type === "Identifier"
-    ? (path.get("id") as NodePath<BabelTypes.Identifier>)
-    : null;
-}
-
-function isIdentifierReferenced(
-  ident: NodePath<BabelTypes.Identifier>
-): boolean {
-  let binding = ident.scope.getBinding(ident.node.name);
-  if (binding?.referenced) {
-    // Functions can reference themselves, so we need to check if there's a
-    // binding outside the function scope or not.
-    if (binding.path.type === "FunctionDeclaration") {
-      return !binding.constantViolations
-        .concat(binding.referencePaths)
-        // Check that every reference is contained within the function:
-        .every((ref) => ref.findParent((parent) => parent === binding?.path));
-    }
-
-    return true;
-  }
-  return false;
-}
+import { parse, traverse, generate } from "./babel";
 
 export const removeExports = (
   source: string,
   exportsToRemove: string[],
   generateOptions: GeneratorOptions = {}
 ) => {
-  let document = parse(source, { sourceType: "module" });
+  let ast = parse(source, { sourceType: "module" });
 
-  let referencedIdentifiers = new Set<NodePath<BabelTypes.Identifier>>();
-  let removedExports = new Set<string>();
+  let previouslyReferencedIdentifiers = findReferencedIdentifiers(ast);
+  let exportsFiltered = false;
+  let markedForRemoval = new Set<NodePath<BabelTypes.Node>>();
 
-  let markImport = (
-    path: NodePath<
-      | BabelTypes.ImportSpecifier
-      | BabelTypes.ImportDefaultSpecifier
-      | BabelTypes.ImportNamespaceSpecifier
-    >
-  ) => {
-    let local = path.get("local");
-    if (isIdentifierReferenced(local)) {
-      referencedIdentifiers.add(local);
-    }
-  };
-
-  let markFunction = (
-    path: NodePath<
-      | BabelTypes.FunctionDeclaration
-      | BabelTypes.FunctionExpression
-      | BabelTypes.ArrowFunctionExpression
-    >
-  ) => {
-    let identifier = getIdentifier(path);
-    if (identifier?.node && isIdentifierReferenced(identifier)) {
-      referencedIdentifiers.add(identifier);
-    }
-  };
-
-  traverse(document, {
-    VariableDeclarator(variablePath) {
-      if (variablePath.node.id.type === "Identifier") {
-        let local = variablePath.get("id") as NodePath<BabelTypes.Identifier>;
-        if (isIdentifierReferenced(local)) {
-          referencedIdentifiers.add(local);
-        }
-      } else if (variablePath.node.id.type === "ObjectPattern") {
-        let pattern = variablePath.get(
-          "id"
-        ) as NodePath<BabelTypes.ObjectPattern>;
-
-        let properties = pattern.get("properties");
-        properties.forEach((p) => {
-          let local = p.get(
-            p.node.type === "ObjectProperty"
-              ? "value"
-              : p.node.type === "RestElement"
-              ? "argument"
-              : (function () {
-                  throw new Error("invariant");
-                })()
-          ) as NodePath<BabelTypes.Identifier>;
-          if (isIdentifierReferenced(local)) {
-            referencedIdentifiers.add(local);
-          }
-        });
-      } else if (variablePath.node.id.type === "ArrayPattern") {
-        let pattern = variablePath.get(
-          "id"
-        ) as NodePath<BabelTypes.ArrayPattern>;
-
-        let elements = pattern.get("elements");
-        elements.forEach((element) => {
-          let local: NodePath<BabelTypes.Identifier>;
-          if (element.node?.type === "Identifier") {
-            local = element as NodePath<BabelTypes.Identifier>;
-          } else if (element.node?.type === "RestElement") {
-            local = element.get("argument") as NodePath<BabelTypes.Identifier>;
-          } else {
-            return;
-          }
-
-          if (isIdentifierReferenced(local)) {
-            referencedIdentifiers.add(local);
-          }
-        });
-      }
-    },
-
-    FunctionDeclaration: markFunction,
-    FunctionExpression: markFunction,
-    ArrowFunctionExpression: markFunction,
-    ImportSpecifier: markImport,
-    ImportDefaultSpecifier: markImport,
-    ImportNamespaceSpecifier: markImport,
-
-    ExportNamedDeclaration(path) {
-      let shouldRemove = false;
-
-      // Handle re-exports: export { preload } from './foo'
-      path.node.specifiers = path.node.specifiers.filter((spec) => {
-        if (spec.exported.type !== "Identifier") {
-          return true;
-        }
-
-        let { name } = spec.exported;
-        for (let namedExport of exportsToRemove) {
-          if (name === namedExport) {
-            removedExports.add(namedExport);
-            return false;
-          }
-        }
-
-        return true;
-      });
-
-      let { declaration } = path.node;
-
-      // When no re-exports are left, remove the path
-      if (!declaration && path.node.specifiers.length === 0) {
-        shouldRemove = true;
-      }
-
-      if (declaration && declaration.type === "VariableDeclaration") {
-        declaration.declarations = declaration.declarations.filter(
-          (declarator: BabelTypes.VariableDeclarator) => {
-            for (let name of exportsToRemove) {
-              if ((declarator.id as BabelTypes.Identifier).name === name) {
-                removedExports.add(name);
+  traverse(ast, {
+    ExportDeclaration(path) {
+      // export { foo };
+      // export { bar } from "./module";
+      if (path.node.type === "ExportNamedDeclaration") {
+        if (path.node.specifiers.length) {
+          path.node.specifiers = path.node.specifiers.filter((specifier) => {
+            // Filter out individual specifiers
+            if (
+              specifier.type === "ExportSpecifier" &&
+              specifier.exported.type === "Identifier"
+            ) {
+              if (exportsToRemove.includes(specifier.exported.name)) {
+                exportsFiltered = true;
                 return false;
               }
             }
             return true;
+          });
+          // Remove the entire export statement if all specifiers were removed
+          if (path.node.specifiers.length === 0) {
+            markedForRemoval.add(path);
           }
-        );
-        if (declaration.declarations.length === 0) {
-          shouldRemove = true;
+        }
+
+        // export const foo = ...;
+        // export const [ foo ] = ...;
+        if (path.node.declaration?.type === "VariableDeclaration") {
+          let declaration = path.node.declaration;
+          declaration.declarations = declaration.declarations.filter(
+            (declaration) => {
+              // export const foo = ...;
+              // export const foo = ..., bar = ...;
+              if (
+                declaration.id.type === "Identifier" &&
+                exportsToRemove.includes(declaration.id.name)
+              ) {
+                // Filter out individual variables
+                exportsFiltered = true;
+                return false;
+              }
+
+              // export const [ foo ] = ...;
+              // export const { foo } = ...;
+              if (
+                declaration.id.type === "ArrayPattern" ||
+                declaration.id.type === "ObjectPattern"
+              ) {
+                // NOTE: These exports cannot be safely removed, so instead we
+                // validate them to ensure that any exports that are intended to
+                // be removed are not present
+                validateDestructuredExports(declaration.id, exportsToRemove);
+              }
+
+              return true;
+            }
+          );
+          // Remove the entire export statement if all variables were removed
+          if (declaration.declarations.length === 0) {
+            markedForRemoval.add(path);
+          }
+        }
+
+        // export function foo() {}
+        if (path.node.declaration?.type === "FunctionDeclaration") {
+          let id = path.node.declaration.id;
+          if (id && exportsToRemove.includes(id.name)) {
+            markedForRemoval.add(path);
+          }
+        }
+
+        // export class Foo() {}
+        if (path.node.declaration?.type === "ClassDeclaration") {
+          let id = path.node.declaration.id;
+          if (id && exportsToRemove.includes(id.name)) {
+            markedForRemoval.add(path);
+          }
         }
       }
 
-      if (declaration && declaration.type === "FunctionDeclaration") {
-        for (let name of exportsToRemove) {
-          if (declaration.id?.name === name) {
-            shouldRemove = true;
-            removedExports.add(name);
-          }
-        }
-      }
-
-      if (shouldRemove) {
-        path.remove();
+      // export default ...;
+      if (
+        path.node.type === "ExportDefaultDeclaration" &&
+        exportsToRemove.includes("default")
+      ) {
+        markedForRemoval.add(path);
       }
     },
   });
 
-  if (removedExports.size === 0) {
-    // No server-specific exports found so there's
-    // no need to remove unused references
-    return generate(document, generateOptions);
+  if (markedForRemoval.size > 0 || exportsFiltered) {
+    for (let path of markedForRemoval) {
+      path.remove();
+    }
+
+    // Run dead code elimination on any newly unreferenced identifiers
+    deadCodeElimination(ast, previouslyReferencedIdentifiers);
   }
 
-  let referencesRemovedInThisPass: number;
-
-  let sweepFunction = (
-    path: NodePath<
-      | BabelTypes.FunctionDeclaration
-      | BabelTypes.FunctionExpression
-      | BabelTypes.ArrowFunctionExpression
-    >
-  ) => {
-    let identifier = getIdentifier(path);
-    if (
-      identifier?.node &&
-      referencedIdentifiers.has(identifier) &&
-      !isIdentifierReferenced(identifier)
-    ) {
-      ++referencesRemovedInThisPass;
-
-      if (
-        t.isAssignmentExpression(path.parentPath.node) ||
-        t.isVariableDeclarator(path.parentPath.node)
-      ) {
-        path.parentPath.remove();
-      } else {
-        path.remove();
-      }
-    }
-  };
-
-  let sweepImport = (
-    path: NodePath<
-      | BabelTypes.ImportSpecifier
-      | BabelTypes.ImportDefaultSpecifier
-      | BabelTypes.ImportNamespaceSpecifier
-    >
-  ) => {
-    let local = path.get("local");
-    if (referencedIdentifiers.has(local) && !isIdentifierReferenced(local)) {
-      ++referencesRemovedInThisPass;
-      path.remove();
-      if (
-        (path.parent as BabelTypes.ImportDeclaration).specifiers.length === 0
-      ) {
-        path.parentPath.remove();
-      }
-    }
-  };
-
-  // Traverse again to remove unused references. This happens at least once,
-  // then repeats until no more references are removed.
-  do {
-    referencesRemovedInThisPass = 0;
-
-    traverse(document, {
-      Program(path) {
-        path.scope.crawl();
-      },
-      // eslint-disable-next-line no-loop-func
-      VariableDeclarator(variablePath) {
-        if (variablePath.node.id.type === "Identifier") {
-          let local = variablePath.get("id") as NodePath<BabelTypes.Identifier>;
-          if (
-            referencedIdentifiers.has(local) &&
-            !isIdentifierReferenced(local)
-          ) {
-            ++referencesRemovedInThisPass;
-            variablePath.remove();
-          }
-        } else if (variablePath.node.id.type === "ObjectPattern") {
-          let pattern = variablePath.get(
-            "id"
-          ) as NodePath<BabelTypes.ObjectPattern>;
-
-          let beforeCount = referencesRemovedInThisPass;
-          let properties = pattern.get("properties");
-          properties.forEach((property) => {
-            let local = property.get(
-              property.node.type === "ObjectProperty"
-                ? "value"
-                : property.node.type === "RestElement"
-                ? "argument"
-                : (function () {
-                    throw new Error("invariant");
-                  })()
-            ) as NodePath<BabelTypes.Identifier>;
-
-            if (
-              referencedIdentifiers.has(local) &&
-              !isIdentifierReferenced(local)
-            ) {
-              ++referencesRemovedInThisPass;
-              property.remove();
-            }
-          });
-
-          if (
-            beforeCount !== referencesRemovedInThisPass &&
-            pattern.get("properties").length < 1
-          ) {
-            variablePath.remove();
-          }
-        } else if (variablePath.node.id.type === "ArrayPattern") {
-          let pattern = variablePath.get(
-            "id"
-          ) as NodePath<BabelTypes.ArrayPattern>;
-
-          let beforeCount = referencesRemovedInThisPass;
-          let elements = pattern.get("elements");
-          elements.forEach((e) => {
-            let local: NodePath<BabelTypes.Identifier>;
-            if (e.node?.type === "Identifier") {
-              local = e as NodePath<BabelTypes.Identifier>;
-            } else if (e.node?.type === "RestElement") {
-              local = e.get("argument") as NodePath<BabelTypes.Identifier>;
-            } else {
-              return;
-            }
-
-            if (
-              referencedIdentifiers.has(local) &&
-              !isIdentifierReferenced(local)
-            ) {
-              ++referencesRemovedInThisPass;
-              e.remove();
-            }
-          });
-
-          if (
-            beforeCount !== referencesRemovedInThisPass &&
-            pattern.get("elements").length < 1
-          ) {
-            variablePath.remove();
-          }
-        }
-      },
-      FunctionDeclaration: sweepFunction,
-      FunctionExpression: sweepFunction,
-      ArrowFunctionExpression: sweepFunction,
-      ImportSpecifier: sweepImport,
-      ImportDefaultSpecifier: sweepImport,
-      ImportNamespaceSpecifier: sweepImport,
-    });
-  } while (referencesRemovedInThisPass);
-
-  return generate(document, generateOptions);
+  return generate(ast, generateOptions);
 };
+
+function validateDestructuredExports(
+  id: BabelTypes.ArrayPattern | BabelTypes.ObjectPattern,
+  exportsToRemove: string[]
+) {
+  if (id.type === "ArrayPattern") {
+    for (let element of id.elements) {
+      if (!element) {
+        continue;
+      }
+
+      // [ foo ]
+      if (
+        element.type === "Identifier" &&
+        exportsToRemove.includes(element.name)
+      ) {
+        throw invalidDestructureError(element.name);
+      }
+
+      // [ ...foo ]
+      if (
+        element.type === "RestElement" &&
+        element.argument.type === "Identifier" &&
+        exportsToRemove.includes(element.argument.name)
+      ) {
+        throw invalidDestructureError(element.argument.name);
+      }
+
+      // [ [...] ]
+      // [ {...} ]
+      if (element.type === "ArrayPattern" || element.type === "ObjectPattern") {
+        validateDestructuredExports(element, exportsToRemove);
+      }
+    }
+  }
+
+  if (id.type === "ObjectPattern") {
+    for (let property of id.properties) {
+      if (!property) {
+        continue;
+      }
+
+      if (
+        property.type === "ObjectProperty" &&
+        property.key.type === "Identifier"
+      ) {
+        // { foo }
+        if (
+          property.value.type === "Identifier" &&
+          exportsToRemove.includes(property.value.name)
+        ) {
+          throw invalidDestructureError(property.value.name);
+        }
+
+        // { foo: [...] }
+        // { foo: {...} }
+        if (
+          property.value.type === "ArrayPattern" ||
+          property.value.type === "ObjectPattern"
+        ) {
+          validateDestructuredExports(property.value, exportsToRemove);
+        }
+      }
+
+      // { ...foo }
+      if (
+        property.type === "RestElement" &&
+        property.argument.type === "Identifier" &&
+        exportsToRemove.includes(property.argument.name)
+      ) {
+        throw invalidDestructureError(property.argument.name);
+      }
+    }
+  }
+}
+
+function invalidDestructureError(name: string) {
+  return new Error(`Cannot remove destructured export "${name}"`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,6 +642,9 @@ importers:
       arg:
         specifier: ^5.0.1
         version: 5.0.2
+      babel-dead-code-elimination:
+        specifier: ^1.0.6
+        version: 1.0.6
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -6514,6 +6517,17 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
+
+  /babel-dead-code-elimination@1.0.6:
+    resolution: {integrity: sha512-JxFi9qyRJpN0LjEbbjbN8g0ux71Qppn9R8Qe3k6QzHg2CaKsbUQtbn307LQGiDLGjV6JCtEFqfxzVig9MyDCHQ==}
+    dependencies:
+      '@babel/core': 7.24.3
+      '@babel/parser': 7.24.1
+      '@babel/traverse': 7.24.1
+      '@babel/types': 7.24.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.22.9):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}


### PR DESCRIPTION
This migrates to @pcattori's awesome [babel-dead-code-elimination](https://github.com/pcattori/babel-dead-code-elimination) library. This means that our code no longer needs to deal with any dead code elimination, and instead only needs to focus on removing exports.

While migrating, I noticed a number of scenarios we didn't have tests for, so I've fleshed out the test suite a bit more.

I also noticed that we didn't handle removal of destructured exports (e.g. `export { loader } = { loader: () => { ... } }`, but since it's an edge case that's not trivial to support, and since the current behaviour is that they're not removed, it's better for us to simply throw an error if any exports to be removed are destructured.