### PR TITLE
Call patchRoutesOnMiss when matching slug routes in case there exist higher scoring static routes

### DIFF
--- a/.changeset/cyan-bobcats-notice.md
+++ b/.changeset/cyan-bobcats-notice.md
@@ -1,0 +1,7 @@
+---
+"@remix-run/router": patch
+---
+
+Fog of War: Update `unstable_patchRoutesOnMiss` logic so that we call the method when we match routes with dynamic param or splat segments in case there exists a higher-scoring static route that we've not yet discovered.
+
+- We also now leverage an internal FIFO queue of previous paths we've already called `unstable_patchRouteOnMiss` against so that we don't re-call on subsequent navigations to the same path

--- a/packages/router/__tests__/lazy-discovery-test.ts
+++ b/packages/router/__tests__/lazy-discovery-test.ts
@@ -1259,6 +1259,136 @@ describe("Lazy Route Discovery (Fog of War)", () => {
     unsubscribe();
   });
 
+  it('does not re-call for previously called "good" paths', async () => {
+    let count = 0;
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          path: "/",
+        },
+        {
+          id: "param",
+          path: ":param",
+        },
+      ],
+      async unstable_patchRoutesOnMiss() {
+        count++;
+        await tick();
+        // Nothing to patch - there is no better static route in this case
+      },
+    });
+
+    await router.navigate("/whatever");
+    expect(count).toBe(1);
+    expect(router.state.location.pathname).toBe("/whatever");
+    expect(router.state.matches.map((m) => m.route.id)).toEqual(["param"]);
+
+    await router.navigate("/");
+    expect(count).toBe(1);
+    expect(router.state.location.pathname).toBe("/");
+
+    await router.navigate("/whatever");
+    expect(count).toBe(1); // Not called again
+    expect(router.state.location.pathname).toBe("/whatever");
+    expect(router.state.matches.map((m) => m.route.id)).toEqual(["param"]);
+  });
+
+  it("does not re-call for previously called 404 paths", async () => {
+    let count = 0;
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          id: "index",
+          path: "/",
+        },
+        {
+          id: "static",
+          path: "static",
+        },
+      ],
+      async unstable_patchRoutesOnMiss() {
+        count++;
+      },
+    });
+
+    await router.navigate("/junk");
+    expect(count).toBe(1);
+    expect(router.state.location.pathname).toBe("/junk");
+    expect(router.state.errors?.index).toEqual(
+      new ErrorResponseImpl(
+        404,
+        "Not Found",
+        new Error('No route matches URL "/junk"'),
+        true
+      )
+    );
+
+    await router.navigate("/");
+    expect(count).toBe(1);
+    expect(router.state.location.pathname).toBe("/");
+    expect(router.state.errors).toBeNull();
+
+    await router.navigate("/junk");
+    expect(count).toBe(1);
+    expect(router.state.location.pathname).toBe("/junk");
+    expect(router.state.errors?.index).toEqual(
+      new ErrorResponseImpl(
+        404,
+        "Not Found",
+        new Error('No route matches URL "/junk"'),
+        true
+      )
+    );
+  });
+
+  it("caps internal fifo queue at 1000 paths", async () => {
+    let count = 0;
+    router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        {
+          path: "/",
+        },
+        {
+          id: "param",
+          path: ":param",
+        },
+      ],
+      async unstable_patchRoutesOnMiss() {
+        count++;
+        // Nothing to patch - there is no better static route in this case
+      },
+    });
+
+    // Fill it up with 1000 paths
+    for (let i = 1; i <= 1000; i++) {
+      await router.navigate(`/path-${i}`);
+      expect(count).toBe(i);
+      expect(router.state.location.pathname).toBe(`/path-${i}`);
+
+      await router.navigate("/");
+      expect(count).toBe(i);
+      expect(router.state.location.pathname).toBe("/");
+    }
+
+    // Don't call patchRoutesOnMiss since this is the first item in the queue
+    await router.navigate(`/path-1`);
+    expect(count).toBe(1000);
+    expect(router.state.location.pathname).toBe(`/path-1`);
+
+    // Call patchRoutesOnMiss and evict the first item
+    await router.navigate(`/path-1001`);
+    expect(count).toBe(1001);
+    expect(router.state.location.pathname).toBe(`/path-1001`);
+
+    // Call patchRoutesOnMiss since this item was evicted
+    await router.navigate(`/path-1`);
+    expect(count).toBe(1002);
+    expect(router.state.location.pathname).toBe(`/path-1`);
+  });
+
   describe("errors", () => {
     it("lazy 404s (GET navigation)", async () => {
       let childrenDfd = createDeferred<AgnosticDataRouteObject[]>();

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -3194,13 +3194,16 @@ export function createRouter(init: RouterInit): Router {
         return { active: true, matches: fogMatches || [] };
       } else {
         let leafRoute = matches[matches.length - 1].route;
-        if (
+        let matchedSplat =
           leafRoute.path &&
-          (leafRoute.path === "*" || leafRoute.path.endsWith("/*"))
-        ) {
-          // If we matched a splat, it might only be because we haven't yet fetched
-          // the children that would match with a higher score, so let's fetch
-          // around and find out
+          (leafRoute.path === "*" || leafRoute.path.endsWith("/*"));
+        let matchedDynamic = matches.some(
+          (m) => m.route.path && m.route.path.startsWith(":")
+        );
+        if (matchedDynamic || matchedSplat) {
+          // If we matched a slug or splat, it might only be because we haven't
+          // yet discovered other routes that would match with a higher score,
+          // so let's fetch around and find out
           let partialMatches = matchRoutesImpl<AgnosticDataRouteObject>(
             routesToUse,
             pathname,


### PR DESCRIPTION
This PR updates the fog of war implementation to treat dynamic-param (slug) routes the same way we treat splat routes and call `unstable_patchRotuesOnMiss` if we match a slug route just in case there exists a higher-scoring static route we don't yet know about.

TODO: 
* [x] Rename from `patchRoutesOnMiss` to something else since it's no longer only on a "miss" but on a "match that we're not confident is the best match"
  * going to do this in a separate PR
* [x] We should probably move the `knownGoodPaths` logic from Remix inside the router to avoid needing to re-call this for the same slug route over and over?  Add some cleanup when the Set reaches a certain size to cap memory consumption.
* [x] Add unit tests

Closes https://github.com/remix-run/remix/issues/9799