### PR TITLE
Remove defineRoutes from routes.ts

### DIFF
--- a/docs/start/installation.md
+++ b/docs/start/installation.md
@@ -89,11 +89,11 @@ export default function Home() {
 
 ```ts filename=app/routes.ts
 import {
-  defineRoutes,
+  type RoutesConfig,
   index,
 } from "@react-router/dev/routes";
 
-export default defineRoutes([index("./home.tsx")]);
+export const routes: RoutesConfig = [index("./home.tsx")];
 ```
 
 ```tsx filename=vite.config.ts

--- a/docs/start/routing.md
+++ b/docs/start/routing.md
@@ -11,13 +11,13 @@ Routes are configured in `app/routes.ts`. The Vite plugin uses this file to crea
 
 ```ts filename=app/routes.ts
 import {
-  defineRoutes,
+  type RoutesConfig,
   route,
   index,
   layout,
 } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   index("./home.tsx"),
   route("about", "./about.tsx"),
 
@@ -31,7 +31,7 @@ export default defineRoutes([
     route(":city", "./concerts/city.tsx"),
     route("trending", "./concerts/trending.tsx"),
   ]),
-]);
+];
 ```
 
 ## File System Routes
@@ -39,28 +39,28 @@ export default defineRoutes([
 If you prefer a file system routing convention, you can use the convention provided with Remix v2, but you can also make your own.
 
 ```tsx filename=app/routes.ts
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 import { remixRoutes } from "@react-router/remix-v2-routes";
 
-export default defineRoutes(await remixRoutes());
+export const routes: RoutesConfig = remixRoutes();
 ```
 
 You can also mix routing conventions into a single array of routes.
 
 ```tsx filename=app/routes.ts
 import {
-  defineRoutes,
+  type RoutesConfig,
   route,
 } from "@react-router/dev/routes";
 import { remixRoutes } from "@react-router/remix-v2-routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   // Provide Remix v2 file system routes
   ...(await remixRoutes()),
 
   // Then provide additional config routes
   route("/can/still/add/more", "./more.tsx"),
-]);
+];
 ```
 
 ## Linking
@@ -92,17 +92,17 @@ Routes can be nested inside parent routes. Nested routes are rendered into their
 
 ```ts filename=app/routes.ts
 import {
-  defineRoutes,
+  type RoutesConfig,
   route,
   index,
 } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   route("dashboard", "./dashboard.tsx", [
     index("./home.tsx"),
     route("settings", "./settings.tsx"),
   ]),
-]);
+];
 ```
 
 ```tsx filename=app/dashboard.tsx
@@ -127,13 +127,13 @@ Using `layout`, layout routes create new nesting for their children, but they do
 
 ```tsx filename=app/routes.ts lines=[9,15]
 import {
-  defineRoutes,
+  type RoutesConfig,
   route,
   layout,
   index,
 } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   layout("./marketing/layout.tsx", [
     index("./marketing/home.tsx"),
     route("contact", "./marketing/contact.tsx"),
@@ -145,7 +145,7 @@ export default defineRoutes([
       route(":pid/edit", "./projects/edit-project.tsx"),
     ]),
   ]),
-]);
+];
 ```
 
 ## Index Routes
@@ -158,12 +158,12 @@ Index routes render into their parent's [Outlet][outlet] at their parent's URL (
 
 ```ts filename=app/routes.ts
 import {
-  defineRoutes,
+  type RoutesConfig,
   route,
   index,
 } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   // renders into the root.tsx Outlet at /
   index("./home.tsx"),
   route("dashboard", "./dashboard.tsx", [
@@ -171,7 +171,7 @@ export default defineRoutes([
     index("./dashboard-home.tsx"),
     route("settings", "./dashboard-settings.tsx"),
   ]),
-]);
+];
 ```
 
 Note that index routes can't have children.
@@ -255,28 +255,6 @@ You can destructure the `*`, you just have to assign it a new name. A common nam
 ```tsx
 const { "*": splat } = params;
 ```
-
-## Case Sensitive Routes
-
-You can make your routes case sensitive by exporting a `config` object from `app/routes.ts`:
-
-```ts filename=app/routes.ts
-import {
-  defineRoutes,
-  route,
-} from "@react-router/dev/routes";
-
-export const config = {
-  caseSensitive: true,
-};
-
-export default defineRoutes([
-  route("wEll-aCtuAlly", "./well-actually.tsx"),
-]);
-```
-
-- Will match `"wEll-aCtuAlly"`
-- Will not match `"well-actually"`
 
 ## Component Routes
 

--- a/docs/upgrading/vite-component-routes.md
+++ b/docs/upgrading/vite-component-routes.md
@@ -176,14 +176,14 @@ To get back to rendering your app, we'll configure a "catchall" route that match
 Create a file at `src/routes.ts` and add this:
 
 ```ts filename=src/routes.ts
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   {
     path: "*",
     file: "src/catchall.tsx",
   },
-]);
+];
 ```
 
 And then create the catchall route module and render your existing root App component within it.
@@ -221,9 +221,9 @@ export default function App() {
 You can move the definition to a `routes.ts` file:
 
 ```tsx filename=src/routes.ts
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   {
     path: "/pages/:id",
     file: "./containers/page.tsx",
@@ -232,7 +232,7 @@ export default defineRoutes([
     path: "*",
     file: "src/catchall.tsx",
   },
-]);
+];
 ```
 
 And then edit the route module to use the Route Module API:

--- a/docs/upgrading/vite-router-provider.md
+++ b/docs/upgrading/vite-router-provider.md
@@ -197,14 +197,14 @@ ReactDOM.hydrateRoot(
 You can move the definition to a `routes.ts` file:
 
 ```tsx filename=src/routes.ts
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 
-export default defineRoutes([
+export const routes: RoutesConfig = [
   {
     path: "/pages/:id",
     file: "./containers/page.tsx",
   },
-]);
+];
 ```
 
 And then edit the route module to use the Route Module API:

--- a/integration/helpers/node-template/app/routes.ts
+++ b/integration/helpers/node-template/app/routes.ts
@@ -1,4 +1,4 @@
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 import { remixRoutes } from "@react-router/remix-v2-routes";
 
-export default defineRoutes(await remixRoutes());
+export const routes: RoutesConfig = remixRoutes();

--- a/integration/helpers/vite-cloudflare-template/app/routes.ts
+++ b/integration/helpers/vite-cloudflare-template/app/routes.ts
@@ -1,4 +1,4 @@
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 import { remixRoutes } from "@react-router/remix-v2-routes";
 
-export default defineRoutes(await remixRoutes());
+export const routes: RoutesConfig = remixRoutes();

--- a/integration/helpers/vite-template/app/routes.ts
+++ b/integration/helpers/vite-template/app/routes.ts
@@ -1,4 +1,4 @@
-import { defineRoutes } from "@react-router/dev/routes";
+import { type RoutesConfig } from "@react-router/dev/routes";
 import { remixRoutes } from "@react-router/remix-v2-routes";
 
-export default defineRoutes(await remixRoutes());
+export const routes: RoutesConfig = remixRoutes();

--- a/integration/remix-v2-routes-test.ts
+++ b/integration/remix-v2-routes-test.ts
@@ -26,20 +26,18 @@ test.describe("remix v2 routes", () => {
           });
         `,
         "app/routes.ts": js`
-          import { defineRoutes } from "@react-router/dev/routes";  
+          import { type RoutesConfig } from "@react-router/dev/routes";  
           import { remixRoutes } from "@react-router/remix-v2-routes";
 
-          export default defineRoutes(
-            await remixRoutes({
-              ignoredRouteFiles: ["**/ignored-route.*"],
-              routes: async (defineRoutes) => {
-                // Ensure async routes work
-                return defineRoutes((route) => {
-                  route("/custom/route", "custom-route.tsx")
-                });
-              }
-            })
-          );
+          export const routes: RoutesConfig = remixRoutes({
+            ignoredRouteFiles: ["**/ignored-route.*"],
+            routes: async (defineRoutes) => {
+              // Ensure async routes work
+              return defineRoutes((route) => {
+                route("/custom/route", "custom-route.tsx")
+              });
+            }
+          });
         `,
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "react-router";

--- a/integration/routes-config-test.ts
+++ b/integration/routes-config-test.ts
@@ -44,14 +44,14 @@ test.describe("routes config", () => {
     let files: Files = async ({ port }) => ({
       "vite.config.js": await viteConfig.basic({ port }),
       "app/routes.ts": js`
-        import { defineRoutes } from "@react-router/dev/routes";
+        import { type RoutesConfig } from "@react-router/dev/routes";
 
-        export default defineRoutes([
+        export const routes: RoutesConfig = [
           {
             file: "test-route-1.tsx",
             index: true,
           },
-        ]);
+        ];
       `,
       "app/test-route-1.tsx": `
         export default () => <div data-test-route>Test route 1</div>
@@ -102,14 +102,14 @@ test.describe("routes config", () => {
         export { default } from "./actual-routes";
       `,
       "app/actual-routes.ts": js`
-        import { defineRoutes } from "@react-router/dev/routes";
+        import { type RoutesConfig } from "@react-router/dev/routes";
 
-        export default defineRoutes([
+        export const routes: RoutesConfig = [
           {
             file: "test-route-1.tsx",
             index: true,
           },
-        ]);
+        ];
       `,
       "app/test-route-1.tsx": `
         export default () => <div data-test-route>Test route 1</div>

--- a/integration/routes-config-test.ts
+++ b/integration/routes-config-test.ts
@@ -99,7 +99,7 @@ test.describe("routes config", () => {
     let files: Files = async ({ port }) => ({
       "vite.config.js": await viteConfig.basic({ port }),
       "app/routes.ts": js`
-        export { default } from "./actual-routes";
+        export { routes } from "./actual-routes";
       `,
       "app/actual-routes.ts": js`
         import { type RoutesConfig } from "@react-router/dev/routes";

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -503,10 +503,10 @@ test.describe("SPA Mode", () => {
             });
           `,
           "src/routes.ts": js`
-            import { defineRoutes } from "@react-router/dev/routes";
+            import { type RoutesConfig } from "@react-router/dev/routes";
             import { remixRoutes } from "@react-router/remix-v2-routes";
 
-            export default defineRoutes(await remixRoutes());
+            export const routes: RoutesConfig = remixRoutes();
           `,
           "src/root.tsx": js`
             import {
@@ -592,10 +592,10 @@ test.describe("SPA Mode", () => {
             });
           `,
           "src/routes.ts": js`
-            import { defineRoutes } from "@react-router/dev/routes";
+            import { type RoutesConfig } from "@react-router/dev/routes";
             import { remixRoutes } from "@react-router/remix-v2-routes";
 
-            export default defineRoutes(await remixRoutes());
+            export const routes: RoutesConfig = remixRoutes();
           `,
           "src/root.tsx": js`
             import {

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -190,12 +190,6 @@ function createLayout(
   };
 }
 
-export function defineRoutes<Routes extends RoutesConfig>(
-  routes: Routes
-): Routes {
-  return routes;
-}
-
 export const route = createRoute;
 export const index = createIndex;
 export const layout = createLayout;

--- a/packages/react-router-dev/routes.ts
+++ b/packages/react-router-dev/routes.ts
@@ -1,9 +1,3 @@
 export type { RoutesConfig, ConfigRoute } from "./config/routes";
 
-export {
-  defineRoutes,
-  route,
-  index,
-  layout,
-  getAppDirectory,
-} from "./config/routes";
+export { route, index, layout, getAppDirectory } from "./config/routes";

--- a/playground/compiler/app/routes.ts
+++ b/playground/compiler/app/routes.ts
@@ -1,3 +1,3 @@
-import { defineRoutes, index } from "@react-router/dev/routes";
+import { type RoutesConfig, index } from "@react-router/dev/routes";
 
-export default defineRoutes([index("routes/_index.tsx")]);
+export const routes: RoutesConfig = [index("routes/_index.tsx")];


### PR DESCRIPTION
Now that `defineRoutes` is just an identity function for typing purposes, I'm swapping it for a type annotation. To make this annotation easier, I'm switching from a default export to `export cont routes: RoutesConfig = [...]`.