### PR TITLE
Scope Vite dev exports in `dev/vite` entry

### DIFF
--- a/.changeset/angry-papayas-flow.md
+++ b/.changeset/angry-papayas-flow.md
@@ -1,0 +1,17 @@
+---
+"@react-router/dev": major
+---
+
+For Remix consumers migrating to React Router, the `vitePlugin` and `cloudflareDevProxyVitePlugin` exports have been renamed and nested under `@react-router/dev/vite` to remove the `vitePlugin` naming convention .
+
+```diff
+-import {
+-  vitePlugin as remix,
+-  cloudflareDevProxyVitePlugin,
+-} from "@remix/dev";
+
++import {
++  reactRouter,
++  cloudflareDevProxy,
++} from "@react-router/dev/vite";
+```

--- a/.changeset/remove-manifest-option.md
+++ b/.changeset/remove-manifest-option.md
@@ -9,7 +9,7 @@ The `manifest` option been superseded by the more powerful `buildEnd` hook since
 If you were using the `manifest` option, you can replace it with a `buildEnd` hook that writes the manifest to disk like this:
 
 ```js
-import { vitePlugin as reactRouter } from "@react-router/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { writeFile } from "node:fs/promises";
 
 export default {

--- a/docs/guides/prerendering.md
+++ b/docs/guides/prerendering.md
@@ -20,7 +20,7 @@ This is still something that could be done entirely in userland, but it's be so 
 To enable pre-rendering, add the `prerender` option to your React Router Vite plugin to tell React Router which paths to pre-render:
 
 ```ts filename=vite.config.ts
-import { vitePlugin as reactRouter } from "@remix-run/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
@@ -35,7 +35,7 @@ export default defineConfig({
 `prerender` can also be a function, which allows you to dynamically generate the paths -- after fetching blog posts from your CMS for example:
 
 ```ts filename=vite.config.ts
-import { vitePlugin as reactRouter } from "@remix-run/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({

--- a/integration/flat-routes-test.ts
+++ b/integration/flat-routes-test.ts
@@ -20,7 +20,7 @@ test.describe("flat routes", () => {
       files: {
         "vite.config.js": `
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             plugins: [reactRouter({

--- a/integration/helpers/vite-cloudflare-template/vite.config.ts
+++ b/integration/helpers/vite-cloudflare-template/vite.config.ts
@@ -1,9 +1,6 @@
-import {
-  vitePlugin as reactRouter,
-  cloudflareDevProxyVitePlugin as reactRouterCloudflareDevProxy,
-} from "@react-router/dev";
+import { reactRouter, cloudflareDevProxy } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [reactRouterCloudflareDevProxy(), reactRouter()],
+  plugins: [cloudflareDevProxy(), reactRouter()],
 });

--- a/integration/helpers/vite-template/vite.config.ts
+++ b/integration/helpers/vite-template/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePlugin as reactRouter } from "@react-router/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -14,7 +14,7 @@ import glob from "glob";
 import dedent from "dedent";
 import type { Page } from "@playwright/test";
 import { test as base, expect } from "@playwright/test";
-import type { VitePluginConfig } from "@react-router/dev";
+import type { VitePluginConfig } from "@react-router/dev/vite";
 
 const require = createRequire(import.meta.url);
 
@@ -47,7 +47,7 @@ export const viteConfig = {
     };
 
     return dedent`
-      import { vitePlugin as reactRouter } from "@react-router/dev";
+      import { reactRouter } from "@react-router/dev/vite";
       import { envOnlyMacros } from "vite-env-only";
       import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -14,7 +14,7 @@ import glob from "glob";
 import dedent from "dedent";
 import type { Page } from "@playwright/test";
 import { test as base, expect } from "@playwright/test";
-import type { VitePluginConfig } from "@react-router/dev/vite";
+import type { ReactRouterConfig } from "@react-router/dev/vite";
 
 const require = createRequire(import.meta.url);
 
@@ -42,7 +42,7 @@ export const viteConfig = {
     fsAllow?: string[];
     spaMode?: boolean;
   }) => {
-    let pluginOptions: VitePluginConfig = {
+    let config: ReactRouterConfig = {
       ssr: !args.spaMode,
     };
 
@@ -54,7 +54,7 @@ export const viteConfig = {
       export default {
         ${await viteConfig.server(args)}
         plugins: [
-          reactRouter(${JSON.stringify(pluginOptions)}),
+          reactRouter(${JSON.stringify(config)}),
           envOnlyMacros(),
           tsconfigPaths()
         ],

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1356,10 +1356,10 @@ test.describe("single-fetch", () => {
         ...files,
         "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as remix } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
           export default defineConfig({
             plugins: [
-              remix({
+              reactRouter({
                 basename: '/base',
               }),
             ],

--- a/integration/vite-absolute-base-test.ts
+++ b/integration/vite-absolute-base-test.ts
@@ -6,7 +6,7 @@ import { test, viteConfig } from "./helpers/vite.js";
 
 let files: Files = async ({ port }) => ({
   "vite.config.ts": dedent`
-    import { vitePlugin as reactRouter } from "@react-router/dev";
+    import { reactRouter } from "@react-router/dev/vite";
     
     export default {
       base: "http://localhost:${port}/",

--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -65,7 +65,7 @@ async function viteConfigFile({
   basename?: string;
 }) {
   return js`
-    import { vitePlugin as reactRouter } from "@react-router/dev";
+    import { reactRouter } from "@react-router/dev/vite";
 
     export default {
       ${base !== "/" ? 'base: "' + base + '",' : ""}

--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -25,7 +25,7 @@ test.beforeAll(async () => {
     `,
     "vite.config.ts": js`
       import { defineConfig } from "vite";
-      import { vitePlugin as reactRouter } from "@react-router/dev";
+      import { reactRouter } from "@react-router/dev/vite";
       import mdx from "@mdx-js/rollup";
 
       export default defineConfig({

--- a/integration/vite-cloudflare-test.ts
+++ b/integration/vite-cloudflare-test.ts
@@ -7,15 +7,15 @@ import { test, viteConfig } from "./helpers/vite.js";
 const files: Files = async ({ port }) => ({
   "vite.config.ts": `
     import {
-      vitePlugin as reactRouter,
-      cloudflareDevProxyVitePlugin as reactRouterCloudflareDevProxy,
-    } from "@react-router/dev";
+      reactRouter,
+      cloudflareDevProxy,
+    } from "@react-router/dev/vite";
     import { getLoadContext } from "./load-context";
 
     export default {
       ${await viteConfig.server({ port })}
       plugins: [
-        reactRouterCloudflareDevProxy({ getLoadContext }),
+        cloudflareDevProxy({ getLoadContext }),
         reactRouter(),
       ],
     }

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -151,7 +151,7 @@ const files = {
 };
 
 const VITE_CONFIG = async (port: number) => dedent`
-  import { vitePlugin as reactRouter } from "@react-router/dev";
+  import { reactRouter } from "@react-router/dev/vite";
   import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
 
   export default {

--- a/integration/vite-dev-custom-entry-test.ts
+++ b/integration/vite-dev-custom-entry-test.ts
@@ -18,7 +18,7 @@ test.describe("Vite custom entry dev", () => {
       files: {
         "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             server: {

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -20,7 +20,7 @@ test.describe("Vite dev", () => {
       files: {
         "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
           import mdx from "@mdx-js/rollup";
 
           export default defineConfig({

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -217,7 +217,7 @@ test.describe("Vite / non-route / server-only module referenced by client", () =
 test.describe("Vite / server-only escape hatch", async () => {
   let files: Files = async ({ port }) => ({
     "vite.config.ts": dedent`
-      import { vitePlugin as reactRouter } from "@react-router/dev";
+      import { reactRouter } from "@react-router/dev/vite";
       import { envOnlyMacros } from "vite-env-only";
       import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -61,7 +61,7 @@ test("Vite / HMR & HDR / mdx", async ({ page, dev }) => {
   let files: Files = async ({ port }) => ({
     "vite.config.ts": `
       import { defineConfig } from "vite";
-      import { vitePlugin as reactRouter } from "@react-router/dev";
+      import { reactRouter } from "@react-router/dev/vite";
       import mdx from "@mdx-js/rollup";
 
       export default defineConfig({

--- a/integration/vite-manifests-test.ts
+++ b/integration/vite-manifests-test.ts
@@ -52,7 +52,7 @@ test.describe(() => {
   test.beforeAll(async () => {
     cwd = await createProject({
       "vite.config.ts": dedent(js`
-        import { vitePlugin as reactRouter } from "@react-router/dev";
+        import { reactRouter } from "@react-router/dev/vite";
 
         export default {
           build: { manifest: true },

--- a/integration/vite-plugin-order-validation-test.ts
+++ b/integration/vite-plugin-order-validation-test.ts
@@ -10,7 +10,7 @@ test.describe(() => {
   test.beforeAll(async () => {
     cwd = await createProject({
       "vite.config.ts": dedent`
-        import { vitePlugin as reactRouter } from "@react-router/dev";
+        import { reactRouter } from "@react-router/dev/vite";
         import mdx from "@mdx-js/rollup";
 
         export default {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -13,7 +13,7 @@ import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
 let files = {
   "vite.config.ts": js`
     import { defineConfig } from "vite";
-    import { vitePlugin as reactRouter } from "@react-router/dev";
+    import { reactRouter } from "@react-router/dev/vite";
 
     export default defineConfig({
       build: { manifest: true },
@@ -157,7 +157,7 @@ test.describe("Prerendering", () => {
         ...files,
         "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             build: { manifest: true },

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -11,7 +11,7 @@ const js = String.raw;
 
 const files = {
   "vite.config.ts": dedent(js`
-    import { vitePlugin as reactRouter } from "@react-router/dev";
+    import { reactRouter } from "@react-router/dev/vite";
     import fs from "node:fs/promises";
     import serializeJs from "serialize-javascript";
 

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -121,7 +121,7 @@ test.describe(() => {
     port = await getPort();
     cwd = await createProject({
       "vite.config.ts": dedent(js`
-        import { vitePlugin as reactRouter } from "@react-router/dev";
+        import { reactRouter } from "@react-router/dev/vite";
 
         export default {
           ${await viteConfig.server({ port })}

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -22,7 +22,7 @@ test.describe("SPA Mode", () => {
         let cwd = await createProject({
           "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             plugins: [reactRouter({ ssr: false })],
@@ -53,7 +53,7 @@ test.describe("SPA Mode", () => {
         let cwd = await createProject({
           "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             plugins: [reactRouter({ ssr: false })],
@@ -82,7 +82,7 @@ test.describe("SPA Mode", () => {
         let cwd = await createProject({
           "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             plugins: [reactRouter({ ssr: false })],
@@ -154,7 +154,7 @@ test.describe("SPA Mode", () => {
         let cwd = await createProject({
           "vite.config.ts": js`
           import { defineConfig } from "vite";
-          import { vitePlugin as reactRouter } from "@react-router/dev";
+          import { reactRouter } from "@react-router/dev/vite";
 
           export default defineConfig({
             plugins: [reactRouter({ ssr: false })],
@@ -181,7 +181,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               plugins: [reactRouter({ ssr: false })],
@@ -226,7 +226,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               plugins: [reactRouter({
@@ -304,7 +304,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               plugins: [reactRouter({ ssr: false })],
@@ -490,7 +490,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               plugins: [reactRouter({
@@ -573,7 +573,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               plugins: [reactRouter({
@@ -643,7 +643,7 @@ test.describe("SPA Mode", () => {
         files: {
           "vite.config.ts": js`
             import { defineConfig } from "vite";
-            import { vitePlugin as reactRouter } from "@react-router/dev";
+            import { reactRouter } from "@react-router/dev/vite";
 
             export default defineConfig({
               build: { manifest: true },

--- a/packages/react-router-dev/config.ts
+++ b/packages/react-router-dev/config.ts
@@ -17,20 +17,20 @@ import { flatRoutes } from "./config/flatRoutes";
 import { detectPackageManager } from "./cli/detectPackageManager";
 
 const excludedConfigPresetKeys = ["presets"] as const satisfies ReadonlyArray<
-  keyof VitePluginConfig
+  keyof ReactRouterConfig
 >;
 
 type ExcludedConfigPresetKey = (typeof excludedConfigPresetKeys)[number];
 
-type ConfigPreset = Omit<VitePluginConfig, ExcludedConfigPresetKey>;
+type ConfigPreset = Omit<ReactRouterConfig, ExcludedConfigPresetKey>;
 
 export type Preset = {
   name: string;
   reactRouterConfig?: (args: {
-    reactRouterUserConfig: VitePluginConfig;
+    reactRouterUserConfig: ReactRouterConfig;
   }) => ConfigPreset | Promise<ConfigPreset>;
   reactRouterConfigResolved?: (args: {
-    reactRouterConfig: ResolvedVitePluginConfig;
+    reactRouterConfig: ResolvedReactRouterConfig;
   }) => void | Promise<void>;
 };
 
@@ -78,11 +78,11 @@ export type BuildManifest = DefaultBuildManifest | ServerBundlesBuildManifest;
 
 type BuildEndHook = (args: {
   buildManifest: BuildManifest | undefined;
-  reactRouterConfig: ResolvedVitePluginConfig;
+  reactRouterConfig: ResolvedReactRouterConfig;
   viteConfig: Vite.ResolvedConfig;
 }) => void | Promise<void>;
 
-export type VitePluginConfig = {
+export type ReactRouterConfig = {
   /**
    * The path to the `app` directory, relative to `remix.config.js`. Defaults
    * to `"app"`.
@@ -164,7 +164,7 @@ export type VitePluginConfig = {
   ssr?: boolean;
 };
 
-export type ResolvedVitePluginConfig = Readonly<{
+export type ResolvedReactRouterConfig = Readonly<{
   /**
    * The absolute path to the application source directory.
    */
@@ -219,13 +219,13 @@ export type ResolvedVitePluginConfig = Readonly<{
 }>;
 
 let mergeReactRouterConfig = (
-  ...configs: VitePluginConfig[]
-): VitePluginConfig => {
+  ...configs: ReactRouterConfig[]
+): ReactRouterConfig => {
   let reducer = (
-    configA: VitePluginConfig,
-    configB: VitePluginConfig
-  ): VitePluginConfig => {
-    let mergeRequired = (key: keyof VitePluginConfig) =>
+    configA: ReactRouterConfig,
+    configB: ReactRouterConfig
+  ): ReactRouterConfig => {
+    let mergeRequired = (key: keyof ReactRouterConfig) =>
       configA[key] !== undefined && configB[key] !== undefined;
 
     return {
@@ -317,11 +317,11 @@ export async function resolveReactRouterConfig({
   viteCommand,
 }: {
   rootDirectory: string;
-  reactRouterUserConfig: VitePluginConfig;
+  reactRouterUserConfig: ReactRouterConfig;
   viteUserConfig: Vite.UserConfig;
   viteCommand: Vite.ConfigEnv["command"];
 }) {
-  let presets: VitePluginConfig[] = (
+  let presets: ReactRouterConfig[] = (
     await Promise.all(
       (reactRouterUserConfig.presets ?? []).map(async (preset) => {
         if (!preset.name) {
@@ -334,7 +334,7 @@ export async function resolveReactRouterConfig({
           return null;
         }
 
-        let configPreset: VitePluginConfig = omit(
+        let configPreset: ReactRouterConfig = omit(
           await preset.reactRouterConfig({ reactRouterUserConfig }),
           excludedConfigPresetKeys
         );
@@ -352,7 +352,7 @@ export async function resolveReactRouterConfig({
     serverBuildFile: "index.js",
     serverModuleFormat: "esm",
     ssr: true,
-  } as const satisfies Partial<VitePluginConfig>;
+  } as const satisfies Partial<ReactRouterConfig>;
 
   let {
     appDirectory: userAppDirectory,
@@ -437,7 +437,7 @@ export async function resolveReactRouterConfig({
 
   let future: FutureConfig = {};
 
-  let reactRouterConfig: ResolvedVitePluginConfig = deepFreeze({
+  let reactRouterConfig: ResolvedReactRouterConfig = deepFreeze({
     appDirectory,
     basename,
     buildDirectory,
@@ -463,7 +463,7 @@ export async function resolveEntryFiles({
   reactRouterConfig,
 }: {
   rootDirectory: string;
-  reactRouterConfig: ResolvedVitePluginConfig;
+  reactRouterConfig: ResolvedReactRouterConfig;
 }) {
   let { appDirectory } = reactRouterConfig;
 

--- a/packages/react-router-dev/index.ts
+++ b/packages/react-router-dev/index.ts
@@ -1,11 +1,3 @@
 export * as cli from "./cli/index";
 
 export type { Manifest as AssetsManifest } from "./manifest";
-export type {
-  BuildManifest,
-  Preset,
-  ServerBundlesFunction,
-  VitePluginConfig,
-} from "./config";
-export { reactRouterVitePlugin as vitePlugin } from "./vite/plugin";
-export { cloudflareDevProxyVitePlugin } from "./vite/cloudflare-dev-proxy";

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./vite": {
+      "types": "./dist/vite.d.ts",
+      "default": "./dist/vite.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {

--- a/packages/react-router-dev/rollup.config.js
+++ b/packages/react-router-dev/rollup.config.js
@@ -26,7 +26,7 @@ module.exports = function rollup() {
       external(id) {
         return isBareModuleId(id);
       },
-      input: `${SOURCE_DIR}/index.ts`,
+      input: [`${SOURCE_DIR}/index.ts`, `${SOURCE_DIR}/vite.ts`],
       output: {
         banner: createBanner("@react-router/dev", version),
         dir: OUTPUT_DIR,

--- a/packages/react-router-dev/vite.ts
+++ b/packages/react-router-dev/vite.ts
@@ -2,7 +2,7 @@ export type {
   BuildManifest,
   Preset,
   ServerBundlesFunction,
-  VitePluginConfig,
+  ReactRouterConfig,
 } from "./config";
 
 export { reactRouterVitePlugin as reactRouter } from "./vite/plugin";

--- a/packages/react-router-dev/vite.ts
+++ b/packages/react-router-dev/vite.ts
@@ -1,0 +1,9 @@
+export type {
+  BuildManifest,
+  Preset,
+  ServerBundlesFunction,
+  VitePluginConfig,
+} from "./config";
+
+export { reactRouterVitePlugin as reactRouter } from "./vite/plugin";
+export { cloudflareDevProxyVitePlugin as cloudflareDevProxy } from "./vite/cloudflare-dev-proxy";

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -36,8 +36,8 @@ import { combineURLs } from "./combine-urls";
 import { removeExports } from "./remove-exports";
 import { importViteEsmSync, preloadViteEsm } from "./import-vite-esm-sync";
 import {
-  type VitePluginConfig,
-  type ResolvedVitePluginConfig,
+  type ReactRouterConfig,
+  type ResolvedReactRouterConfig,
   resolveReactRouterConfig,
   resolveEntryFiles,
   resolvePublicPath,
@@ -157,7 +157,7 @@ export type ReactRouterPluginContext = ReactRouterPluginSsrBuildContext & {
   entryClientFilePath: string;
   entryServerFilePath: string;
   publicPath: string;
-  reactRouterConfig: ResolvedVitePluginConfig;
+  reactRouterConfig: ResolvedReactRouterConfig;
   viteManifestEnabled: boolean;
 };
 
@@ -169,7 +169,7 @@ let injectHmrRuntimeId = VirtualModule.id("inject-hmr-runtime");
 
 const resolveRelativeRouteFilePath = (
   route: ConfigRoute,
-  reactRouterConfig: ResolvedVitePluginConfig
+  reactRouterConfig: ResolvedReactRouterConfig
 ) => {
   let vite = importViteEsmSync();
   let file = route.file;
@@ -368,7 +368,7 @@ export let getServerBuildDirectory = (ctx: ReactRouterPluginContext) =>
       : [])
   );
 
-let getClientBuildDirectory = (reactRouterConfig: ResolvedVitePluginConfig) =>
+let getClientBuildDirectory = (reactRouterConfig: ResolvedReactRouterConfig) =>
   path.join(reactRouterConfig.buildDirectory, "client");
 
 let defaultEntriesDir = path.resolve(__dirname, "..", "config", "defaults");
@@ -410,7 +410,7 @@ let deepFreeze = (o: any) => {
   return o;
 };
 
-type ReactRouterVitePlugin = (config?: VitePluginConfig) => Vite.Plugin[];
+type ReactRouterVitePlugin = (config?: ReactRouterConfig) => Vite.Plugin[];
 export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
   let reactRouterUserConfig = _config ?? {};
 
@@ -1552,7 +1552,7 @@ function isEqualJson(v1: unknown, v2: unknown) {
 }
 
 function addRefreshWrapper(
-  reactRouterConfig: ResolvedVitePluginConfig,
+  reactRouterConfig: ResolvedReactRouterConfig,
   code: string,
   id: string
 ): string {
@@ -1615,7 +1615,7 @@ if (import.meta.hot && !inWebWorker) {
 }`;
 
 function getRoute(
-  pluginConfig: ResolvedVitePluginConfig,
+  pluginConfig: ResolvedReactRouterConfig,
   file: string
 ): ConfigRoute | undefined {
   let vite = importViteEsmSync();

--- a/packages/react-router-dev/vite/styles.ts
+++ b/packages/react-router-dev/vite/styles.ts
@@ -3,7 +3,7 @@ import type { ServerBuild } from "react-router";
 import { matchRoutes } from "react-router";
 import type { ModuleNode, ViteDevServer } from "vite";
 
-import type { ResolvedVitePluginConfig } from "../config";
+import type { ResolvedReactRouterConfig } from "../config";
 import { resolveFileUrl } from "./resolve-file-url";
 
 type ServerRouteManifest = ServerBuild["routes"];
@@ -184,7 +184,7 @@ export const getStylesForUrl = async ({
 }: {
   viteDevServer: ViteDevServer;
   rootDirectory: string;
-  reactRouterConfig: Pick<ResolvedVitePluginConfig, "appDirectory" | "routes">;
+  reactRouterConfig: Pick<ResolvedReactRouterConfig, "appDirectory" | "routes">;
   entryClientFilePath: string;
   cssModulesManifest: Record<string, string>;
   build: ServerBuild;

--- a/playground/compiler-express/vite.config.ts
+++ b/playground/compiler-express/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePlugin as reactRouter } from "@react-router/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/playground/compiler-spa/vite.config.ts
+++ b/playground/compiler-spa/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePlugin as reactRouter } from "@react-router/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/playground/compiler/vite.config.ts
+++ b/playground/compiler/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePlugin as reactRouter } from "@react-router/dev";
+import { reactRouter } from "@react-router/dev/vite";
 import { installGlobals } from "@react-router/node";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";


### PR DESCRIPTION
This PR adds a `@react-router/dev/vite` entry so that all Vite-related exports don't need to be namespaced or aliased. We avoided this in the past because we didn't use package exports to limit reaching into package internals, but since we now define package exports, we're free to make this change.

```diff
-import {
-  vitePlugin as reactRouter,
-  cloudflareDevProxyVitePlugin,
-} from "@react-router/dev";

+import {
+  reactRouter,
+  cloudflareDevProxy,
+} from "@react-router/dev/vite";
```