### PR TITLE
fix(remix-v2-routes): sync version

### DIFF
--- a/packages/react-router-remix-v2-routes/package.json
+++ b/packages/react-router-remix-v2-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/remix-v2-routes",
-  "version": "2.9.0-pre.0",
+  "version": "6.26.2",
   "description": "Remix v2 routing conventions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"


### PR DESCRIPTION
This aligns the version number with the rest of the packages.