### PR TITLE
docs: Update use-navigate.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -236,6 +236,7 @@
 - shivamsinghchahar
 - SimenB
 - SkayuX
+- slavwritescode
 - smithki
 - souzasmatheus
 - srmagura

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -29,7 +29,7 @@ type RelativeRoutingType = "route" | "path";
 
 </details>
 
-<docs-warning>It's usually better to use [`redirect`][redirect] in [`loaders`][loaders] and [`actions`][actions] than this hook</docs-warning>
+<docs-warning>It's usually better to use [`redirect`][redirect] in [`loaders`][loaders] and [`actions`][actions] than this hook</docs-warning> when the redirect is in response to data.
 
 The `useNavigate` hook returns a function that lets you navigate programmatically, for example in an effect:
 


### PR DESCRIPTION
A subtle difference in the wording was missing in the useNavigate page as opposed to what was written in the redirect page. We are advised that useNavigate is not a good solution but only in response to programmatical redirection in relation to changes in data not as a whole. Current wording makes it out to seem like you should never use useNavigate.