### PR TITLE
`ssr` field will be omitted and `scan` will be `true` when vite does its

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1325,7 +1325,12 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
       name: "react-router-dot-server",
       enforce: "pre",
       async resolveId(id, importer, options) {
-        if (options?.ssr) return;
+        // https://vitejs.dev/config/dep-optimization-options
+        let isOptimizeDeps =
+          viteCommand === "serve" &&
+          (options as { scan?: boolean })?.scan === true;
+
+        if (isOptimizeDeps || options?.ssr) return;
 
         let isResolving = options?.custom?.["react-router-dot-server"] ?? false;
         if (isResolving) return;


### PR DESCRIPTION
client dep optimization pass for local dev

in that case, the module graph is treated like a client-module graph without any transforms, so we need to disable the `.server` detection during deps discovery

in the future, it would be better to have separate module graphs for client and server without requiring transforms so that this all works with Vite out-of-the-box and server dependencies are not optimized for use by the client

See https://github.com/remix-run/remix/pull/9921