### PR TITLE
robust single fetch serialization

### DIFF
--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -73,6 +73,16 @@ const files = {
       };
     }
 
+    class MyClass {
+      a: string
+      b: bigint
+      constructor(a: string, b: bigint) {
+        this.a = a
+        this.b = b
+      }
+      c() {}
+    }
+
     export function loader({ request }) {
       if (new URL(request.url).searchParams.has("error")) {
         throw new Error("Loader Error");
@@ -80,6 +90,8 @@ const files = {
       return {
         message: "DATA",
         date: new Date("${ISO_DATE}"),
+        function: () => {},
+        class: new MyClass("hello", BigInt(1)),
       };
     }
 
@@ -115,6 +127,16 @@ const files = {
       }, { status: 201, headers: { 'X-Action': 'yes' }});
     }
 
+    class MyClass {
+      a: string
+      b: Date
+      constructor(a: string, b: Date) {
+        this.a = a
+        this.b = b
+      }
+      c() {}
+    }
+
     export function loader({ request }) {
       if (new URL(request.url).searchParams.has("error")) {
         throw new Error("Loader Error");
@@ -122,6 +144,8 @@ const files = {
       return data({
         message: "DATA",
         date: new Date("${ISO_DATE}"),
+        function: () => {},
+        class: new MyClass("hello", BigInt(1)),
       }, { status: 206, headers: { 'X-Loader': 'yes' }});
     }
 
@@ -171,7 +195,7 @@ test.describe("single-fetch", () => {
     });
 
     res = await fixture.requestSingleFetchData("/data.data");
-    expect(res.data).toEqual({
+    expect(res.data).toStrictEqual({
       root: {
         data: {
           message: "ROOT",
@@ -181,6 +205,11 @@ test.describe("single-fetch", () => {
         data: {
           message: "DATA",
           date: new Date(ISO_DATE),
+          function: undefined,
+          class: {
+            a: "hello",
+            b: BigInt(1),
+          },
         },
       },
     });
@@ -236,7 +265,7 @@ test.describe("single-fetch", () => {
     let res = await fixture.requestSingleFetchData("/data-with-response.data");
     expect(res.status).toEqual(206);
     expect(res.headers.get("X-Loader")).toEqual("yes");
-    expect(res.data).toEqual({
+    expect(res.data).toStrictEqual({
       root: {
         data: {
           message: "ROOT",
@@ -246,6 +275,11 @@ test.describe("single-fetch", () => {
         data: {
           message: "DATA",
           date: new Date(ISO_DATE),
+          function: undefined,
+          class: {
+            a: "hello",
+            b: BigInt(1),
+          },
         },
       },
     });

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -374,6 +374,14 @@ export function decodeViaTurboStream(
         if (type === "SingleFetchRedirect") {
           return { value: { [SingleFetchRedirectSymbol]: rest[0] } };
         }
+
+        if (type === "SingleFetchClassInstance") {
+          return { value: rest[0] };
+        }
+
+        if (type === "SingleFetchFallback") {
+          return { value: undefined };
+        }
       },
     ],
   });

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -359,5 +359,17 @@ export function encodeViaTurboStream(
         }
       },
     ],
+    postPlugins: [
+      (value) => {
+        if (!value) return;
+        if (typeof value !== "object") return;
+
+        return [
+          "SingleFetchClassInstance",
+          Object.fromEntries(Object.entries(value)),
+        ];
+      },
+      () => ["SingleFetchFallback"],
+    ],
   });
 }

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -42,7 +42,7 @@
     "react-router": "workspace:*",
     "set-cookie-parser": "^2.6.0",
     "source-map": "^0.7.3",
-    "turbo-stream": "2.3.0"
+    "turbo-stream": "2.4.0"
   },
   "devDependencies": {
     "@types/set-cookie-parser": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,8 +557,8 @@ importers:
         specifier: ^0.7.3
         version: 0.7.4
       turbo-stream:
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 2.4.0
+        version: 2.4.0
     devDependencies:
       '@types/set-cookie-parser':
         specifier: ^2.4.1
@@ -13613,8 +13613,8 @@ packages:
       yargs: 17.7.2
     dev: false
 
-  /turbo-stream@2.3.0:
-    resolution: {integrity: sha512-PhEr9mdexoVv+rJkQ3c8TjrN3DUghX37GNJkSMksoPR4KrXIPnM2MnqRt07sViIqX9IdlhrgtTSyjoVOASq6cg==}
+  /turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
     dev: false
 
   /type-check@0.4.0:


### PR DESCRIPTION
1. serialize class instances via `Object.fromEntries(Object.entries(obj))` to omit methods
2. serilaize anything that would otherwise be unserializable as `undefined`

(1) is important as TS can't distinguish between plain objects and class instances, so both of those need to be handled the same way if we want good type safety

(2) is important so that we never get runtime errors from returning "unserializable" data from loaders/actions

This was implemented in Remix in this PR: https://github.com/remix-run/remix/pull/9893