### PR TITLE
Add relative routes.ts helpers

### DIFF
--- a/integration/routes-config-test.ts
+++ b/integration/routes-config-test.ts
@@ -224,4 +224,28 @@ test.describe("routes config", () => {
       );
     }).toPass();
   });
+
+  test("supports absolute route file paths", async ({ page, dev }) => {
+    let files: Files = async ({ port }) => ({
+      "vite.config.js": await viteConfig.basic({ port }),
+      "app/routes.ts": js`
+        import path from "node:path";
+        import { type RouteConfig } from "@react-router/dev/routes";
+
+        export const routes: RouteConfig = [
+          {
+            file: path.resolve(import.meta.dirname, "test-route.tsx"),
+            index: true,
+          },
+        ];
+      `,
+      "app/test-route.tsx": `
+        export default () => <div data-test-route>Test route</div>
+      `,
+    });
+    let { port } = await dev(files);
+
+    await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+    await expect(page.locator("[data-test-route]")).toHaveText("Test route");
+  });
 });

--- a/packages/react-router-dev/__tests__/routes-config-test.ts
+++ b/packages/react-router-dev/__tests__/routes-config-test.ts
@@ -1,4 +1,4 @@
-import { route, layout, index } from "../config/routes";
+import { route, layout, index, relative } from "../config/routes";
 
 describe("routes config", () => {
   describe("route helpers", () => {
@@ -192,6 +192,70 @@ describe("routes config", () => {
             ],
             "file": "layout.tsx",
             "id": "custom-id",
+          }
+        `);
+      });
+    });
+
+    describe("relative", () => {
+      it("supports relative routes", () => {
+        let { route } = relative("/path/to/dirname");
+        expect(
+          route("parent", "nested/parent.tsx", [
+            route("child", "nested/child.tsx", { id: "child" }),
+          ])
+        ).toMatchInlineSnapshot(`
+          {
+            "children": [
+              {
+                "children": undefined,
+                "file": "/path/to/dirname/nested/child.tsx",
+                "id": "child",
+                "path": "child",
+              },
+            ],
+            "file": "/path/to/dirname/nested/parent.tsx",
+            "path": "parent",
+          }
+        `);
+      });
+
+      it("supports relative index routes", () => {
+        let { index } = relative("/path/to/dirname");
+        expect([
+          index("nested/without-options.tsx"),
+          index("nested/with-options.tsx", { id: "with-options" }),
+        ]).toMatchInlineSnapshot(`
+          [
+            {
+              "file": "/path/to/dirname/nested/without-options.tsx",
+              "index": true,
+            },
+            {
+              "file": "/path/to/dirname/nested/with-options.tsx",
+              "id": "with-options",
+              "index": true,
+            },
+          ]
+        `);
+      });
+
+      it("supports relative layout routes", () => {
+        let { layout } = relative("/path/to/dirname");
+        expect(
+          layout("nested/parent.tsx", [
+            layout("nested/child.tsx", { id: "child" }),
+          ])
+        ).toMatchInlineSnapshot(`
+          {
+            "children": [
+              {
+                "children": undefined,
+                "file": "/path/to/dirname/nested/child.tsx",
+                "id": "child",
+              },
+            ],
+            "file": "/path/to/dirname/nested/parent.tsx",
           }
         `);
       });

--- a/packages/react-router-dev/routes.ts
+++ b/packages/react-router-dev/routes.ts
@@ -1,3 +1,9 @@
 export type { RouteConfig, RouteConfigEntry } from "./config/routes";
 
-export { route, index, layout, getAppDirectory } from "./config/routes";
+export {
+  route,
+  index,
+  layout,
+  relative,
+  getAppDirectory,
+} from "./config/routes";


### PR DESCRIPTION
This adds a `relative` helper function to the `@react-router/dev/routes` API as a convenience for defining routes that are relative to a custom directory rather the app directory, which is the default.

For example, if you have multiple `routes.ts` files nested within your project, you can scope all route files to the directory that each `routes.ts` sits in:

```ts
// app/feature/routes.ts
import { type RouteConfig, relative }  from "@react-router/dev/routes";

const { route, index, layout } = relative(import.meta.dirname);

export const routes: RouteConfig = [
  route("hello", "./routes/hello.tsx"),
  // etc.
];
```

Which then allows for easy composition at the root level:

```ts
// app/routes.ts
import { type RouteConfig } from "@react-router/dev/routes";
import * as feature from "./feature/routes";

export const routes: RouteConfig = [
  ...feature.routes,
];
```