### PR TITLE
Remove internal discoverRoutes queue and make patch idempotent

### DIFF
--- a/.changeset/unlucky-keys-collect.md
+++ b/.changeset/unlucky-keys-collect.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Remove internal `discoveredRoutes` FIFO queue from `unstable_patchRoutesOnNavigation`


### PR DESCRIPTION
Removed this fifo queue because it was a bit overly restrictive and prevents use cases such as the one described in https://github.com/remix-run/react-router/discussions/11947.  This can be implemented in user land if required (as [Remix does](https://github.com/remix-run/remix/blob/main/packages/remix-react/fog-of-war.ts#L22)).