### PR TITLE
update path-to-regexp to v1.9.0

### DIFF
--- a/packages/react-router/docs/api/Redirect.md
+++ b/packages/react-router/docs/api/Redirect.md
@@ -10,7 +10,7 @@ Rendering a `<Redirect>` will navigate to a new location. The new location will 
 
 ## to: string
 
-The URL to redirect to. Any valid URL path that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
+The URL to redirect to. Any valid URL path that [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0) understands.
 All URL parameters that are used in `to` must be covered by `from`.
 
 ```jsx
@@ -19,7 +19,7 @@ All URL parameters that are used in `to` must be covered by `from`.
 
 ## to: object
 
-A location to redirect to. `pathname` can be any valid URL path that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
+A location to redirect to. `pathname` can be any valid URL path that [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0) understands.
 
 ```jsx
 <Redirect
@@ -43,7 +43,7 @@ When `true`, redirecting will push a new entry onto the history instead of repla
 
 ## from: string
 
-A pathname to redirect from. Any valid URL path that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
+A pathname to redirect from. Any valid URL path that [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0) understands.
 All matched URL parameters are provided to the pattern in `to`. Must contain all parameters that are used in `to`. Additional parameters not used by `to` are ignored.
 
 **Note:** This can only be used to match a location when rendering a `<Redirect>` inside of a `<Switch>`. See [`<Switch children>`](./Switch.md#children-node) for more details.

--- a/packages/react-router/docs/api/Route.md
+++ b/packages/react-router/docs/api/Route.md
@@ -190,7 +190,7 @@ This could also be useful for animations:
 
 ## path: string | string[]
 
-Any valid URL path or array of paths that [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) understands.
+Any valid URL path or array of paths that [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0) understands.
 
 ```jsx
 <Route path="/users/:id">

--- a/packages/react-router/docs/guides/migrating.md
+++ b/packages/react-router/docs/guides/migrating.md
@@ -214,7 +214,7 @@ In v4, you must re-pass these properties to the `to` prop:
 
 ### matchPattern(pattern, pathname)
 
-In v3, you could use the same matching code used internally to check if a path matched a pattern. In v4 this has been replaced by [matchPath](/packages/react-router/docs/api/matchPath.md) which is powered by the [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0) library.
+In v3, you could use the same matching code used internally to check if a path matched a pattern. In v4 this has been replaced by [matchPath](/packages/react-router/docs/api/matchPath.md) which is powered by the [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0) library.
 
 ### formatPattern(pattern, params)
 
@@ -229,7 +229,7 @@ const THING_PATH = "/thing/:id";
 </Link>;
 ```
 
-In v4, you can achieve the same functionality using the [`compile`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#compile-reverse-path-to-regexp) function in [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0).
+In v4, you can achieve the same functionality using the [`compile`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0#compile-reverse-path-to-regexp) function in [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0).
 
 ```jsx
 // v4
@@ -241,7 +241,7 @@ const thingPath = pathToRegexp.compile(THING_PATH);
 
 ### getParamNames
 
-The `getParamNames` functionality can be achieved using the [`parse`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#parse) function in [`path-to-regexp@^1.7.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0).
+The `getParamNames` functionality can be achieved using the [`parse`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0#parse) function in [`path-to-regexp@^1.9.0`](https://github.com/pillarjs/path-to-regexp/tree/v1.9.0).
 
 ## Link
 

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -47,7 +47,7 @@
     "history": "^4.9.0",
     "hoist-non-react-statics": "^3.1.0",
     "loose-envify": "^1.3.1",
-    "path-to-regexp": "^1.7.0",
+    "path-to-regexp": "^1.9.0",
     "prop-types": "^15.6.2",
     "react-is": "^16.6.0",
     "tiny-invariant": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,10 +8150,10 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+path-to-regexp@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
for projects that are still stuck on v5, but need to pass security audits