### PR TITLE
Improve route config validation

### DIFF
--- a/integration/route-config-test.ts
+++ b/integration/route-config-test.ts
@@ -13,27 +13,29 @@ import {
 
 const js = String.raw;
 
-test.describe("routes config", () => {
-  test("fails the build if routes config is missing", async () => {
+test.describe("route config", () => {
+  test("fails the build if route config is missing", async () => {
     let cwd = await createProject();
     await fs.rm(path.join(cwd, "app/routes.ts"));
     let buildResult = build({ cwd });
     expect(buildResult.status).toBe(1);
     expect(buildResult.stderr.toString()).toContain(
-      'Could not find a routes config file at "app/routes.ts"'
+      'Route config file not found at "app/routes.ts"'
     );
   });
 
-  test("fails the build if routes config is invalid", async () => {
+  test("fails the build if route config is invalid", async () => {
     let cwd = await createProject({
       "app/routes.ts": `export default INVALID(`,
     });
     let buildResult = build({ cwd });
     expect(buildResult.status).toBe(1);
-    expect(buildResult.stderr.toString()).toContain("Route config is invalid");
+    expect(buildResult.stderr.toString()).toContain(
+      'Route config in "routes.ts" is invalid.'
+    );
   });
 
-  test("fails the dev process if routes config is initially invalid", async ({
+  test("fails the dev process if route config is initially invalid", async ({
     dev,
   }) => {
     let files: Files = async ({ port }) => ({
@@ -46,13 +48,12 @@ test.describe("routes config", () => {
     } catch (error: any) {
       devError = error;
     }
-    expect(devError?.toString()).toContain("Route config is invalid");
+    expect(devError?.toString()).toContain(
+      'Route config in "routes.ts" is invalid.'
+    );
   });
 
-  test("supports correcting an invalid routes config", async ({
-    page,
-    dev,
-  }) => {
+  test("supports correcting an invalid route config", async ({ page, dev }) => {
     let files: Files = async ({ port }) => ({
       "vite.config.js": await viteConfig.basic({ port }),
       "app/routes.ts": js`
@@ -104,7 +105,7 @@ test.describe("routes config", () => {
     }).toPass();
   });
 
-  test("supports correcting an invalid routes config module graph", async ({
+  test("supports correcting an invalid route config module graph", async ({
     page,
     dev,
   }) => {
@@ -162,7 +163,7 @@ test.describe("routes config", () => {
     }).toPass();
   });
 
-  test("supports correcting a missing routes config", async ({ page, dev }) => {
+  test("supports correcting a missing route config", async ({ page, dev }) => {
     let files: Files = async ({ port }) => ({
       "vite.config.js": await viteConfig.basic({ port }),
       "app/routes.ts": js`

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -66,7 +66,8 @@
     "react-refresh": "^0.14.0",
     "semver": "^7.3.7",
     "set-cookie-parser": "^2.6.0",
-    "vite-node": "^1.6.0"
+    "vite-node": "^1.6.0",
+    "valibot": "^0.41.0"
   },
   "devDependencies": {
     "@react-router/serve": "workspace:*",

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -9,11 +9,12 @@ import omit from "lodash/omit";
 import PackageJson from "@npmcli/package-json";
 
 import {
-  setAppDirectory,
-  configRoutesToRouteManifest,
   type RouteManifest,
   type RouteManifestEntry,
   type RouteConfig,
+  setAppDirectory,
+  validateRouteConfig,
+  configRoutesToRouteManifest,
 } from "../config/routes";
 import { detectPackageManager } from "../cli/detectPackageManager";
 import { importViteEsmSync } from "./import-vite-esm-sync";
@@ -421,7 +422,7 @@ export async function resolveReactRouterConfig({
         path.relative(rootDirectory, path.join(appDirectory, "routes.ts"))
       );
       throw new FriendlyError(
-        `Could not find a routes config file at "${routeConfigDisplayPath}"`
+        `Route config file not found at "${routeConfigDisplayPath}".`
       );
     }
 
@@ -432,16 +433,13 @@ export async function resolveReactRouterConfig({
 
     let routeConfig = await routeConfigExport;
 
-    if (!routeConfig) {
-      throw new FriendlyError(
-        `No "routes" export defined in "${routeConfigFile}"`
-      );
-    }
+    let result = validateRouteConfig({
+      routeConfigFile,
+      routeConfig,
+    });
 
-    if (!Array.isArray(routeConfig)) {
-      throw new FriendlyError(
-        `Routes exported from "${routeConfigFile}" must be an array`
-      );
+    if (!result.valid) {
+      throw new FriendlyError(result.message);
     }
 
     routes = { ...routes, ...configRoutesToRouteManifest(routeConfig) };
@@ -459,7 +457,7 @@ export async function resolveReactRouterConfig({
       error instanceof FriendlyError
         ? colors.red(error.message)
         : [
-            colors.red("Route config is invalid."),
+            colors.red(`Route config in "${routeConfigFile}" is invalid.`),
             "",
             error.loc?.file && error.loc?.column && error.frame
               ? [
@@ -473,7 +471,7 @@ export async function resolveReactRouterConfig({
               : error.stack,
           ]
             .flat()
-            .join("\n"),
+            .join("\n") + "\n",
       {
         error,
         clear: !isFirstLoad,

--- a/packages/react-router-fs-routes/__tests__/routeManifestToRouteConfig-test.ts
+++ b/packages/react-router-fs-routes/__tests__/routeManifestToRouteConfig-test.ts
@@ -14,7 +14,7 @@ const cleanIds = (obj: any) =>
   );
 
 describe("routeManifestToRouteConfig", () => {
-  test("creates routes config", () => {
+  test("creates route config", () => {
     let routeManifestConfig = routeManifestToRouteConfig({
       "routes/home": {
         id: "routes/home",
@@ -85,7 +85,7 @@ describe("routeManifestToRouteConfig", () => {
     `);
   });
 
-  test("creates routes config with IDs", () => {
+  test("creates route config with IDs", () => {
     let routeConfig = routeManifestToRouteConfig({
       home: {
         path: "/",

--- a/packages/react-router-remix-config-routes-adapter/__tests__/routeManifestToRouteConfig-test.ts
+++ b/packages/react-router-remix-config-routes-adapter/__tests__/routeManifestToRouteConfig-test.ts
@@ -15,7 +15,7 @@ const cleanIds = (obj: any) =>
   );
 
 describe("routeManifestToRouteConfig", () => {
-  test("creates routes config", () => {
+  test("creates route config", () => {
     let remixRoutes = routeManifestToRouteConfig(
       defineRoutes((route) => {
         route("/", "routes/home.js");
@@ -69,7 +69,7 @@ describe("routeManifestToRouteConfig", () => {
     `);
   });
 
-  test("creates routes config with IDs", () => {
+  test("creates route config with IDs", () => {
     let configRoutes = routeManifestToRouteConfig(
       defineRoutes((route) => {
         route("/", "routes/home.js", { id: "home" });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 0.0.5
       '@rollup/plugin-babel':
         specifier: ^5.3.1
-        version: 5.3.1(@babel/core@7.22.9)(rollup@2.79.1)
+        version: 5.3.1(@babel/core@7.22.9)(@types/babel__core@7.20.5)(rollup@2.79.1)
       '@rollup/plugin-node-resolve':
         specifier: ^11.0.1
         version: 11.2.1(rollup@2.79.1)
@@ -87,7 +87,7 @@ importers:
         version: 5.17.0
       '@testing-library/react':
         specifier: ^13.4.0
-        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@8.17.1)
@@ -132,7 +132,7 @@ importers:
         version: 5.3.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.5.0
-        version: 7.5.0(@typescript-eslint/parser@7.5.0)(eslint@8.57.0)(typescript@5.4.5)
+        version: 7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser':
         specifier: ^7.5.0
         version: 7.5.0(eslint@8.57.0)(typescript@5.4.5)
@@ -159,16 +159,16 @@ importers:
         version: 8.57.0
       eslint-config-react-app:
         specifier: ^7.0.1
-        version: 7.0.1(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.22.5)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
+        version: 7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.9))(@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-flowtype:
         specifier: ^8.0.3
-        version: 8.0.3(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.22.5)(eslint@8.57.0)
+        version: 8.0.3(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.9))(@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9))(eslint@8.57.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.5.0)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
       eslint-plugin-jest:
         specifier: ^27.9.0
-        version: 27.9.0(@typescript-eslint/eslint-plugin@7.5.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
+        version: 27.9.0(@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-jsx-a11y:
         specifier: ^6.8.0
         version: 6.8.0(eslint@8.57.0)
@@ -189,7 +189,7 @@ importers:
         version: 5.1.11
       jest:
         specifier: ^29.6.4
-        version: 29.7.0
+        version: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
       jest-environment-jsdom:
         specifier: ^29.6.2
         version: 29.6.2
@@ -258,13 +258,13 @@ importers:
         version: 3.1.1
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@18.19.26)(terser@5.15.0)
       vite-env-only:
         specifier: ^3.0.1
-        version: 3.0.1(vite@5.1.3)
+        version: 3.0.1(vite@5.1.3(@types/node@18.19.26)(terser@5.15.0))
       vite-tsconfig-paths:
         specifier: ^4.2.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3)
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@18.19.26)(terser@5.15.0))
       wait-on:
         specifier: ^7.0.1
         version: 7.2.0
@@ -291,7 +291,7 @@ importers:
         version: 1.14.2
       '@vanilla-extract/vite-plugin':
         specifier: ^3.9.2
-        version: 3.9.5(vite@5.1.3)
+        version: 3.9.5(@types/node@20.11.30)(terser@5.15.0)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
       cheerio:
         specifier: ^1.0.0-rc.12
         version: 1.0.0-rc.12
@@ -366,7 +366,7 @@ importers:
         version: 5.1.6
       vite-tsconfig-paths:
         specifier: ^4.2.2
-        version: 4.3.2(typescript@5.1.6)(vite@5.1.3)
+        version: 4.3.2(typescript@5.1.6)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
 
   integration/helpers/node-template:
     dependencies:
@@ -415,7 +415,7 @@ importers:
         version: 1.14.2
       '@vanilla-extract/vite-plugin':
         specifier: ^3.9.2
-        version: 3.9.5(vite@5.1.3)
+        version: 3.9.5(@types/node@20.11.30)(terser@5.15.0)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
       getos:
         specifier: ^3.2.1
         version: 3.2.1
@@ -473,7 +473,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
       wrangler:
         specifier: ^3.28.2
         version: 3.64.0(@cloudflare/workers-types@4.20240712.0)
@@ -494,7 +494,7 @@ importers:
         version: 1.14.2
       '@vanilla-extract/vite-plugin':
         specifier: ^3.9.2
-        version: 3.9.5(vite@5.1.3)
+        version: 3.9.5(@types/node@20.11.30)(terser@5.15.0)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -537,13 +537,13 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
       vite-env-only:
         specifier: ^3.0.1
-        version: 3.0.1(vite@5.1.3)
+        version: 3.0.1(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.1.6)(vite@5.1.3)
+        version: 4.3.2(typescript@5.1.6)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
 
   packages/react-router:
     dependencies:
@@ -668,7 +668,7 @@ importers:
         version: 4.1.2
       dedent:
         specifier: ^1.5.3
-        version: 1.5.3
+        version: 1.5.3(babel-plugin-macros@3.1.0)
       es-module-lexer:
         specifier: ^1.3.1
         version: 1.5.0
@@ -708,9 +708,12 @@ importers:
       typescript:
         specifier: ^5.1.0
         version: 5.4.5
+      valibot:
+        specifier: ^0.41.0
+        version: 0.41.0(typescript@5.4.5)
       vite-node:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@18.19.26)
+        version: 1.6.0(@types/node@18.19.26)(terser@5.15.0)
     devDependencies:
       '@react-router/serve':
         specifier: workspace:*
@@ -780,7 +783,7 @@ importers:
         version: 1.3.3
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@18.19.26)(terser@5.15.0)
       wrangler:
         specifier: ^3.28.2
         version: 3.64.0(@cloudflare/workers-types@4.20240712.0)
@@ -951,10 +954,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3)
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
 
   playground/compiler-express:
     dependencies:
@@ -1012,10 +1015,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3)
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
 
   playground/compiler-spa:
     dependencies:
@@ -1046,10 +1049,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.0
-        version: 5.1.3(@types/node@18.19.26)
+        version: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3)
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))
 
 packages:
 
@@ -7040,6 +7043,14 @@ packages:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
     engines: {node: '>=10.12.0'}
 
+  valibot@0.41.0:
+    resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -9365,7 +9376,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -9379,7 +9390,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.26)
+      jest-config: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -9822,12 +9833,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.22.9)(rollup@2.79.1)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.22.9)(@types/babel__core@7.20.5)(rollup@2.79.1)':
     dependencies:
       '@babel/core': 7.22.9
       '@babel/helper-module-imports': 7.22.5
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
 
   '@rollup/plugin-node-resolve@11.2.1(rollup@2.79.1)':
     dependencies:
@@ -9850,8 +9863,9 @@ snapshots:
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       resolve: 1.22.3
       rollup: 2.79.1
-      tslib: 2.6.2
       typescript: 5.4.5
+    optionalDependencies:
+      tslib: 2.6.2
 
   '@rollup/pluginutils@3.1.0(rollup@2.79.1)':
     dependencies:
@@ -9865,6 +9879,7 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 2.79.1
 
   '@rollup/rollup-android-arm-eabi@4.13.1':
@@ -9952,7 +9967,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@13.4.0(react-dom@18.2.0)(react@18.2.0)':
+  '@testing-library/react@13.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.22.6
       '@testing-library/dom': 8.17.1
@@ -10250,7 +10265,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.0
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
@@ -10264,11 +10279,12 @@ snapshots:
       natural-compare-lite: 1.4.0
       semver: 7.5.4
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0)(eslint@8.57.0)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
       '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@5.4.5)
@@ -10283,6 +10299,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.5.4
       ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10302,6 +10319,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       debug: 4.3.4
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10314,6 +10332,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 7.5.0
       debug: 4.3.4
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10335,6 +10354,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10346,6 +10366,7 @@ snapshots:
       debug: 4.3.4
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10363,6 +10384,7 @@ snapshots:
       is-glob: 4.0.3
       semver: 7.5.4
       tsutils: 3.21.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10377,6 +10399,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.5.4
       ts-api-utils: 1.3.0(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -10442,7 +10465,7 @@ snapshots:
       modern-ahocorasick: 1.0.1
       outdent: 0.8.0
 
-  '@vanilla-extract/integration@6.5.0':
+  '@vanilla-extract/integration@6.5.0(@types/node@20.11.30)(terser@5.15.0)':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.3)
@@ -10455,8 +10478,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.6.1
       outdent: 0.8.0
-      vite: 5.1.3(@types/node@18.19.26)
-      vite-node: 1.6.0(@types/node@18.19.26)
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
+      vite-node: 1.6.0(@types/node@20.11.30)(terser@5.15.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10469,13 +10492,13 @@ snapshots:
 
   '@vanilla-extract/private@1.0.4': {}
 
-  '@vanilla-extract/vite-plugin@3.9.5(vite@5.1.3)':
+  '@vanilla-extract/vite-plugin@3.9.5(@types/node@20.11.30)(terser@5.15.0)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0))':
     dependencies:
-      '@vanilla-extract/integration': 6.5.0
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.11.30)(terser@5.15.0)
       outdent: 0.8.0
       postcss: 8.4.38
       postcss-load-config: 4.0.2(postcss@8.4.38)
-      vite: 5.1.3(@types/node@18.19.26)
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -11217,13 +11240,13 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  create-jest@29.7.0:
+  create-jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.26)
+      jest-config: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -11354,9 +11377,13 @@ snapshots:
 
   dedent@0.7.0: {}
 
-  dedent@1.5.1: {}
+  dedent@1.5.1(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
-  dedent@1.5.3: {}
+  dedent@1.5.3(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
 
   deep-is@0.1.4: {}
 
@@ -11717,23 +11744,24 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.22.5)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.9))(@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5):
     dependencies:
       '@babel/core': 7.24.3
       '@babel/eslint-parser': 7.24.1(@babel/core@7.24.3)(eslint@8.57.0)
       '@rushstack/eslint-patch': 1.10.1
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.22.5)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5)
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.9))(@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       eslint-plugin-testing-library: 5.11.1(eslint@8.57.0)(typescript@5.4.5)
+    optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
@@ -11751,25 +11779,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
-      debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@5.4.5)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.18.6)(@babel/plugin-transform-react-jsx@7.22.5)(eslint@8.57.0):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.9))(@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.22.9))(eslint@8.57.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.9)
       '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.22.9)
@@ -11777,9 +11807,35 @@ snapshots:
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
     dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.13.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0):
+    dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -11788,7 +11844,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -11798,53 +11854,31 @@ snapshots:
       object.values: 1.2.0
       semver: 6.3.1
       tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.5.0)(eslint@8.57.0):
-    dependencies:
+    optionalDependencies:
       '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@5.4.5)
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
-      jest: 29.7.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      jest: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.5.0)(eslint@8.57.0)(jest@29.7.0)(typescript@5.4.5):
+  eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0))(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.5.0(@typescript-eslint/parser@7.5.0)(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
-      jest: 29.7.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      jest: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -12810,7 +12844,7 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0:
+  jest-circus@29.7.0(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/expect': 29.7.0
@@ -12819,7 +12853,7 @@ snapshots:
       '@types/node': 18.19.26
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.5.1
+      dedent: 1.5.1(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
@@ -12836,16 +12870,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0:
+  jest-cli@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0
+      create-jest: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.26)
+      jest-config: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -12855,19 +12889,18 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.26):
+  jest-config@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.24.3
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.26
       babel-jest: 29.7.0(@babel/core@7.24.3)
       chalk: 4.1.2
       ci-info: 3.8.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
@@ -12880,6 +12913,8 @@ snapshots:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 18.19.26
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12994,7 +13029,7 @@ snapshots:
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
-    dependencies:
+    optionalDependencies:
       jest-resolve: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -13147,12 +13182,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0:
+  jest@29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0
+      jest-cli: 29.7.0(@types/node@18.19.26)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14445,8 +14480,9 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.38):
     dependencies:
       lilconfig: 3.1.1
-      postcss: 8.4.38
       yaml: 2.4.1
+    optionalDependencies:
+      postcss: 8.4.38
 
   postcss-nested@6.0.1(postcss@8.4.38):
     dependencies:
@@ -15368,11 +15404,11 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tsconfck@3.0.3(typescript@5.1.6):
-    dependencies:
+    optionalDependencies:
       typescript: 5.1.6
 
   tsconfck@3.0.3(typescript@5.4.5):
-    dependencies:
+    optionalDependencies:
       typescript: 5.4.5
 
   tsconfig-paths@3.15.0:
@@ -15671,6 +15707,10 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
 
+  valibot@0.41.0(typescript@5.4.5):
+    optionalDependencies:
+      typescript: 5.4.5
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -15709,7 +15749,7 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-env-only@3.0.1(vite@5.1.3):
+  vite-env-only@3.0.1(vite@5.1.3(@types/node@18.19.26)(terser@5.15.0)):
     dependencies:
       '@babel/core': 7.24.3
       '@babel/generator': 7.24.1
@@ -15718,17 +15758,30 @@ snapshots:
       '@babel/types': 7.24.0
       babel-dead-code-elimination: 1.0.1
       micromatch: 4.0.5
-      vite: 5.1.3(@types/node@18.19.26)
+      vite: 5.1.3(@types/node@18.19.26)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite-node@1.6.0(@types/node@18.19.26):
+  vite-env-only@3.0.1(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0)):
+    dependencies:
+      '@babel/core': 7.24.3
+      '@babel/generator': 7.24.1
+      '@babel/parser': 7.24.1
+      '@babel/traverse': 7.24.1
+      '@babel/types': 7.24.0
+      babel-dead-code-elimination: 1.0.1
+      micromatch: 4.0.5
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-node@1.6.0(@types/node@18.19.26)(terser@5.15.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.3(@types/node@18.19.26)
+      vite: 5.1.3(@types/node@18.19.26)(terser@5.15.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -15739,34 +15792,75 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.1.6)(vite@5.1.3):
+  vite-node@1.6.0(@types/node@20.11.30)(terser@5.15.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-tsconfig-paths@4.3.2(typescript@5.1.6)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0)):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.1.6)
-      vite: 5.1.3(@types/node@18.19.26)
+    optionalDependencies:
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.1.3):
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@18.19.26)(terser@5.15.0)):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.4.5)
-      vite: 5.1.3(@types/node@18.19.26)
+    optionalDependencies:
+      vite: 5.1.3(@types/node@18.19.26)(terser@5.15.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.1.3(@types/node@18.19.26):
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@20.11.30)(terser@5.15.0)):
     dependencies:
-      '@types/node': 18.19.26
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@5.4.5)
+    optionalDependencies:
+      vite: 5.1.3(@types/node@20.11.30)(terser@5.15.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@5.1.3(@types/node@18.19.26)(terser@5.15.0):
+    dependencies:
       esbuild: 0.19.12
       postcss: 8.4.38
       rollup: 4.13.1
     optionalDependencies:
+      '@types/node': 18.19.26
       fsevents: 2.3.3
+      terser: 5.15.0
+
+  vite@5.1.3(@types/node@20.11.30)(terser@5.15.0):
+    dependencies:
+      esbuild: 0.19.12
+      postcss: 8.4.38
+      rollup: 4.13.1
+    optionalDependencies:
+      '@types/node': 20.11.30
+      fsevents: 2.3.3
+      terser: 5.15.0
 
   vscode-oniguruma@1.7.0: {}
 
@@ -15890,7 +15984,6 @@ snapshots:
   wrangler@3.64.0(@cloudflare/workers-types@4.20240712.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
-      '@cloudflare/workers-types': 4.20240712.0
       '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
       '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
       blake3-wasm: 2.1.5
@@ -15907,6 +16000,7 @@ snapshots:
       unenv: unenv-nightly@1.10.0-1717606461.a117952
       xxhash-wasm: 1.0.2
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20240712.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
This PR centralises and tests the route config validation logic, and extends it with [Valibot](https://valibot.dev/) to provide better error messages when the route config value is invalid.

Note I went with Valibot since it's better optimised for file size, meaning it'll be a more appropriate choice if we ever want to perform similar validation in the browser.