### PR TITLE
Stabilize viewTransiton and flushSync options

### DIFF
--- a/.changeset/stabilize-flush-sync.md
+++ b/.changeset/stabilize-flush-sync.md
@@ -1,0 +1,7 @@
+---
+"react-router-dom": minor
+"react-router": minor
+"@remix-run/router": minor
+---
+
+Stabilize the `unstable_flushSync` option for navigations and fetchers

--- a/.changeset/stabilize-view-transitions.md
+++ b/.changeset/stabilize-view-transitions.md
@@ -1,0 +1,7 @@
+---
+"react-router-dom": minor
+"react-router": minor
+"@remix-run/router": minor
+---
+
+Stabilize the `unstable_viewTransition` option for navigations and the corresponding `unstable_useViewTransitionState` hook

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -27,7 +27,7 @@ interface FormProps
   reloadDocument?: boolean;
   replace?: boolean;
   state?: any;
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 }
 ```
 
@@ -281,9 +281,9 @@ If you are using [`<ScrollRestoration>`][scrollrestoration], this lets you preve
 
 See also: [`<Link preventScrollReset>`][link-preventscrollreset]
 
-## `unstable_viewTransition`
+## `viewTransition`
 
-The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+The `viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`useViewTransitionState()`][use-view-transition-state].
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -23,7 +23,7 @@ interface LinkProps
   reloadDocument?: boolean;
   replace?: boolean;
   state?: any;
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 }
 
 type To = string | Partial<Path>;
@@ -171,24 +171,24 @@ let { state } = useLocation();
 
 The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
 
-## `unstable_viewTransition`
+## `viewTransition`
 
-The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`:
+The `viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`:
 
 ```jsx
-<Link to={to} unstable_viewTransition>
+<Link to={to} viewTransition>
   Click me
 </Link>
 ```
 
-If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state] hook (or check out the `transitioning` class and `isTransitioning` render prop in [NavLink][navlink]):
+If you need to apply specific styles for this view transition, you will also need to leverage the [`useViewTransitionState()`][use-view-transition-state] hook (or check out the `transitioning` class and `isTransitioning` render prop in [NavLink][navlink]):
 
 ```jsx
 function ImageLink(to) {
   const isTransitioning =
-    unstable_useViewTransitionState(to);
+    useViewTransitionState(to);
   return (
-    <Link to={to} unstable_viewTransition>
+    <Link to={to} viewTransition>
       <p
         style={{
           viewTransitionName: isTransitioning
@@ -212,7 +212,7 @@ function ImageLink(to) {
 }
 ```
 
-<docs-warning>`unstable_viewTransition` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
+<docs-warning>`viewTransition` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 

--- a/docs/components/nav-link.md
+++ b/docs/components/nav-link.md
@@ -123,9 +123,9 @@ When a `NavLink` is active it will automatically apply `<a aria-current="page">`
 
 The `reloadDocument` property can be used to skip client side routing and let the browser handle the transition normally (as if it were an `<a href>`).
 
-## `unstable_viewTransition`
+## `viewTransition`
 
-The `unstable_viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. By default, during the transition a `transitioning` class will be added to the `<a>` element that you can use to customize the view transition.
+The `viewTransition` prop enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. By default, during the transition a `transitioning` class will be added to the `<a>` element that you can use to customize the view transition.
 
 ```css
 a.transitioning p {
@@ -138,7 +138,7 @@ a.transitioning img {
 ```
 
 ```jsx
-<NavLink to={to} unstable_viewTransition>
+<NavLink to={to} viewTransition>
   <p>Image Number {idx}</p>
   <img src={src} alt={`Img ${idx}`} />
 </NavLink>
@@ -147,7 +147,7 @@ a.transitioning img {
 You may also use the `className`/`style` props or the render props passed to `children` to further customize based on the `isTransitioning` value.
 
 ```jsx
-<NavLink to={to} unstable_viewTransition>
+<NavLink to={to} viewTransition>
   {({ isTransitioning }) => (
     <>
       <p

--- a/docs/hooks/use-fetcher.md
+++ b/docs/hooks/use-fetcher.md
@@ -133,9 +133,9 @@ If you find yourself calling this function inside of click handlers, you can pro
 
 <docs-info>Any `fetcher.load` calls that are active on the page will be re-executed as part of revalidation (either after a navigation submission, another fetcher submission, or a `useRevalidator()` call)</docs-info>
 
-#### `options.unstable_flushSync`
+#### `options.flushSync`
 
-The `unstable_flushSync` option tells React Router DOM to wrap the initial state update for this `fetcher.load` in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
+The `flushSync` option tells React Router DOM to wrap the initial state update for this `fetcher.load` in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 

--- a/docs/hooks/use-navigate.md
+++ b/docs/hooks/use-navigate.md
@@ -20,8 +20,8 @@ interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  unstable_flushSync?: boolean;
-  unstable_viewTransition?: boolean;
+  flushSync?: boolean;
+  viewTransition?: boolean;
 }
 
 type RelativeRoutingType = "route" | "path";
@@ -114,19 +114,19 @@ new URL("..", window.origin + location.pathname + "/");
 // 'https://remix.run/docs/en/main/start/'
 ```
 
-## `options.unstable_flushSync`
+## `options.flushSync`
 
-The `unstable_flushSync` option tells React Router DOM to wrap the initial state update for this navigation in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
+The `flushSync` option tells React Router DOM to wrap the initial state update for this navigation in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
 
-<docs-warning>`unstable_flushSync` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
+<docs-warning>`flushSync` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 
-## `options.unstable_viewTransition`
+## `options.viewTransition`
 
-The `unstable_viewTransition` option enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`unstable_useViewTransitionState()`][use-view-transition-state].
+The `viewTransition` option enables a [View Transition][view-transitions] for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the [`useViewTransitionState()`][use-view-transition-state].
 
-<docs-warning>`unstable_viewTransition` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
+<docs-warning>`viewTransition` only works when using a data router, see [Picking a Router][picking-a-router]</docs-warning>
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 

--- a/docs/hooks/use-submit.md
+++ b/docs/hooks/use-submit.md
@@ -160,11 +160,11 @@ Because submissions are navigations, the options may also contain the other navi
 - `relative`
 - `replace`
 - `state`
-- `unstable_viewTransition`
+- `viewTransition`
 
-### `options.unstable_flushSync`
+### `options.flushSync`
 
-The `unstable_flushSync` option tells React Router DOM to wrap the initial state update for this submission in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
+The `flushSync` option tells React Router DOM to wrap the initial state update for this submission in a [`ReactDOM.flushSync`][flush-sync] call instead of the default [`React.startTransition`][start-transition]. This allows you to perform synchronous DOM actions immediately after the update is flushed to the DOM.
 
 <docs-warning>Please note that this API is marked unstable and may be subject to breaking changes without a major release</docs-warning>
 

--- a/docs/hooks/use-view-transition-state.md
+++ b/docs/hooks/use-view-transition-state.md
@@ -1,14 +1,14 @@
 ---
-title: unstable_useViewTransitionState
+title: useViewTransitionState
 ---
 
-# `unstable_useViewTransitionState`
+# `useViewTransitionState`
 
 <details>
   <summary>Type declaration</summary>
 
 ```tsx
-declare function unstable_useViewTransitionState(
+declare function useViewTransitionState(
   to: To,
   opts: { relative?: "route" : "path" } = {}
 ): boolean;
@@ -24,17 +24,16 @@ interface Path {
 
 </details>
 
-This hook returns `true` when there is an active [View Transition][view-transitions] to the specified location. This can be used to apply finer-grained styles to elements to further customize the view transition. This requires that view transitions have been enabled for the given navigation via the [unstable_viewTransition][link-view-transition] prop on the `Link` (or the `Form`, `navigate`, or `submit` call).
+This hook returns `true` when there is an active [View Transition][view-transitions] to the specified location. This can be used to apply finer-grained styles to elements to further customize the view transition. This requires that view transitions have been enabled for the given navigation via the [viewTransition][link-view-transition] prop on the `Link` (or the `Form`, `navigate`, or `submit` call).
 
 Consider clicking on an image in a list that you need to expand into the hero image on the destination page:
 
 ```jsx
 function NavImage({ src, alt, id }) {
   const to = `/images/${id}`;
-  const isTransitioning =
-    unstable_useViewTransitionState(to);
+  const isTransitioning = useViewTransitionState(to);
   return (
-    <Link to={to} unstable_viewTransition>
+    <Link to={to} viewTransition>
       <img
         src={src}
         alt={alt}
@@ -49,5 +48,5 @@ function NavImage({ src, alt, id }) {
 }
 ```
 
-[link-view-transition]: ../components/link#unstable_viewtransition
+[link-view-transition]: ../components/link#viewtransition
 [view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API

--- a/docs/routers/picking-a-router.md
+++ b/docs/routers/picking-a-router.md
@@ -146,5 +146,5 @@ The following APIs are introduced in React Router 6.4 and will only work when us
 [userouteloaderdata]: ../hooks/use-route-loader-data
 [usesubmit]: ../hooks/use-submit
 [useblocker]: ../hooks/use-blocker
-[viewtransition-link]: ../components/link#unstable_viewtransition
-[viewtransition-navigate]: ../hooks/use-navigate#optionsunstable_viewtransition
+[viewtransition-link]: ../components/link#viewtransition
+[viewtransition-navigate]: ../hooks/use-navigate#optionsviewtransition

--- a/packages/react-router-dom/__tests__/data-browser-router-test.tsx
+++ b/packages/react-router-dom/__tests__/data-browser-router-test.tsx
@@ -7405,13 +7405,13 @@ function testDomRouter(
                 return (
                   <div>
                     <Link to="/a">/a</Link>
-                    <Link to="/b" unstable_viewTransition>
+                    <Link to="/b" viewTransition>
                       /b
                     </Link>
                     <Form action="/c">
                       <button type="submit">/c</button>
                     </Form>
-                    <Form action="/d" unstable_viewTransition>
+                    <Form action="/d" viewTransition>
                       <button type="submit">/d</button>
                     </Form>
                     <Outlet />
@@ -7486,7 +7486,7 @@ function testDomRouter(
               Component() {
                 return (
                   <>
-                    <Link to="/page" unstable_viewTransition>
+                    <Link to="/page" viewTransition>
                       /page
                     </Link>
                     <Outlet />

--- a/packages/react-router-dom/__tests__/flush-sync-navigations-test.tsx
+++ b/packages/react-router-dom/__tests__/flush-sync-navigations-test.tsx
@@ -33,7 +33,7 @@ describe("flushSync", () => {
               <>
                 <h1>About</h1>
                 <button
-                  onClick={() => navigate("/", { unstable_flushSync: true })}
+                  onClick={() => navigate("/", { flushSync: true })}
                 >
                   Go to /
                 </button>
@@ -61,14 +61,14 @@ describe("flushSync", () => {
     expect(spy).toBeCalledTimes(1);
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     fireEvent.click(screen.getByText("Go to /"));
     await waitFor(() => screen.getByText("Home"));
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: true })
+      expect.objectContaining({ flushSync: true })
     );
 
     expect(spy).toBeCalledTimes(2);
@@ -110,7 +110,7 @@ describe("flushSync", () => {
                   onClick={() =>
                     submit(
                       {},
-                      { method: "post", action: "/", unstable_flushSync: true }
+                      { method: "post", action: "/", flushSync: true }
                     )
                   }
                 >
@@ -138,14 +138,14 @@ describe("flushSync", () => {
     fireEvent.click(screen.getByText("Go to /about"));
     await waitFor(() => screen.getByText("About"));
     expect(spy).toBeCalledTimes(2);
-    expect(spy.mock.calls[0][1].unstable_flushSync).toBe(false);
-    expect(spy.mock.calls[1][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[0][1].flushSync).toBe(false);
+    expect(spy.mock.calls[1][1].flushSync).toBe(false);
 
     fireEvent.click(screen.getByText("Go to /"));
     await waitFor(() => screen.getByText("Home"));
     expect(spy).toBeCalledTimes(4);
-    expect(spy.mock.calls[2][1].unstable_flushSync).toBe(true);
-    expect(spy.mock.calls[3][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[2][1].flushSync).toBe(true);
+    expect(spy.mock.calls[3][1].flushSync).toBe(false);
 
     router.dispose();
   });
@@ -167,7 +167,7 @@ describe("flushSync", () => {
                 <pre>{`async:${fetcher1.data}:${fetcher1.state}`}</pre>
                 <button
                   onClick={() =>
-                    fetcher2.load("/fetch", { unstable_flushSync: true })
+                    fetcher2.load("/fetch", { flushSync: true })
                   }
                 >
                   Load sync
@@ -202,14 +202,14 @@ describe("flushSync", () => {
     fireEvent.click(screen.getByText("Load async"));
     await waitFor(() => screen.getByText("async:LOADER:idle"));
     expect(spy).toBeCalledTimes(2);
-    expect(spy.mock.calls[0][1].unstable_flushSync).toBe(false);
-    expect(spy.mock.calls[1][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[0][1].flushSync).toBe(false);
+    expect(spy.mock.calls[1][1].flushSync).toBe(false);
 
     fireEvent.click(screen.getByText("Load sync"));
     await waitFor(() => screen.getByText("sync:LOADER:idle"));
     expect(spy).toBeCalledTimes(4);
-    expect(spy.mock.calls[2][1].unstable_flushSync).toBe(true);
-    expect(spy.mock.calls[3][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[2][1].flushSync).toBe(true);
+    expect(spy.mock.calls[3][1].flushSync).toBe(false);
 
     router.dispose();
   });
@@ -238,7 +238,7 @@ describe("flushSync", () => {
                   onClick={() =>
                     fetcher2.submit(
                       {},
-                      { method: "post", action: "/", unstable_flushSync: true }
+                      { method: "post", action: "/", flushSync: true }
                     )
                   }
                 >
@@ -267,16 +267,16 @@ describe("flushSync", () => {
     fireEvent.click(screen.getByText("Submit async"));
     await waitFor(() => screen.getByText("async:ACTION:idle"));
     expect(spy).toBeCalledTimes(3);
-    expect(spy.mock.calls[0][1].unstable_flushSync).toBe(false);
-    expect(spy.mock.calls[1][1].unstable_flushSync).toBe(false);
-    expect(spy.mock.calls[2][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[0][1].flushSync).toBe(false);
+    expect(spy.mock.calls[1][1].flushSync).toBe(false);
+    expect(spy.mock.calls[2][1].flushSync).toBe(false);
 
     fireEvent.click(screen.getByText("Submit sync"));
     await waitFor(() => screen.getByText("sync:ACTION:idle"));
     expect(spy).toBeCalledTimes(6);
-    expect(spy.mock.calls[3][1].unstable_flushSync).toBe(true);
-    expect(spy.mock.calls[4][1].unstable_flushSync).toBe(false);
-    expect(spy.mock.calls[5][1].unstable_flushSync).toBe(false);
+    expect(spy.mock.calls[3][1].flushSync).toBe(true);
+    expect(spy.mock.calls[4][1].flushSync).toBe(false);
+    expect(spy.mock.calls[5][1].flushSync).toBe(false);
 
     router.dispose();
   });

--- a/packages/react-router-dom/dom.ts
+++ b/packages/react-router-dom/dom.ts
@@ -188,7 +188,7 @@ interface SharedSubmitOptions {
   /**
    * Enable flushSync for this submission's state updates
    */
-  unstable_flushSync?: boolean;
+  flushSync?: boolean;
 }
 
 /**
@@ -225,7 +225,7 @@ export interface SubmitOptions extends FetcherSubmitOptions {
   /**
    * Enable view transitions on this submission navigation
    */
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 }
 
 const supportedFormEncTypes: Set<FormEncType> = new Set([

--- a/packages/react-router-dom/index.tsx
+++ b/packages/react-router-dom/index.tsx
@@ -520,8 +520,8 @@ export function RouterProvider({
       newState: RouterState,
       {
         deletedFetchers,
-        unstable_flushSync: flushSync,
-        unstable_viewTransitionOpts: viewTransitionOpts,
+        flushSync: flushSync,
+        viewTransitionOpts: viewTransitionOpts,
       }
     ) => {
       deletedFetchers.forEach((key) => fetcherData.current.delete(key));
@@ -931,7 +931,7 @@ export interface LinkProps
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   to: To;
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 }
 
 const isBrowser =
@@ -955,7 +955,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       to,
       preventScrollReset,
-      unstable_viewTransition,
+      viewTransition,
       ...rest
     },
     ref
@@ -1005,7 +1005,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       target,
       preventScrollReset,
       relative,
-      unstable_viewTransition,
+      viewTransition,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -1062,7 +1062,7 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       end = false,
       style: styleProp,
       to,
-      unstable_viewTransition,
+      viewTransition,
       children,
       ...rest
     },
@@ -1077,7 +1077,7 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       // Conditional usage is OK here because the usage of a data router is static
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useViewTransitionState(path) &&
-      unstable_viewTransition === true;
+      viewTransition === true;
 
     let toPathname = navigator.encodeLocation
       ? navigator.encodeLocation(path).pathname
@@ -1161,7 +1161,7 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
         ref={ref}
         style={style}
         to={to}
-        unstable_viewTransition={unstable_viewTransition}
+        viewTransition={viewTransition}
       >
         {typeof children === "function" ? children(renderProps) : children}
       </Link>
@@ -1256,7 +1256,7 @@ export interface FormProps extends SharedFormProps {
   /**
    * Enable view transitions on this Form navigation
    */
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 }
 
 type HTMLSubmitEvent = React.BaseSyntheticEvent<
@@ -1286,7 +1286,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
       onSubmit,
       relative,
       preventScrollReset,
-      unstable_viewTransition,
+      viewTransition,
       ...props
     },
     forwardedRef
@@ -1316,7 +1316,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
         state,
         relative,
         preventScrollReset,
-        unstable_viewTransition,
+        viewTransition,
       });
     };
 
@@ -1411,14 +1411,14 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state,
     preventScrollReset,
     relative,
-    unstable_viewTransition,
+    viewTransition,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    unstable_viewTransition?: boolean;
+    viewTransition?: boolean;
   } = {}
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
@@ -1442,7 +1442,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
           state,
           preventScrollReset,
           relative,
-          unstable_viewTransition,
+          viewTransition,
         });
       }
     },
@@ -1456,7 +1456,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       to,
       preventScrollReset,
       relative,
-      unstable_viewTransition,
+      viewTransition,
     ]
   );
 }
@@ -1586,7 +1586,7 @@ export function useSubmit(): SubmitFunction {
           body,
           formMethod: options.method || (method as HTMLFormMethod),
           formEncType: options.encType || (encType as FormEncType),
-          unstable_flushSync: options.unstable_flushSync,
+          flushSync: options.flushSync,
         });
       } else {
         router.navigate(options.action || action, {
@@ -1598,8 +1598,8 @@ export function useSubmit(): SubmitFunction {
           replace: options.replace,
           state: options.state,
           fromRouteId: currentRouteId,
-          unstable_flushSync: options.unstable_flushSync,
-          unstable_viewTransition: options.unstable_viewTransition,
+          flushSync: options.flushSync,
+          viewTransition: options.viewTransition,
         });
       }
     },
@@ -1664,7 +1664,7 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
     FetcherFormProps & React.RefAttributes<HTMLFormElement>
   >;
   submit: FetcherSubmitFunction;
-  load: (href: string, opts?: { unstable_flushSync?: boolean }) => void;
+  load: (href: string, opts?: { flushSync?: boolean }) => void;
 };
 
 // TODO: (v7) Change the useFetcher generic default from `any` to `unknown`
@@ -1714,7 +1714,7 @@ export function useFetcher<TData = any>({
 
   // Fetcher additions
   let load = React.useCallback(
-    (href: string, opts?: { unstable_flushSync?: boolean }) => {
+    (href: string, opts?: { flushSync?: boolean }) => {
       invariant(routeId, "No routeId available for fetcher.load()");
       router.fetch(fetcherKey, routeId, href, opts);
     },
@@ -2007,7 +2007,7 @@ function useViewTransitionState(
 
   invariant(
     vtContext != null,
-    "`unstable_useViewTransitionState` must be used within `react-router-dom`'s `RouterProvider`.  " +
+    "`useViewTransitionState` must be used within `react-router-dom`'s `RouterProvider`.  " +
       "Did you accidentally import `RouterProvider` from `react-router`?"
   );
 
@@ -2030,11 +2030,11 @@ function useViewTransitionState(
   // destination.  This ensures that other PUSH navigations that reverse
   // an indicated transition apply.  I.e., on the list view you have:
   //
-  //   <NavLink to="/details/1" unstable_viewTransition>
+  //   <NavLink to="/details/1" viewTransition>
   //
   // If you click the breadcrumb back to the list view:
   //
-  //   <NavLink to="/list" unstable_viewTransition>
+  //   <NavLink to="/list" viewTransition>
   //
   // We should apply the transition because it's indicated as active going
   // from /list -> /details/1 and therefore should be active on the reverse
@@ -2045,6 +2045,6 @@ function useViewTransitionState(
   );
 }
 
-export { useViewTransitionState as unstable_useViewTransitionState };
+export { useViewTransitionState as useViewTransitionState };
 
 //#endregion

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -101,8 +101,8 @@ export interface NavigateOptions {
   state?: any;
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  unstable_flushSync?: boolean;
-  unstable_viewTransition?: boolean;
+  flushSync?: boolean;
+  viewTransition?: boolean;
 }
 
 /**

--- a/packages/router/__tests__/flush-sync-test.ts
+++ b/packages/router/__tests__/flush-sync-test.ts
@@ -19,23 +19,23 @@ describe("flushSync", () => {
     let A = await t.navigate("/a");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
     await A.loaders.a.resolve("A");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
-    let B = await t.navigate("/b", { unstable_flushSync: true });
+    let B = await t.navigate("/b", { flushSync: true });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: true })
+      expect.objectContaining({ flushSync: true })
     );
     await B.loaders.b.resolve("B");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     unsubscribe();
@@ -59,27 +59,27 @@ describe("flushSync", () => {
     });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
     await A.actions.a.resolve("A");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     let B = await t.navigate("/b", {
       formMethod: "post",
       formData: createFormData({}),
-      unstable_flushSync: true,
+      flushSync: true,
     });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: true })
+      expect.objectContaining({ flushSync: true })
     );
     await B.actions.b.resolve("B");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     unsubscribe();
@@ -97,17 +97,17 @@ describe("flushSync", () => {
     let A = await t.fetch("/", key);
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
     expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
 
     await A.loaders.root.resolve("ROOT");
     expect(t.router.state.fetchers.get(key)?.data).toBe("ROOT");
 
-    let B = await t.fetch("/", key, { unstable_flushSync: true });
+    let B = await t.fetch("/", key, { flushSync: true });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: true })
+      expect.objectContaining({ flushSync: true })
     );
     expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
 
@@ -115,7 +115,7 @@ describe("flushSync", () => {
     expect(t.router.state.fetchers.get(key)?.data).toBe("ROOT2");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     unsubscribe();
@@ -136,25 +136,25 @@ describe("flushSync", () => {
     });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
     expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
 
     await A.actions.root.resolve("ROOT");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
     expect(t.router.state.fetchers.get(key)?.data).toBe("ROOT");
 
     let B = await t.fetch("/", key, {
       formMethod: "post",
       formData: createFormData({}),
-      unstable_flushSync: true,
+      flushSync: true,
     });
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: true })
+      expect.objectContaining({ flushSync: true })
     );
     expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
 
@@ -162,7 +162,7 @@ describe("flushSync", () => {
     expect(t.router.state.fetchers.get(key)?.data).toBe("ROOT2");
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
-      expect.objectContaining({ unstable_flushSync: false })
+      expect.objectContaining({ flushSync: false })
     );
 
     unsubscribe();

--- a/packages/router/__tests__/view-transition-test.ts
+++ b/packages/router/__tests__/view-transition-test.ts
@@ -20,18 +20,18 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/a" }),
       }),
-      expect.objectContaining({ unstable_viewTransitionOpts: undefined })
+      expect.objectContaining({ viewTransitionOpts: undefined })
     );
 
     // PUSH /a -> /b - w/ transition
-    t.navigate("/b", { unstable_viewTransition: true });
+    t.navigate("/b", { viewTransition: true });
     expect(spy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/b" }),
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: {
+        viewTransitionOpts: {
           currentLocation: expect.objectContaining({ pathname: "/a" }),
           nextLocation: expect.objectContaining({ pathname: "/b" }),
         },
@@ -46,7 +46,7 @@ describe("view transitions", () => {
         location: expect.objectContaining({ pathname: "/a" }),
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: {
+        viewTransitionOpts: {
           // Args reversed on POP so same hooks apply
           currentLocation: expect.objectContaining({ pathname: "/a" }),
           nextLocation: expect.objectContaining({ pathname: "/b" }),
@@ -61,7 +61,7 @@ describe("view transitions", () => {
         navigation: IDLE_NAVIGATION,
         location: expect.objectContaining({ pathname: "/" }),
       }),
-      expect.objectContaining({ unstable_viewTransitionOpts: undefined })
+      expect.objectContaining({ viewTransitionOpts: undefined })
     );
 
     unsubscribe();
@@ -75,13 +75,13 @@ describe("view transitions", () => {
     let spy = jest.fn();
     let unsubscribe = t.router.subscribe(spy);
 
-    let A = await t.navigate("/a", { unstable_viewTransition: true });
+    let A = await t.navigate("/a", { viewTransition: true });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0]).toEqual([
       expect.objectContaining({
         navigation: expect.objectContaining({ state: "loading" }),
       }),
-      expect.objectContaining({ unstable_viewTransitionOpts: undefined }),
+      expect.objectContaining({ viewTransitionOpts: undefined }),
     ]);
     expect(A.loaders.a.stub).toHaveBeenCalledTimes(1);
 
@@ -93,7 +93,7 @@ describe("view transitions", () => {
         revalidation: "loading",
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: undefined,
+        viewTransitionOpts: undefined,
       }),
     ]);
     expect(spy.mock.calls[2]).toEqual([
@@ -101,7 +101,7 @@ describe("view transitions", () => {
         navigation: expect.objectContaining({ state: "loading" }),
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: undefined,
+        viewTransitionOpts: undefined,
       }),
     ]);
     expect(spy).toHaveBeenLastCalledWith(
@@ -109,7 +109,7 @@ describe("view transitions", () => {
         navigation: expect.objectContaining({ state: "loading" }),
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: undefined,
+        viewTransitionOpts: undefined,
       })
     );
     expect(B.loaders.a.stub).toHaveBeenCalledTimes(1);
@@ -127,7 +127,7 @@ describe("view transitions", () => {
         },
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: {
+        viewTransitionOpts: {
           currentLocation: expect.objectContaining({ pathname: "/" }),
           nextLocation: expect.objectContaining({ pathname: "/a" }),
         },
@@ -152,7 +152,7 @@ describe("view transitions", () => {
     let A = await t.navigate("/a", {
       formMethod: "post",
       formData: createFormData({}),
-      unstable_viewTransition: true,
+      viewTransition: true,
     });
 
     await A.actions.a.redirect("/b");
@@ -162,7 +162,7 @@ describe("view transitions", () => {
         location: expect.objectContaining({ pathname: "/b" }),
       }),
       expect.objectContaining({
-        unstable_viewTransitionOpts: {
+        viewTransitionOpts: {
           currentLocation: expect.objectContaining({ pathname: "/" }),
           nextLocation: expect.objectContaining({ pathname: "/b" }),
         },

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -448,8 +448,8 @@ export interface RouterSubscriber {
     state: RouterState,
     opts: {
       deletedFetchers: string[];
-      unstable_viewTransitionOpts?: ViewTransitionOpts;
-      unstable_flushSync: boolean;
+      viewTransitionOpts?: ViewTransitionOpts;
+      flushSync: boolean;
     }
   ): void;
 }
@@ -475,7 +475,7 @@ export type RelativeRoutingType = "route" | "path";
 type BaseNavigateOrFetchOptions = {
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
-  unstable_flushSync?: boolean;
+  flushSync?: boolean;
 };
 
 // Only allowed for navigations
@@ -483,7 +483,7 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
   replace?: boolean;
   state?: any;
   fromRouteId?: string;
-  unstable_viewTransition?: boolean;
+  viewTransition?: boolean;
 };
 
 // Only allowed for submission navigations
@@ -1183,8 +1183,8 @@ export function createRouter(init: RouterInit): Router {
     [...subscribers].forEach((subscriber) =>
       subscriber(state, {
         deletedFetchers: deletedFetchersKeys,
-        unstable_viewTransitionOpts: opts.viewTransitionOpts,
-        unstable_flushSync: opts.flushSync === true,
+        viewTransitionOpts: opts.viewTransitionOpts,
+        flushSync: opts.flushSync === true,
       })
     );
 
@@ -1407,7 +1407,7 @@ export function createRouter(init: RouterInit): Router {
         ? opts.preventScrollReset === true
         : undefined;
 
-    let flushSync = (opts && opts.unstable_flushSync) === true;
+    let flushSync = (opts && opts.flushSync) === true;
 
     let blockerKey = shouldBlockNavigation({
       currentLocation,
@@ -1446,7 +1446,7 @@ export function createRouter(init: RouterInit): Router {
       pendingError: error,
       preventScrollReset,
       replace: opts && opts.replace,
-      enableViewTransition: opts && opts.unstable_viewTransition,
+      enableViewTransition: opts && opts.viewTransition,
       flushSync,
     });
   }
@@ -2140,7 +2140,7 @@ export function createRouter(init: RouterInit): Router {
     }
 
     if (fetchControllers.has(key)) abortFetcher(key);
-    let flushSync = (opts && opts.unstable_flushSync) === true;
+    let flushSync = (opts && opts.flushSync) === true;
 
     let routesToUse = inFlightDataRoutes || dataRoutes;
     let normalizedPath = normalizeTo(


### PR DESCRIPTION
For replaying in v7:

```
for F in $(find . -type f -not -path "./node_modules/*" -not -path "./.git/*" -not -path "./examples/*" -not -path "./.changeset/*" -not -name "CHANGELOG.md" -not -name "*.png" -not -name "*.jpeg" -not -name "*.ico"); do
  sed -i '' 's/unstable_viewTransition/viewTransition/g' $F;  
  sed -i '' 's/unstable_useViewTransition/useViewTransition/g' $F;  
  sed -i '' 's/unstable_flushSync/flushSync/g' $F;  
done
```