### PR TITLE
Add support for prerender:true

### DIFF
--- a/.github/workflows/shared-integration.yml
+++ b/.github/workflows/shared-integration.yml
@@ -59,3 +59,4 @@ jobs:
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: "pnpm test:integration --project=${{ matrix.browser }}"
+        timeout-minutes: 40

--- a/docs/guides/prerendering.md
+++ b/docs/guides/prerendering.md
@@ -34,7 +34,7 @@ export default defineConfig({
 });
 ```
 
-Alternatively, you can tell React Router specifically which paths to pre-render:
+If you need to prerender paths with dynamic/splat parameters, or you only want to prerender a subset of your static paths, you can provide an array of paths:
 
 ```ts filename=vite.config.ts
 import { reactRouter } from "@react-router/dev/vite";

--- a/docs/guides/prerendering.md
+++ b/docs/guides/prerendering.md
@@ -17,7 +17,24 @@ This is still something that could be done entirely in userland, but it's be so 
 
 ## Configuration
 
-To enable pre-rendering, add the `prerender` option to your React Router Vite plugin to tell React Router which paths to pre-render:
+To enable pre-rendering, add the `prerender` option to your React Router Vite plugin to enable prerendering.
+
+In the simplest use-case, `prerender: true` will prerender all static routes defined in your application (excluding any paths that contain dynamic or splat params):
+
+```ts filename=vite.config.ts
+import { reactRouter } from "@react-router/dev/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    reactRouter({
+      prerender: true,
+    }),
+  ],
+});
+```
+
+Alternatively, you can tell React Router specifically which paths to pre-render:
 
 ```ts filename=vite.config.ts
 import { reactRouter } from "@react-router/dev/vite";
@@ -32,7 +49,7 @@ export default defineConfig({
 });
 ```
 
-`prerender` can also be a function, which allows you to dynamically generate the paths -- after fetching blog posts from your CMS for example:
+`prerender` can also be a function, which allows you to dynamically generate the paths -- after fetching blog posts from your CMS for example. This function receives a single argument with a `getStaticPaths` function that you can call to retrieve all static paths defined in your application.
 
 ```ts filename=vite.config.ts
 import { reactRouter } from "@react-router/dev/vite";
@@ -41,9 +58,12 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     reactRouter({
-      async prerender() {
+      async prerender({ getStaticPaths }) {
         let slugs = await getSlugsFromCms();
-        return ["/", ...slugs.map((s) => `/blog/${s}`)];
+        return [
+          ...getStaticPaths(),
+          ...slugs.map((s) => `/blog/${s}`),
+        ];
       },
     }),
   ],

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -127,7 +127,7 @@ function listAllFiles(_dir: string) {
   recurse(_dir);
 
   // Normalize *nix/windows paths
-  return files.map((f) => path.relative(_dir, f).replace("\\", "/"));
+  return files.map((f) => path.relative(_dir, f).replace("\\\\", "/"));
 }
 
 test.describe("Prerendering", () => {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -113,7 +113,7 @@ function listAllFiles(_dir: string) {
 
   function recurse(dir: string) {
     fs.readdirSync(dir).forEach((file) => {
-      const absolute = path.join(dir, file);
+      const absolute = path.join(dir, file.replace(path.sep, ""));
       if (fs.statSync(absolute).isDirectory()) {
         if (![".vite", "assets"].includes(file)) {
           return recurse(absolute);
@@ -127,7 +127,7 @@ function listAllFiles(_dir: string) {
   recurse(_dir);
 
   // Normalize *nix/windows paths
-  return files.map((f) => path.relative(_dir, f).replace("\\\\", "/"));
+  return files.map((f) => path.relative(_dir, f).replace("\\", "/"));
 }
 
 test.describe("Prerendering", () => {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -113,12 +113,13 @@ function listAllFiles(_dir: string) {
 
   function recurse(dir: string) {
     fs.readdirSync(dir).forEach((file) => {
-      const absolute = path.join(dir, file.replace(path.sep, ""));
+      const absolute = dir + "/" + file;
       if (fs.statSync(absolute).isDirectory()) {
         if (![".vite", "assets"].includes(file)) {
           return recurse(absolute);
         }
       } else {
+        console.log({ dir, file, absolute });
         return files.push(absolute);
       }
     });
@@ -127,7 +128,15 @@ function listAllFiles(_dir: string) {
   recurse(_dir);
 
   // Normalize *nix/windows paths
-  return files.map((f) => path.relative(_dir, f).replace("\\", "/"));
+  return files.map((f) => {
+    console.log({
+      dir: _dir,
+      f,
+      relative: path.relative(_dir, f),
+      result: path.relative(_dir, f).replace("\\", "/"),
+    });
+    return path.relative(_dir, f).replace("\\", "/");
+  });
 }
 
 test.describe("Prerendering", () => {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -19,7 +19,7 @@ let files = {
       build: { manifest: true },
       plugins: [
         reactRouter({
-          prerender: ['/', '/about'],
+          prerender: true,
         })
       ],
     });
@@ -108,6 +108,26 @@ let files = {
   `,
 };
 
+function listAllFiles(_dir: string) {
+  let files: string[] = [];
+
+  function recurse(dir: string) {
+    fs.readdirSync(dir).forEach((file) => {
+      const absolute = path.join(dir, file);
+      if (fs.statSync(absolute).isDirectory()) {
+        if (![".vite", "assets"].includes(file)) {
+          return recurse(absolute);
+        }
+      } else {
+        return files.push(absolute);
+      }
+    });
+  }
+
+  recurse(_dir);
+  return files.map((f) => f.replace(_dir + "/", ""));
+}
+
 test.describe("Prerendering", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
@@ -116,24 +136,57 @@ test.describe("Prerendering", () => {
     appFixture.close();
   });
 
-  test("Prerenders a static array of routes", async () => {
+  test("Prerenders known static routes when true is specified", async () => {
     fixture = await createFixture({
-      files,
+      files: {
+        ...files,
+        "app/routes/parent.tsx": js`
+          import { Outlet } from 'react-router'
+          export default function Component() {
+            return <Outlet/>
+          }
+        `,
+        "app/routes/parent.child.tsx": js`
+          import { Outlet } from 'react-router'
+          export function loader() {
+            return null;
+          }
+          export default function Component() {
+            return <Outlet/>
+          }
+        `,
+        "app/routes/$slug.tsx": js`
+          import { Outlet } from 'react-router'
+          export function loader() {
+            return null;
+          }
+          export default function Component() {
+            return <Outlet/>
+          }
+        `,
+        "app/routes/$.tsx": js`
+          import { Outlet } from 'react-router'
+          export function loader() {
+            return null;
+          }
+          export default function Component() {
+            return <Outlet/>
+          }
+        `,
+      },
     });
     appFixture = await createAppFixture(fixture);
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
-    expect(fs.readdirSync(clientDir).sort()).toEqual([
-      ".vite",
+    expect(listAllFiles(clientDir).sort()).toEqual([
       "_root.data",
-      "about",
       "about.data",
-      "assets",
+      "about/index.html",
       "favicon.ico",
       "index.html",
-    ]);
-    expect(fs.readdirSync(path.join(clientDir, "about"))).toEqual([
-      "index.html",
+      "parent/child.data",
+      "parent/child/index.html",
+      "parent/index.html",
     ]);
 
     let res = await fixture.requestDocument("/");
@@ -151,7 +204,7 @@ test.describe("Prerendering", () => {
     expect(html).toMatch('<p data-loader-data="true">About Loader Data</p>');
   });
 
-  test("Prerenders a dynamic array of routes", async () => {
+  test("Prerenders a static array of routes", async () => {
     fixture = await createFixture({
       files: {
         ...files,
@@ -176,16 +229,70 @@ test.describe("Prerendering", () => {
     appFixture = await createAppFixture(fixture);
 
     let clientDir = path.join(fixture.projectDir, "build", "client");
-    expect(fs.readdirSync(clientDir).sort()).toEqual([
-      ".vite",
+    expect(listAllFiles(clientDir).sort()).toEqual([
       "_root.data",
-      "about",
       "about.data",
-      "assets",
+      "about/index.html",
       "favicon.ico",
       "index.html",
     ]);
-    expect(fs.readdirSync(path.join(clientDir, "about"))).toEqual([
+
+    let res = await fixture.requestDocument("/");
+    let html = await res.text();
+    expect(html).toMatch("<title>Index Title: Index Loader Data</title>");
+    expect(html).toMatch("<h1>Root</h1>");
+    expect(html).toMatch('<h2 data-route="true">Index</h2>');
+    expect(html).toMatch('<p data-loader-data="true">Index Loader Data</p>');
+
+    res = await fixture.requestDocument("/about");
+    html = await res.text();
+    expect(html).toMatch("<title>About Title: About Loader Data</title>");
+    expect(html).toMatch("<h1>Root</h1>");
+    expect(html).toMatch('<h2 data-route="true">About</h2>');
+    expect(html).toMatch('<p data-loader-data="true">About Loader Data</p>');
+  });
+
+  test("Prerenders a dynamic array of routes based on the static routes", async () => {
+    fixture = await createFixture({
+      files: {
+        ...files,
+        "vite.config.ts": js`
+          import { defineConfig } from "vite";
+          import { reactRouter } from "@react-router/dev/vite";
+
+          export default defineConfig({
+            build: { manifest: true },
+            plugins: [
+              reactRouter({
+                async prerender({ getStaticPaths }) {
+                  return [...getStaticPaths(), "/a", "/b"];
+                },
+              })
+            ],
+          });
+        `,
+        "app/routes/$slug.tsx": js`
+          export function loader() {
+            return null
+          }
+          export default function component() {
+            return null;
+          }
+        `,
+      },
+    });
+    appFixture = await createAppFixture(fixture);
+
+    let clientDir = path.join(fixture.projectDir, "build", "client");
+    expect(listAllFiles(clientDir).sort()).toEqual([
+      "_root.data",
+      "a.data",
+      "a/index.html",
+      "about.data",
+      "about/index.html",
+      "b.data",
+      "b/index.html",
+      "favicon.ico",
       "index.html",
     ]);
 
@@ -230,6 +337,20 @@ test.describe("Prerendering", () => {
     fixture = await createFixture({
       files: {
         ...files,
+        "vite.config.ts": js`
+          import { defineConfig } from "vite";
+          import { reactRouter } from "@react-router/dev/vite";
+
+          export default defineConfig({
+            build: { manifest: true },
+            plugins: [
+              reactRouter({
+                // Don't prerender the /not-prerendered route
+                prerender: ["/", "/about"],
+              })
+            ],
+          });
+        `,
         "app/routes/about.tsx": js`
           import { useLoaderData } from 'react-router';
           export function loader({ request }) {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -125,7 +125,9 @@ function listAllFiles(_dir: string) {
   }
 
   recurse(_dir);
-  return files.map((f) => f.replace(_dir + "/", ""));
+
+  // Normalize *nix/windows paths
+  return files.map((f) => path.relative(_dir, f).replace("\\", "/"));
 }
 
 test.describe("Prerendering", () => {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -133,10 +133,10 @@ function listAllFiles(_dir: string) {
       dir: _dir,
       f,
       relative: path.relative(_dir, f),
-      relative2: f.replace(_dir, ""),
+      relative2: f.replace(_dir, "").replace(/^\\/, ""),
       result: path.relative(_dir, f).replace("\\", "/"),
     });
-    return f.replace(_dir, "");
+    return f.replace(_dir, "").replace(/^\\/, "");
   });
 }
 

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -113,6 +113,7 @@ function listAllFiles(_dir: string) {
 
   function recurse(dir: string) {
     fs.readdirSync(dir).forEach((file) => {
+      // Join with posix separator for consistency
       const absolute = dir + "/" + file;
       if (fs.statSync(absolute).isDirectory()) {
         if (![".vite", "assets"].includes(file)) {

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -133,9 +133,10 @@ function listAllFiles(_dir: string) {
       dir: _dir,
       f,
       relative: path.relative(_dir, f),
+      relative2: f.replace(_dir, ""),
       result: path.relative(_dir, f).replace("\\", "/"),
     });
-    return path.relative(_dir, f).replace("\\", "/");
+    return f.replace(_dir, "");
   });
 }
 

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -119,7 +119,6 @@ function listAllFiles(_dir: string) {
           return recurse(absolute);
         }
       } else {
-        console.log({ dir, file, absolute });
         return files.push(absolute);
       }
     });
@@ -128,16 +127,7 @@ function listAllFiles(_dir: string) {
   recurse(_dir);
 
   // Normalize *nix/windows paths
-  return files.map((f) => {
-    console.log({
-      dir: _dir,
-      f,
-      relative: path.relative(_dir, f),
-      relative2: f.replace(_dir, "").replace(/^\\/, ""),
-      result: path.relative(_dir, f).replace("\\", "/"),
-    });
-    return f.replace(_dir, "").replace(/^\\/, "");
-  });
+  return files.map((f) => f.replace(_dir, "").replace(/^\//, ""));
 }
 
 test.describe("Prerendering", () => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pretest:integration": "pnpm build",
     "test:integration": "pnpm playwright:integration",
     "posttest:integration": "pnpm clean:integration",
-    "playwright:integration": "playwright test --config ./integration/playwright.config.ts prerender",
+    "playwright:integration": "playwright test --config ./integration/playwright.config.ts",
     "changeset": "changeset",
     "changeset:version": "changeset version && node ./scripts/remove-prerelease-changelogs.mjs",
     "publish": "node scripts/publish.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pretest:integration": "pnpm build",
     "test:integration": "pnpm playwright:integration",
     "posttest:integration": "pnpm clean:integration",
-    "playwright:integration": "playwright test --config ./integration/playwright.config.ts",
+    "playwright:integration": "playwright test --config ./integration/playwright.config.ts prerender",
     "changeset": "changeset",
     "changeset:version": "changeset version && node ./scripts/remove-prerelease-changelogs.mjs",
     "publish": "node scripts/publish.js",

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -364,6 +364,7 @@ export async function resolveReactRouterConfig({
   }
 
   let isValidPrerenderConfig =
+    prerender == null ||
     typeof prerender === "boolean" ||
     Array.isArray(prerender) ||
     typeof prerender === "function";

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -125,7 +125,12 @@ export type ReactRouterConfig = {
    * An array of URLs to prerender to HTML files at build time.  Can also be a
    * function returning an array to dynamically generate URLs.
    */
-  prerender?: Array<string> | (() => Array<string> | Promise<Array<string>>);
+  prerender?:
+    | boolean
+    | Array<string>
+    | ((args: {
+        getStaticPaths: () => string[];
+      }) => Array<string> | Promise<Array<string>>);
   /**
    * An array of React Router plugin config presets to ease integration with
    * other platforms and tools.
@@ -174,9 +179,10 @@ export type ResolvedReactRouterConfig = Readonly<{
    */
   future: FutureConfig;
   /**
-   * An array of URLs to prerender to HTML files at build time.
+   * An array of URLs to prerender to HTML files at build time.  Can also be a
+   * function returning an array to dynamically generate URLs.
    */
-  prerender: Array<string> | null;
+  prerender: ReactRouterConfig["prerender"];
   /**
    * An object of all available routes, keyed by route id.
    */
@@ -335,7 +341,7 @@ export async function resolveReactRouterConfig({
     basename,
     buildDirectory: userBuildDirectory,
     buildEnd,
-    prerender: prerenderConfig,
+    prerender,
     serverBuildFile,
     serverBundles,
     serverModuleFormat,
@@ -357,21 +363,19 @@ export async function resolveReactRouterConfig({
     serverBundles = undefined;
   }
 
-  let prerender: Array<string> | null = null;
-  if (prerenderConfig) {
-    if (Array.isArray(prerenderConfig)) {
-      prerender = prerenderConfig;
-    } else if (typeof prerenderConfig === "function") {
-      prerender = await prerenderConfig();
-    } else {
-      logger.error(
-        colors.red(
-          "The `prerender` config must be an array of string paths, or a function " +
-            "returning an array of string paths"
-        )
-      );
-      process.exit(1);
-    }
+  let isValidPrerenderConfig =
+    typeof prerender === "boolean" ||
+    Array.isArray(prerender) ||
+    typeof prerender === "function";
+
+  if (!isValidPrerenderConfig) {
+    logger.error(
+      colors.red(
+        "The `prerender` config must be a boolean, an array of string paths, " +
+          "or a function returning a boolean or array of string paths"
+      )
+    );
+    process.exit(1);
   }
 
   let appDirectory = path.resolve(rootDirectory, userAppDirectory || "app");

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1227,7 +1227,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
             );
           }
 
-          if (ctx.reactRouterConfig.prerender != null) {
+          if (
+            ctx.reactRouterConfig.prerender != null &&
+            ctx.reactRouterConfig.prerender !== false
+          ) {
             // If we have prerender routes, that takes precedence over SPA mode
             // which is ssr:false and only the rot route being rendered
             await handlePrerender(
@@ -1834,7 +1837,22 @@ async function handlePrerender(
   );
 
   let routes = createPrerenderRoutes(build.routes);
-  let routesToPrerender = reactRouterConfig.prerender || ["/"];
+  let routesToPrerender: string[];
+  if (typeof reactRouterConfig.prerender === "boolean") {
+    invariant(reactRouterConfig.prerender, "Expected prerender:true");
+    routesToPrerender = determineStaticPrerenderRoutes(
+      routes,
+      viteConfig,
+      true
+    );
+  } else if (typeof reactRouterConfig.prerender === "function") {
+    routesToPrerender = await reactRouterConfig.prerender({
+      getStaticPaths: () =>
+        determineStaticPrerenderRoutes(routes, viteConfig, false),
+    });
+  } else {
+    routesToPrerender = reactRouterConfig.prerender || ["/"];
+  }
   let requestInit = {
     headers: {
       // Header that can be used in the loader to know if you're running at
@@ -1862,6 +1880,47 @@ async function handlePrerender(
       viteConfig,
       requestInit
     );
+  }
+
+  function determineStaticPrerenderRoutes(
+    routes: DataRouteObject[],
+    viteConfig: Vite.ResolvedConfig,
+    isBooleanUsage = false
+  ): string[] {
+    // Always start with the root/index route included
+    let paths: string[] = ["/"];
+    let paramRoutes: string[] = [];
+
+    // Then recursively add any new path defined by the tree
+    function recurse(subtree: typeof routes, prefix = "") {
+      for (let route of subtree) {
+        let newPath = [prefix, route.path].join("/").replace(/\/\/+/g, "/");
+        if (route.path) {
+          let segments = route.path.split("/");
+          if (segments.some((s) => s.startsWith(":") || s === "*")) {
+            paramRoutes.push(route.path);
+          } else {
+            paths.push(newPath);
+          }
+        }
+        if (route.children) {
+          recurse(route.children, newPath);
+        }
+      }
+    }
+    recurse(routes);
+
+    if (paramRoutes) {
+      viteConfig.logger.warn(
+        "The follwing paths were not pre-rendered because Dynamic Param and Splat " +
+          "routes are not prerendered when using `prerender:true`. You may want to " +
+          "consider using the `1prerender()` API if you wish to prerender slug and " +
+          "splat routes."
+      );
+    }
+
+    // Clean double slashes and remove trailing slashes
+    return paths.map((p) => p.replace(/\/\/+/g, "/").replace(/(.+)\/$/, "$1"));
   }
 
   async function prerenderData(


### PR DESCRIPTION
In simple "true static" sites, React Router can determine all of the static paths so there's no reason to require the app to tell us about the static paths via an array/function.  This PR adds support for `prerender: true` which will walk your route tree and automatically prerender any paths that don't have dynamic/splat params.

We also expose this internal logic to the function API so you can just add your own dynamic paths on top of the known static paths:

```js
export default defineConfig({
  plugins: [
    reactRouter({
      async prerender({ getStaticPaths }) {
        let slugs = await getBlogSlugsFromCms();
        return [
          ...getStaticPaths(),
          ...slugs.map((s) => `/blog/${s}`),
        ];
      },
    }),
  ],
});
```

In a `routes.ts` landscape this will be nice to avoid needing to add a route in 3 places - FS, `routes.ts`, `prerender`