### PR TITLE
Typesafety: Fix vite-node resolution in TS plugin

### DIFF
--- a/packages/react-router-dev/typescript/typegen.ts
+++ b/packages/react-router-dev/typescript/typegen.ts
@@ -34,7 +34,9 @@ export async function watch(ctx: Context) {
   const appDirectory = Path.normalize(ctx.appDirectory);
   const routesTsPath = Path.join(appDirectory, "routes.ts");
 
-  const routesViteNodeContext = await ViteNode.createContext();
+  const routesViteNodeContext = await ViteNode.createContext({
+    root: ctx.rootDirectory,
+  });
   async function getRoutes(): Promise<RouteManifest> {
     routesViteNodeContext.devServer.moduleGraph.invalidateAll();
     routesViteNodeContext.runner.moduleCache.clear();


### PR DESCRIPTION
Note, this is a PR to https://github.com/remix-run/react-router/pull/12019.

Within the context of the TS plugin running within my editor, the root directory of the vite-node server was `"/"` rather than the project directory.

It looks like this is because it was defaulting to the current working directory, which is different in a TS plugin context compared to regular Vite / CLI usage. If I log `process.cwd()` within the TS plugin, I get `"/"`.

The fix was to explicitly pass our resolved root directory to vite-node rather than relying on cwd by default.