### PR TITLE
fix:Grammatical error

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -184,7 +184,7 @@
 - mcansh
 - MeatSim
 - MenouerBetty
-- Mtende-Kuyokwa
+- mtendekuyokwa19
 - mfijas
 - MichaelDeBoey
 - michal-antczak

--- a/contributors.yml
+++ b/contributors.yml
@@ -184,6 +184,7 @@
 - mcansh
 - MeatSim
 - MenouerBetty
+- Mtende-Kuyokwa
 - mfijas
 - MichaelDeBoey
 - michal-antczak

--- a/docs/start/tutorial.md
+++ b/docs/start/tutorial.md
@@ -91,7 +91,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ```
 
-This first route is what we often call the "root route" since the rest of our routes will render inside of it. It will serve as the root layout of the UI, we'll have nested layouts as we get farther along.
+This first route is what we often call the "root route" since the rest of our routes will render inside of it. It will serve as the root layout of the UI, we'll have nested layouts as we get further along.
 
 ## The Root Route
 


### PR DESCRIPTION
The sentence said "farther along" instead of "further along" which is grammatically wrong.

The docs have a grammatical error. It says "farther along" instead of "further along" This is grammatically incorrect.
A reference for extra support is here [here](https://www.dictionary.com/e/farther-vs-further/#:~:text=The%20widely%20accepted%20rule%20is%20to%20use%20farther%20when%20being%20literal%20and%20discussing%20a%20physical%20distance%2C%20as%20in%20%E2%80%9CHe%20went%20farther%20down%20the%20road.%E2%80%9D%C2%A0Further%20is%20used%20when%20discussing%20a%20more%20symbolic%20distance%20or%20to%20discuss%20a%20degree%20or%20extent%2C%20as%20in%C2%A0%E2%80%9CI%20wanted%20to%20discuss%20it%20further%2C%20but%20we%20didn%E2%80%99t%20have%20time.%E2%80%9D) .

[This](https://reactrouter.com/en/main/start/tutorial#:~:text=we%27ll%20have%20nested%20layouts%20as%20we%20get%20farther%20along.) is the docs error. 