### PR TITLE
docs(start/overview): add `Search Params` section

### DIFF
--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -697,7 +697,7 @@ When you get better at React Router, you get better at the web platform.
 
 ## Search Params
 
-React Router can read and modify the [query string][querystring]. This process is handeled with [`URLSearchParams`][urlsearchparams]. We often get and set the Search Params using `useSearchParams`.
+React Router can read and modify the [query string][querystring]. You can set the search params using `useSearchParams`, which returns [`URLSearchParams`][urlsearchparams] and a setter function.
 
 ```jsx lines=[2,5,8]
 function App() {
@@ -719,7 +719,7 @@ function App() {
 }
 ```
 
-You can also use `Link` or `useNavigate` to change the Search Params.
+You can also use `Link` or `useNavigate` to change the search params.
 
 ```jsx lines=[3,9,16]
 function App() {

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -697,7 +697,31 @@ When you get better at React Router, you get better at the web platform.
 
 ## Search Params
 
-<docs-info>TODO:</docs-info>
+React Router can read and modify the [query string][querystring]. This process is handeled with [`URLSearchParams`][urlsearchparams].
+
+```jsx lines=[2,5,8]
+function App() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // access a specific param
+  const query = searchParams.get("q") || "";
+
+  function handleClick() {
+    setSearchParams({ q: "example" });
+  }
+
+  return (
+    <>
+      <p>The value of the search param with key q is: {query}</p>
+      <button onClick={handleClick}>Change search params</button>
+    </>
+  );
+}
+```
+
+See:
+
+- [`useSearchParams`][usesearchparams]
 
 ## Location State
 
@@ -733,3 +757,5 @@ When you get better at React Router, you get better at the web platform.
 [signal]: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 [urlsearchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [htmlform]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+[querystring]: https://developer.mozilla.org/en-US/docs/Web/API/Location/search
+[usesearchparams]: ../hooks/use-search-params

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -697,7 +697,7 @@ When you get better at React Router, you get better at the web platform.
 
 ## Search Params
 
-React Router can read and modify the [query string][querystring]. This process is handeled with [`URLSearchParams`][urlsearchparams].
+React Router can read and modify the [query string][querystring]. This process is handeled with [`URLSearchParams`][urlsearchparams]. We often get and set the Search Params using `useSearchParams`.
 
 ```jsx lines=[2,5,8]
 function App() {
@@ -719,9 +719,35 @@ function App() {
 }
 ```
 
+You can also use `Link` or `useNavigate` to change the Search Params.
+
+```jsx lines=[3,9,16]
+function App() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  // access a specific param
+  const query = searchParams.get("q") || "";
+
+  function handleClick() {
+    navigate({ search: "q=example" });
+  }
+
+  return (
+    <>
+      <p>The value of the search param with key q is: {query}</p>
+      <button onClick={handleClick}>Change search params</button>
+      <Link to={{ search: "q=example" }}>Change search params</Link>
+    </>
+  );
+}
+```
+
 See:
 
 - [`useSearchParams`][usesearchparams]
+- [`useNavigate`][usenavigate]
+- [`Link`][link]
 
 ## Location State
 
@@ -759,3 +785,4 @@ See:
 [htmlform]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 [querystring]: https://developer.mozilla.org/en-US/docs/Web/API/Location/search
 [usesearchparams]: ../hooks/use-search-params
+[link]: ../components/link


### PR DESCRIPTION
Added a Search Params section to the Feature Overview in the documentation. It includes a simple description with references, along with an example showing the main concepts.