### PR TITLE
chore(type): clarify the types are drived from the Agnostic types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -200,6 +200,7 @@
 - nilubisan
 - Nismit
 - nnhjs
+- nightohl
 - noisypigeon
 - Nurai1
 - Obi-Dann

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -35,6 +35,7 @@ import type {
   Navigator,
   NonIndexRouteObject,
   PatchRoutesOnNavigationFunction,
+  ReactSpecificAdded,
   RouteMatch,
   RouteObject,
   ViewTransitionContextObject,
@@ -619,24 +620,11 @@ export function Outlet(props: OutletProps): React.ReactElement | null {
 /**
  * @category Types
  */
-export interface PathRouteProps {
-  caseSensitive?: NonIndexRouteObject["caseSensitive"];
-  path?: NonIndexRouteObject["path"];
-  id?: NonIndexRouteObject["id"];
+export interface PathRouteProps
+  extends Omit<NonIndexRouteObject, "lazy" | "children">,
+    ReactSpecificAdded {
   lazy?: LazyRouteFunction<NonIndexRouteObject>;
-  loader?: NonIndexRouteObject["loader"];
-  action?: NonIndexRouteObject["action"];
-  hasErrorBoundary?: NonIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: NonIndexRouteObject["shouldRevalidate"];
-  handle?: NonIndexRouteObject["handle"];
-  index?: false;
   children?: React.ReactNode;
-  element?: React.ReactNode | null;
-  hydrateFallbackElement?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-  Component?: React.ComponentType | null;
-  HydrateFallback?: React.ComponentType | null;
-  ErrorBoundary?: React.ComponentType | null;
 }
 
 /**
@@ -647,24 +635,10 @@ export interface LayoutRouteProps extends PathRouteProps {}
 /**
  * @category Types
  */
-export interface IndexRouteProps {
-  caseSensitive?: IndexRouteObject["caseSensitive"];
-  path?: IndexRouteObject["path"];
-  id?: IndexRouteObject["id"];
+export interface IndexRouteProps
+  extends Omit<IndexRouteObject, "lazy">,
+    ReactSpecificAdded {
   lazy?: LazyRouteFunction<IndexRouteObject>;
-  loader?: IndexRouteObject["loader"];
-  action?: IndexRouteObject["action"];
-  hasErrorBoundary?: IndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: IndexRouteObject["shouldRevalidate"];
-  handle?: IndexRouteObject["handle"];
-  index: true;
-  children?: undefined;
-  element?: React.ReactNode | null;
-  hydrateFallbackElement?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-  Component?: React.ComponentType | null;
-  HydrateFallback?: React.ComponentType | null;
-  ErrorBoundary?: React.ComponentType | null;
 }
 
 export type RouteProps = PathRouteProps | LayoutRouteProps | IndexRouteProps;

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -22,7 +22,16 @@ import type {
 
 // Create react-specific types from the agnostic types in @remix-run/router to
 // export from react-router
-export interface IndexRouteObject {
+export interface ReactSpecificAdded {
+  element?: React.ReactNode | null;
+  hydrateFallbackElement?: React.ReactNode | null;
+  errorElement?: React.ReactNode | null;
+  Component?: React.ComponentType | null;
+  HydrateFallback?: React.ComponentType | null;
+  ErrorBoundary?: React.ComponentType | null;
+}
+
+export interface IndexRouteObject extends ReactSpecificAdded {
   caseSensitive?: AgnosticIndexRouteObject["caseSensitive"];
   path?: AgnosticIndexRouteObject["path"];
   id?: AgnosticIndexRouteObject["id"];
@@ -31,18 +40,13 @@ export interface IndexRouteObject {
   hasErrorBoundary?: AgnosticIndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: AgnosticIndexRouteObject["shouldRevalidate"];
   handle?: AgnosticIndexRouteObject["handle"];
+  lazy?: LazyRouteFunction<RouteObject>;
+
   index: true;
   children?: undefined;
-  element?: React.ReactNode | null;
-  hydrateFallbackElement?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-  Component?: React.ComponentType | null;
-  HydrateFallback?: React.ComponentType | null;
-  ErrorBoundary?: React.ComponentType | null;
-  lazy?: LazyRouteFunction<RouteObject>;
 }
 
-export interface NonIndexRouteObject {
+export interface NonIndexRouteObject extends ReactSpecificAdded{
   caseSensitive?: AgnosticNonIndexRouteObject["caseSensitive"];
   path?: AgnosticNonIndexRouteObject["path"];
   id?: AgnosticNonIndexRouteObject["id"];
@@ -51,15 +55,10 @@ export interface NonIndexRouteObject {
   hasErrorBoundary?: AgnosticNonIndexRouteObject["hasErrorBoundary"];
   shouldRevalidate?: AgnosticNonIndexRouteObject["shouldRevalidate"];
   handle?: AgnosticNonIndexRouteObject["handle"];
+  lazy?: LazyRouteFunction<RouteObject>;
+  
   index?: false;
   children?: RouteObject[];
-  element?: React.ReactNode | null;
-  hydrateFallbackElement?: React.ReactNode | null;
-  errorElement?: React.ReactNode | null;
-  Component?: React.ComponentType | null;
-  HydrateFallback?: React.ComponentType | null;
-  ErrorBoundary?: React.ComponentType | null;
-  lazy?: LazyRouteFunction<RouteObject>;
 }
 
 export type RouteObject = IndexRouteObject | NonIndexRouteObject;

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -31,34 +31,17 @@ export interface ReactSpecificAdded {
   ErrorBoundary?: React.ComponentType | null;
 }
 
-export interface IndexRouteObject extends ReactSpecificAdded {
-  caseSensitive?: AgnosticIndexRouteObject["caseSensitive"];
-  path?: AgnosticIndexRouteObject["path"];
-  id?: AgnosticIndexRouteObject["id"];
-  loader?: AgnosticIndexRouteObject["loader"];
-  action?: AgnosticIndexRouteObject["action"];
-  hasErrorBoundary?: AgnosticIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: AgnosticIndexRouteObject["shouldRevalidate"];
-  handle?: AgnosticIndexRouteObject["handle"];
+export interface IndexRouteObject
+  extends Omit<AgnosticIndexRouteObject, "lazy">,
+    ReactSpecificAdded {
   lazy?: LazyRouteFunction<RouteObject>;
-
-  index: true;
-  children?: undefined;
 }
 
-export interface NonIndexRouteObject extends ReactSpecificAdded{
-  caseSensitive?: AgnosticNonIndexRouteObject["caseSensitive"];
-  path?: AgnosticNonIndexRouteObject["path"];
-  id?: AgnosticNonIndexRouteObject["id"];
-  loader?: AgnosticNonIndexRouteObject["loader"];
-  action?: AgnosticNonIndexRouteObject["action"];
-  hasErrorBoundary?: AgnosticNonIndexRouteObject["hasErrorBoundary"];
-  shouldRevalidate?: AgnosticNonIndexRouteObject["shouldRevalidate"];
-  handle?: AgnosticNonIndexRouteObject["handle"];
-  lazy?: LazyRouteFunction<RouteObject>;
-  
-  index?: false;
+export interface NonIndexRouteObject
+  extends Omit<AgnosticNonIndexRouteObject, "lazy" | "children">,
+    ReactSpecificAdded {
   children?: RouteObject[];
+  lazy?: LazyRouteFunction<RouteObject>;
 }
 
 export type RouteObject = IndexRouteObject | NonIndexRouteObject;


### PR DESCRIPTION
### Changes
Hi there! It's my first contribution to this project :)

I understand that **Agnostic** is typed to be used universally, and the types are added and modified after inheriting it to fit the **React** environment.

At first, I was curious about the types, but as I looked through the list, I found it challenging to understand concepts such as whether they inherit from `Agnostic`, how much of the original `Agnostic` is carried over, whether all elements of Agnostic are included or only some are borrowed, and the differences between `Index` and `NonIndex`. Of course, my lack of background knowledge contributes to this difficulty.

Considering this, I thought that if it were clear in the types that they are defined after inheriting from `Agnostic` to fit the environment, it would be much easier to understand. So, I made some modifications based on that idea!

### IndexRouteObject, NonIndexRouteObject
<img width="1773" alt="image" src="https://github.com/user-attachments/assets/2888851d-78af-4cbd-b64d-f0360613a04a">

### PathRouteProps, IndexPathRouteProps
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/bfcb196d-2447-4678-8753-5a4e49fa0996">

### Test
<img width="307" alt="image" src="https://github.com/user-attachments/assets/ea730c29-2dc7-4c7c-bea2-da0337b9af2d">
