### PR TITLE
Route chunks: Support shared imports

### DIFF
--- a/packages/react-router-dev/vite/route-chunks-test.ts
+++ b/packages/react-router-dev/vite/route-chunks-test.ts
@@ -165,6 +165,26 @@ describe("route chunks", () => {
       `);
     });
 
+    test("shared imports", () => {
+      const code = dedent`
+        import { shared } from "./shared";
+        export const chunk = shared("chunk");
+        export const main = shared("main");
+      `;
+      expect(hasChunkableExport(code, "chunk", ...cache)).toBe(true);
+      expect(hasChunkableExport(code, "main", ...cache)).toBe(true);
+      expect(getChunkedExport(code, "chunk", {}, ...cache)?.code)
+        .toMatchInlineSnapshot(`
+        "import { shared } from "./shared";
+        export const chunk = shared("chunk");"
+      `);
+      expect(getChunkedExport(code, "main", {}, ...cache)?.code)
+        .toMatchInlineSnapshot(`
+        "import { shared } from "./shared";
+        export const main = shared("main");"
+      `);
+    });
+
     test("re-exports using shared statement", () => {
       const code = dedent`
         export { chunk1, chunk2, main } from "./shared";


### PR DESCRIPTION
One glaring oversight in the chunking algorithm is that shared imports should be allowed.

For example, these exports should be chunkable, even though they both reference the same import:

```ts
import { shared } from "./shared";
export const chunk = shared("chunk");
export const main = shared("main");
```

Before this PR, this example would have resulted in a needless de-opt.