### PR TITLE
Allow returning undefined from loaders/actions (part 2)

### DIFF
--- a/.changeset/red-feet-shop.md
+++ b/.changeset/red-feet-shop.md
@@ -1,0 +1,7 @@
+---
+"react-router": minor
+---
+
+[REMOVE] Allow returning undefined from loaders/actions part 2
+
+- This is a follow up to #11680 which missed some of the Remix codepaths

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -493,109 +493,73 @@ test.describe("ErrorBoundary", () => {
   test.describe("if no error boundary exists in the app", () => {
     let NO_ROOT_BOUNDARY_LOADER = "/loader-bad" as const;
     let NO_ROOT_BOUNDARY_ACTION = "/action-bad" as const;
-    let NO_ROOT_BOUNDARY_LOADER_RETURN = "/loader-no-return" as const;
-    let NO_ROOT_BOUNDARY_ACTION_RETURN = "/action-no-return" as const;
 
     test.beforeAll(async () => {
       fixture = await createFixture({
         files: {
           "app/root.tsx": js`
-              import { Links, Meta, Outlet, Scripts } from "react-router";
+            import { Links, Meta, Outlet, Scripts } from "react-router";
 
-              export default function Root() {
-                return (
-                  <html lang="en">
-                    <head>
-                      <Meta />
-                      <Links />
-                    </head>
-                    <body>
-                      <Outlet />
-                      <Scripts />
-                    </body>
-                  </html>
-                );
-              }
-            `,
+            export default function Root() {
+              return (
+                <html lang="en">
+                  <head>
+                    <Meta />
+                    <Links />
+                  </head>
+                  <body>
+                    <Outlet />
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+          `,
 
           "app/routes/_index.tsx": js`
-              import { Link, Form } from "react-router";
+            import { Link, Form } from "react-router";
 
-              export default function () {
-                return (
-                  <div>
-                    <h1>Home</h1>
-                    <Link to="${NO_ROOT_BOUNDARY_LOADER_RETURN}">Loader no return</Link>
-                    <Form method="post">
-                      <button formAction="${NO_ROOT_BOUNDARY_ACTION}" type="submit">
-                        Action go boom
-                      </button>
-                      <button formAction="${NO_ROOT_BOUNDARY_ACTION_RETURN}" type="submit">
-                        Action no return
-                      </button>
-                    </Form>
-                  </div>
-                )
-              }
-            `,
+            export default function () {
+              return (
+                <div>
+                  <h1>Home</h1>
+                  <Form method="post">
+                    <button formAction="${NO_ROOT_BOUNDARY_ACTION}" type="submit">
+                      Action go boom
+                    </button>
+                  </Form>
+                </div>
+              )
+            }
+          `,
 
           [`app/routes${NO_ROOT_BOUNDARY_LOADER}.jsx`]: js`
-              export async function loader() {
-                throw Error("BLARGH");
-              }
+            export async function loader() {
+              throw Error("BLARGH");
+            }
 
-              export default function () {
-                return (
-                  <div>
-                    <h1>Hello</h1>
-                  </div>
-                )
-              }
-            `,
+            export default function () {
+              return (
+                <div>
+                  <h1>Hello</h1>
+                </div>
+              )
+            }
+          `,
 
           [`app/routes${NO_ROOT_BOUNDARY_ACTION}.jsx`]: js`
-              export async function action() {
-                throw Error("YOOOOOOOO WHAT ARE YOU DOING");
-              }
+            export async function action() {
+              throw Error("YOOOOOOOO WHAT ARE YOU DOING");
+            }
 
-              export default function () {
-                return (
-                  <div>
-                    <h1>Goodbye</h1>
-                  </div>
-                )
-              }
-            `,
-
-          [`app/routes${NO_ROOT_BOUNDARY_LOADER_RETURN}.jsx`]: js`
-              import { useLoaderData } from "react-router";
-
-              export async function loader() {}
-
-              export default function () {
-                let data = useLoaderData();
-                return (
-                  <div>
-                    <h1>{data}</h1>
-                  </div>
-                )
-              }
-            `,
-
-          [`app/routes${NO_ROOT_BOUNDARY_ACTION_RETURN}.jsx`]: js`
-              import { useActionData } from "react-router";
-
-              export async function action() {}
-
-              export default function () {
-                let data = useActionData();
-                return (
-                  <div>
-                    <h1>{data}</h1>
-                  </div>
-                )
-              }
-            `,
+            export default function () {
+              return (
+                <div>
+                  <h1>Goodbye</h1>
+                </div>
+              )
+            }
+          `,
         },
       });
       appFixture = await createAppFixture(fixture);
@@ -615,40 +579,6 @@ test.describe("ErrorBoundary", () => {
       let app = new PlaywrightFixture(appFixture, page);
       await app.goto("/");
       await app.clickSubmitButton(NO_ROOT_BOUNDARY_ACTION);
-      await page.waitForSelector(`text=${INTERNAL_ERROR_BOUNDARY_HEADING}`);
-      expect(await app.getHtml("h1")).toMatch(INTERNAL_ERROR_BOUNDARY_HEADING);
-    });
-
-    test("bubbles to internal boundary if loader doesn't return (document requests)", async () => {
-      let res = await fixture.requestDocument(NO_ROOT_BOUNDARY_LOADER_RETURN);
-      expect(res.status).toBe(500);
-      expect(await res.text()).toMatch(INTERNAL_ERROR_BOUNDARY_HEADING);
-    });
-
-    test("bubbles to internal boundary if loader doesn't return", async ({
-      page,
-    }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      await app.clickLink(NO_ROOT_BOUNDARY_LOADER_RETURN);
-      await page.waitForSelector(`text=${INTERNAL_ERROR_BOUNDARY_HEADING}`);
-      expect(await app.getHtml("h1")).toMatch(INTERNAL_ERROR_BOUNDARY_HEADING);
-    });
-
-    test("bubbles to internal boundary if action doesn't return (document requests)", async () => {
-      let res = await fixture.requestDocument(NO_ROOT_BOUNDARY_ACTION_RETURN, {
-        method: "post",
-      });
-      expect(res.status).toBe(500);
-      expect(await res.text()).toMatch(INTERNAL_ERROR_BOUNDARY_HEADING);
-    });
-
-    test("bubbles to internal boundary if action doesn't return", async ({
-      page,
-    }) => {
-      let app = new PlaywrightFixture(appFixture, page);
-      await app.goto("/");
-      await app.clickSubmitButton(NO_ROOT_BOUNDARY_ACTION_RETURN);
       await page.waitForSelector(`text=${INTERNAL_ERROR_BOUNDARY_HEADING}`);
       expect(await app.getHtml("h1")).toMatch(INTERNAL_ERROR_BOUNDARY_HEADING);
     });

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -601,6 +601,7 @@ test.describe("single-fetch", () => {
     await page.waitForSelector("#error");
     expect(urls).toEqual([]);
   });
+
   test("returns headers correctly for singular loader and action calls", async () => {
     let fixture = await createFixture({
       files: {
@@ -3431,5 +3432,92 @@ test.describe("single-fetch", () => {
       }
     }
     expect(remixScriptsCount).toBe(4);
+  });
+
+  test("supports loaders that return undefined", async ({ page }) => {
+    let fixture = await createFixture(
+      {
+        files: {
+          ...files,
+          "app/routes/_index.tsx": js`
+            import { Link } from "react-router";
+
+            export default function () {
+              return <Link to="/loader">Go to /loader</Link>;
+            }
+          `,
+          "app/routes/loader.tsx": js`
+            import { useLoaderData } from "react-router";
+
+            export async function loader() {}
+
+            export default function () {
+              let data = useLoaderData();
+              return <h1>{data === undefined? 'It worked!' : 'Error'}</h1>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+
+    // Document requests
+    let res = await fixture.requestDocument("/loader");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatch("It worked!");
+
+    // SPA navigations
+    let appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickLink("/loader");
+    await page.waitForSelector("h1");
+    expect(await app.getHtml("h1")).toMatch("It worked!");
+  });
+
+  test("supports actions that return undefined", async ({ page }) => {
+    let fixture = await createFixture(
+      {
+        files: {
+          ...files,
+          "app/routes/_index.tsx": js`
+            import { Form } from "react-router";
+
+            export default function () {
+              return (
+                <Form method="post" action="/action">
+                  <input name="test" />
+                  <button type="submit">Submit</button>
+                </Form>
+              );
+            }
+          `,
+          "app/routes/action.tsx": js`
+            import { useActionData } from "react-router";
+
+            export async function action() {}
+
+            export default function () {
+              let data = useActionData();
+              return <h1>{data === undefined? 'It worked!' : 'Error'}</h1>;
+            }
+          `,
+        },
+      },
+      ServerMode.Development
+    );
+
+    // Document requests
+    let res = await fixture.requestDocument("/action");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatch("It worked!");
+
+    // SPA navigations
+    let appFixture = await createAppFixture(fixture, ServerMode.Development);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickSubmitButton("/action");
+    await page.waitForSelector("h1");
+    expect(await app.getHtml("h1")).toMatch("It worked!");
   });
 });

--- a/packages/react-router/__tests__/router/revalidate-test.ts
+++ b/packages/react-router/__tests__/router/revalidate-test.ts
@@ -796,7 +796,6 @@ describe("router.revalidate", () => {
       navigation: IDLE_NAVIGATION,
       revalidation: "idle",
       loaderData: {
-        root: undefined,
         index: "INDEX_DATA*",
       },
       errors: {

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -142,7 +142,7 @@ function createHydratedRouter(): RemixRouter {
           ) &&
           (route.HydrateFallback || !manifestRoute.hasLoader)
         ) {
-          hydrationData.loaderData![routeId] = undefined;
+          delete hydrationData.loaderData![routeId];
         } else if (manifestRoute && !manifestRoute.hasLoader) {
           // Since every Remix route gets a `loader` on the client side to load
           // the route JS module, we need to add a `null` value to `loaderData`

--- a/packages/react-router/lib/dom/ssr/server.tsx
+++ b/packages/react-router/lib/dom/ssr/server.tsx
@@ -61,7 +61,7 @@ export function ServerRouter({
       shouldHydrateRouteLoader(manifestRoute, route, context.isSpaMode) &&
       (route.HydrateFallback || !manifestRoute.hasLoader)
     ) {
-      context.staticHandlerContext.loaderData[routeId] = undefined;
+      delete context.staticHandlerContext.loaderData[routeId];
     }
   }
 

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -832,7 +832,7 @@ export function _renderMatches(
         let { loaderData, errors } = dataRouterState;
         let needsToRunLoader =
           match.route.loader &&
-          !(match.route.id in loaderData) &&
+          !loaderData.hasOwnProperty(match.route.id) &&
           (!errors || errors[match.route.id] === undefined);
         if (match.route.lazy || needsToRunLoader) {
           // We found the first route that's not ready to render (waiting on

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -832,7 +832,7 @@ export function _renderMatches(
         let { loaderData, errors } = dataRouterState;
         let needsToRunLoader =
           match.route.loader &&
-          loaderData[match.route.id] === undefined &&
+          !(match.route.id in loaderData) &&
           (!errors || errors[match.route.id] === undefined);
         if (match.route.lazy || needsToRunLoader) {
           // We found the first route that's not ready to render (waiting on

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -4268,7 +4268,7 @@ function getMatchesToLoad(
         return true;
       }
       return (
-        !(route.id in state.loaderData) &&
+        !state.loaderData.hasOwnProperty(route.id) &&
         // Don't re-run if the loader ran and threw an error
         (!state.errors || state.errors[route.id] === undefined)
       );
@@ -4407,7 +4407,7 @@ function isNewLoader(
 
   // Handle the case that we don't have data for a re-used route, potentially
   // from a prior error
-  let isMissingData = !(match.route.id in currentLoaderData);
+  let isMissingData = !currentLoaderData.hasOwnProperty(match.route.id);
 
   // Always load if this is a net-new route or we don't yet have data
   return isNew || isMissingData;

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -4263,7 +4263,7 @@ function getMatchesToLoad(
         return true;
       }
       return (
-        state.loaderData[route.id] === undefined &&
+        !(route.id in state.loaderData) &&
         // Don't re-run if the loader ran and threw an error
         (!state.errors || state.errors[route.id] === undefined)
       );
@@ -4402,7 +4402,7 @@ function isNewLoader(
 
   // Handle the case that we don't have data for a re-used route, potentially
   // from a prior error
-  let isMissingData = currentLoaderData[match.route.id] === undefined;
+  let isMissingData = !(match.route.id in currentLoaderData);
 
   // Always load if this is a net-new route or we don't yet have data
   return isNew || isMissingData;
@@ -5106,7 +5106,9 @@ function processRouteLoaderData(
       }
 
       // Clear our any prior loaderData for the throwing route
-      loaderData[id] = undefined;
+      if (id in loaderData) {
+        delete loaderData[id];
+      }
 
       // Once we find our first (highest) error, we set the status code and
       // prevent deeper status codes from overriding

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -20,45 +20,16 @@ export interface AppLoadContext {
  */
 export type AppData = unknown;
 
-export async function callRouteAction({
-  loadContext,
-  action,
-  params,
-  request,
-  routeId,
-}: {
-  request: Request;
-  action: ActionFunction;
-  params: ActionFunctionArgs["params"];
-  loadContext: AppLoadContext;
-  routeId: string;
-}) {
-  let result = await action({
-    request: stripRoutesParam(stripIndexParam(request)),
-    context: loadContext,
-    params,
-  });
-
-  return result;
-}
-
-export async function callRouteLoader({
-  loadContext,
-  loader,
-  params,
-  request,
-  routeId,
-}: {
-  request: Request;
-  loader: LoaderFunction;
-  params: LoaderFunctionArgs["params"];
-  loadContext: AppLoadContext;
-  routeId: string;
-}) {
-  let result = await loader({
-    request: stripRoutesParam(stripIndexParam(request)),
-    context: loadContext,
-    params,
+// Need to use RR's version here to permit the optional context even
+// though we know it'll always be provided in remix
+export async function callRouteHandler(
+  handler: LoaderFunction | ActionFunction,
+  args: LoaderFunctionArgs | ActionFunctionArgs
+) {
+  let result = await handler({
+    request: stripRoutesParam(stripIndexParam(args.request)),
+    params: args.params,
+    context: args.context,
   });
 
   return result;

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -39,13 +39,6 @@ export async function callRouteAction({
     params,
   });
 
-  if (result === undefined) {
-    throw new Error(
-      `You defined an action for route "${routeId}" but didn't return ` +
-        `anything from your \`action\` function. Please return a value or \`null\`.`
-    );
-  }
-
   return result;
 }
 
@@ -67,13 +60,6 @@ export async function callRouteLoader({
     context: loadContext,
     params,
   });
-
-  if (result === undefined) {
-    throw new Error(
-      `You defined a loader for route "${routeId}" but didn't return ` +
-        `anything from your \`loader\` function. Please return a value or \`null\`.`
-    );
-  }
 
   return result;
 }

--- a/packages/react-router/lib/server-runtime/headers.ts
+++ b/packages/react-router/lib/server-runtime/headers.ts
@@ -23,9 +23,12 @@ export function getDocumentHeaders(
     let { actionHeaders, actionData, loaderHeaders, loaderData } = context;
     context.matches.slice(boundaryIdx).some((match) => {
       let id = match.route.id;
-      if (actionHeaders[id] && (!actionData || !(id in actionData))) {
+      if (
+        actionHeaders[id] &&
+        (!actionData || !actionData.hasOwnProperty(id))
+      ) {
         errorHeaders = actionHeaders[id];
-      } else if (loaderHeaders[id] && !(id in loaderData)) {
+      } else if (loaderHeaders[id] && !loaderData.hasOwnProperty(id)) {
         errorHeaders = loaderHeaders[id];
       }
       return errorHeaders != null;

--- a/packages/react-router/lib/server-runtime/headers.ts
+++ b/packages/react-router/lib/server-runtime/headers.ts
@@ -23,9 +23,9 @@ export function getDocumentHeaders(
     let { actionHeaders, actionData, loaderHeaders, loaderData } = context;
     context.matches.slice(boundaryIdx).some((match) => {
       let id = match.route.id;
-      if (actionHeaders[id] && (!actionData || actionData[id] === undefined)) {
+      if (actionHeaders[id] && (!actionData || !(id in actionData))) {
         errorHeaders = actionHeaders[id];
-      } else if (loaderHeaders[id] && loaderData[id] === undefined) {
+      } else if (loaderHeaders[id] && !(id in loaderData)) {
         errorHeaders = loaderHeaders[id];
       }
       return errorHeaders != null;

--- a/packages/react-router/lib/server-runtime/routes.ts
+++ b/packages/react-router/lib/server-runtime/routes.ts
@@ -3,9 +3,13 @@ import type {
   LoaderFunctionArgs as RRLoaderFunctionArgs,
   ActionFunctionArgs as RRActionFunctionArgs,
 } from "../router/utils";
-import { callRouteAction, callRouteLoader } from "./data";
+import { callRouteHandler } from "./data";
 import type { FutureConfig } from "../dom/ssr/entry";
-import type { ServerRouteModule } from "./routeModules";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  ServerRouteModule,
+} from "./routeModules";
 
 export interface RouteManifest<Route> {
   [routeId: string]: Route;
@@ -88,27 +92,15 @@ export function createStaticHandlerDataRoutes(
         route.id === "root" || route.module.ErrorBoundary != null,
       id: route.id,
       path: route.path,
+      // Need to use RR's version in the param typed here to permit the optional
+      // context even though we know it'll always be provided in remix
       loader: route.module.loader
-        ? // Need to use RR's version here to permit the optional context even
-          // though we know it'll always be provided in remix
-          (args: RRLoaderFunctionArgs, dataStrategyCtx?: unknown) =>
-            callRouteLoader({
-              request: args.request,
-              params: args.params,
-              loadContext: args.context,
-              loader: route.module.loader!,
-              routeId: route.id,
-            })
+        ? (args: RRLoaderFunctionArgs) =>
+            callRouteHandler(route.module.loader!, args as LoaderFunctionArgs)
         : undefined,
       action: route.module.action
-        ? (args: RRActionFunctionArgs, dataStrategyCtx?: unknown) =>
-            callRouteAction({
-              request: args.request,
-              params: args.params,
-              loadContext: args.context,
-              action: route.module.action!,
-              routeId: route.id,
-            })
+        ? (args: RRActionFunctionArgs) =>
+            callRouteHandler(route.module.action!, args as ActionFunctionArgs)
         : undefined,
       handle: route.module.handle,
     };

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -230,9 +230,9 @@ export async function singleFetchLoaders(
 
     loadedMatches.forEach((m) => {
       let { id } = m.route;
-      if (context.errors && id in context.errors) {
+      if (context.errors && context.errors.hasOwnProperty(id)) {
         results[id] = { error: context.errors[id] };
-      } else if (id in context.loaderData) {
+      } else if (context.loaderData.hasOwnProperty(id)) {
         results[id] = { data: context.loaderData[id] };
       }
     });

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -229,12 +229,11 @@ export async function singleFetchLoaders(
       : context.matches;
 
     loadedMatches.forEach((m) => {
-      let data = context.loaderData?.[m.route.id];
-      let error = context.errors?.[m.route.id];
-      if (error !== undefined) {
-        results[m.route.id] = { error };
-      } else if (data !== undefined) {
-        results[m.route.id] = { data };
+      let { id } = m.route;
+      if (context.errors && id in context.errors) {
+        results[id] = { error: context.errors[id] };
+      } else if (id in context.loaderData) {
+        results[id] = { data: context.loaderData[id] };
       }
     });
 


### PR DESCRIPTION
Follow up to https://github.com/remix-run/react-router/pull/11680 which missed some of the Remix codepath checks.