### PR TITLE
Skip route entry virtual module in dev

### DIFF
--- a/.changeset/friendly-turtles-juggle.md
+++ b/.changeset/friendly-turtles-juggle.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Skip `?route-entry=1` virtual module in development. This is an optimization for the production build and results in an unnecessary additional module request to the Vite dev server.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -714,7 +714,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = (_config) => {
           `${resolveFileUrl(
             ctx,
             resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
-          )}${ROUTE_ENTRY_QUERY_STRING}`
+          )}`
         ),
         hasAction: sourceExports.includes("action"),
         hasLoader: sourceExports.includes("loader"),


### PR DESCRIPTION
As noted in the changest, the `route-entry?1` virtual module is an optimization for the production build and results in an unnecessary additional module request to the Vite dev server during development.