### PR TITLE
Rename private data router global

### DIFF
--- a/packages/react-router-dev/vite/static/refresh-utils.cjs
+++ b/packages/react-router-dev/vite/static/refresh-utils.cjs
@@ -49,21 +49,21 @@ const enqueueUpdate = debounce(async () => {
         .map((route) => route.id)
     );
 
-    let routes = __reactRouterInstance.createRoutesForHMR(
+    let routes = __reactRouterDataRouter.createRoutesForHMR(
       needsRevalidation,
       manifest.routes,
       window.__reactRouterRouteModules,
       window.__reactRouterContext.future,
       window.__reactRouterContext.isSpaMode
     );
-    __reactRouterInstance._internalSetRoutes(routes);
+    __reactRouterDataRouter._internalSetRoutes(routes);
     routeUpdates.clear();
     window.__reactRouterRouteModuleUpdates.clear();
   }
 
   try {
     window.__reactRouterHdrActive = true;
-    await __reactRouterInstance.revalidate();
+    await __reactRouterDataRouter.revalidate();
   } finally {
     window.__reactRouterHdrActive = false;
   }

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -192,7 +192,7 @@ function createHydratedRouter(): DataRouter {
   router.createRoutesForHMR =
     /* spacer so ts-ignore does not affect the right hand of the assignment */
     createClientRoutesWithHMRRevalidationOptOut;
-  window.__reactRouterInstance = router;
+  window.__reactRouterDataRouter = router;
 
   return router;
 }

--- a/packages/react-router/lib/dom/global.ts
+++ b/packages/react-router/lib/dom/global.ts
@@ -36,7 +36,7 @@ declare global {
   var __reactRouterContext: WindowReactRouterContext | undefined;
   var __reactRouterManifest: AssetsManifest | undefined;
   var __reactRouterRouteModules: RouteModules | undefined;
-  var __reactRouterInstance: DataRouter | undefined;
+  var __reactRouterDataRouter: DataRouter | undefined;
   var __reactRouterHdrActive: boolean;
   var __reactRouterClearCriticalCss: (() => void) | undefined;
   var $RefreshRuntime$:


### PR DESCRIPTION
This is a minor aesthetic nitpick. The `__reactRouterInstance` global was a rename of the `__remixRouter` global to avoid a Remix reference, but at the time it wasn't clear what a good name for it would be. We've since renamed the `RemixRouter` export to `DataRouter` which allows us to give this a better, more consistent name.