### PR TITLE
Revert template to tailwind v3

### DIFF
--- a/templates/basic/app/app.css
+++ b/templates/basic/app/app.css
@@ -1,9 +1,6 @@
-@import "tailwindcss";
-
-@theme {
-  --font-family-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 html,
 body {

--- a/templates/basic/app/routes/home.tsx
+++ b/templates/basic/app/routes/home.tsx
@@ -15,7 +15,7 @@ export default function Index() {
           <h1 className="leading text-2xl font-bold text-gray-800 dark:text-gray-100">
             Welcome to <span className="sr-only">React Router</span>
           </h1>
-          <div className="w-md max-w-[100vw] p-4 aspect-[605/347]">
+          <div className="w-[450px] max-w-[100vw] p-4 aspect-[605/347]">
             <img
               src="/logo-light.svg"
               alt="Remix"

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@react-router/node": "7.0.0-pre.0",
     "@react-router/serve": "7.0.0-pre.0",
-    "@tailwindcss/vite": "^4.0.0-alpha.25",
     "isbot": "^5.1.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -21,7 +20,9 @@
     "@react-router/dev": "7.0.0-pre.0",
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
-    "tailwindcss": "^4.0.0-alpha.25",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
     "vite-tsconfig-paths": "^5.0.1"

--- a/templates/basic/postcss.config.js
+++ b/templates/basic/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/templates/basic/tailwind.config.ts
+++ b/templates/basic/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./app/**/{**,.client,.server}/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: [
+          '"Inter"',
+          "ui-sans-serif",
+          "system-ui",
+          "sans-serif",
+          '"Apple Color Emoji"',
+          '"Segoe UI Emoji"',
+          '"Segoe UI Symbol"',
+          '"Noto Color Emoji"',
+        ],
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/templates/basic/vite.config.ts
+++ b/templates/basic/vite.config.ts
@@ -1,8 +1,7 @@
-import tailwindcss from "@tailwindcss/vite";
 import { reactRouter } from "@react-router/dev/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  plugins: [reactRouter(), tsconfigPaths()],
 });


### PR DESCRIPTION
Unfortunately [tailwind v4 doesn't work on Stackblitz quite yet](https://github.com/tailwindlabs/tailwindcss/issues/13133) so we're going back to 3 for now since so many people use Stackblitz to send us repos

I'm so sorry @alexanderson1993