### PR TITLE
Update/ apply generic to useLocation hook

### DIFF
--- a/.changeset/good-eggs-design.md
+++ b/.changeset/good-eggs-design.md
@@ -1,0 +1,5 @@
+---
+"react-router": minor
+---
+
+update: add generic type parameter to useLocation for state

--- a/contributors.yml
+++ b/contributors.yml
@@ -200,6 +200,7 @@
 - nilubisan
 - Nismit
 - nnhjs
+- nightohl
 - noisypigeon
 - Nurai1
 - Obi-Dann

--- a/examples/modal/src/App.tsx
+++ b/examples/modal/src/App.tsx
@@ -14,12 +14,12 @@ import "@reach/dialog/styles.css";
 import { IMAGES, getImageById } from "./images";
 
 export default function App() {
-  let location = useLocation();
+  let location = useLocation<{ backgroundLocation?: Location }>();
 
   // The `backgroundLocation` state is the location that we were at when one of
   // the gallery links was clicked. If it's there, use it as the location for
   // the <Routes> so we show the gallery in the background, behind the modal.
-  let state = location.state as { backgroundLocation?: Location };
+  let { state } = location;
 
   return (
     <div>

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -588,7 +588,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
           {
             path: "b",
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -655,7 +655,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
           {
             path: "b",
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -728,7 +728,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
               return null;
             },
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -803,7 +803,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
               return null;
             },
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -128,7 +128,7 @@ export function useInRouterContext(): boolean {
 
   @category Hooks
  */
-export function useLocation(): Location {
+export function useLocation<State = any>(): Location<State> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the


### PR DESCRIPTION
## motivation
The `Location` type has already been made to accept Generic type for `state`.
```ts
export interface Location<State = any> extends Path {
    /**
     * A value of arbitrary data associated with this location.
     */
    state: State;
    /**
     * A unique string associated with this location. May be used to safely store
     * and retrieve data in some other storage API, like localStorage.
     *
     * Note: This value is always "default" on the initial location.
     */
    key: string;
}

```
But `useLocation` hook doesn't made to utilize it, so we've needed to typecasting to set the type of state.
```ts
// definition
export declare function useLocation(): Location;

// we've used to set type like this
let { state } = useLocation() as { state: { count: number } };
```

## changed
so I modified the `useLocation` hook to accept a **generic** type parameter for `state`, improving type safety and allowing for direct specification of state type.
(To minimize code changes and ensure there are no issues with the existing code, this PR simply follows the previously defined `any` types in `Location` and only adds generics to `useLocation`)
```ts
export function useLocation<State = any>(): Location<State>
```
we can use now like below
```ts
let { state } = useLocation<{ count: number }>();
```

## Further
The `state` can have **arbitrary structures**, and currently, its type is set to `any`. 
So, it would be better to narrow down the types on the usage side.

To improve this, I suggest changing the default type from `any` to `unknown`. This would enforce setting types explicitly through generics before using the `state`. 
Moreover the default value is documented as `null`, it's not clearly reflected in the code as it just says `any`. Therefore, using `State | null` would make this clearer in the code.

However, when this feature is applied, every `state` type definition from `useLocation` is enforced, leading to many type errors. Therefore, I believe this should be addressed in a separate PR.
After this PR, I'll address this change!