### PR TITLE
docs(start/overview): fix a typo in Search Params section

### DIFF
--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -725,7 +725,7 @@ function App() {
 
 You can also use `Link` or `useNavigate` to change the search params.
 
-```jsx lines=[3,9,16]
+```jsx lines=[3,9,20]
 function App() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();


### PR DESCRIPTION
Change the highlighted line from 16 to 20 in the last example. @brookslybrand is familiar with this section
![image](https://github.com/user-attachments/assets/3e88fb78-83ef-4b46-9700-c8b3538e29ed)
