### PR TITLE
docs(start/overview): add `Location State` section

### DIFF
--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -761,7 +761,7 @@ See:
 
 ## Location State
 
-React Router can read and modify the [location state][location-state], which is a part of [`location`][location] object. You can get the [`location`][location] object using `useLocation`.
+React Router can read and modify the [location state][location-state], which is a part of [`location`][location] object. You can get the [`location`][location] object using [`useLocation`][use-location].
 
 ```jsx lines=[2,7]
 function App() {

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -763,7 +763,7 @@ See:
 
 React Router can read and modify the [location state][location-state], which is a part of [`location`][location] object. You can get the [`location`][location] object using [`useLocation`][use-location].
 
-```jsx lines=[2,7]
+```tsx lines=[2,7]
 function App() {
   const location = useLocation();
 
@@ -776,9 +776,9 @@ function App() {
 }
 ```
 
-You can use `<Link state>` or `useNavigate` to change the location state.
+You can use [`<Link state>`][link-component-state-prop] or [`useNavigate`][use-navigate] to change the location state.
 
-```jsx lines=[2,6,11-13]
+```tsx lines=[2,6,11-13]
 function App() {
   const navigate = useNavigate();
 
@@ -805,7 +805,7 @@ See:
 
 - [`useLocation`][use-location]
 - [`Link`][link]
-- [`useNavigate`][usenavigate]
+- [`useNavigate`][use-navigate]
 
 [path]: ../route/route#path
 [loader]: ../route/loader
@@ -843,3 +843,5 @@ See:
 [location-state]: ../hooks/use-location#locationstate
 [location]: ../utils/location
 [use-location]: ../hooks/use-location
+[use-navigate]: ../hooks/use-navigate
+[link-component-state-prop]: ../components/link#state

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -761,19 +761,16 @@ See:
 
 ## Location State
 
-React Router can read and modify the [location state][locationstate], which is a part of [`location`][location] object. You can get the [`location`][location] object using `useLocation`.
+React Router can read and modify the [location state][location-state], which is a part of [`location`][location] object. You can get the [`location`][location] object using `useLocation`.
 
-```jsx lines=[2,5]
+```jsx lines=[2,7]
 function App() {
   const location = useLocation();
-
-  //get location state object from location object
-  const locationState = location.state;
 
   return (
     <p>
       The current location state value is:
-      {locationState.someValue}
+      {location.state.someValue}
     </p>
   );
 }
@@ -781,20 +778,22 @@ function App() {
 
 You can use `<Link state>` or `useNavigate` to change the location state.
 
-```jsx lines=[2,5,10]
+```jsx lines=[2,6,11-13]
 function App() {
   const navigate = useNavigate();
-
-  function handleClick() {
-    navigate("/home", { state: { someValue: "example" } });
-  }
 
   return (
     <>
       <Link to="/home" state={{ someValue: "example" }}>
         Go to home page with state
       </Link>
-      <button onClick={handleClick}>
+      <button
+        onClick={() =>
+          navigate("/home", {
+            state: { someValue: "example" },
+          })
+        }
+      >
         Go to home page with state
       </button>
     </>
@@ -804,7 +803,7 @@ function App() {
 
 See:
 
-- [`useLocation`][uselocation]
+- [`useLocation`][use-location]
 - [`Link`][link]
 - [`useNavigate`][usenavigate]
 
@@ -841,6 +840,6 @@ See:
 [querystring]: https://developer.mozilla.org/en-US/docs/Web/API/Location/search
 [usesearchparams]: ../hooks/use-search-params
 [link]: ../components/link
-[locationstate]: https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationstate
+[location-state]: https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationstate
 [location]: ../utils/location
-[uselocation]: ../hooks/use-location
+[use-location]: ../hooks/use-location

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -761,7 +761,7 @@ See:
 
 ## Location State
 
-React Router can read and modify the [location state][location-state], which is a part of [`location`][location] object. You can get the [`location`][location] object using [`useLocation`][use-location].
+React Router can read and modify the [location state][location-state], which is a part of the [`location`][location] object. You can retrieve the [`location`][location] object using [`useLocation`][use-location].
 
 ```tsx lines=[2,7]
 function App() {

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -840,6 +840,6 @@ See:
 [querystring]: https://developer.mozilla.org/en-US/docs/Web/API/Location/search
 [usesearchparams]: ../hooks/use-search-params
 [link]: ../components/link
-[location-state]: https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationstate
+[location-state]: ../hooks/use-location#locationstate
 [location]: ../utils/location
 [use-location]: ../hooks/use-location

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -776,7 +776,7 @@ function App() {
 }
 ```
 
-You can use [`<Link state>`][link-component-state-prop] or [`useNavigate`][use-navigate] to change the location state.
+You can use [`<Link state>`][link-component-state-prop] or [`useNavigate`][use-navigate] to change the [location state][location-state].
 
 ```tsx lines=[2,6,11-13]
 function App() {

--- a/docs/start/overview.md
+++ b/docs/start/overview.md
@@ -761,7 +761,52 @@ See:
 
 ## Location State
 
-<docs-info>TODO:</docs-info>
+React Router can read and modify the [location state][locationstate], which is a part of [`location`][location] object. You can get the [`location`][location] object using `useLocation`.
+
+```jsx lines=[2,5]
+function App() {
+  const location = useLocation();
+
+  //get location state object from location object
+  const locationState = location.state;
+
+  return (
+    <p>
+      The current location state value is:
+      {locationState.someValue}
+    </p>
+  );
+}
+```
+
+You can use `<Link state>` or `useNavigate` to change the location state.
+
+```jsx lines=[2,5,10]
+function App() {
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate("/home", { state: { someValue: "example" } });
+  }
+
+  return (
+    <>
+      <Link to="/home" state={{ someValue: "example" }}>
+        Go to home page with state
+      </Link>
+      <button onClick={handleClick}>
+        Go to home page with state
+      </button>
+    </>
+  );
+}
+```
+
+See:
+
+- [`useLocation`][uselocation]
+- [`Link`][link]
+- [`useNavigate`][usenavigate]
 
 [path]: ../route/route#path
 [loader]: ../route/loader
@@ -796,3 +841,6 @@ See:
 [querystring]: https://developer.mozilla.org/en-US/docs/Web/API/Location/search
 [usesearchparams]: ../hooks/use-search-params
 [link]: ../components/link
+[locationstate]: https://github.com/remix-run/history/blob/main/docs/api-reference.md#locationstate
+[location]: ../utils/location
+[uselocation]: ../hooks/use-location


### PR DESCRIPTION
Added a **missing "Location State" section** to the documentation. 
Provided a clear explanation, along with examples demonstrating how to read and modify the location state using `useLocation`, `Link` and `useNavigate`.