### PR TITLE
Route chunks: Add "enforce" option

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -41,7 +41,9 @@ export const viteConfig = {
     port: number;
     fsAllow?: string[];
     spaMode?: boolean;
-    routeChunks?: boolean;
+    routeChunks?: NonNullable<
+      ReactRouterConfig["future"]
+    >["unstable_routeChunks"];
   }) => {
     let config: ReactRouterConfig = {
       ssr: !args.spaMode,

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -82,7 +82,7 @@ interface FutureConfig {
   /**
    * Automatically split route modules into multiple chunks when possible.
    */
-  unstable_routeChunks?: boolean;
+  unstable_routeChunks?: boolean | "enforce";
 }
 
 export type BuildManifest = DefaultBuildManifest | ServerBundlesBuildManifest;
@@ -502,7 +502,7 @@ export async function resolveReactRouterConfig({
   }
 
   let future: FutureConfig = {
-    unstable_routeChunks: Boolean(userFuture?.unstable_routeChunks),
+    unstable_routeChunks: userFuture?.unstable_routeChunks ?? false,
   };
 
   let reactRouterConfig: ResolvedReactRouterConfig = deepFreeze({

--- a/packages/react-router-dev/vite/route-chunks.ts
+++ b/packages/react-router-dev/vite/route-chunks.ts
@@ -928,7 +928,7 @@ export function detectRouteChunks(
 }
 
 const mainChunkName = "main" as const;
-const chunkedExportNames = ["clientAction", "clientLoader"] as const;
+export const chunkedExportNames = ["clientAction", "clientLoader"] as const;
 export type RouteChunkName =
   | typeof mainChunkName
   | (typeof chunkedExportNames)[number];


### PR DESCRIPTION
This allows more performance sensitive consumers to ensure that a de-opt never occurs and that client loaders/actions never end up in the same chunk as the rest of the route module exports.