### PR TITLE
Fix picking-a-router link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -283,3 +283,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- apple-yagi

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1247,7 +1247,7 @@ enum DataRouterStateHook {
 function getDataRouterConsoleError(
   hookName: DataRouterHook | DataRouterStateHook
 ) {
-  return `${hookName} must be used within a data router.  See https://reactrouter.com/routers/picking-a-router.`;
+  return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
 }
 
 function useDataRouterContext(hookName: DataRouterHook) {

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -949,7 +949,7 @@ enum DataRouterStateHook {
 function getDataRouterConsoleError(
   hookName: DataRouterHook | DataRouterStateHook
 ) {
-  return `${hookName} must be used within a data router.  See https://reactrouter.com/routers/picking-a-router.`;
+  return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
 }
 
 function useDataRouterContext(hookName: DataRouterHook) {


### PR DESCRIPTION
The link provided in the error message was https://reactrouter.com/routers/picking-a-router, which led to a Not Found page. It appears the correct link should be https://reactrouter.com/en/main/routers/picking-a-router, so I have updated it accordingly.