### PR TITLE
Expose patchRoutesOnNavigation errors directly

### DIFF
--- a/.changeset/shy-chicken-talk.md
+++ b/.changeset/shy-chicken-talk.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Expose errors thown from `patchRoutesOnNavigation` directly to `useRouteError` instead of wrapping them in a 400 `ErrorResponse` instance

--- a/packages/router/__tests__/lazy-discovery-test.ts
+++ b/packages/router/__tests__/lazy-discovery-test.ts
@@ -2064,15 +2064,7 @@ describe("Lazy Route Discovery (Fog of War)", () => {
         actionData: null,
         loaderData: {},
         errors: {
-          a: new ErrorResponseImpl(
-            400,
-            "Bad Request",
-            new Error(
-              'Unable to match URL "/a/b" - the `patchRoutesOnNavigation()` ' +
-                "function threw the following error:\nError: broke!"
-            ),
-            true
-          ),
+          a: new Error("broke!"),
         },
       });
       expect(router.state.matches.map((m) => m.route.id)).toEqual(["a"]);
@@ -2139,15 +2131,7 @@ describe("Lazy Route Discovery (Fog of War)", () => {
         actionData: null,
         loaderData: {},
         errors: {
-          a: new ErrorResponseImpl(
-            400,
-            "Bad Request",
-            new Error(
-              'Unable to match URL "/a/b" - the `patchRoutesOnNavigation()` ' +
-                "function threw the following error:\nError: broke!"
-            ),
-            true
-          ),
+          a: new Error("broke!"),
         },
       });
       expect(router.state.matches.map((m) => m.route.id)).toEqual(["a"]);
@@ -2213,16 +2197,7 @@ describe("Lazy Route Discovery (Fog of War)", () => {
         actionData: null,
         loaderData: {},
         errors: {
-          parent: new ErrorResponseImpl(
-            400,
-            "Bad Request",
-            new Error(
-              'Unable to match URL "/parent/child/grandchild" - the ' +
-                "`patchRoutesOnNavigation()` function threw the following " +
-                "error:\nError: broke!"
-            ),
-            true
-          ),
+          parent: new Error("broke!"),
         },
       });
       expect(router.state.matches.map((m) => m.route.id)).toEqual([
@@ -2274,16 +2249,7 @@ describe("Lazy Route Discovery (Fog of War)", () => {
         actionData: null,
         loaderData: {},
         errors: {
-          parent: new ErrorResponseImpl(
-            400,
-            "Bad Request",
-            new Error(
-              'Unable to match URL "/parent/child/grandchild" - the ' +
-                "`patchRoutesOnNavigation()` function threw the following " +
-                "error:\nError: broke!"
-            ),
-            true
-          ),
+          parent: new Error("broke!"),
         },
       });
       expect(router.state.matches.map((m) => m.route.id)).toEqual([


### PR DESCRIPTION
This was raised as [feedback](https://github.com/remix-run/react-router/issues/11775#issuecomment-2227793201) and makes sense to avoid RR doing any intermediary processing/wrapping on an error thrown in user code.  The internal `ErrorResponse` errors should be limited to true internal routing errors.  We should expose user-thrown errors directly like we do for loaders/actions