### PR TITLE
docs(components/form): add `Registration Form` example

### DIFF
--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -377,7 +377,7 @@ You can access those values from the `request.url`
 
 ## Registration Form
 
-We can use Mutation Submissions in registration workflow.
+We can use [Mutation Submissions][#mutation-submissions] in registration workflow.
 
 ```tsx
 function RegisterForm() {
@@ -385,26 +385,26 @@ function RegisterForm() {
 
   return (
     <Form method="post">
-      <label>Name</label>
+      <label labelFor="name">Name</label>
       <input type="text" name="name" />
 
-      <label>Email</label>
+      <label labelFor="email">Email</label>
       <input type="email" name="email" />
 
-      <label>Password</label>
+      <label labelFor="password">Password</label>
       <input type="password" name="password" />
 
       <button type="submit">Register</button>
 
-      {actionData && actionData.error && (
+      {actionData?.error ? (
         <p>An error occured: {actionData.error}</p>
-      )}
+      ) : null}
     </Form>
   );
 }
 ```
 
-When the user submits the form by clicking "Register", the `action` is executed. Note that we are accessing the returned value from the `action` in our component using `useActionData`[useactiondata].
+When the user submits the form by clicking "Register", the [`action`][action] function is executed. Note that we are accessing the returned value from the [`action`][action] function in our component using [`useActionData`][useactiondata].
 
 ```tsx
 <Route
@@ -428,7 +428,7 @@ When the user submits the form by clicking "Register", the `action` is executed.
 />
 ```
 
-In the `action`, we then access the form data (name, email and password) using the `request.formData` function. After that, the POST request is sent to the server. If it is successful, the user will be redirected to `/dashboard` page. Otherwise, an error message will appear.
+In the [`action`][action], we then access the form data (`name`, `email` and `password`) using the [`request.formData`][request-formData-method] method. After that, the `POST` request is sent to the server. If it is successful, the user will be redirected to `/dashboard` page. Otherwise, an error message will appear.
 
 **See also:**
 

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -385,13 +385,13 @@ function RegisterForm() {
 
   return (
     <Form method="post">
-      <label labelFor="name">Name</label>
+      <label htmlFor="name">Name</label>
       <input type="text" name="name" />
 
-      <label labelFor="email">Email</label>
+      <label htmlFor="email">Email</label>
       <input type="email" name="email" />
 
-      <label labelFor="password">Password</label>
+      <label htmlFor="password">Password</label>
       <input type="password" name="password" />
 
       <button type="submit">Register</button>

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -375,6 +375,66 @@ You can access those values from the `request.url`
 
 - [useSubmit][usesubmit]
 
+## Registration Form
+
+We can use Mutation Submissions in registration workflow.
+
+```tsx
+function RegisterForm() {
+  const actionData = useActionData();
+
+  return (
+    <Form method="post">
+      <label>Name</label>
+      <input type="text" name="name" />
+
+      <label>Email</label>
+      <input type="email" name="email" />
+
+      <label>Password</label>
+      <input type="password" name="password" />
+
+      <button type="submit">Register</button>
+
+      {actionData && actionData.error && (
+        <p>An error occured: {actionData.error}</p>
+      )}
+    </Form>
+  );
+}
+```
+
+When the user submits the form by clicking "Register", the `action` is executed. Note that we are accessing the returned value from the `action` in our component using `useActionData`[useactiondata].
+
+```tsx
+<Route
+  path="/register"
+  action={async ({ request }) => {
+    const data = await request.formData();
+
+    const postData = {
+      name: data.get("name"),
+      email: data.get("email"),
+      password: data.get("password"),
+    };
+
+    try {
+      await fakePostRequest(postData);
+      return redirect("/dashboard");
+    } catch (e) {
+      return { error: "Cannot send the request" };
+    }
+  }}
+/>
+```
+
+In the `action`, we then access the form data (name, email and password) using the `request.formData` function. After that, the POST request is sent to the server. If it is successful, the user will be redirected to `/dashboard` page. Otherwise, an error message will appear.
+
+**See also:**
+
+- [`useActionData`][useactiondata]
+- [`redirect`][redirect]
+
 [usenavigation]: ../hooks/use-navigation
 [useactiondata]: ../hooks/use-action-data
 [formdata]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
@@ -397,3 +457,4 @@ You can access those values from the `request.url`
 [use-view-transition-state]: ../hooks//use-view-transition-state
 [view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API
 [relativesplatpath]: ../hooks/use-resolved-path#splat-paths
+[redirect]: ../fetch/redirect

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -458,3 +458,5 @@ In the [`action`][action], we then access the form data (`name`, `email` and `pa
 [view-transitions]: https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API
 [relativesplatpath]: ../hooks/use-resolved-path#splat-paths
 [redirect]: ../fetch/redirect
+[action]: ../route/action
+[request-formData-method]: ../guides/form-data

--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -377,7 +377,7 @@ You can access those values from the `request.url`
 
 ## Registration Form
 
-We can use [Mutation Submissions][#mutation-submissions] in registration workflow.
+We can use [Mutation Submissions][mutation-submissions] in registration workflow.
 
 ```tsx
 function RegisterForm() {
@@ -460,3 +460,4 @@ In the [`action`][action], we then access the form data (`name`, `email` and `pa
 [redirect]: ../fetch/redirect
 [action]: ../route/action
 [request-formData-method]: ../guides/form-data
+[mutation-submissions]: #mutation-submissions


### PR DESCRIPTION
Added an **additional "Registration Form"** example to the **Form Component documentation**.
Demonstrated how to use `Mutation Submissions` in the registration workflow. Showed how to work with returned data from the `action` using `useActionData`. 