### PR TITLE
Clean paths in relative route helper snapshots

### DIFF
--- a/packages/react-router-dev/__tests__/route-config-test.ts
+++ b/packages/react-router-dev/__tests__/route-config-test.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { normalizePath } from "vite";
+
 import {
   validateRouteConfig,
   route,
@@ -6,6 +9,15 @@ import {
   prefix,
   relative,
 } from "../config/routes";
+
+const cleanPathsForSnapshot = (obj: any): any =>
+  JSON.parse(
+    JSON.stringify(obj, (_key, value) =>
+      typeof value === "string" && path.isAbsolute(value)
+        ? normalizePath(value.replace(process.cwd(), "{{CWD}}"))
+        : value
+    )
+  );
 
 describe("route config", () => {
   describe("validateRouteConfig", () => {
@@ -460,40 +472,43 @@ describe("route config", () => {
 
     describe("relative", () => {
       it("supports relative routes", () => {
-        let { route } = relative("/path/to/dirname");
+        let { route } = relative(path.join(process.cwd(), "/path/to/dirname"));
         expect(
-          route("parent", "nested/parent.tsx", [
-            route("child", "nested/child.tsx", { id: "child" }),
-          ])
+          cleanPathsForSnapshot(
+            route("parent", "nested/parent.tsx", [
+              route("child", "nested/child.tsx", { id: "child" }),
+            ])
+          )
         ).toMatchInlineSnapshot(`
           {
             "children": [
               {
-                "children": undefined,
-                "file": "/path/to/dirname/nested/child.tsx",
+                "file": "{{CWD}}/path/to/dirname/nested/child.tsx",
                 "id": "child",
                 "path": "child",
               },
             ],
-            "file": "/path/to/dirname/nested/parent.tsx",
+            "file": "{{CWD}}/path/to/dirname/nested/parent.tsx",
             "path": "parent",
           }
         `);
       });
 
       it("supports relative index routes", () => {
-        let { index } = relative("/path/to/dirname");
-        expect([
-          index("nested/without-options.tsx"),
-          index("nested/with-options.tsx", { id: "with-options" }),
-        ]).toMatchInlineSnapshot(`
+        let { index } = relative(path.join(process.cwd(), "/path/to/dirname"));
+        expect(
+          cleanPathsForSnapshot([
+            index("nested/without-options.tsx"),
+            index("nested/with-options.tsx", { id: "with-options" }),
+          ])
+        ).toMatchInlineSnapshot(`
           [
             {
-              "file": "/path/to/dirname/nested/without-options.tsx",
+              "file": "{{CWD}}/path/to/dirname/nested/without-options.tsx",
               "index": true,
             },
             {
-              "file": "/path/to/dirname/nested/with-options.tsx",
+              "file": "{{CWD}}/path/to/dirname/nested/with-options.tsx",
               "id": "with-options",
               "index": true,
             },
@@ -502,21 +517,22 @@ describe("route config", () => {
       });
 
       it("supports relative layout routes", () => {
-        let { layout } = relative("/path/to/dirname");
+        let { layout } = relative(path.join(process.cwd(), "/path/to/dirname"));
         expect(
-          layout("nested/parent.tsx", [
-            layout("nested/child.tsx", { id: "child" }),
-          ])
+          cleanPathsForSnapshot(
+            layout("nested/parent.tsx", [
+              layout("nested/child.tsx", { id: "child" }),
+            ])
+          )
         ).toMatchInlineSnapshot(`
           {
             "children": [
               {
-                "children": undefined,
-                "file": "/path/to/dirname/nested/child.tsx",
+                "file": "{{CWD}}/path/to/dirname/nested/child.tsx",
                 "id": "child",
               },
             ],
-            "file": "/path/to/dirname/nested/parent.tsx",
+            "file": "{{CWD}}/path/to/dirname/nested/parent.tsx",
           }
         `);
       });


### PR DESCRIPTION
This is needed to ensure the tests can run on Windows. This was picked up when porting `routes.ts` support to Remix since the unit tests are run on Windows in that repo.