### PR TITLE
fix: Fix for typegen issue

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -285,3 +285,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- AlemTuzlak

--- a/packages/react-router-dev/typescript/typegen.ts
+++ b/packages/react-router-dev/typescript/typegen.ts
@@ -184,7 +184,7 @@ function parseParams(urlpath: string) {
       if (param.includes(".")) {
         param = param.split(".")[0];
       }
-      const isOptional = param.endsWith("?");
+      let isOptional = param.endsWith("?");
       if (isOptional) {
         param = param.slice(0, -1); // omit trailing `?`
       }

--- a/packages/react-router-dev/typescript/typegen.ts
+++ b/packages/react-router-dev/typescript/typegen.ts
@@ -180,7 +180,11 @@ function parseParams(urlpath: string) {
     .filter((s) => s.startsWith(":"))
     .forEach((param) => {
       param = param.slice(1); // omit leading `:`
-      let isOptional = param.endsWith("?");
+      // If there was an escaped dot, we need to remove it (eg $lang[.]xml => lang.xml => lang)
+      if (param.includes(".")) {
+        param = param.split(".")[0];
+      }
+      const isOptional = param.endsWith("?");
       if (isOptional) {
         param = param.slice(0, -1); // omit trailing `?`
       }


### PR DESCRIPTION
As the title said, I found this issue while testing out the new typegen and I have a sitemap that's located under `/sitemap/$lang[.]xml` which caused it to generate a param `lang.xml` which is invalid TS and it broke the typefile.

How to repro:
1. create a pre-release repo
2. add sitemap/$lang[.]xml.ts to routes and use the flat-routes routing convention
3. run typegen (before the output was lang.xml, now it's lang)
4. go to the `+types/filename` and check the Params