### PR TITLE
Update v7 docs to reflect that `ssr` is set to true by default

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -17,6 +17,7 @@
 - alexandernanberg
 - alexanderson1993
 - alexlbr
+- amanape
 - AmRo045
 - amsal
 - andreiduca

--- a/docs/start/rendering.md
+++ b/docs/start/rendering.md
@@ -11,7 +11,7 @@ There are three rendering strategies in React Router:
 - Server Side Rendering
 - Static Pre-rendering
 
-All routes are always client side rendered as the user navigates around the app. However, you can control server rendering and static pre-rendering with the `ssr` and `prerender` options in the Vite plugin.
+You can control server rendering and static pre-rendering with the `ssr` and `prerender` options in the Vite plugin.
 
 ## Server Side Rendering
 
@@ -22,7 +22,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   plugins: [
     reactRouter({
-      // defaults to false
+      // defaults to true
       ssr: true,
     }),
   ],


### PR DESCRIPTION
IMO `ssr` should be set to `false` by default, but here are the doc changes in-case its thats not the desired behavior.

Source: https://github.com/remix-run/react-router/blob/66613c0c6d1b2ba4f3636b660ba55803286d695c/packages/react-router-dev/vite/config.ts#L331-L337