### PR TITLE
fix(react-router): (v7) fix static prerender non-ascii problem

### DIFF
--- a/.changeset/shiny-cameras-try.md
+++ b/.changeset/shiny-cameras-try.md
@@ -1,0 +1,7 @@
+---
+"integration": patch
+"@react-router/dev": patch
+"react-router": patch
+---
+
+fix(react-router): (v7) fix static prerender of non-ascii characters

--- a/contributors.yml
+++ b/contributors.yml
@@ -227,6 +227,7 @@
 - rubeonline
 - ryanflorence
 - ryanhiebert
+- saengmotmi
 - sanketshah19
 - saul-atomrigs
 - sbolel

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1888,7 +1888,7 @@ async function handlePrerender(
         reactRouterConfig,
         viteConfig,
         data
-          ? { headers: { ...headers, "X-React-Router-Prerender-Data": data } }
+          ? { headers: { ...headers, "X-React-Router-Prerender-Data": encodeURI(data) } }
           : { headers }
       );
     }

--- a/packages/react-router/lib/server-runtime/routes.ts
+++ b/packages/react-router/lib/server-runtime/routes.ts
@@ -79,9 +79,12 @@ export function createStaticHandlerDataRoutes(
             // If we're prerendering, use the data passed in from prerendering
             // the .data route so we dom't call loaders twice
             if (args.request.headers.has("X-React-Router-Prerender-Data")) {
-              let encoded = args.request.headers.get(
+              const preRenderedData = args.request.headers.get(
                 "X-React-Router-Prerender-Data"
               );
+              let encoded = preRenderedData
+                ? decodeURI(preRenderedData)
+                : preRenderedData;
               invariant(encoded, "Missing prerendered data for route");
               let uint8array = new TextEncoder().encode(encoded);
               let stream = new ReadableStream({


### PR DESCRIPTION
fix #12160 

- Fixed an issue where builds would fail during static prerendering in React Router v7 when the data passed to the loader contains non-ASCII characters, such as Korean.
- Applied encodeURI to the X-React-Router-Prerender-Data header when making requests to localhost in the loader, and added decodeURI processing on the receiving end.
- Added relevant tests and confirmed that they pass.

Screenshot 1: Attempted static prerendering, which failed.

![image](https://github.com/user-attachments/assets/50a94c9d-c95c-4115-a800-6d00e72a1ae5)

Screenshot 2: Used `console.log` to inspect the `requestInit` object inside `prerenderRoute` to identify the point where prerendering fails.

![image](https://github.com/user-attachments/assets/b2be3e71-3897-4ba1-b761-ee093a239453)

Screenshot 3: Confirmed that the non-ASCII data is correctly passed to the loader after applying `encodeURI`/`decodeURI`.

![image](https://github.com/user-attachments/assets/aba9942d-9082-46bb-95e1-3e02dcb174b9)
