### PR TITLE
Add generics for loader data, action data, and fetchers

### DIFF
--- a/.changeset/long-peas-doubt.md
+++ b/.changeset/long-peas-doubt.md
@@ -1,0 +1,15 @@
+---
+"react-router": major
+---
+
+Migrate Remix type generics to React Router
+
+- These generics are provided for Remix v2 migration purposes
+- These generics and the APIs they exist on should be considered informally deprecated in favor of the new `Route.*` types
+- Anyone migrating from React Router v6 should probably not leverage these new generics and should migrate straight to the `Route.*` types
+- For React Router v6 users, these generics are new and should not impact your app, with one exception
+  - `useFetcher` previously had an optional generic (used primarily by Remix v2) that expected the data type
+  - This has been updated in v7 to expect the type of the function that generates the data (i.e., `typeof loader`/`typeof action`)
+  - Therefore, you should update your usages:
+    - ❌ `useFetcher<LoaderData>()`
+    - ✅ `useFetcher<typeof loader>()`

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -817,14 +817,14 @@ export function Routes({
   return useRoutes(createRoutesFromChildren(children), location);
 }
 
-export interface AwaitResolveRenderFunction {
-  (data: Awaited<any>): React.ReactNode;
+export interface AwaitResolveRenderFunction<Resolve = any> {
+  (data: Awaited<Resolve>): React.ReactNode;
 }
 
 /**
  * @category Types
  */
-export interface AwaitProps {
+export interface AwaitProps<Resolve> {
   /**
   When using a function, the resolved value is provided as the parameter.
 
@@ -923,7 +923,7 @@ export interface AwaitProps {
   }
   ```
    */
-  resolve: TrackedPromise | any;
+  resolve: Resolve;
 }
 
 /**
@@ -967,7 +967,11 @@ function Book() {
 @category Components
 
 */
-export function Await({ children, errorElement, resolve }: AwaitProps) {
+export function Await<Resolve>({
+  children,
+  errorElement,
+  resolve,
+}: AwaitProps<Resolve>) {
   return (
     <AwaitErrorBoundary resolve={resolve} errorElement={errorElement}>
       <ResolveAwait>{children}</ResolveAwait>

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -88,7 +88,7 @@ import {
   useResolvedPath,
   useRouteId,
 } from "../hooks";
-import type { DeprecatedSerializeFrom } from "../types";
+import type { SerializeFrom } from "../types";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Global Stuff
@@ -1814,7 +1814,7 @@ export function useFetcher<T = any>({
     ```
    */
   key?: string;
-} = {}): FetcherWithComponents<DeprecatedSerializeFrom<T>> {
+} = {}): FetcherWithComponents<SerializeFrom<T>> {
   let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
   let state = useDataRouterState(DataRouterStateHook.UseFetcher);
   let fetcherData = React.useContext(FetchersContext);

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -88,6 +88,7 @@ import {
   useResolvedPath,
   useRouteId,
 } from "../hooks";
+import { DeprecatedSerializeFrom } from "../types";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Global Stuff
@@ -1792,7 +1793,7 @@ export type FetcherWithComponents<TData> = Fetcher<TData> & {
 
   @category Hooks
  */
-export function useFetcher<TData = any>({
+export function useFetcher<T = any>({
   key,
 }: {
   /**
@@ -1813,7 +1814,7 @@ export function useFetcher<TData = any>({
     ```
    */
   key?: string;
-} = {}): FetcherWithComponents<TData> {
+} = {}): FetcherWithComponents<DeprecatedSerializeFrom<T>> {
   let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
   let state = useDataRouterState(DataRouterStateHook.UseFetcher);
   let fetcherData = React.useContext(FetchersContext);

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -88,7 +88,7 @@ import {
   useResolvedPath,
   useRouteId,
 } from "../hooks";
-import { DeprecatedSerializeFrom } from "../types";
+import type { DeprecatedSerializeFrom } from "../types";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Global Stuff

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -32,9 +32,6 @@ import { useLocation } from "../../hooks";
 import { getPartialManifest, isFogOfWarEnabled } from "./fog-of-war";
 import type { PageLinkDescriptor } from "../../router/links";
 
-// TODO: Temporary shim until we figure out the way to handle typings in v7
-export type SerializeFrom<D> = D extends () => {} ? Awaited<ReturnType<D>> : D;
-
 function useDataRouterContext() {
   let context = React.useContext(DataRouterContext);
   invariant(

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -9,10 +9,10 @@ import type {
   ShouldRevalidateFunction,
 } from "../../router/utils";
 
-import type { SerializeFrom } from "./components";
 import type { EntryRoute } from "./routes";
 import type { DataRouteMatch } from "../../context";
 import type { LinkDescriptor } from "../../router/links";
+import type { DeprecatedSerializeFrom } from "../../types";
 
 export interface RouteModules {
   [routeId: string]: RouteModule | undefined;
@@ -42,7 +42,7 @@ export type ClientActionFunction = (
  * Arguments passed to a route `clientAction` function
  */
 export type ClientActionFunctionArgs = ActionFunctionArgs<undefined> & {
-  serverAction: <T = unknown>() => Promise<SerializeFrom<T>>;
+  serverAction: <T = unknown>() => Promise<DeprecatedSerializeFrom<T>>;
 };
 
 /**
@@ -58,7 +58,7 @@ export type ClientLoaderFunction = ((
  * Arguments passed to a route `clientLoader` function
  */
 export type ClientLoaderFunctionArgs = LoaderFunctionArgs<undefined> & {
-  serverLoader: <T = unknown>() => Promise<SerializeFrom<T>>;
+  serverLoader: <T = unknown>() => Promise<DeprecatedSerializeFrom<T>>;
 };
 
 /**
@@ -100,7 +100,9 @@ export interface MetaMatch<
 > {
   id: RouteId;
   pathname: DataRouteMatch["pathname"];
-  data: Loader extends LoaderFunction ? SerializeFrom<Loader> : unknown;
+  data: Loader extends LoaderFunction
+    ? DeprecatedSerializeFrom<Loader>
+    : unknown;
   handle?: RouteHandle;
   params: DataRouteMatch["params"];
   meta: MetaDescriptor[];
@@ -129,7 +131,9 @@ export interface MetaArgs<
   >
 > {
   data:
-    | (Loader extends LoaderFunction ? SerializeFrom<Loader> : unknown)
+    | (Loader extends LoaderFunction
+        ? DeprecatedSerializeFrom<Loader>
+        : unknown)
     | undefined;
   params: Params;
   location: Location;

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -96,11 +96,11 @@ export interface LinksFunction {
 
 export interface MetaMatch<
   RouteId extends string = string,
-  Loader extends LoaderFunction | unknown = unknown
+  Loader extends LoaderFunction | ClientLoaderFunction | unknown = unknown
 > {
   id: RouteId;
   pathname: DataRouteMatch["pathname"];
-  data: Loader extends LoaderFunction
+  data: Loader extends LoaderFunction | ClientLoaderFunction
     ? DeprecatedSerializeFrom<Loader>
     : unknown;
   handle?: RouteHandle;
@@ -110,10 +110,10 @@ export interface MetaMatch<
 }
 
 export type MetaMatches<
-  MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
+  MatchLoaders extends Record<
     string,
-    unknown
-  >
+    LoaderFunction | ClientLoaderFunction | unknown
+  > = Record<string, unknown>
 > = Array<
   {
     [K in keyof MatchLoaders]: MetaMatch<
@@ -124,14 +124,14 @@ export type MetaMatches<
 >;
 
 export interface MetaArgs<
-  Loader extends LoaderFunction | unknown = unknown,
-  MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
+  Loader extends LoaderFunction | ClientLoaderFunction | unknown = unknown,
+  MatchLoaders extends Record<
     string,
-    unknown
-  >
+    LoaderFunction | ClientLoaderFunction | unknown
+  > = Record<string, unknown>
 > {
   data:
-    | (Loader extends LoaderFunction
+    | (Loader extends LoaderFunction | ClientLoaderFunction
         ? DeprecatedSerializeFrom<Loader>
         : unknown)
     | undefined;
@@ -192,11 +192,11 @@ export interface MetaArgs<
  * ```
  */
 export interface MetaFunction<
-  Loader extends LoaderFunction | unknown = unknown,
-  MatchLoaders extends Record<string, LoaderFunction | unknown> = Record<
+  Loader extends LoaderFunction | ClientLoaderFunction | unknown = unknown,
+  MatchLoaders extends Record<
     string,
-    unknown
-  >
+    LoaderFunction | ClientLoaderFunction | unknown
+  > = Record<string, unknown>
 > {
   (args: MetaArgs<Loader, MatchLoaders>): MetaDescriptor[] | undefined;
 }

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -12,7 +12,7 @@ import type {
 import type { EntryRoute } from "./routes";
 import type { DataRouteMatch } from "../../context";
 import type { LinkDescriptor } from "../../router/links";
-import type { DeprecatedSerializeFrom } from "../../types";
+import type { SerializeFrom } from "../../types";
 
 export interface RouteModules {
   [routeId: string]: RouteModule | undefined;
@@ -42,7 +42,7 @@ export type ClientActionFunction = (
  * Arguments passed to a route `clientAction` function
  */
 export type ClientActionFunctionArgs = ActionFunctionArgs<undefined> & {
-  serverAction: <T = unknown>() => Promise<DeprecatedSerializeFrom<T>>;
+  serverAction: <T = unknown>() => Promise<SerializeFrom<T>>;
 };
 
 /**
@@ -58,7 +58,7 @@ export type ClientLoaderFunction = ((
  * Arguments passed to a route `clientLoader` function
  */
 export type ClientLoaderFunctionArgs = LoaderFunctionArgs<undefined> & {
-  serverLoader: <T = unknown>() => Promise<DeprecatedSerializeFrom<T>>;
+  serverLoader: <T = unknown>() => Promise<SerializeFrom<T>>;
 };
 
 /**
@@ -101,7 +101,7 @@ export interface MetaMatch<
   id: RouteId;
   pathname: DataRouteMatch["pathname"];
   data: Loader extends LoaderFunction | ClientLoaderFunction
-    ? DeprecatedSerializeFrom<Loader>
+    ? SerializeFrom<Loader>
     : unknown;
   handle?: RouteHandle;
   params: DataRouteMatch["params"];
@@ -132,7 +132,7 @@ export interface MetaArgs<
 > {
   data:
     | (Loader extends LoaderFunction | ClientLoaderFunction
-        ? DeprecatedSerializeFrom<Loader>
+        ? SerializeFrom<Loader>
         : unknown)
     | undefined;
   params: Params;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -48,7 +48,7 @@ import {
   resolveTo,
   stripBasename,
 } from "./router/utils";
-import type { DeprecatedSerializeFrom } from "./types";
+import type { SerializeFrom } from "./types";
 
 // TODO: Let's get this back to using an import map and development/production
 // condition once we get the rollup build replaced
@@ -1083,10 +1083,10 @@ export function useMatches(): UIMatch[] {
 
   @category Hooks
  */
-export function useLoaderData<T = any>(): DeprecatedSerializeFrom<T> {
+export function useLoaderData<T = any>(): SerializeFrom<T> {
   let state = useDataRouterState(DataRouterStateHook.UseLoaderData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
-  return state.loaderData[routeId] as DeprecatedSerializeFrom<T>;
+  return state.loaderData[routeId] as SerializeFrom<T>;
 }
 
 /**
@@ -1118,9 +1118,9 @@ export function useLoaderData<T = any>(): DeprecatedSerializeFrom<T> {
  */
 export function useRouteLoaderData<T = any>(
   routeId: string
-): DeprecatedSerializeFrom<T> | undefined {
+): SerializeFrom<T> | undefined {
   let state = useDataRouterState(DataRouterStateHook.UseRouteLoaderData);
-  return state.loaderData[routeId] as DeprecatedSerializeFrom<T> | undefined;
+  return state.loaderData[routeId] as SerializeFrom<T> | undefined;
 }
 
 /**
@@ -1148,13 +1148,11 @@ export function useRouteLoaderData<T = any>(
 
   @category Hooks
  */
-export function useActionData<T = any>():
-  | DeprecatedSerializeFrom<T>
-  | undefined {
+export function useActionData<T = any>(): SerializeFrom<T> | undefined {
   let state = useDataRouterState(DataRouterStateHook.UseActionData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
   return (state.actionData ? state.actionData[routeId] : undefined) as
-    | DeprecatedSerializeFrom<T>
+    | SerializeFrom<T>
     | undefined;
 }
 

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -48,6 +48,7 @@ import {
   resolveTo,
   stripBasename,
 } from "./router/utils";
+import type { DeprecatedSerializeFrom } from "./types";
 
 // TODO: Let's get this back to using an import map and development/production
 // condition once we get the rollup build replaced
@@ -1082,10 +1083,10 @@ export function useMatches(): UIMatch[] {
 
   @category Hooks
  */
-export function useLoaderData(): unknown {
+export function useLoaderData<T = any>(): DeprecatedSerializeFrom<T> {
   let state = useDataRouterState(DataRouterStateHook.UseLoaderData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
-  return state.loaderData[routeId];
+  return state.loaderData[routeId] as DeprecatedSerializeFrom<T>;
 }
 
 /**
@@ -1115,9 +1116,11 @@ export function useLoaderData(): unknown {
 
   @category Hooks
  */
-export function useRouteLoaderData(routeId: string): unknown {
+export function useRouteLoaderData<T = any>(
+  routeId: string
+): DeprecatedSerializeFrom<T> | undefined {
   let state = useDataRouterState(DataRouterStateHook.UseRouteLoaderData);
-  return state.loaderData[routeId];
+  return state.loaderData[routeId] as DeprecatedSerializeFrom<T> | undefined;
 }
 
 /**
@@ -1145,10 +1148,14 @@ export function useRouteLoaderData(routeId: string): unknown {
 
   @category Hooks
  */
-export function useActionData(): unknown {
+export function useActionData<T = any>():
+  | DeprecatedSerializeFrom<T>
+  | undefined {
   let state = useDataRouterState(DataRouterStateHook.UseActionData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
-  return state.actionData ? state.actionData[routeId] : undefined;
+  return (state.actionData ? state.actionData[routeId] : undefined) as
+    | DeprecatedSerializeFrom<T>
+    | undefined;
 }
 
 /**

--- a/packages/react-router/lib/types.ts
+++ b/packages/react-router/lib/types.ts
@@ -1,3 +1,7 @@
+import type {
+  ClientLoaderFunctionArgs,
+  ClientActionFunctionArgs,
+} from "./dom/ssr/routeModules";
 import type { DataWithResponseInit } from "./router/utils";
 import type { AppLoadContext } from "./server-runtime/data";
 import type { Serializable } from "./server-runtime/single-fetch";
@@ -120,6 +124,19 @@ type Serialize<T> =
   T extends Record<any, any> ? {[K in keyof T]: Serialize<T[K]>} :
 
   undefined
+
+/**
+ * @deprecated Generics on data APIs such as `useLoaderData`, `useActionData`,
+ * `meta`, etc. are deprecated in favor of the `Route.*` types generated via
+ * `react-router typegen`
+ */
+export type DeprecatedSerializeFrom<T> = T extends (
+  ...args: infer Args
+) => unknown
+  ? Args extends [ClientLoaderFunctionArgs | ClientActionFunctionArgs]
+    ? ClientData<DataFrom<T>>
+    : ServerData<DataFrom<T>>
+  : T;
 
 export type CreateServerLoaderArgs<Params> = ServerDataFunctionArgs<Params>;
 

--- a/packages/react-router/lib/types.ts
+++ b/packages/react-router/lib/types.ts
@@ -130,9 +130,7 @@ type Serialize<T> =
  * `meta`, etc. are deprecated in favor of the `Route.*` types generated via
  * `react-router typegen`
  */
-export type DeprecatedSerializeFrom<T> = T extends (
-  ...args: infer Args
-) => unknown
+export type SerializeFrom<T> = T extends (...args: infer Args) => unknown
   ? Args extends [ClientLoaderFunctionArgs | ClientActionFunctionArgs]
     ? ClientData<DataFrom<T>>
     : ServerData<DataFrom<T>>


### PR DESCRIPTION
Stacked on https://github.com/remix-run/react-router/pull/12177

Handles bringing over Remix generics for:
* `useLoaderData`/`useActionData`
* `useFetcher`
* `useRouteLoaderData`
* `meta()`
* `Await`
* `serverLoader`/`serverAction`

Am I missing anything else?

Available for testing in `0.0.0-experimental-7c6c0664d`