### PR TITLE
fix: resolve config directory relative to flat output file structure

### DIFF
--- a/.changeset/serious-beds-approve.md
+++ b/.changeset/serious-beds-approve.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+resolve config directory relative to flat output file structure

--- a/packages/react-router-dev/cli/commands.ts
+++ b/packages/react-router-dev/cli/commands.ts
@@ -117,7 +117,7 @@ export async function generateEntry(
     return;
   }
 
-  let defaultsDirectory = path.resolve(__dirname, "..", "config", "defaults");
+  let defaultsDirectory = path.resolve(__dirname, "config", "defaults");
   let defaultEntryClient = path.resolve(defaultsDirectory, "entry.client.tsx");
 
   let defaultEntryServer = path.resolve(

--- a/packages/react-router-dev/cli/commands.ts
+++ b/packages/react-router-dev/cli/commands.ts
@@ -117,7 +117,12 @@ export async function generateEntry(
     return;
   }
 
-  let defaultsDirectory = path.resolve(__dirname, "config", "defaults");
+  let defaultsDirectory = path.resolve(
+    path.dirname(require.resolve("@react-router/dev/package.json")),
+    "dist",
+    "config",
+    "defaults"
+  );
   let defaultEntryClient = path.resolve(defaultsDirectory, "entry.client.tsx");
 
   let defaultEntryServer = path.resolve(

--- a/packages/react-router-dev/tsup.config.ts
+++ b/packages/react-router-dev/tsup.config.ts
@@ -15,7 +15,7 @@ const entry = [
   "typescript/plugin.ts",
 ];
 
-const external = ["./static/refresh-utils.cjs"];
+const external = ["./static/refresh-utils.cjs", /^(?!\.)/];
 
 export default defineConfig([
   {

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -529,7 +529,7 @@ export async function resolveEntryFiles({
 }) {
   let { appDirectory } = reactRouterConfig;
 
-  let defaultsDirectory = path.resolve(__dirname, "..", "config", "defaults");
+  let defaultsDirectory = path.resolve(__dirname, "config", "defaults");
 
   let userEntryClientFile = findEntry(appDirectory, "entry.client");
   let userEntryServerFile = findEntry(appDirectory, "entry.server");

--- a/packages/react-router-dev/vite/config.ts
+++ b/packages/react-router-dev/vite/config.ts
@@ -529,7 +529,12 @@ export async function resolveEntryFiles({
 }) {
   let { appDirectory } = reactRouterConfig;
 
-  let defaultsDirectory = path.resolve(__dirname, "config", "defaults");
+  let defaultsDirectory = path.resolve(
+    path.dirname(require.resolve("@react-router/dev/package.json")),
+    "dist",
+    "config",
+    "defaults"
+  );
 
   let userEntryClientFile = findEntry(appDirectory, "entry.client");
   let userEntryServerFile = findEntry(appDirectory, "entry.server");

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -373,7 +373,7 @@ export let getServerBuildDirectory = (ctx: ReactRouterPluginContext) =>
 let getClientBuildDirectory = (reactRouterConfig: ResolvedReactRouterConfig) =>
   path.join(reactRouterConfig.buildDirectory, "client");
 
-let defaultEntriesDir = path.resolve(__dirname, "..", "config", "defaults");
+let defaultEntriesDir = path.resolve(__dirname, "config", "defaults");
 let defaultEntries = fse
   .readdirSync(defaultEntriesDir)
   .map((filename) => path.join(defaultEntriesDir, filename));

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -373,7 +373,12 @@ export let getServerBuildDirectory = (ctx: ReactRouterPluginContext) =>
 let getClientBuildDirectory = (reactRouterConfig: ResolvedReactRouterConfig) =>
   path.join(reactRouterConfig.buildDirectory, "client");
 
-let defaultEntriesDir = path.resolve(__dirname, "config", "defaults");
+let defaultEntriesDir = path.resolve(
+  path.dirname(require.resolve("@react-router/dev/package.json")),
+  "dist",
+  "config",
+  "defaults"
+);
 let defaultEntries = fse
   .readdirSync(defaultEntriesDir)
   .map((filename) => path.join(defaultEntriesDir, filename));

--- a/packages/react-router/tsup.config.ts
+++ b/packages/react-router/tsup.config.ts
@@ -14,9 +14,6 @@ export default defineConfig([
     format: ["cjs"],
     outDir: "dist",
     dts: true,
-    external: [
-      /*.*/
-    ],
     banner: {
       js: createBanner(pkg.name, pkg.version),
     },
@@ -31,9 +28,6 @@ export default defineConfig([
     format: ["esm"],
     outDir: "dist",
     dts: true,
-    external: [
-      /*.*/
-    ],
     banner: {
       js: createBanner(pkg.name, pkg.version),
     },


### PR DESCRIPTION
Build output is bundled now so things are collapsed to the root of the dist directory. We now need to resolve the config dir relative to the root, not the input file structure.