### PR TITLE
fix: take the `appDirectory` into account when generating types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -218,6 +218,7 @@
 - promet99
 - pyitphyoaung
 - refusado
+- rifaidev
 - rimian
 - robbtraister
 - RobHannay

--- a/packages/react-router-dev/typescript/typegen.ts
+++ b/packages/react-router-dev/typescript/typegen.ts
@@ -28,7 +28,7 @@ function getDirectory(ctx: Context) {
 export function getPath(ctx: Context, route: RouteManifestEntry): string {
   return Path.join(
     getDirectory(ctx),
-    Path.basename(ctx.appDirectory),
+    Path.relative(ctx.rootDirectory, ctx.appDirectory),
     Path.dirname(route.file),
     "+types." + Pathe.filename(route.file) + ".d.ts"
   );


### PR DESCRIPTION
This PR fixes [#12162](https://github.com/remix-run/react-router/issues/12162) by modify the type generation logic to consider custom `appDirectory` config in the Vite plugin.

> [!NOTE]
> While a recent [change](https://github.com/remix-run/react-router/pull/12203/commits/e392cfc7974ef51f64358014686d8b51599855c0) updated the logic to use `Path.basename(ctx.appDirectory)`, this only captures the base name of the directory (e.g., "app" in "src/app"). This PR modifies the logic to utilize the full relative path provided in the `appDirectory` configuration.

_This change ensures that the types are generated in the correct location, as specified by the `appDirectory` config. It has no impact on existing functionality and simply aligns the type generation with the user's chosen configuration._



