### PR TITLE
fix(react-router-serve): ensure node_env set before react loaded

### DIFF
--- a/packages/react-router-serve/bin.js
+++ b/packages/react-router-serve/bin.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
+process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 require("./dist/cli");


### PR DESCRIPTION
Fixes #12078. 

Error only reproducible with React v19 but even with React v18 the dev react and prod react-dom modules are loaded, it just doesn't hard error. 