### PR TITLE
Update links to documentation for router utils

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -131,6 +131,7 @@
 - JesusTheHun
 - jimniels
 - jmargeta
+- johngeorgesample
 - johnpangalos
 - jonkoops
 - jrakotoharisoa

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1,4 +1,3 @@
-
 import type { Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";
 

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -1,3 +1,4 @@
+
 import type { Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";
 
@@ -504,7 +505,7 @@ export function convertRoutesToDataRoutes(
 /**
  * Matches the given routes to a location and returns the match data.
  *
- * @see https://reactrouter.com/utils/match-routes
+ * @see https://reactrouter.com/en/main/utils/match-routes
  */
 export function matchRoutes<
   RouteObjectType extends AgnosticRouteObject = AgnosticRouteObject
@@ -857,7 +858,7 @@ function matchRouteBranch<
 /**
  * Returns a path with params interpolated.
  *
- * @see https://reactrouter.com/utils/generate-path
+ * @see https://reactrouter.com/en/main/utils/generate-path
  */
 export function generatePath<Path extends string>(
   originalPath: Path,
@@ -963,7 +964,7 @@ type Mutable<T> = {
  * Performs pattern matching on a URL pathname and returns information about
  * the match.
  *
- * @see https://reactrouter.com/utils/match-path
+ * @see https://reactrouter.com/en/main/utils/match-path
  */
 export function matchPath<
   ParamKey extends ParamParseKey<Path>,
@@ -1123,7 +1124,7 @@ export function stripBasename(
 /**
  * Returns a resolved path object relative to the given pathname.
  *
- * @see https://reactrouter.com/utils/resolve-path
+ * @see https://reactrouter.com/en/main/utils/resolve-path
  */
 export function resolvePath(to: To, fromPathname = "/"): Path {
   let {


### PR DESCRIPTION
Howdy! I was digging into the source this morning and found all the links in `packages/router/utils.ts` were 404'ing.