### PR TITLE
Add `watch` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm run --filter=\"./packages/**/*\" build",
+    "watch": "pnpm build && pnpm run --filter=\"./packages/**/*\" --parallel build --watch",
     "clean": "git clean -fdX .",
     "clean:build": "git clean -fdx -e node_modules .",
     "clean:integration": "node ./integration/helpers/cleanup.mjs",


### PR DESCRIPTION
This reintroduces the `watch` npm script on top of the new build script setup.