### PR TITLE
fix(typegen): use actual relative path for import

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -157,6 +157,7 @@
 - kylegirard
 - landisdesign
 - latin-1
+- lazuee
 - lequangdongg
 - liuhanqu
 - lkwr


### PR DESCRIPTION
This update ensures that `typegen` uses the actual relative path for `import` statements, rather than defaulting to the filename.

Here’s an example of the updated type-safe route generated by `typegen`:
```diff
// React Router generated types for route:
// routes/_index.tsx

import * as T from "react-router/types"

export type Params = {}

--type RouteModule = typeof import("./_index")
++type RouteModule = typeof import("../../../../app/routes/_index")
```

This change improves path accuracy for generated imports in type-safe routes. 