### PR TITLE
Add hashbang to CLI entries

### DIFF
--- a/packages/create-react-router/cli.ts
+++ b/packages/create-react-router/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import process from "node:process";
 
 import { createReactRouter } from "./index";

--- a/packages/react-router-dev/cli/index.ts
+++ b/packages/react-router-dev/cli/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { run } from "./run";
 
 run().then(

--- a/packages/react-router-serve/cli.ts
+++ b/packages/react-router-serve/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";


### PR DESCRIPTION
These were lost from the build output when migrating from Rollup to tsup. Rather than adding them via the banner like we did before, we need to have the hashbangs at the top of our CLI entry files: https://tsup.egoist.dev/#building-cli-app