### PR TITLE
Add `.react-router` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ node_modules/
 /packages/*/dist/
 /packages/*/LICENSE.md
 
+# v7 build files
+.react-router
+
 .wireit
 .eslintcache
 .tmp

--- a/integration/helpers/vite-template/.gitignore
+++ b/integration/helpers/vite-template/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /.cache
 /build
 .env
+.react-router


### PR DESCRIPTION
I noticed that the Vite test template's `.react-router` directory wasn't gitignored within the Vite integration test template after running `pnpm typecheck`.