### PR TITLE
Fix docs usage of dev command

### DIFF
--- a/docs/upgrading/vite-component-routes.md
+++ b/docs/upgrading/vite-component-routes.md
@@ -163,7 +163,7 @@ Note that your `root.tsx` file will be statically generated and served as the en
 At this point you should be able to to boot the app and see the root layout.
 
 ```shellscript
-npm react-router vite:dev
+npx react-router dev
 ```
 
 - Search the [Upgrading Discussion](#TODO) category

--- a/docs/upgrading/vite-router-provider.md
+++ b/docs/upgrading/vite-router-provider.md
@@ -159,7 +159,7 @@ Note that your `root.tsx` file will be statically generated and served as the en
 At this point you should be able to to boot the app.
 
 ```shellscript
-npm react-router vite:dev
+npx react-router dev
 ```
 
 If you're having trouble


### PR DESCRIPTION
I noticed the docs were using the old Remix format of `vite:dev` rather than just `dev`. The docs were also trying to run the CLI via `npm react-router` rather than `npx`.