### PR TITLE
v7_skipActionStatusRevalidation -> v7_skipActionErrorRevalidation in Docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -287,3 +287,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- andreasottosson-polestar

--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -201,7 +201,7 @@ createBrowserRouter(routes, {
 });
 ```
 
-### v7_skipActionStatusRevalidation
+### v7_skipActionErrorRevalidation
 
 <docs-warning>If you are not using a `createBrowserRouter` you can skip this</docs-warning>
 
@@ -212,7 +212,7 @@ When this flag is enabled, loaders will no longer revalidate by default after an
 ```tsx
 createBrowserRouter(routes, {
   future: {
-    v7_skipActionStatusRevalidation: true,
+    v7_skipActionErrorRevalidation: true,
   },
 });
 ```


### PR DESCRIPTION
Quick one.. v7_skipActionStatusRevalidation is named v7_skipActionErrorRevalidation, at least in RR 6.27.0.

Is this a typo?