### PR TITLE
chore: change `v7_skipActionStatusRevalidation` to `v7_skipActionErrorRevalidation`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -238,6 +238,7 @@
 - shivamsinghchahar
 - SimenB
 - SkayuX
+- skratchdot
 - smithki
 - souzasmatheus
 - srmagura

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -200,7 +200,7 @@ createBrowserRouter(routes, {
 });
 ```
 
-## v7_skipActionStatusRevalidation
+## v7_skipActionErrorRevalidation
 
 <docs-warning>If you are not using a `createBrowserRouter` you can skip this</docs-warning>
 
@@ -211,7 +211,7 @@ When this flag is enabled, loaders will no longer revalidate by default after an
 ```tsx
 createBrowserRouter(routes, {
   future: {
-    v7_skipActionStatusRevalidation: true,
+    v7_skipActionErrorRevalidation: true,
   },
 });
 ```


### PR DESCRIPTION
I am seeing warnings like:
```
      ⚠️ React Router Future Flag Warning: The revalidation behavior after 4xx/5xx `action` responses is changing in v7. You can use the `v7_skipActionErrorRevalidation` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_skipactionerrorrevalidation.
```

in my console, but the https://reactrouter.com/v6/upgrading/future#v7_skipactionerrorrevalidation link does not resolve to a section on the `/v6/upgrading/future` page.