### PR TITLE
Add createRequestListener to @react-router/node

### DIFF
--- a/packages/react-router-node/index.ts
+++ b/packages/react-router-node/index.ts
@@ -1,3 +1,5 @@
+export { type RequestListenerOptions, createRequestListener } from "./server";
+
 export { createFileSessionStorage } from "./sessions/fileStorage";
 
 export {

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -68,6 +68,7 @@
     }
   },
   "dependencies": {
+    "@mjackson/node-fetch-server": "^0.2.0",
     "source-map-support": "^0.5.21",
     "stream-slice": "^0.1.2",
     "undici": "^6.19.2"

--- a/packages/react-router-node/server.ts
+++ b/packages/react-router-node/server.ts
@@ -1,0 +1,32 @@
+import type { RequestListener } from "node:http";
+
+import type { AppLoadContext, ServerBuild } from "react-router";
+import { createRequestHandler } from "react-router";
+import type { ClientAddress } from "@mjackson/node-fetch-server";
+import { createRequestListener as createRequestListener_ } from "@mjackson/node-fetch-server";
+
+export interface RequestListenerOptions {
+  build: ServerBuild | (() => ServerBuild | Promise<ServerBuild>);
+  getLoadContext?: (
+    request: Request,
+    client: ClientAddress
+  ) => AppLoadContext | Promise<AppLoadContext>;
+  mode?: string;
+}
+
+/**
+ * Creates a request listener that handles requests using Node's built-in HTTP server.
+ *
+ * @param options Options for creating a request listener.
+ * @returns A request listener that can be used with `http.createServer`.
+ */
+export function createRequestListener(
+  options: RequestListenerOptions
+): RequestListener {
+  let handleRequest = createRequestHandler(options.build, options.mode);
+
+  return createRequestListener_(async (request, client) => {
+    let loadContext = await options.getLoadContext?.(request, client);
+    return handleRequest(request, loadContext);
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,9 @@ importers:
 
   packages/react-router-node:
     dependencies:
+      '@mjackson/node-fetch-server':
+        specifier: ^0.2.0
+        version: 0.2.0
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -2755,6 +2758,9 @@ packages:
     resolution: {integrity: sha512-j0II91OCm4ld+l5QVgXXMQGxVVcAWIQJakYWi1dv5pefDHASJyCYER2TsdH7Alf958GoFSM7ugukWyvDq/UY4A==}
     peerDependencies:
       rollup: '>=2'
+
+  '@mjackson/node-fetch-server@0.2.0':
+    resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
 
   '@mswjs/cookies@0.2.2':
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -10618,6 +10624,8 @@ snapshots:
       vfile: 6.0.1
     transitivePeerDependencies:
       - supports-color
+
+  '@mjackson/node-fetch-server@0.2.0': {}
 
   '@mswjs/cookies@0.2.2':
     dependencies:


### PR DESCRIPTION
This PR adds a `createRequestListener` function to `@react-router/node` using `@mjackson/node-fetch-server` under the hood.