### PR TITLE
typegen: meta + links

### DIFF
--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -30,15 +30,19 @@ const viteConfig = tsx`
   };
 `;
 
-const assertType = tsx`
-  export function assertType<T>(t: T) {}
+const expectType = tsx`
+  export type Expect<T extends true> = T
+
+  export type Equal<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends
+    (<T>() => T extends Y ? 1 : 2) ? true : false
 `;
 
 test.describe("typegen", () => {
   test("basic", async () => {
     const cwd = await createProject({
       "vite.config.ts": viteConfig,
-      "app/assertType.ts": assertType,
+      "app/expect-type.ts": expectType,
       "app/routes.ts": tsx`
         import { type RouteConfig, route } from "@react-router/dev/routes";
 
@@ -47,16 +51,16 @@ test.describe("typegen", () => {
         ]
       `,
       "app/routes/product.tsx": tsx`
-        import { assertType } from "../assertType"
+        import { Expect, Equal } from "../expect-type"
         import type { Route } from "./+types.product"
 
         export function loader({ params }: Route.LoaderArgs) {
-          assertType<string>(params.id)
+          type Test = Expect<Equal<typeof params.id, string>>
           return { planet: "world" }
         }
 
         export default function Component({ loaderData }: Route.ComponentProps) {
-          assertType<string>(loaderData.planet)
+          type Test = Expect<Equal<typeof loaderData.planet, string>>
           return <h1>Hello, {loaderData.planet}!</h1>
         }
       `,
@@ -72,7 +76,7 @@ test.describe("typegen", () => {
     test("repeated", async () => {
       const cwd = await createProject({
         "vite.config.ts": viteConfig,
-        "app/assertType.ts": assertType,
+        "app/expect-type.ts": expectType,
         "app/routes.ts": tsx`
           import { type RouteConfig, route } from "@react-router/dev/routes";
 
@@ -81,11 +85,12 @@ test.describe("typegen", () => {
           ]
         `,
         "app/routes/repeated-params.tsx": tsx`
-          import { assertType } from "../assertType"
+          import { Expect, Equal } from "../expect-type"
           import type { Route } from "./+types.repeated-params"
 
           export function loader({ params }: Route.LoaderArgs) {
-            assertType<[string, string | undefined, string]>(params.id)
+            type Expected = [string, string | undefined, string]
+            type Test = Expect<Equal<typeof params.id, Expected>>
             return null
           }
         `,
@@ -99,7 +104,7 @@ test.describe("typegen", () => {
     test("splat", async () => {
       const cwd = await createProject({
         "vite.config.ts": viteConfig,
-        "app/assertType.ts": assertType,
+        "app/expect-type.ts": expectType,
         "app/routes.ts": tsx`
           import { type RouteConfig, route } from "@react-router/dev/routes";
 
@@ -108,11 +113,11 @@ test.describe("typegen", () => {
           ]
         `,
         "app/routes/splat.tsx": tsx`
-          import { assertType } from "../assertType"
+          import { Expect, Equal } from "../expect-type"
           import type { Route } from "./+types.splat"
 
           export function loader({ params }: Route.LoaderArgs) {
-            assertType<string>(params["*"])
+            type Test = Expect<Equal<typeof params["*"], string>>
             return null
           }
         `,
@@ -126,7 +131,7 @@ test.describe("typegen", () => {
     test("with extension", async () => {
       const cwd = await createProject({
         "vite.config.ts": viteConfig,
-        "app/assertType.ts": assertType,
+        "app/expect-type.ts": expectType,
         "app/routes.ts": tsx`
           import { type RouteConfig, route } from "@react-router/dev/routes";
 
@@ -136,20 +141,20 @@ test.describe("typegen", () => {
           ]
         `,
         "app/routes/param-with-ext.tsx": tsx`
-          import { assertType } from "../assertType"
+          import { Expect, Equal } from "../expect-type"
           import type { Route } from "./+types.param-with-ext"
 
           export function loader({ params }: Route.LoaderArgs) {
-            assertType<string>(params["lang"])
+            type Test = Expect<Equal<typeof params["lang"], string>>
             return null
           }
         `,
         "app/routes/optional-param-with-ext.tsx": tsx`
-          import { assertType } from "../assertType"
+          import { Expect, Equal } from "../expect-type"
           import type { Route } from "./+types.optional-param-with-ext"
 
           export function loader({ params }: Route.LoaderArgs) {
-            assertType<string | undefined>(params["user"])
+            type Test = Expect<Equal<typeof params["user"], string | undefined>>
             return null
           }
         `,
@@ -164,9 +169,9 @@ test.describe("typegen", () => {
   test("clientLoader.hydrate = true", async () => {
     const cwd = await createProject({
       "vite.config.ts": viteConfig,
-      "app/assertType.ts": assertType,
+      "app/expect-type.ts": expectType,
       "app/routes/_index.tsx": tsx`
-        import { assertType } from "../assertType"
+        import { Expect, Equal } from "../expect-type"
         import type { Route } from "./+types._index"
 
         export function loader() {
@@ -183,7 +188,7 @@ test.describe("typegen", () => {
         }
 
         export default function Component({ loaderData }: Route.ComponentProps) {
-          assertType<{ client: string }>(loaderData)
+          type Test = Expect<Equal<typeof loaderData, { client: string }>>
           return <h1>Hello from {loaderData.client}!</h1>
         }
       `,
@@ -203,18 +208,18 @@ test.describe("typegen", () => {
           plugins: [reactRouter({ appDirectory: "src/myapp" })],
         };
       `,
-      "app/assertType.ts": assertType,
+      "app/expect-type.ts": expectType,
       "app/routes/products.$id.tsx": tsx`
-        import { assertType } from "../assertType"
+        import { Expect, Equal } from "../expect-type"
         import type { Route } from "./+types.products.$id"
 
         export function loader({ params }: Route.LoaderArgs) {
-          assertType<string>(params.id)
+          type Test = Expect<Equal<typeof params.id, string>>
           return { planet: "world" }
         }
 
         export default function Component({ loaderData }: Route.ComponentProps) {
-          assertType<string>(loaderData.planet)
+          type Test = Expect<Equal<typeof loaderData.planet, string>>
           return <h1>Hello, {loaderData.planet}!</h1>
         }
       `,

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -21,6 +21,13 @@ export function generate(
       export type LoaderData = T.CreateLoaderData<RouteModule>
       export type ActionData = T.CreateActionData<RouteModule>
 
+      export type LinkDescriptors = T.LinkDescriptors
+      export type LinksFunction = () => LinkDescriptors
+
+      export type MetaArgs = T.CreateMetaArgs<Params, LoaderData>
+      export type MetaDescriptors = T.MetaDescriptors
+      export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+
       export type LoaderArgs = T.CreateServerLoaderArgs<Params>
       export type ClientLoaderArgs = T.CreateClientLoaderArgs<Params, RouteModule>
       export type ActionArgs = T.CreateServerActionArgs<Params>

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -205,6 +205,7 @@ export type {
   MetaFunction,
   LinksFunction,
 } from "./lib/dom/ssr/routeModules";
+export type { MetaMatch } from "./lib/types/meta-match";
 export type { ServerRouterProps } from "./lib/dom/ssr/server";
 export { ServerRouter } from "./lib/dom/ssr/server";
 export type { RoutesTestStubProps } from "./lib/dom/ssr/routes-test-stub";

--- a/packages/react-router/lib/types/meta-match.ts
+++ b/packages/react-router/lib/types/meta-match.ts
@@ -1,0 +1,11 @@
+import type { MetaDescriptor } from "../dom/ssr/routeModules";
+
+export type MetaMatch<LoaderData> = {
+  id: string;
+  pathname: string;
+  data: LoaderData;
+  handle?: unknown;
+  params: Record<string, string | undefined>;
+  meta: MetaDescriptor[];
+  error?: unknown;
+};

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -1,4 +1,8 @@
+import type { MetaDescriptor } from "../dom/ssr/routeModules";
+import type { LinkDescriptor } from "../router/links";
 import type { AppLoadContext } from "../server-runtime/data";
+
+import type { MetaMatch } from "./meta-match";
 import type { ClientDataFrom, ServerDataFrom } from "./route-data";
 import type { Equal, Expect, Func } from "./utils";
 
@@ -13,6 +17,17 @@ type RouteModule = {
   default?: unknown;
   ErrorBoundary?: unknown;
 };
+
+export type LinkDescriptors = LinkDescriptor[];
+
+export type CreateMetaArgs<Params, LoaderData> = {
+  location: Location;
+  params: Params;
+  data: LoaderData;
+  error?: unknown;
+  matches: Array<MetaMatch<unknown>>;
+};
+export type MetaDescriptors = MetaDescriptor[];
 
 // prettier-ignore
 type IsHydrate<ClientLoader> =

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -44,7 +44,7 @@
       }
     },
     "./route-module": {
-      "types": "./dist/production/lib/route-module.d.ts"
+      "types": "./dist/production/lib/types/route-module.d.ts"
     },
     "./dom": {
       "node": {


### PR DESCRIPTION
For `matches` in `meta`, loop over them and match by something like `id` and then cast it. This is equivalent to the generic we had in Remix but with less boilerplate:

```ts
// Remix v2
import type { ParentLoader } from "./parent-route"
import type { GrandparentLoader } from "./grandparent-route"

export function loader() {}

export function meta({ data, matches }: MetaArgs<
  typeof loader,
  {
    "parent-route": ParentLoader,
    "grandparent-route": GrandparentLoader,
  } // 👆 giant generic for ancestor routes
>) {
  for (let match of matches) {
    if (match.id === "parent-route") {
      const safeMatch = match as { data: SerializeFrom<ParentLoader> }
      // 👆 doing that giant generic didn't really help, we still have to cast it here!
    }
  }
}
```

```ts
// React Router v7
import { MetaMatch } from "react-router"

import type { Route as Parent } from "./+types.parent-route"
import type { Route as Grandparent } from "./+types.grandparent-route"
import type { Route } from "./+types.this-route"

export function loader() {}

export function meta({ data, matches }: Route.MetaArgs) {
  for (let match of matches) {
    if (match.id === "parent-route") {
      const safeMatch = match as MetaMatch<Parent.LoaderData>
    }
  }
}
```

Not only is this simpler and less code, but it also has correct loader data across `loader`, `clientLoader`, `clientLoader.hydrate`, and `HydrateFallback`.

## Future work

In the future, I plan to improve typegen so that information about parent routes is generated for each route, which would take all the casting for `MetaMatch` out of the picture