### PR TITLE
typegen: `+types.<route>` -> `+types/<route>`

### DIFF
--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -52,7 +52,7 @@ test.describe("typegen", () => {
       `,
       "app/routes/product.tsx": tsx`
         import { Expect, Equal } from "../expect-type"
-        import type { Route } from "./+types.product"
+        import type { Route } from "./+types/product"
 
         export function loader({ params }: Route.LoaderArgs) {
           type Test = Expect<Equal<typeof params.id, string>>
@@ -86,7 +86,7 @@ test.describe("typegen", () => {
         `,
         "app/routes/repeated-params.tsx": tsx`
           import { Expect, Equal } from "../expect-type"
-          import type { Route } from "./+types.repeated-params"
+          import type { Route } from "./+types/repeated-params"
 
           export function loader({ params }: Route.LoaderArgs) {
             type Expected = [string, string | undefined, string]
@@ -114,7 +114,7 @@ test.describe("typegen", () => {
         `,
         "app/routes/splat.tsx": tsx`
           import { Expect, Equal } from "../expect-type"
-          import type { Route } from "./+types.splat"
+          import type { Route } from "./+types/splat"
 
           export function loader({ params }: Route.LoaderArgs) {
             type Test = Expect<Equal<typeof params["*"], string>>
@@ -142,7 +142,7 @@ test.describe("typegen", () => {
         `,
         "app/routes/param-with-ext.tsx": tsx`
           import { Expect, Equal } from "../expect-type"
-          import type { Route } from "./+types.param-with-ext"
+          import type { Route } from "./+types/param-with-ext"
 
           export function loader({ params }: Route.LoaderArgs) {
             type Test = Expect<Equal<typeof params["lang"], string>>
@@ -151,7 +151,7 @@ test.describe("typegen", () => {
         `,
         "app/routes/optional-param-with-ext.tsx": tsx`
           import { Expect, Equal } from "../expect-type"
-          import type { Route } from "./+types.optional-param-with-ext"
+          import type { Route } from "./+types/optional-param-with-ext"
 
           export function loader({ params }: Route.LoaderArgs) {
             type Test = Expect<Equal<typeof params["user"], string | undefined>>
@@ -172,7 +172,7 @@ test.describe("typegen", () => {
       "app/expect-type.ts": expectType,
       "app/routes/_index.tsx": tsx`
         import { Expect, Equal } from "../expect-type"
-        import type { Route } from "./+types._index"
+        import type { Route } from "./+types/_index"
 
         export function loader() {
           return { server: "server" }
@@ -211,7 +211,7 @@ test.describe("typegen", () => {
       "app/expect-type.ts": expectType,
       "app/routes/products.$id.tsx": tsx`
         import { Expect, Equal } from "../expect-type"
-        import type { Route } from "./+types.products.$id"
+        import type { Route } from "./+types/products.$id"
 
         export function loader({ params }: Route.LoaderArgs) {
           type Test = Expect<Equal<typeof params.id, string>>
@@ -281,7 +281,7 @@ test.describe("typegen", () => {
       `,
       "app/routes/current.tsx": tsx`
         import { Expect, Equal } from "../expect-type"
-        import type { Route } from "./+types.current"
+        import type { Route } from "./+types/current"
 
         export function meta({ matches }: Route.MetaArgs) {
           const parent1 = matches[1]

--- a/packages/react-router-dev/typegen/context.ts
+++ b/packages/react-router-dev/typegen/context.ts
@@ -1,7 +1,4 @@
-import * as Path from "pathe";
-import * as Pathe from "pathe/utils";
-
-import type { RouteManifest, RouteManifestEntry } from "../config/routes";
+import type { RouteManifest } from "../config/routes";
 import type * as ViteNode from "../vite/vite-node";
 
 export type Context = {
@@ -10,13 +7,3 @@ export type Context = {
   routeConfigEnv: ViteNode.Context;
   routes: RouteManifest;
 };
-
-export function getTypesPath(ctx: Context, route: RouteManifestEntry) {
-  const typegenDir = Path.join(ctx.rootDirectory, ".react-router/types");
-  return Path.join(
-    typegenDir,
-    Path.relative(ctx.rootDirectory, ctx.appDirectory),
-    Path.dirname(route.file),
-    "+types." + Pathe.filename(route.file) + ".d.ts"
-  );
-}

--- a/packages/react-router-dev/typegen/paths.ts
+++ b/packages/react-router-dev/typegen/paths.ts
@@ -13,6 +13,6 @@ export function getTypesPath(ctx: Context, route: RouteManifestEntry) {
     getTypesDir(ctx),
     Path.relative(ctx.rootDirectory, ctx.appDirectory),
     Path.dirname(route.file),
-    "+types." + Pathe.filename(route.file) + ".d.ts"
+    "+types/" + Pathe.filename(route.file) + ".d.ts"
   );
 }

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -8,6 +8,8 @@ import type { Equal, Expect, Func, Pretty } from "./utils";
 type IsDefined<T> = Equal<T, undefined> extends true ? false : true;
 
 type RouteModule = {
+  meta?: Func;
+  links?: Func;
   loader?: Func;
   clientLoader?: Func;
   action?: Func;

--- a/playground/compiler/app/routes/_index.tsx
+++ b/playground/compiler/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { Route } from "./+types._index";
+import type { Route } from "./+types/_index";
 
 export function loader({ params }: Route.LoaderArgs) {
   return { planet: "world", date: new Date(), fn: () => 1 };

--- a/playground/compiler/app/routes/product.tsx
+++ b/playground/compiler/app/routes/product.tsx
@@ -1,4 +1,4 @@
-import type { Route } from "./+types.product";
+import type { Route } from "./+types/product";
 
 export function loader({ params }: Route.LoaderArgs) {
   return { name: `Super cool product #${params.id}` };


### PR DESCRIPTION
The `.` was adding more noise to the import as another special symbol. Plus the `/` makes it easier to see that the thing after `+types/` is just the name of the current route module.