### PR TITLE
typegen: not ignored by skipLibCheck

### DIFF
--- a/packages/react-router-dev/typegen/paths.ts
+++ b/packages/react-router-dev/typegen/paths.ts
@@ -13,6 +13,6 @@ export function getTypesPath(ctx: Context, route: RouteManifestEntry) {
     getTypesDir(ctx),
     Path.relative(ctx.rootDirectory, ctx.config.appDirectory),
     Path.dirname(route.file),
-    "+types/" + Pathe.filename(route.file) + ".d.ts"
+    "+types/" + Pathe.filename(route.file) + ".ts"
   );
 }

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -17,6 +17,7 @@ type RouteModule = {
   HydrateFallback?: unknown;
   default?: unknown;
   ErrorBoundary?: unknown;
+  [key: string]: unknown; // allow user-defined exports
 };
 
 export type LinkDescriptors = LinkDescriptor[];


### PR DESCRIPTION
previously, typegen'd files had a `.d.ts` extension but that means any errors within those typegen'd files would not show up due to `skipLibCheck: true`. so instead, we generate `.ts` files.

this makes sense as the typegen'd files are part of your app's domain, not part of a library.

also fixed a type error in typegen'd files by allowing user-defined exports in the route module type