### PR TITLE
fix wrong linking for Get Started link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -291,3 +291,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- thethmuu

--- a/docs/index.md
+++ b/docs/index.md
@@ -141,4 +141,4 @@ export async function action({
 
 Route modules also provide conventions for SEO, asset loading, error boundaries, and more.
 
-[Get Started](./framework/start/installation) with React Router as a framework.
+[Get Started](./start/framework/installation) with React Router as a framework.


### PR DESCRIPTION
a small mistake found between "https://reactrouter.com/dev/start/framework/installation" and "https://reactrouter.com/dev/framework/start/installation".