### PR TITLE
Fix template `routes.ts`

### DIFF
--- a/templates/basic/app/routes.ts
+++ b/templates/basic/app/routes.ts
@@ -1,4 +1,3 @@
-import type { RouteConfig } from "@react-router/dev/routes";
-import { index } from "@react-router/dev/routes";
+import { type RouteConfig, index } from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export const routes: RouteConfig = [index("routes/home.tsx")];


### PR DESCRIPTION
The template is pointing at the last pre-release so it needs to use the old `routes.ts` API until the next release.