### PR TITLE
un-deprecate types for library mode

### DIFF
--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -33,8 +33,6 @@ export interface RouteModule {
 
 /**
  * A function that handles data mutations for a route on the client
- *
- * @deprecated Use `Route.ClientActionArgs` from generated `+types.<route>`
  */
 export type ClientActionFunction = (
   args: ClientActionFunctionArgs
@@ -42,8 +40,6 @@ export type ClientActionFunction = (
 
 /**
  * Arguments passed to a route `clientAction` function
- *
- * @deprecated Use `Route.ClientActionArgs` from generated `+types.<route>`
  */
 export type ClientActionFunctionArgs = ActionFunctionArgs<undefined> & {
   serverAction: <T = unknown>() => Promise<SerializeFrom<T>>;
@@ -51,8 +47,6 @@ export type ClientActionFunctionArgs = ActionFunctionArgs<undefined> & {
 
 /**
  * A function that loads data for a route on the client
- *
- * @deprecated Use `Route.ClientLoaderArgs` from generated `+types.<route>`
  */
 export type ClientLoaderFunction = ((
   args: ClientLoaderFunctionArgs
@@ -62,8 +56,6 @@ export type ClientLoaderFunction = ((
 
 /**
  * Arguments passed to a route `clientLoader` function
- *
- * @deprecated Use `Route.ClientLoaderArgs` from generated `+types.<route>`
  */
 export type ClientLoaderFunctionArgs = LoaderFunctionArgs<undefined> & {
   serverLoader: <T = unknown>() => Promise<SerializeFrom<T>>;
@@ -96,8 +88,6 @@ export type LayoutComponent = ComponentType<{
  * A function that defines `<link>` tags to be inserted into the `<head>` of
  * the document on route transitions.
  *
- * @deprecated Use `Route.LinksFunction` from generated `+types.<route>`
- *
  * @see https://remix.run/route/meta
  */
 export interface LinksFunction {
@@ -119,9 +109,6 @@ export interface MetaMatch<
   error?: unknown;
 }
 
-/**
- * @deprecated Use `{ matches }` from `Route.MetaArgs` from generated `+types.<route>`
- */
 export type MetaMatches<
   MatchLoaders extends Record<
     string,
@@ -136,9 +123,6 @@ export type MetaMatches<
   }[keyof MatchLoaders]
 >;
 
-/**
- * @deprecated Use `Route.MetaArgs` from generated `+types.<route>`
- */
 export interface MetaArgs<
   Loader extends LoaderFunction | ClientLoaderFunction | unknown = unknown,
   MatchLoaders extends Record<
@@ -162,8 +146,6 @@ export interface MetaArgs<
  * metadata HTML tags in a route. These tags are not rendered on descendant
  * routes in the route hierarchy. In other words, they will only be rendered on
  * the route in which they are exported.
- *
- * @deprecated Use `Route.MetaFunction` from generated `+types.<route>`
  *
  * @param Loader - The type of the current route's loader function
  * @param MatchLoaders - Mapping from a parent route's filepath to its loader


### PR DESCRIPTION
Using React Router as a library (not framework) still requires use of these types for now