### PR TITLE
allow undefined in setSearchParams

### DIFF
--- a/packages/react-router/lib/dom/dom.ts
+++ b/packages/react-router/lib/dom/dom.ts
@@ -47,7 +47,7 @@ export type ParamKeyValuePair = [string, string];
 export type URLSearchParamsInit =
   | string
   | ParamKeyValuePair[]
-  | Record<string, string | string[]>
+  | Record<string, undefined | string | string[]>
   | URLSearchParams;
 
 /**
@@ -86,7 +86,7 @@ export function createSearchParams(
       ? init
       : Object.keys(init).reduce((memo, key) => {
           let value = init[key];
-          return memo.concat(
+          return value === undefined ? memo : memo.concat(
             Array.isArray(value) ? value.map((v) => [key, v]) : [[key, value]]
           );
         }, [] as ParamKeyValuePair[])


### PR DESCRIPTION
Currently, when one uses

```
const [searchParams, setSearchParams] = useSearchParams(),
```

then setSearchParams has to be used like this:

```
const filterA: string | undefined = getFilter('A');
const filterB: string | undefined = getFilter('B');
const filterC: string | undefined = getFilter('C');

const params: Record<string, string> = {
  ...(filterA && { filterA }),
  ...(filterB && { filterB }),
  ...(filterC && { filterC }),
};

setSearchParams(params);
```

Note that setting the properties of the params object to empty strings has a different behavior:

```
const params: Record<string, string> = {
  filterA: filterA ?? '',
  filterB: filterB ?? '',
  filterC: filterC ?? ''
};

setSearchParams(params);
```

In this case (with empty strings) the url will look like this: "localhost:1234/?filterA=&filterB=&filterC=", which is not expected, I suppose it should just be "localhost:1234" instead.

Hence the proposed changes.