### PR TITLE
fix type error in template’s vite.config.ts for `reactRouter()` in 7.0.0-pre.6

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -289,6 +289,7 @@
 - xcsnowcity
 - yionr
 - yracnet
+- ytori
 - yuleicul
 - zeromask1337
 - zheng-chuang

--- a/templates/basic/vite.config.ts
+++ b/templates/basic/vite.config.ts
@@ -3,8 +3,5 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    reactRouter(),
-    tsconfigPaths(),
-  ],
+  plugins: [reactRouter(), tsconfigPaths()],
 });

--- a/templates/basic/vite.config.ts
+++ b/templates/basic/vite.config.ts
@@ -4,10 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [
-    reactRouter({
-      // Server-side render by default, to enable SPA mode set this to `false`
-      ssr: true,
-    }),
+    reactRouter(),
     tsconfigPaths(),
   ],
 });


### PR DESCRIPTION
Thank you for the release of 7.0.0-pre.6!

This PR fixes a type error in the `vite.config.ts` file of the template.

As shown below, I have corrected the issue to prevent a type error with the argument of `reactRouter()`.
Based on the changes in [this PR](https://github.com/remix-run/react-router/pull/12251/files#diff-a3bab4882f30379b024250c37c5a9bcdf36e3f17bf237e67da8195fe3ff1aad2L420), `reactRouter()` should not take any arguments, and the configuration needs to be defined in the `react-router.config.ts` file.

Before :
```sh
$ npm run typecheck

> typecheck
> react-router typegen && tsc

vite.config.ts:7:17 - error TS2554: Expected 0 arguments, but got 1.

 7     reactRouter({
                   ~
 8       // Server-side render by default, to enable SPA mode set this to `false`
 9       ssr: true,
   ~~~~~~~~~~~~~~~~
10     }),
   ~~~~~


Found 1 error in vite.config.ts:7
```

After :
```sh
$ npm run typecheck

> typecheck
> react-router typegen && tsc

$
```