### PR TITLE
Fix typegen watcher leak on dev restart

### DIFF
--- a/.changeset/nice-cobras-sparkle.md
+++ b/.changeset/nice-cobras-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Ensure typegen file watcher is cleaned up when Vite dev server restarts

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -15,10 +15,14 @@ export async function run(rootDirectory: string) {
   await writeAll(ctx);
 }
 
+export type Watcher = {
+  close: () => Promise<void>;
+};
+
 export async function watch(
   rootDirectory: string,
   { logger }: { logger?: vite.Logger } = {}
-) {
+): Promise<Watcher> {
   const ctx = await createContext({ rootDirectory, watch: true });
   await writeAll(ctx);
   logger?.info(pc.green("generated types"), { timestamp: true, clear: true });
@@ -38,6 +42,10 @@ export async function watch(
       });
     }
   });
+
+  return {
+    close: async () => await ctx.configLoader.close(),
+  };
 }
 
 async function createContext({

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -409,6 +409,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
   let cssModulesManifest: Record<string, string> = {};
   let viteChildCompiler: Vite.ViteDevServer | null = null;
   let reactRouterConfigLoader: ConfigLoader;
+  let typegenWatcherPromise: Promise<Typegen.Watcher> | undefined;
   let logger: Vite.Logger;
   let firstLoad = true;
 
@@ -748,7 +749,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           viteUserConfig.root ?? process.env.REACT_ROUTER_ROOT ?? process.cwd();
 
         if (viteCommand === "serve") {
-          Typegen.watch(rootDirectory, {
+          typegenWatcherPromise = Typegen.watch(rootDirectory, {
             // ignore `info` logs from typegen since they are redundant when Vite plugin logs are active
             logger: vite.createLogger("warn", { prefix: "[react-router]" }),
           });
@@ -1246,6 +1247,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       async buildEnd() {
         await viteChildCompiler?.close();
         await reactRouterConfigLoader.close();
+
+        let typegenWatcher = await typegenWatcherPromise;
+        await typegenWatcher?.close();
       },
     },
     {


### PR DESCRIPTION
If the dev server is restarted (e.g. when Vite config changes) the old file watcher is still hanging around, with the following showing up in the terminal: `MaxListenersExceededWarning: Possible EventEmitter memory leak detected.`

I've confirmed that when restarting the dev server, Vite calls the `buildEnd` hook, so to fix this we need to ensure the typegen watcher is cleaned up at the same time.

Note that this is a minimal fix that aims to maintain the current architecture as much as possible, but I think it'd be worth following up with making the typegen code accept a `ConfigLoader` so that it can be shared with the Vite plugin rather than having two instances of it.