### PR TITLE
docs: fix broken links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,8 +16,8 @@ body:
         Before you ask a question, here are some resources to get help first:
 
         - Read the docs: https://reactrouter.com
-        - Check out the list of frequently asked questions: https://reactrouter.com/start/faq
-        - Explore examples: https://reactrouter.com/start/examples
+        - Check out the list of frequently asked questions: https://reactrouter.com/main/start/faq
+        - Explore examples: https://reactrouter.com/main/start/examples
         - Ask in chat: https://rmx.as/discord
         - Look for/ask questions on Stack Overflow: https://stackoverflow.com/questions/tagged/react-router
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 React Router is a multi-strategy router for React bridging the gap from React 18 to React 19. You can use it maximally as a React framework or minimally as a library with your own architecture.
 
 - [Getting Started - Framework](https://reactrouter.com/start/framework/installation)
-- [Getting Started - Library](https://react.router.com/start/library/installation)
+- [Getting Started - Library](https://reactrouter.com/start/library/installation)
 - [Upgrade from v6](https://reactrouter.com/upgrading/v6)
 - [Upgrade from Remix](https://reactrouter.com/upgrading/remix)
 - [Changelog](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md)

--- a/contributors.yml
+++ b/contributors.yml
@@ -277,6 +277,7 @@
 - underager
 - valerii15298
 - ValiantCat
+- vdusart
 - vijaypushkin
 - vikingviolinist
 - vishwast03


### PR DESCRIPTION
I fixed some broken links, but there are still a few left and I don't know what you want to do with them... I guess the doc isn't written yet :)

But just in case, here they are:
```md
# In the README.md file

- [Getting Started - Framework](https://reactrouter.com/start/framework/installation)
- [Getting Started - Library](https://reactrouter.com/start/library/installation)
- [Upgrade from v6](https://reactrouter.com/upgrading/v6)
- [Upgrade from Remix](https://reactrouter.com/upgrading/remix)
```

Thanks for maintaining react-route :smile: 