### PR TITLE
moved for API docs

### DIFF
--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -106,7 +106,7 @@ export {
   Routes,
   createMemoryRouter,
   createRoutesFromChildren,
-  createRoutesFromChildren as createRoutesFromElements,
+  createRoutesFromElements,
   renderMatches,
 } from "./lib/components";
 export {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1172,6 +1172,11 @@ export function createRoutesFromChildren(
 }
 
 /**
+ * Create route objects from JSX elements instead of arrays of objects
+ */
+export let createRoutesFromElements = createRoutesFromChildren;
+
+/**
  * Renders the result of `matchRoutes()` into a React element.
  *
  * @category Utils


### PR DESCRIPTION
the auto generated api docs put it in a  weird spot with a weird URL when it’s defined in the index file instead of with the rest of the functions