### PR TITLE
fix broken link in the home page of dev branch

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -290,6 +290,7 @@
 - xcsnowcity
 - yionr
 - yracnet
+- ytori
 - yuleicul
 - zeromask1337
 - zheng-chuang

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ ReactDOM.createRoot(root).render(
 );
 ```
 
-[Get Started](./library/installation) with React Router as a library.
+[Get Started](./start/library/installation) with React Router as a library.
 
 ## React Router as a framework
 


### PR DESCRIPTION
The "Get Started" link in the [React Router as a Library section](https://reactrouter.com/dev/home#react-router-as-a-library) was broken and has been updated to the correct URL.
