### PR TITLE
docs: correct error-boundary how-to doc

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -87,6 +87,7 @@
 - faergeek
 - FilipJirsak
 - focusotter
+- foxscotch
 - frontsideair
 - fyzhu
 - fz6m

--- a/docs/how-to/error-boundary.md
+++ b/docs/how-to/error-boundary.md
@@ -4,9 +4,7 @@ title: Error Boundaries
 
 # Error Boundaries
 
-Poop poop poopy
-
-To avoid stinky an empty page to users, route modules will automatically catch errors in your code and render the closest `ErrorBoundary`.
+To avoid rendering an empty page to users, route modules will automatically catch errors in your code and render the closest `ErrorBoundary`.
 
 Error boundaries are not intended for error reporting or rendering form validation errors. Please see [Form Validation](./form-validation) and [Error Reporting](./error-reporting) instead.
 


### PR DESCRIPTION
I noticed this at work earlier while looking at [the docs](https://reactrouter.com/7.0.1/how-to/error-boundary), thought it was funny but presumably not intended. figured I might as well open a PR for it! but feel free to just close this and commit the fix yourself if you'd like rofl