### PR TITLE
docs(how-to/route-module-type-safety): update `tsconfig` reference

### DIFF
--- a/docs/how-to/route-module-type-safety.md
+++ b/docs/how-to/route-module-type-safety.md
@@ -19,9 +19,9 @@ React Router generates types into a `.react-router/` directory at the root of yo
 
 ## 2. Include the generated types in tsconfig
 
-Edit your tsconfig to get TypeScript to use the generated types. Additionally, `rootDirs` needs to be configured so the types can be imported as relative siblings to route modules.
+Edit tsconfig.app.json to get TypeScript to use the generated types. Additionally, `rootDirs` needs to be configured so the types can be imported as relative siblings to route modules.
 
-```json filename=tsconfig.json
+```json filename=tsconfig.app.json
 {
   "include": [".react-router/types/**/*"],
   "compilerOptions": {


### PR DESCRIPTION
Vite comes with 3 ts config files. The current docs assume a single tsconfig.json. 

If I change the plain tsconfig.json to this:

```ts
{
  "files": [],
  "references": [
    { "path": "./tsconfig.app.json" },
    { "path": "./tsconfig.node.json" }
  ],
  "include": [".react-router/types/**/*"],
  "compilerOptions": {
    "rootDirs": [".", "./.react-router/types"]
  }
}
```

I get this error: Referenced project '/Users/coryhouse/Projects/react-router-7-demo/tsconfig.app.json' must have setting "composite": true.

Should these changes be applied to one of the other Vite tsconfig files?

