### PR TITLE
Exclude Response from loader & action types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -221,6 +221,7 @@
 - petersendidit
 - printfn
 - promet99
+- pveyes
 - pyitphyoaung
 - refusado
 - rifaidev

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -72,11 +72,14 @@ type IsHydrate<ClientLoader> =
   ClientLoader extends { hydrate: false } ? false :
   false
 
-export type CreateLoaderData<T extends RouteModule> = _CreateLoaderData<
-  ServerDataFrom<T["loader"]>,
-  ClientDataFrom<T["clientLoader"]>,
-  IsHydrate<T["clientLoader"]>,
-  T extends { HydrateFallback: Func } ? true : false
+export type CreateLoaderData<T extends RouteModule> = Exclude<
+  _CreateLoaderData<
+    ServerDataFrom<T["loader"]>,
+    ClientDataFrom<T["clientLoader"]>,
+    IsHydrate<T["clientLoader"]>,
+    T extends { HydrateFallback: Func } ? true : false
+  >,
+  Response
 >;
 
 // prettier-ignore
@@ -95,9 +98,12 @@ type _CreateLoaderData<
   IsDefined<ServerLoaderData> extends true ? ServerLoaderData :
   undefined
 
-export type CreateActionData<T extends RouteModule> = _CreateActionData<
-  ServerDataFrom<T["action"]>,
-  ClientDataFrom<T["clientAction"]>
+export type CreateActionData<T extends RouteModule> = Exclude<
+  _CreateActionData<
+    ServerDataFrom<T["action"]>,
+    ClientDataFrom<T["clientAction"]>
+  >,
+  Response
 >;
 
 // prettier-ignore


### PR DESCRIPTION
Fix https://github.com/remix-run/react-router/issues/12335

I don't think we ever need a `Response` type here so we can just exclude them from `CreateLoaderData` and `CreateActionData`. Not sure what tests to add because it's a type change