### PR TITLE
docs(start/framework/route-module): fix types

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -305,3 +305,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- serranoarevalo

--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -316,10 +316,10 @@ export default function Root() {
 By default, all routes are revalidated after actions. This function allows a route to opt-out of revalidation for actions that don't affect its data.
 
 ```tsx
-import type { Route } from "./+types/my-route";
+import type { ShouldRevalidateFunctionArgs } from "react-router";
 
 export function shouldRevalidate(
-  arg: Route.ShouldRevalidateArg
+  arg: ShouldRevalidateFunctionArgs
 ) {
   return true;
 }


### PR DESCRIPTION
As far as I'm aware `Route.ShouldRevalidateArg` is not being generated when calling `typegen` so I'm updating the documentation accordingly to use `ShouldRevalidateFunctionArgs`