### PR TITLE
Expose createRemixHeaders, createRemixRequest, and sendRemixResponse from @react-router/express

### DIFF
--- a/packages/react-router-express/index.ts
+++ b/packages/react-router-express/index.ts
@@ -1,2 +1,2 @@
 export type { GetLoadContextFunction, RequestHandler } from "./server";
-export { createRequestHandler } from "./server";
+export { createRequestHandler, createRemixRequest, createRemixHeaders, sendRemixResponse } from "./server";


### PR DESCRIPTION
There are valid reason to use these functions as mentioned in this issue: https://github.com/remix-run/react-router/issues/11643#issuecomment-2250030825

I found that these functions were already exported by server.ts, but not by index.ts – which block import from application code.

The tests are already covered, so I don't think adding tests is necessary.