### PR TITLE
fix(fs-routes): throw error if routes directory is missing

### DIFF
--- a/.changeset/honest-dots-deliver.md
+++ b/.changeset/honest-dots-deliver.md
@@ -1,0 +1,5 @@
+---
+"@react-router/fs-routes": patch
+---
+
+Throw error in `flatRoutes` if routes directory is missing

--- a/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
+++ b/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
+import { mkdirSync, rmdirSync, createFileSync, rmSync } from "fs-extra";
 
 import type { RouteManifestEntry } from "../manifest";
 
 import {
+  flatRoutes,
   flatRoutesUniversal,
   getRoutePathConflictErrorMessage,
   getRouteIdConflictErrorMessage,
@@ -875,6 +877,30 @@ describe("flatRoutes", () => {
         ])
       );
       expect(routes).toHaveLength(3);
+    });
+  });
+
+  describe("throw correct error", () => {
+    beforeEach(() => {
+      mkdirSync(APP_DIR, { recursive: true });
+    });
+    afterEach(() => {
+      rmdirSync(APP_DIR);
+    });
+
+    test("root route is not found", () => {
+      expect(() => flatRoutes(APP_DIR)).toThrow(
+        `Could not find a root route module in the app directory: test/root/app`
+      );
+    });
+
+    test("routes dir is not found", () => {
+      const rootRoute = path.join(APP_DIR, "root.tsx");
+      createFileSync(rootRoute);
+      expect(() => flatRoutes(APP_DIR)).toThrow(
+        `Could not find the routes directory: test/root/app/routes. Did you forget to create it?`
+      );
+      rmSync(rootRoute);
     });
   });
 });

--- a/packages/react-router-fs-routes/flatRoutes.ts
+++ b/packages/react-router-fs-routes/flatRoutes.ts
@@ -89,7 +89,7 @@ export function flatRoutes(
     );
   }
 
-  if (!fs.existsSync(rootRoute)) {
+  if (!fs.existsSync(routesDir)) {
     throw new Error(
       `Could not find the routes directory: ${routesDir}. Did you forget to create it?`
     );


### PR DESCRIPTION
The `flatRoutes` function is supposed to throw error if the `routesDir` does not exist. But due to a type, it was checking for `rootRoute` again and throwing error regarding missing `routesDir`. 

Fixed the typo and couple of tests to check for correct error to be thrown in both scenarios.