### PR TITLE
Add support for encrypted cookies

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -204,6 +204,7 @@
 - ned-park
 - nilubisan
 - Nismit
+- njdancer
 - nnhjs
 - noisypigeon
 - Nurai1

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "playground": "node ./scripts/playground.js",
     "prerelease": "pnpm build",
     "release": "changeset publish",
-    "test": "jest --projects packages/react-router --watch",
+    "test": "jest",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest",
     "typecheck": "pnpm run --recursive --parallel typecheck",
     "test:integration:run": "pnpm playwright:integration",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "playground": "node ./scripts/playground.js",
     "prerelease": "pnpm build",
     "release": "changeset publish",
-    "test": "jest",
+    "test": "jest --projects packages/react-router --watch",
     "test:inspect": "node --inspect-brk ./node_modules/.bin/jest",
     "typecheck": "pnpm run --recursive --parallel typecheck",
     "test:integration:run": "pnpm playwright:integration",

--- a/packages/react-router/__tests__/server-runtime/cookies-test.ts
+++ b/packages/react-router/__tests__/server-runtime/cookies-test.ts
@@ -94,11 +94,11 @@ describe("cookies", () => {
 
   it("parses/serializes encrypted object values", async () => {
     let encryptedCookie = createCookie("my-cookie", {
-      secrets: ["12345678901234567890123456789012"],
+      secrets: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
       encrypt: true,
     });
-    let setCookie2 = await encryptedCookie.serialize({ hello: "mjackson" });
-    let value = await encryptedCookie.parse(getCookieFromSetCookie(setCookie2));
+    let setCookie = await encryptedCookie.serialize({ hello: "mjackson" });
+    let value = await encryptedCookie.parse(getCookieFromSetCookie(setCookie));
 
     expect(value).toMatchInlineSnapshot(`
       {
@@ -127,7 +127,7 @@ describe("cookies", () => {
 
     let encryptedCookie = createCookie("my-cookie", {
       // Must be 32 bytes (256 bits) long
-      secrets: ["12345678901234567890123456789012"],
+      secrets: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
       encrypt: true,
     });
     let setCookie2 = await encryptedCookie.serialize({ hello: "mjackson" });
@@ -148,6 +148,37 @@ describe("cookies", () => {
     expect(value).toBeNull();
   });
 
+  it("fails to parse encrypted object values with incorrect key", async () => {
+    let cookie = createCookie("my-cookie", {
+      secrets: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+      encrypt: true,
+    });
+    let setCookie = await cookie.serialize({ hello: "mjackson" });
+    let cookie2 = createCookie("my-cookie", {
+      secrets: ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"],
+      encrypt: true,
+    });
+    let value = await cookie2.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value).toBeNull();
+
+    let cookie3 = createCookie("my-cookie", {
+      secrets: ["secret1"],
+    });
+    let value2 = await cookie3.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value2).toBeNull();
+  });
+
+  it("fails to create encrypted cookies without a secret", async () => {
+    expect(() =>
+      // @ts-expect-error missing secrets
+      createCookie("my-cookie", {
+        encrypt: true,
+      })
+    ).toThrow();
+  });
+
   it("supports secret rotation", async () => {
     let cookie = createCookie("my-cookie", {
       secrets: ["secret1"],
@@ -164,6 +195,38 @@ describe("cookies", () => {
     // A new secret enters the rotation...
     cookie = createCookie("my-cookie", {
       secrets: ["secret2", "secret1"],
+    });
+
+    // cookie should still be able to parse old cookies.
+    let oldValue = await cookie.parse(getCookieFromSetCookie(setCookie));
+    expect(oldValue).toMatchObject(value);
+
+    // New Set-Cookie should be different, it uses a differet secret.
+    let setCookie2 = await cookie.serialize(value);
+    expect(setCookie).not.toEqual(setCookie2);
+  });
+
+  it("supports encryption key rotation", async () => {
+    let cookie = createCookie("my-cookie", {
+      secrets: ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"],
+      encrypt: true,
+    });
+    let setCookie = await cookie.serialize({ hello: "mjackson" });
+    let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+
+    expect(value).toMatchInlineSnapshot(`
+      {
+        "hello": "mjackson",
+      }
+    `);
+
+    // A new secret enters the rotation...
+    cookie = createCookie("my-cookie", {
+      secrets: [
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ],
+      encrypt: true,
     });
 
     // cookie should still be able to parse old cookies.

--- a/packages/react-router/lib/server-runtime/cookies.ts
+++ b/packages/react-router/lib/server-runtime/cookies.ts
@@ -20,6 +20,11 @@ export interface CookieSignatureOptions {
    */
   secrets?: string[];
 
+  /**
+   * Enables encryption of the cookie contents using "AES-GCM".
+   *
+   * Encryption keys should be provided in the `secrets` array and are able to be rotated in the same way as with signing. When using encryption, unlike signing, secrets must be 32 bytes long.
+   */
   encrypt?: false;
 }
 

--- a/packages/react-router/lib/server-runtime/cookies.ts
+++ b/packages/react-router/lib/server-runtime/cookies.ts
@@ -20,13 +20,19 @@ export interface CookieSignatureOptions {
    */
   secrets?: string[];
 
+  encrypt?: false;
+}
+
+interface CookieEncryptionOptions {
+  secrets: Required<CookieSignatureOptions>["secrets"];
+
   // TODO: Add description
-  encrypt?: boolean;
+  encrypt: true;
 }
 
 export type CookieOptions = ParseOptions &
   SerializeOptions &
-  CookieSignatureOptions;
+  (CookieSignatureOptions | CookieEncryptionOptions);
 
 /**
  * A HTTP cookie.
@@ -86,6 +92,12 @@ export const createCookie = (
     sameSite: "lax" as const,
     ...cookieOptions,
   };
+
+  if (encrypt && secrets?.length === 0) {
+    throw new Error(
+      `Cannot encrypt cookie "${name}" without providing a secret.`
+    );
+  }
 
   warnOnceAboutExpiresCookie(name, options.expires);
 

--- a/packages/react-router/lib/server-runtime/crypto.ts
+++ b/packages/react-router/lib/server-runtime/crypto.ts
@@ -4,10 +4,7 @@ export const sign = async (value: string, secret: string): Promise<string> => {
   let data = encoder.encode(value);
   let key = await createKey(secret, ["sign"]);
   let signature = await crypto.subtle.sign("HMAC", key, data);
-  let hash = btoa(String.fromCharCode(...new Uint8Array(signature))).replace(
-    /=+$/,
-    ""
-  );
+  let hash = uint8ArrayToBase64(signature);
 
   return value + "." + hash;
 };
@@ -23,25 +20,113 @@ export const unsign = async (
   let data = encoder.encode(value);
 
   let key = await createKey(secret, ["verify"]);
-  let signature = byteStringToUint8Array(atob(hash));
+  let signature = base64ToUint8Array(hash);
   let valid = await crypto.subtle.verify("HMAC", key, signature, data);
 
   return valid ? value : false;
 };
 
+// Originally taken from https://github.com/nadrama-com/simple-secure-webcrypto/blob/49bf711d8ad39e5be0d01d1407d19979bfde9269/src/index.ts#L49
+export const encrypt = async (
+  value: string,
+  secret: string
+): Promise<string> => {
+  let data = encoder.encode(value);
+  let key = await createKey(secret, ["encrypt"]);
+
+  // generate a random 96 bit (12 byte) initilization vector
+  // important: iv must never be reused with a given key.
+  let iv = crypto.getRandomValues(new Uint8Array(12));
+  // encrypt cookie to ciphertext
+  let ciphertext = await crypto.subtle.encrypt(
+    {
+      name: "AES-GCM",
+      iv,
+    },
+    key,
+    data
+  );
+
+  // convert iv and ciphertext to base64-encoded strings
+  let ivString = uint8ArrayToBase64(iv);
+  let ciphertextString = uint8ArrayToBase64(ciphertext);
+  return ivString + "." + ciphertextString;
+};
+
+export const decrypt = async (
+  cookie: string,
+  secret: string
+): Promise<string | false> => {
+  let index = cookie.lastIndexOf(".");
+  let ivString = cookie.slice(0, index);
+  let ciphertextString = cookie.slice(index + 1);
+
+  let key = await createKey(secret, ["decrypt"]);
+
+  // get iv and ciphertext
+  let iv = base64ToUint8Array(ivString);
+  if (iv.length !== 12) {
+    throw new Error("Invalid IV length - must be 96 bits (12 bytes)");
+  }
+  let ciphertext = base64ToUint8Array(ciphertextString);
+  if (ciphertext.length === 0) {
+    throw new Error("Invalid ciphertext length - cannot be empty");
+  }
+
+  // decrypt ciphertext to plaintext
+  let decrypted;
+  try {
+    decrypted = await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: iv,
+      },
+      key,
+      ciphertext
+    );
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "OperationError") {
+      return false;
+    }
+  }
+
+  let decoder = new TextDecoder();
+  return decoder.decode(decrypted);
+};
+
 const createKey = async (
   secret: string,
   usages: CryptoKey["usages"]
-): Promise<CryptoKey> =>
-  crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    usages
-  );
+): Promise<CryptoKey> => {
+  if (usages.includes("encrypt") || usages.includes("decrypt")) {
+    let key = encoder.encode(secret);
+    if (key.length !== 32) {
+      throw new Error(
+        "Invalid secret key length - must be 256 bits (32 bytes)"
+      );
+    }
 
-function byteStringToUint8Array(byteString: string): Uint8Array {
+    return crypto.subtle.importKey(
+      "raw",
+      key,
+      { name: "AES-GCM" },
+      false,
+      usages
+    );
+  } else {
+    return crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      usages
+    );
+  }
+};
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const byteString = atob(base64);
+
   let array = new Uint8Array(byteString.length);
 
   for (let i = 0; i < byteString.length; i++) {
@@ -49,4 +134,10 @@ function byteStringToUint8Array(byteString: string): Uint8Array {
   }
 
   return array;
+}
+
+function uint8ArrayToBase64(
+  array: ArrayLike<number> | ArrayBufferLike
+): string {
+  return btoa(String.fromCharCode(...new Uint8Array(array))).replace(/=+$/, "");
 }


### PR DESCRIPTION
Cookies currently support cryptographic signatures which ensure the validity of a message but do nothing to obscure the cookie contents from unauthorised access. In most cases this is sufficient however there are some circumstances where it is beneficial to have the cookie value fully obscured.

With Remix, I was previously able to use createCookieFactory by passing an encrypt and decrypt function into sign and unsign respectively. With react router 7, this function is no longer exported. Further to this the remaining API's seemed to provide no method for an async function to be injected into this process. As such, and given that web crypto is now a requirement it seemed like this might as well be added to the library.