### PR TITLE
Cloudflare server entry template

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -306,3 +306,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- doichev-kostia

--- a/packages/react-router-dev/config/defaults/entry.server.cloudflare.tsx
+++ b/packages/react-router-dev/config/defaults/entry.server.cloudflare.tsx
@@ -1,0 +1,54 @@
+import {
+  type AppLoadContext,
+  type EntryContext,
+  ServerRouter,
+} from "react-router";
+import { isbot } from "isbot";
+import { renderToReadableStream } from "react-dom/server";
+
+const ABORT_DELAY = 5_000;
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  loadContext: AppLoadContext
+) {
+  let userAgent = request.headers.get("user-agent");
+
+  let ac = new AbortController();
+
+  let timeoutId = setTimeout(() => {
+    ac.abort();
+  }, ABORT_DELAY);
+
+  let body = await renderToReadableStream(
+    <ServerRouter
+      context={routerContext}
+      url={request.url}
+      abortDelay={ABORT_DELAY}
+    />,
+    {
+      signal: ac.signal,
+      onError(error: unknown) {
+        responseStatusCode = 500;
+        console.error(error);
+      },
+    }
+  );
+
+  /** Ensure requests from bots and SPA Mode renders wait for all content to load before responding
+   * {@link https://react.dev/reference/react-dom/server/renderToReadableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation | Waiting for all content to load for crawlers and static generation }
+   */
+  if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+    await body.allReady;
+  }
+
+  responseHeaders.set("Content-Type", "text/html");
+  clearTimeout(timeoutId);
+  return new Response(body, {
+    headers: responseHeaders,
+    status: responseStatusCode,
+  });
+}


### PR DESCRIPTION
Added the special `entry.server.tsx` for the Cloudflare runtime. 

This is quite similar to one in Remix (https://github.com/remix-run/remix/blob/b9d03c4f68b42b7093d6bf5137b61455febb03ee/packages/remix-dev/config/defaults/entry.server.cloudflare.tsx)

I wanted to use the `AbortSignal.timeout(ms)` API. However, it started giving errors like
```
TypeError: Invalid state: Controller is already closed
    at ReadableByteStreamController.close (node:internal/webstreams/readablestream:1159:13)
```
Therefore, I just use setTimeout and clean it up afterwards

## Questions

- Should I create a changeset entry for the internal defaults?
- How do you want to resolve which runtime to use, node or cloudflare?
