### PR TITLE
docs(upgrading/v6): add linux example in `Update imports` section

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -241,6 +241,7 @@
 - saul-atomrigs
 - sbolel
 - scarf005
+- sealer3
 - senseibarni
 - sergiodxa
 - sgalhs

--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -329,6 +329,12 @@ Instead of manually updating imports, you can use this command. Make sure your g
 find ./path/to/src \( -name "*.tsx" -o -name "*.ts" -o -name "*.js" -o -name "*.jsx" \) -type f -exec sed -i '' 's|from "react-router-dom"|from "react-router"|g' {} +
 ```
 
+If you have GNU `sed` installed (most Linux distributions), use this command instead:
+
+```shellscript nonumber
+find ./path/to/src \( -name "*.tsx" -o -name "*.ts" -o -name "*.js" -o -name "*.jsx" \) -type f -exec sed -i 's|from "react-router-dom"|from "react-router"|g' {} +
+```
+
 👉 **Update DOM-specific imports**
 
 `RouterProvider` and `HydratedRouter` come from a deep import because they depend on `"react-dom"`:


### PR DESCRIPTION
The current v6 upgrade docs have a command which applies only for BSD sed (included in macOS or BSD operating systems) and won't work on GNU sed, throwing an error. This PR adds the equivalent command for GNU sed.