### PR TITLE
docs(how-to/file-route-conventions): fix links 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -278,6 +278,7 @@
 - tomasr8
 - tony-sn
 - TooTallNate
+- tosinamuda
 - triangularcube
 - trungpv1601
 - ttys026

--- a/docs/how-to/file-route-conventions.md
+++ b/docs/how-to/file-route-conventions.md
@@ -362,13 +362,13 @@ app/routes/app._index.tsx
 app/routes/app._index/route.tsx
 ```
 
-[route-config-file]: ../start/routing#route-config-file
-[loaders]: ../start/data-loading
-[actions]: ../start/actions
-[routing_guide]: ../start/routing
-[root_route]: ../start/route-module#root-route
-[index_route]: ../start/routing#index-routes
-[nested_routing]: ../start/routing#nested-routes
+[route-config-file]: ../start/framework/routing#configuring-routes
+[loaders]: ../start/framework/data-loading
+[actions]: ../start/framework/actions
+[routing_guide]: ../start/framework/routing
+[root_route]: ../start/framework/route-module
+[index_route]: ../start/framework/routing#index-routes
+[nested_routing]: ../start/framework/routing#nested-routes
 [nested_routes]: #nested-routes
 [dot_delimiters]: #dot-delimiters
 [dynamic_segments]: #dynamic-segments


### PR DESCRIPTION
This PR addresses an issue in the [React Router documentation](https://reactrouter.com/how-to/file-route-conventions) where certain links point to incorrect sections of the docs. Specifically, links are inconsistently directed to `start/[something] `instead of the correct path `start/framework/[something]`.

Changes:
Updated incorrect links to ensure they point to the intended sections under start/framework/[something].

Why:
The current links lead to unrelated parts of the documentation, causing confusion for readers. This update ensures accuracy and improves the user experience.