### PR TITLE
docs(start/framework/testing.md): fix sample code

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -309,3 +309,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- proshunsuke

--- a/docs/start/framework/testing.md
+++ b/docs/start/framework/testing.md
@@ -55,7 +55,7 @@ test("LoginForm renders error messages", async () => {
           },
         };
       },
-    }),
+    },
   ]);
 
   // render the app stub at "/login"


### PR DESCRIPTION
The current code example in the documentation is non-functional due to an unnecessary `)`. Therefore, I'm updating the documentation to remove the unnecessary `)`.