### PR TITLE
temporarily only use one build in export map

### DIFF
--- a/.changeset/curvy-readers-notice.md
+++ b/.changeset/curvy-readers-notice.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+temporarily only use one build in export map so packages can have a peer dependency on react router

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -18,58 +18,46 @@
   "license": "MIT",
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
-  "types": "./dist/production/index.d.ts",
-  "main": "./dist/production/index.js",
-  "module": "./dist/production/index.mjs",
+  "types": "./dist/development/index.d.ts",
+  "main": "./dist/development/index.js",
+  "module": "./dist/development/index.mjs",
   "exports": {
     ".": {
       "node": {
-        "types": "./dist/production/index.d.ts",
-        "development": {
-          "module-sync": "./dist/development/index.mjs",
-          "default": "./dist/development/index.js"
-        },
-        "module-sync": "./dist/production/index.mjs",
-        "default": "./dist/production/index.js"
+        "types": "./dist/development/index.d.ts",
+        "module-sync": "./dist/development/index.mjs",
+        "default": "./dist/development/index.js"
       },
       "import": {
-        "types": "./dist/production/index.d.mts",
-        "development": "./dist/development/index.mjs",
-        "default": "./dist/production/index.mjs"
+        "types": "./dist/development/index.d.mts",
+        "default": "./dist/development/index.mjs"
       },
       "default": {
-        "types": "./dist/production/index.d.ts",
-        "development": "./dist/development/index.js",
-        "default": "./dist/production/index.js"
+        "types": "./dist/development/index.d.ts",
+        "default": "./dist/development/index.js"
       }
     },
     "./route-module": {
       "import": {
-        "types": "./dist/production/lib/types/route-module.d.mts"
+        "types": "./dist/development/lib/types/route-module.d.mts"
       },
       "default": {
-        "types": "./dist/production/lib/types/route-module.d.ts"
+        "types": "./dist/development/lib/types/route-module.d.ts"
       }
     },
     "./dom": {
       "node": {
-        "types": "./dist/production/dom-export.d.ts",
-        "development": {
-          "module-sync": "./dist/development/dom-export.mjs",
-          "default": "./dist/development/dom-export.js"
-        },
-        "module-sync": "./dist/production/dom-export.mjs",
-        "default": "./dist/production/dom-export.js"
+        "types": "./dist/development/dom-export.d.ts",
+        "module-sync": "./dist/development/dom-export.mjs",
+        "default": "./dist/development/dom-export.js"
       },
       "import": {
-        "types": "./dist/production/dom-export.d.mts",
-        "development": "./dist/development/dom-export.mjs",
-        "default": "./dist/production/dom-export.mjs"
+        "types": "./dist/development/dom-export.d.mts",
+        "default": "./dist/development/dom-export.mjs"
       },
       "default": {
-        "types": "./dist/production/dom-export.d.ts",
-        "development": "./dist/development/dom-export.js",
-        "default": "./dist/production/dom-export.js"
+        "types": "./dist/development/dom-export.d.ts",
+        "default": "./dist/development/dom-export.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
with the export map before this commit, there’s a react router context mismatch in react-router-dev because the node process from `react-router dev` isn’t started with `—conditions development`, so it required the production build of `react-router` (because it’s used internally in `react-router-dev`.

Then for the server render, “react-router” is already in the cache so if any node_modules have a peer dep on it, it gets the production build too.

After that, app code runs and asks for “react-router” but this import is processed through vite with the “development” condition, so the app gets a different version of react router

Now if a node_module want’s to useLocation inside of the app, it’s got a different copy of that hook and no router context

This is a temporary patch until we can work out how to get `react-router dev` to get the development build in node without requiring apps to set the conditions