### PR TITLE
fix(dev/typegen): fix non-JS/TS files

### DIFF
--- a/.changeset/two-needles-sell.md
+++ b/.changeset/two-needles-sell.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix typegen for non-{.js,.jsx,.ts,.tsx} routes like .mdx

--- a/contributors.yml
+++ b/contributors.yml
@@ -258,6 +258,7 @@
 - Nismit
 - nnhjs
 - noisypigeon
+- nowells
 - Nurai1
 - Obi-Dann
 - OlegDev1

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -322,11 +322,20 @@ function getRouteAnnotations({
 
 function relativeImportSource(from: string, to: string) {
   let path = Path.relative(Path.dirname(from), to);
+
+  let extension = Path.extname(path);
+
   // no extension
   path = Path.join(Path.dirname(path), Pathe.filename(path));
   if (!path.startsWith("../")) path = "./" + path;
 
-  return path + ".js";
+  // In typescript, we want to support "moduleResolution": "nodenext" as well as not having "allowImportingTsExtensions": true,
+  // so we normalize all JS like files to `.js`, but allow other extensions such as `.mdx` and others that might be used as routes.
+  if (!extension || /\.(js|ts)x?$/.test(extension)) {
+    extension = ".js";
+  }
+
+  return path + extension;
 }
 
 function rootDirsPath(ctx: Context, typesPath: string): string {


### PR DESCRIPTION
https://github.com/remix-run/react-router/pull/12440 introduced a fix for tsconfig, however, it broke non-JS routes (like .mdx)

When we have a file `./app/routes/test/index.mdx` which is a route we get the following error:
```
.react-router/types/app/routes/test/+types/index.ts:10:29 - error TS2307: Cannot find module '../index.js' or its corresponding type declarations.

10 type Module = typeof import("../index.js")
                               ~~~~~~~~~~~~~
```