### PR TITLE
fix(react-router): fix `Blocker` type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -71,6 +71,7 @@
 - david-bezero
 - david-crespo
 - dcblair
+- dchenk
 - decadentsavant
 - dgrijuela
 - DigitalNaut

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -631,8 +631,8 @@ export type Fetcher<TData = any> =
 
 interface BlockerBlocked {
   state: "blocked";
-  reset(): void;
-  proceed(): void;
+  reset: () => void;
+  proceed: () => void;
   location: Location;
 }
 


### PR DESCRIPTION
The way the `BlockerBlocked` interface is defined fails the [unbound-method](https://typescript-eslint.io/rules/unbound-method/) ESLint rule with code like this:
```
const { state, proceed } = useBlocker(hasUnsavedChanges);

useEffect(() => {
  if (state === 'blocked') {
    dialog('You have unsaved changes. Are you sure you want to leave?', {
      onAccept: () => {
        proceed();
      },
    });
  }
}, [dialog, state, proceed]);
```

Because the `reset` and `proceed` function aren't methods of a class, it's more precise to type them as arrow functions, i.e., without a `this` variable.