### PR TITLE
docs: type of action arguments in Handling different request methods example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - 0xEddie
+- aarbi
 - abdallah-nour
 - abeadam
 - abhi-kr-2100

--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -54,7 +54,7 @@ export function loader(_: Route.LoaderArgs) {
   return Response.json({ message: "I handle GET" });
 }
 
-export function action(_: Route.LoaderArgs) {
+export function action(_: Route.ActionArgs) {
   return Response.json({
     message: "I handle everything else",
   });


### PR DESCRIPTION
A small fix to update action arguments type instead of LoaderArgs in Handling different request methods example