### PR TITLE
bug: patchRoutesOnNavigation throws without triggering an error boundary

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -71,6 +71,7 @@
 - david-bezero
 - david-crespo
 - dcblair
+- dchenk
 - decadentsavant
 - dgrijuela
 - DigitalNaut


### PR DESCRIPTION
I encountered a TypeError when my `patchRoutesOnNavigation` function threw an error but there were no partial matches. I tracked the error down to this code in [`packages/react-router/lib/router/router.ts`](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/router.ts#L1866-L1867):
```
        let boundaryId = findNearestBoundary(discoverResult.partialMatches)
          .route.id;
```

The problem is that `findNearestBoundary` can return `undefined`, but it's typed as returning `AgnosticDataRouteMatch`. I was able to reproduce the bug in a test (the first commit on this branch).

Notice the `Cannot read properties of undefined` error in the failing tests.

The reason this matters is that the error boundary does not get triggered in this case.