### PR TITLE
Suppress v7 warnings in production build

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -215,6 +215,7 @@
 - petersendidit
 - promet99
 - pyitphyoaung
+- rakleed
 - refusado
 - rimian
 - robbtraister

--- a/packages/react-router/lib/deprecations.ts
+++ b/packages/react-router/lib/deprecations.ts
@@ -4,7 +4,7 @@ import type { FutureConfig as RenderFutureConfig } from "./components";
 const alreadyWarned: { [key: string]: boolean } = {};
 
 export function warnOnce(key: string, message: string): void {
-  if (!alreadyWarned[message]) {
+  if (process.env.NODE_ENV !== 'production' && !alreadyWarned[message]) {
     alreadyWarned[message] = true;
     console.warn(message);
   }

--- a/packages/react-router/lib/deprecations.ts
+++ b/packages/react-router/lib/deprecations.ts
@@ -4,7 +4,7 @@ import type { FutureConfig as RenderFutureConfig } from "./components";
 const alreadyWarned: { [key: string]: boolean } = {};
 
 export function warnOnce(key: string, message: string): void {
-  if (process.env.NODE_ENV !== 'production' && !alreadyWarned[message]) {
+  if (__DEV__ && !alreadyWarned[message]) {
     alreadyWarned[message] = true;
     console.warn(message);
   }


### PR DESCRIPTION
Closes #12250, see https://github.com/remix-run/react-router/issues/12250#issuecomment-2525223753

I prefer to use default settings and as little configuration as possible, so it is good practice to follow generally accepted standards.

I did the same as it was done in [MobX](https://github.com/mobxjs/mobx/blob/9944edcc8450fa8d328ffcc436acddd85b90e803/packages/mobx-react-lite/src/index.ts#L23) and [Antd](https://github.com/ant-design/ant-design/blob/c2efea0b336cf23d5ec74eb8a6e31743f61558a4/components/select/index.tsx#L251).

@brookslybrand 