### PR TITLE
docs(start/framework/testing): fix code

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -38,6 +38,7 @@
 - aymanemadidi
 - ayushmanchhabra
 - babafemij-k
+- barclayd
 - bavardage
 - bbrowning918
 - BDomzalski

--- a/docs/start/framework/testing.md
+++ b/docs/start/framework/testing.md
@@ -36,7 +36,7 @@ We can test this component with `createRoutesStub`. It takes an array of objects
 
 ```tsx
 import { createRoutesStub } from "react-router";
-import * as Test from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { LoginForm } from "./LoginForm";
 
 test("LoginForm renders error messages", async () => {
@@ -59,12 +59,12 @@ test("LoginForm renders error messages", async () => {
   ]);
 
   // render the app stub at "/login"
-  Test.render(<Stub initialEntries={["/login"]} />);
+  render(<Stub initialEntries={["/login"]} />);
 
   // simulate interactions
-  Test.user.click(screen.getByText("Login"));
-  await Test.waitFor(() => screen.findByText(USER_MESSAGE));
-  await Test.waitFor(() =>
+  screen.getByText("Login").click();
+  await waitFor(() => screen.findByText(USER_MESSAGE));
+  await waitFor(() =>
     screen.findByText(PASSWORD_MESSAGE)
   );
 });

--- a/docs/start/framework/testing.md
+++ b/docs/start/framework/testing.md
@@ -37,6 +37,7 @@ We can test this component with `createRoutesStub`. It takes an array of objects
 ```tsx
 import { createRoutesStub } from "react-router";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from '@testing-library/user-event';
 import { LoginForm } from "./LoginForm";
 
 test("LoginForm renders error messages", async () => {
@@ -62,7 +63,7 @@ test("LoginForm renders error messages", async () => {
   render(<Stub initialEntries={["/login"]} />);
 
   // simulate interactions
-  screen.getByText("Login").click();
+  userEvent.click(screen.getByText("Login"));
   await waitFor(() => screen.findByText(USER_MESSAGE));
   await waitFor(() =>
     screen.findByText(PASSWORD_MESSAGE)


### PR DESCRIPTION
# Changes

* Currently the example in `testing.md` doesn't run/requires amendments for followers of the tutorial to execute in their own codebase
* Follows the recommended way of importing from `@testing-library/react` as per their [docs](https://testing-library.com/docs/react-testing-library/example-intro)
* `@testing-library/react` doesn't export `user`, replaced with `@testing-library/user-event`

Would love to see this page will out some more in the future, especially with e2e examples with playwright and something cool with Vitest Browser Mode would go down a treat too @ryanflorence 🔥 