### PR TITLE
Fix bug report command

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -316,3 +316,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- clovis1122

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -34,13 +34,13 @@ let appFixture: AppFixture;
 // Now try running this test:
 //
 //    ```
-//    pnpm bug-report-test
+//    pnpm playwright:report
 //    ```
 //
 // You can add `--watch` to the end to have it re-run on file changes:
 //
 //    ```
-//    pnpm bug-report-test --watch
+//    pnpm playwright:report -- --watch
 //    ```
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:integration:run": "pnpm playwright:integration",
     "test:integration": "pnpm build && pnpm test:integration:run",
     "posttest:integration:run": "pnpm clean:integration",
+    "playwright:report": "playwright test --config ./integration/playwright.config.ts integration/bug-report-test.ts",
     "playwright:integration": "playwright test --config ./integration/playwright.config.ts",
     "changeset": "changeset",
     "changeset:version": "changeset version && node ./scripts/remove-prerelease-changelogs.mjs",


### PR DESCRIPTION
The bug report test file currently writes about running `pnpm bug-report-test` which is not defined in package.json.

This commit adds a new playwright:report command with the same format as the other scripts and fix the documentation.