### PR TITLE
Add test case for returning responses without body (like HTTP204)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -316,3 +316,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- clovis1122

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -59,10 +59,14 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/_index.tsx": js`
-        import { useLoaderData, Link } from "react-router";
+        import { useLoaderData, Form, Link } from "react-router";
 
         export function loader() {
           return "pizza";
+        }
+
+        export function action() {
+          return new Response(null, { status: 204 });
         }
 
         export default function Index() {
@@ -70,15 +74,11 @@ test.beforeAll(async () => {
           return (
             <div>
               {data}
-              <Link to="/burgers">Other Route</Link>
+              <Form method="POST">
+                <button type="submit">Submit</button>
+              </Form>
             </div>
           )
-        }
-      `,
-
-      "app/routes/burgers.tsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
         }
       `,
     },
@@ -99,14 +99,20 @@ test.afterAll(() => {
 
 test("[description of what you expect it to do]", async ({ page }) => {
   let app = new PlaywrightFixture(appFixture, page);
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      throw new Error(message.text());
+    }
+  });
+
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
   expect(await response.text()).toMatch("pizza");
 
   // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
+  await app.clickElement('button[type="submit"]');
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!


### PR DESCRIPTION
Currently, it seems that neither RR7 or Remix (w/ SingleFetch) support returning responses without a body, such as HTTP204.

Here's a StackBlitz as well: https://stackblitz.com/edit/vitejs-vite-y28rvf4p. Go to /home and click submit.

I spotted the issue in two places: first, on the server: https://github.com/remix-run/react-router/blob/5d96537148d768b304be3bea7237a12351127807/packages/react-router/lib/server-runtime/server.ts#L311

This is where the test error is triggered, because the code attempts to create a response with http status 204 (which does not take a body). I think a simple check for `if (!response.body)` check will suffice.

Assuming the server issue is fixed, the second stumbling block would be on the client in this function: https://github.com/remix-run/react-router/blob/5d96537148d768b304be3bea7237a12351127807/packages/react-router/lib/dom/ssr/single-fetch.tsx#L429.

Calling `decodeViaTurboStream` fails because there's no value to decode.

>Sidenote: There's a check for `res.body` a few lines above, but it doesn't quite work. In my browser (Edge), this value is a `ReadableStream` even on http204. From what I see at [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Response/body):
>>Note: Current browsers don't actually conform to the spec requirement to set the body property to null for responses with no body (for example, responses to [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) requests, or [204 No Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204) responses).

I believe this needs to properly handle the case where `response.body` is null and when `response.body` is an empty stream:
* We can clone the response body (likely expensive).
* Modify tubo-stream to return null/undefined when the stream is empty. Handle this on RR side.
* Modify turbo-stream to throw an error different from SyntaxError. Handle this on RR side.

The relevant code for turbo-stream is [here](https://github.com/jacob-ebey/turbo-stream/blob/bc545ccf1e036dd4e3cd08d00d03efd4187cfa00/src/turbo-stream.ts#L65).

FYI I'm looking forward to seeing this backported into Remix as well. Let me know how I can help.