### PR TITLE
ignore redirects when inferring loader data types

### DIFF
--- a/.changeset/khaki-gifts-grin.md
+++ b/.changeset/khaki-gifts-grin.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Ignore redirects when inferring loader data types

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1367,7 +1367,12 @@ export interface TrackedPromise extends Promise<any> {
 export type RedirectFunction = (
   url: string,
   init?: number | ResponseInit
-) => Response;
+) => Redirect;
+
+// use a `unique symbol` to create a branded type
+// https://egghead.io/blog/using-branded-types-in-typescript
+declare const redirectSymbol: unique symbol;
+export type Redirect = Response & { [redirectSymbol]: never };
 
 /**
  * A redirect response. Sets the status code and the `Location` header.
@@ -1389,7 +1394,7 @@ export const redirect: RedirectFunction = (url, init = 302) => {
   return new Response(null, {
     ...responseInit,
     headers,
-  });
+  }) as Redirect;
 };
 
 /**

--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -2,7 +2,7 @@ import type {
   ClientLoaderFunctionArgs,
   ClientActionFunctionArgs,
 } from "../dom/ssr/routeModules";
-import type { DataWithResponseInit } from "../router/utils";
+import type { DataWithResponseInit, Redirect } from "../router/utils";
 import type { Serializable } from "../server-runtime/single-fetch";
 import type { Equal, Expect, Func, IsAny, Pretty } from "./utils";
 
@@ -44,11 +44,13 @@ type DataFrom<T> =
 
 // prettier-ignore
 type ClientData<T> =
+  T extends Redirect ? never :
   T extends DataWithResponseInit<infer U> ? U :
   T
 
 // prettier-ignore
 type ServerData<T> =
+  T extends Redirect ? never :
   T extends DataWithResponseInit<infer U> ? Serialize<U> :
   Serialize<T>
 
@@ -84,6 +86,7 @@ type __tests = [
       | { data: string; b: Date; c: undefined }
     >
   >,
+  Expect<Equal<ServerDataFrom<() => { a: string } | Redirect>, { a: string }>>,
 
   // ClientDataFrom
   Expect<Equal<ClientDataFrom<any>, undefined>>,
@@ -105,5 +108,6 @@ type __tests = [
       | { json: string; b: Date; c: () => boolean }
       | { data: string; b: Date; c: () => boolean }
     >
-  >
+  >,
+  Expect<Equal<ClientDataFrom<() => { a: string } | Redirect>, { a: string }>>
 ];


### PR DESCRIPTION
Fixes #12335