### PR TITLE
Typesafe useRouteLoaderData behind future flag

### DIFF
--- a/.changeset/eleven-insects-tickle.md
+++ b/.changeset/eleven-insects-tickle.md
@@ -1,0 +1,6 @@
+---
+"@react-router/dev": minor
+"react-router": minor
+---
+
+Add a new `typesafeUseRouteLoaderData` future flag, which, when enabled, improves the type of `useRouteLoaderData` with inference and errors.

--- a/contributors.yml
+++ b/contributors.yml
@@ -136,6 +136,7 @@
 - jenseng
 - JeraldVin
 - JesusTheHun
+- jeyj0
 - jimniels
 - jmargeta
 - johnpangalos

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -85,6 +85,7 @@ type ServerModuleFormat = "esm" | "cjs";
 
 interface FutureConfig {
   unstable_optimizeDeps: boolean;
+  typesafeUseRouteLoaderData: boolean;
 }
 
 export type BuildManifest = DefaultBuildManifest | ServerBundlesBuildManifest;
@@ -482,6 +483,8 @@ async function resolveConfig({
   let future: FutureConfig = {
     unstable_optimizeDeps:
       reactRouterUserConfig.future?.unstable_optimizeDeps ?? false,
+    typesafeUseRouteLoaderData:
+      reactRouterUserConfig.future?.typesafeUseRouteLoaderData ?? false,
   };
 
   let reactRouterConfig: ResolvedReactRouterConfig = deepFreeze({

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -6,9 +6,13 @@ import type vite from "vite";
 
 import { createConfigLoader } from "../config/config";
 
-import { generate } from "./generate";
+import {
+  generate,
+  generateRouteManifest,
+  generateUseRouteLoaderDataType,
+} from "./generate";
 import type { Context } from "./context";
-import { getTypesDir, getTypesPath } from "./paths";
+import { getTypesDir, getTypesPath, getGlobalTypesFilePath } from "./paths";
 
 export async function run(rootDirectory: string) {
   const ctx = await createContext({ rootDirectory, watch: false });
@@ -81,4 +85,17 @@ async function writeAll(ctx: Context): Promise<void> {
     fs.mkdirSync(Path.dirname(typesPath), { recursive: true });
     fs.writeFileSync(typesPath, content);
   });
+
+  const useRouteLoaderDataContent = generateUseRouteLoaderDataType(ctx);
+  const useRouteLoaderDataTypesPath = getGlobalTypesFilePath(
+    ctx,
+    "useRouteLoaderData"
+  );
+  fs.writeFileSync(useRouteLoaderDataTypesPath, useRouteLoaderDataContent);
+
+  if (ctx.config.future.typesafeUseRouteLoaderData) {
+    const routeManifestContent = generateRouteManifest(ctx);
+    const routeManifestPath = getGlobalTypesFilePath(ctx, "routeManifest");
+    fs.writeFileSync(routeManifestPath, routeManifestContent);
+  }
 }

--- a/packages/react-router-dev/typegen/paths.ts
+++ b/packages/react-router-dev/typegen/paths.ts
@@ -16,3 +16,7 @@ export function getTypesPath(ctx: Context, route: RouteManifestEntry) {
     "+types/" + Pathe.filename(route.file) + ".ts"
   );
 }
+
+export function getGlobalTypesFilePath(ctx: Context, fileName: string) {
+  return Path.join(getTypesDir(ctx), Pathe.filename(fileName) + ".d.ts");
+}

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1117,7 +1117,7 @@ export function useLoaderData<T = any>(): SerializeFrom<T> {
   @category Hooks
  */
 export function useRouteLoaderData<T = any>(
-  routeId: string
+  routeId: never // actually string after typegen; never allows typesafeUseRouteLoaderData future flag to work
 ): SerializeFrom<T> | undefined {
   let state = useDataRouterState(DataRouterStateHook.UseRouteLoaderData);
   return state.loaderData[routeId] as SerializeFrom<T> | undefined;


### PR DESCRIPTION
This PR implements a new future flag: `typesafeUseRouteLoaderData`, which improves the type for `useRouteLoaderData` by making use of the new type generation infrastructure.

Note: I'm not sure if this affects library-mode. If it does, there's probably more work to be done.

# Benefits

There are two benefits when enabling the flag:

## Benefit 1: Type Inference

```typescript
// instead of
const data = useRouteLoaderData<typeof rootLoader>("root");

// we just do
const data = useRouteLoaderData("root");
```

## Benefit 2: Type Errors

```typescript
// this throws a type-error if no route with id "doesnt_exist" exists
const data = useRouteLoaderData("doesnt_exist");
```

# How does it work?

The current useRouteLoaderData type from its actual implementation is made impossible to reach, by requiring the parameter `routeId` to be of type `never`. The actual type is then declared using module augmentation within the user's `.react-router/types` directory. The actual generated type depends on the future flag.

## When typesafeUseRouteLoaderData is disabled

Unfortunately, there is an additional generated file in `.react-router/types` for users who don't enable the flag (`.react-router/types/useRouteLoaderData.d.ts`). I'm not sure if that counts as changing the API. I wouldn't say so, but if you disagree I can also understand the reasoning behind that.

If the additional generated file counts as an API change, Benefit 2 will require a different approach to be implementable behind a future flag: namely, a type-level future flag via module augmentation. Benefit 1 (inference) can be implemented without that file in case the flag is disabled (if the parameter is not a RouteId, it would then fall back to the current type if nothing is done to enable Benefit 2).

## When typesafeUseRouteLoaderData is enabled

`react-router typegen` generates two new files in `.react-router/types` when the future flag is enabled:
- `.react-router/types/routeManifest.d.ts` exports two types: `RouteManifest` and `RouteId`. `RouteManifest` is an object type, which maps route ids to the `Info` export of that route's `+types/...` file. I chose to do this in a separate file, as these types might be useful for users as well.
- `.react-router/types/useRouteLoaderData.d.ts` uses module augmentation to declare an new type for `useRouteLoaderData`, which uses the `RouteManifest` and `RouteId` types for `.react-router/types/routeManifest.d.ts`.