### PR TITLE
fix(perf): remove DOM mutation overhead from fog-of-war prefetch

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -75,6 +75,7 @@
 - david-crespo
 - dcblair
 - decadentsavant
+- developit
 - dgrijuela
 - DigitalNaut
 - dmitrytarassov

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -116,14 +116,23 @@ export function useFogOFWarDiscovery(
       if (!path) {
         return;
       }
-      let url = new URL(path, window.location.origin);
-      if (!discoveredPaths.has(url.pathname)) {
-        nextPaths.add(url.pathname);
+      // optimization: use the already-parsed pathname from links
+      let pathname =
+        el.tagName === 'A'
+          ? (el as HTMLAnchorElement).pathname
+          : new URL(path, window.location.origin).pathname;
+      if (!discoveredPaths.has(pathname)) {
+        nextPaths.add(pathname);
       }
     }
 
     // Register and fetch patches for all initially-rendered links/forms
     async function fetchPatches() {
+      // re-check/update registered links
+      document
+        .querySelectorAll("a[data-discover], form[data-discover]")
+        .forEach(registerElement);
+
       let lazyPaths = Array.from(nextPaths.keys()).filter((path) => {
         if (discoveredPaths.has(path)) {
           nextPaths.delete(path);
@@ -150,43 +159,14 @@ export function useFogOFWarDiscovery(
       }
     }
 
-    // Register and fetch patches for all initially-rendered links
-    document.body
-      .querySelectorAll("a[data-discover], form[data-discover]")
-      .forEach((el) => registerElement(el));
+    let debouncedFetchPatches = debounce(fetchPatches, 100);
 
+    // scan and fetch initial links
     fetchPatches();
 
     // Setup a MutationObserver to fetch all subsequently rendered links/form
-    let debouncedFetchPatches = debounce(fetchPatches, 100);
-
-    function isElement(node: Node): node is Element {
-      return node.nodeType === Node.ELEMENT_NODE;
-    }
-
-    let observer = new MutationObserver((records) => {
-      let elements = new Set<Element>();
-      records.forEach((r) => {
-        [r.target, ...r.addedNodes].forEach((node) => {
-          if (!isElement(node)) return;
-          if (node.tagName === "A" && node.getAttribute("data-discover")) {
-            elements.add(node);
-          } else if (
-            node.tagName === "FORM" &&
-            node.getAttribute("data-discover")
-          ) {
-            elements.add(node);
-          }
-          if (node.tagName !== "A") {
-            node
-              .querySelectorAll("a[data-discover], form[data-discover]")
-              .forEach((el) => elements.add(el));
-          }
-        });
-      });
-      elements.forEach((el) => registerElement(el));
-      debouncedFetchPatches();
-    });
+    // It just schedules a full scan since that's faster than checking subtrees
+    let observer = new MutationObserver(debouncedFetchPatches);
 
     observer.observe(document.documentElement, {
       subtree: true,


### PR DESCRIPTION
In a real-world website I am testing this against, this reduces the fog-of-war's blocking JS during SPA transitions from 100ms to 1.2ms.

|Before|After|
|---|---|
| <img width="470" alt="Screenshot 2024-12-13 at 12 05 06 PM" src="https://github.com/user-attachments/assets/b4c59150-d1ce-406c-9c4d-6c794354c32c" /> | <img width="441" alt="Screenshot 2024-12-13 at 12 05 36 PM" src="https://github.com/user-attachments/assets/fcb38b8f-dd7f-475a-bd8d-efad52e82202" /> |