### PR TITLE
feat(react-router): add `LayoutComponentProps` type

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -312,3 +312,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- AlemTuzlak

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -43,6 +43,7 @@ export type {
   RedirectFunction,
   ShouldRevalidateFunction,
   ShouldRevalidateFunctionArgs,
+  LayoutComponentProps,
   UIMatch,
 } from "./lib/router/utils";
 

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { PropsWithChildren } from "react";
 import type { Equal, Expect } from "../types/utils";
 import type { Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Equal, Expect } from "../types/utils";
 import type { Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";
@@ -190,6 +191,10 @@ export interface ShouldRevalidateFunctionArgs {
  */
 export interface ShouldRevalidateFunction {
   (args: ShouldRevalidateFunctionArgs): boolean;
+}
+
+export interface LayoutComponentProps {
+  children: ReactNode
 }
 
 export interface DataStrategyMatch

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -193,9 +193,7 @@ export interface ShouldRevalidateFunction {
   (args: ShouldRevalidateFunctionArgs): boolean;
 }
 
-export interface LayoutComponentProps {
-  children: ReactNode
-}
+export type LayoutComponentProps = PropsWithChildren;
 
 export interface DataStrategyMatch
   extends AgnosticRouteMatch<string, AgnosticDataRouteObject> {


### PR DESCRIPTION
Add the `LayoutComponentProps` utility type instead of us having to manually define it in our projects