### PR TITLE
tests: silence `require(esm)` warnings for Node 22.12

### DIFF
--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -217,6 +217,7 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
           ],
           {
             env: {
+              ...process.env,
               NODE_ENV: mode || "production",
               PORT: port.toFixed(0),
             },

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -1,6 +1,11 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
 
+// silence expected warnings in Node 22.12 about `require(esm)`
+// when it implicitly uses `react-router`'s `module-sync` export condition
+process.env.NODE_OPTIONS =
+  (process.env.NODE_OPTIONS ?? "") + ` --no-warnings=ExperimentalWarning`;
+
 const config: PlaywrightTestConfig = {
   testDir: ".",
   testMatch: ["**/*-test.ts"],


### PR DESCRIPTION
Node 22.12 enables `require(esm)` by default.
As part of this, the `module-sync` export condition gets used whereas in 22.11 that export condition gets ignored.

We've setup out package.json exports for `react-router` to use the `module-sync` condition to point to the ESM version so that no matter where you get `react-router` from you always get the same copy. That's a good thing!

So in 22.11, you get a (duplicate) CJS version of `react-router` and in 22.12 you get a (deduplicated) ESM version of `react-router`.

This is all intended behavior, but Node shipped this new default while still logging warnings for `require(esm)` to stderr. Since many of our integration tests check stderr for warnings, those started failing.

Again, everything is working correctly (and better than in 22.11) so this commit simply silences the experimental warnings from Node so that our integration tests don't mistake expected Node warnings for unexpected warnings/errors.