### PR TITLE
Add layout outlet docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -319,3 +319,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- vladinator1000

--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -153,6 +153,24 @@ export default [
 ] satisfies RouteConfig;
 ```
 
+To see `projects/home.tsx` appear in the layout, we'll need an outlet:
+
+```tsx filename=./projects/project-layout.tsx lines=[8]
+import { Outlet } from "react-router"
+
+export default function ProjectLayout() {
+  return (
+    <div>
+      <aside>Example sidebar</aside>
+      <main>
+        <Outlet />
+      </main>
+    </div>
+  )
+}
+
+```
+
 ## Index Routes
 
 ```ts


### PR DESCRIPTION
I had trouble figuring out how to write layout components in v7, turns out I had to use an outlet. This was a bit confusing to me because I was using children for some reason. I added extra instructions to [the layout routes docs](https://reactrouter.com/start/framework/routing#layout-routes) to help stragglers like me.