### PR TITLE
docs(changelog): fix minor typo in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,7 +341,7 @@ React Router v7 requires the following minimum versions:
 
 #### Adopted Future Flag Behaviors
 
-Remix and React Router follow an [API Development Strategy](https://reactrouter.com/en/main/guides/api-development-strategy) leveraging "Future Flags" to avoid introducing a slew of breaking changes in a major release. Instead, breaking changes are introduce din minor releases behind a flag, allowing users to opt-in at their convenience. In the next major release, all future flag behaviors become the default behavior.
+Remix and React Router follow an [API Development Strategy](https://reactrouter.com/en/main/guides/api-development-strategy) leveraging "Future Flags" to avoid introducing a slew of breaking changes in a major release. Instead, breaking changes are introduced in minor releases behind a flag, allowing users to opt-in at their convenience. In the next major release, all future flag behaviors become the default behavior.
 
 The following previously flagged behaviors are now the default in React Router v7:
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -136,6 +136,7 @@
 - jasikpark
 - jasonpaulos
 - jb-1980
+- jclarkin
 - jdufresne
 - jenseng
 - JeraldVin


### PR DESCRIPTION
## What was done

Spotted and fixed a minor typo in the v7.0.0 changelog:

- Was: `introduce din minor releases`
- Now: `introduced in minor releases`

## User Impact

No functional impact on users.

## Testing

No testing necessary for this PR change - documentation change only.