### PR TITLE
docs: improve template instructions in installation docs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -272,6 +272,7 @@
 - thepedroferrari
 - thethmuu
 - thisiskartik
+- thomasgauvin
 - thomasverleye
 - ThornWu
 - tiborbarsi

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -11,7 +11,7 @@ Most projects start with a template. Let's use a basic template maintained by Re
 npx create-react-router@latest my-react-router-app
 ```
 
-You can also create a project using one of the many available deployment templates, which will configure your project for the hosting provider.
+You can also create a project using one of the many available [deployment templates](https://github.com/remix-run/react-router-templates), which will configure your project for the hosting provider.
 
 ```shellscript nonumber
 npx create-react-router@latest my-node-custom-server-react-router-app --template remix-run/react-router-templates/node-custom-server

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -11,6 +11,18 @@ Most projects start with a template. Let's use a basic template maintained by Re
 npx create-react-router@latest my-react-router-app
 ```
 
+You can also create a project using one of the many available deployment templates, which will configure your project for the hosting provider.
+
+```shellscript nonumber
+npx create-react-router@latest my-node-custom-server-react-router-app --template remix-run/react-router-templates/node-custom-server
+
+npx create-react-router@latest my-cloudflare-react-router-app --template remix-run/react-router-templates/cloudflare
+
+npx create-react-router@latest my-vercel-react-router-app --template remix-run/react-router-templates/vercel
+
+npx create-react-router@latest my-netlify-react-router-app --template remix-run/react-router-templates/netlify
+```
+
 Now change into the new directory and start the app
 
 ```shellscript nonumber

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -17,8 +17,6 @@ You can also create a project using one of the many available [deployment templa
 npx create-react-router@latest my-node-default-react-router-app --template remix-run/react-router-templates/default
 ```
 
-The other available template options are `remix-run/react-router-templates/node-custom-server`, `remix-run/react-router-templates/cloudflare`, `remix-run/react-router-templates/vercel`, and `remix-run/react-router-templates/netlify`. 
-
 Now change into the new directory and start the app
 
 ```shellscript nonumber
@@ -31,7 +29,11 @@ You can now open your browser to `http://localhost:5173`
 
 You can [view the template on GitHub][default-template] to see how to manually set up your project.
 
-To get started with a template that deploys to your preferred host, check out [all of our templates](https://github.com/remix-run/react-router-templates).
+There are a number of [official templates][react-router-templates] available for you to get started with:
+
+```shellscript nonumber
+npx create-react-router@latest --template remix-run/react-router-templates/<template-name>
+```
 
 ---
 
@@ -39,3 +41,4 @@ Next: [Routing](./routing)
 
 [manual_usage]: ../how-to/manual-usage
 [default-template]: https://github.com/remix-run/react-router-templates/tree/main/default
+[react-router-templates]: https://github.com/remix-run/react-router-templates

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -14,14 +14,10 @@ npx create-react-router@latest my-react-router-app
 You can also create a project using one of the many available [deployment templates](https://github.com/remix-run/react-router-templates), which will configure your project for the hosting provider.
 
 ```shellscript nonumber
-npx create-react-router@latest my-node-custom-server-react-router-app --template remix-run/react-router-templates/node-custom-server
-
-npx create-react-router@latest my-cloudflare-react-router-app --template remix-run/react-router-templates/cloudflare
-
-npx create-react-router@latest my-vercel-react-router-app --template remix-run/react-router-templates/vercel
-
-npx create-react-router@latest my-netlify-react-router-app --template remix-run/react-router-templates/netlify
+npx create-react-router@latest my-node-default-react-router-app --template remix-run/react-router-templates/default
 ```
+
+The other available template options are `remix-run/react-router-templates/node-custom-server`, `remix-run/react-router-templates/cloudflare`, `remix-run/react-router-templates/vercel`, and `remix-run/react-router-templates/netlify`. 
 
 Now change into the new directory and start the app
 

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -23,7 +23,7 @@ You can now open your browser to `http://localhost:5173`
 
 You can [view the template on GitHub][default-template] to see how to manually set up your project.
 
-There are a number of [official templates][react-router-templates] available for you to get started with:
+We also have a number of [ready to deploy templates][react-router-templates] available for you to get started with:
 
 ```shellscript nonumber
 npx create-react-router@latest --template remix-run/react-router-templates/<template-name>

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -11,12 +11,6 @@ Most projects start with a template. Let's use a basic template maintained by Re
 npx create-react-router@latest my-react-router-app
 ```
 
-You can also create a project using one of the many available [deployment templates](https://github.com/remix-run/react-router-templates), which will configure your project for the hosting provider.
-
-```shellscript nonumber
-npx create-react-router@latest my-node-default-react-router-app --template remix-run/react-router-templates/default
-```
-
 Now change into the new directory and start the app
 
 ```shellscript nonumber


### PR DESCRIPTION
@brookslybrand and I had a chat on Twitter https://x.com/thomasgauvin/status/1869139471263990106. It'd be nice to feature the deployment templates more apparently in the installation guides (similar to how Vite does it https://vite.dev/guide/#scaffolding-your-first-vite-project)

I opened this PR but I couldn't preview the docs. Not sure if this looks crazy, but I think the idea is in the right direction. The current note of `To get started with a template that deploys to your preferred host, check out [all of our templates](https://github.com/remix-run/react-router-templates).` is too easy to miss, and it requires people to figure out how to create a project from a template ie having to run `npx create-react-router@latest --help` to see the available options, especially for folks may not be as knowledgeable, adds friction. 