### PR TITLE
Properly initialize `NODE_ENV` if not already set

### DIFF
--- a/.changeset/selfish-pianos-grab.md
+++ b/.changeset/selfish-pianos-grab.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Properly initialize `NODE_ENV` if not already set for compatibility with React 19

--- a/contributors.yml
+++ b/contributors.yml
@@ -141,6 +141,7 @@
 - johnpangalos
 - jonkoops
 - jrakotoharisoa
+- jrestall
 - juanpprieto
 - jungwoo3490
 - kachun333

--- a/packages/react-router-dev/bin.js
+++ b/packages/react-router-dev/bin.js
@@ -1,2 +1,15 @@
 #!/usr/bin/env node
+let arg = require("arg");
+
+// Minimal replication of our actual parsing in `run.ts`.  If not already set,
+// default `NODE_ENV` so React loads the proper version in it's CJS entry script.
+// We have to do this before importing `run.ts` since that is what imports
+// `react` (indirectly via `react-router`)
+let args = arg({}, { argv: process.argv.slice(2) });
+if (args._[0] === "dev") {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+} else {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
+}
+
 require("./dist/cli/index");

--- a/packages/react-router-serve/bin.js
+++ b/packages/react-router-serve/bin.js
@@ -1,2 +1,7 @@
 #!/usr/bin/env node
+
+// If not already set, default `NODE_ENV=production` so React loads the proper
+// version in it's CJS entry script
+process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
+
 require("./dist/cli");


### PR DESCRIPTION
It seems React 19 is a bit more strict with `NODE_ENV` and when it's not set by the user there is currently a mismatch between our code and React's code (similar to the issue in https://github.com/remix-run/react-router/issues/12078)

* We default to [`production`](https://github.com/remix-run/react-router/blob/main/packages/react-router-dev/vite/plugin.ts#L63) when we call `vite.resolveConfig` in in `plugin.ts`
* But React defaults to [`development`](https://www.unpkg.com/react@19.0.0/index.js)

This mismatch causes issues because we end up with mismatched versions of React in the bundle versus the `react-router build` runtime.

This PR updates the `react-router` and `react-router-serve` to set `NODE_ENV` accordingly if it's not already set:

* `react-router dev` defaults to `development`
* All other `react-router *` commands default to `production`
* `react-router-serve` defaults to `production`

Closes #12138, #12078