### PR TITLE
add typegen section to framework adoption guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules/
 
 # v7 reference docs
 /public
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,3 @@ node_modules/
 
 # v7 reference docs
 /public
-
-.idea

--- a/contributors.yml
+++ b/contributors.yml
@@ -324,3 +324,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- vorant94

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -245,7 +245,7 @@ export default function Component() {
 
 [View our guide on configuring routes][configuring-routes] to learn more about the `routes.ts` file.
 
-### 7. Configure Typegen
+## 7. Enable type safety
 
 To improve developer experience React Router automatically generates route module type definitions based on `routes.ts` file. There are a couple of places needs to be updated to address it
 

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -245,7 +245,37 @@ export default function Component() {
 
 [View our guide on configuring routes][configuring-routes] to learn more about the `routes.ts` file.
 
-## 7. Boot the app
+### 7. Configure Typegen
+
+To improve developer experience React Router automatically generates route module type definitions based on `routes.ts` file. There are a couple of places needs to be updated to address it
+
+**👉 Add typegen dir to `.gitignore`**
+
+```ignore filename=.gitignore
+.react-router/
+```
+
+**👉 Include typegen as part of `tsconfig.app.json`**
+
+```json5 filename=tsconfig.json
+{
+  "compilerOptions": {
+    "rootDirs": [".", "./.react-router/types"],
+    // ...other options
+  },
+  "src": ["src", ".react-router/types/**/*"],
+}
+```
+
+**👉 Automate execution of typegen on project initialization**
+
+```json filename=package.json
+"scripts": {
+  "prepare": "react-router typegen"
+}
+```
+
+## 8. Boot the app
 
 At this point you should be able to to boot the app and see the root layout.
 
@@ -263,7 +293,7 @@ Now make sure you can boot your app at this point before moving on:
 npm run dev
 ```
 
-## 8. Render your app
+## 9. Render your app
 
 To get back to rendering your app, we'll update the "catchall" route we setup earlier that matches all URLs so that your existing `<Routes>` get a chance to render.
 
@@ -279,7 +309,7 @@ export default function Component() {
 
 Your app should be back on the screen and working as usual!
 
-## 9. Migrate a route to a Route Module
+## 10. Migrate a route to a Route Module
 
 You can now incrementally migrate your routes to route modules.
 

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -394,7 +394,37 @@ export default [
 
 [View our guide on configuring routes][configuring-routes] to learn more about the `routes.ts` file and helper functions to further simplify the route definitions.
 
-## 7. Boot the app
+### 7. Configure Typegen
+
+To improve developer experience React Router automatically generates route module type definitions based on `routes.ts` file. There are a couple of places needs to be updated to address it
+
+**👉 Add typegen dir to `.gitignore`**
+
+```ignore filename=.gitignore
+.react-router/
+```
+
+**👉 Include typegen as part of `tsconfig.app.json`**
+
+```json5 filename=tsconfig.json
+{
+  "compilerOptions": {
+    "rootDirs": [".", "./.react-router/types"],
+    // ...other options
+  },
+  "src": ["src", ".react-router/types/**/*"],
+}
+```
+
+**👉 Automate execution of typegen on project initialization**
+
+```json filename=package.json
+"scripts": {
+  "prepare": "react-router typegen"
+}
+```
+
+## 8. Boot the app
 
 At this point you should be fully migrated to the React Router Vite plugin. Go ahead and update your `dev` script and run the app to make sure everything is working.
 

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -394,7 +394,7 @@ export default [
 
 [View our guide on configuring routes][configuring-routes] to learn more about the `routes.ts` file and helper functions to further simplify the route definitions.
 
-### 7. Configure Typegen
+## 7. Enable type safety
 
 To improve developer experience React Router automatically generates route module type definitions based on `routes.ts` file. There are a couple of places needs to be updated to address it
 


### PR DESCRIPTION
add missing part of framework adoption guide describing what needs to be done to adjust the project for rr7 typegen

part of docs improvement proposed in #12566 