### PR TITLE
docs(upgrading/v6): clarify `partialHydration`

### DIFF
--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -197,7 +197,7 @@ If any of your code is checking for lowercase HTTP methods, you will need to upd
 
 <docs-warning>If you are not using a `<RouterProvider>` you can skip this</docs-warning>
 
-This allows SSR frameworks to provide only partial hydration data. It's unlikely you need to worry about this, just turn the flag on. [View the CHANGELOG](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#partial-hydration) for more information.
+This enables partial hydration of a data router which is primarily used for SSR frameworks, but it is also useful if you are using `lazy` to load your route modules. It's unlikely you need to worry about this, just turn the flag on. [View the CHANGELOG](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#partial-hydration) for more information.
 
 👉 **Enable the Flag**
 


### PR DESCRIPTION
Resolves #12563 

Our language was too SSR-focused, so it made it confusing why `HydrateFallback` might be needed if you're using `createBrowserRouter` in a SPA