### PR TITLE
fix(@react-router/dev): prevent argv parsing crash when optionnal args are passed to the cli

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -233,6 +233,7 @@
 - pavsoldatov
 - pcattori
 - petersendidit
+- phildl
 - pierophp
 - printfn
 - promet99

--- a/packages/react-router-dev/bin.js
+++ b/packages/react-router-dev/bin.js
@@ -5,7 +5,7 @@ let arg = require("arg");
 // default `NODE_ENV` so React loads the proper version in it's CJS entry script.
 // We have to do this before importing `run.ts` since that is what imports
 // `react` (indirectly via `react-router`)
-let args = arg({}, { argv: process.argv.slice(2) });
+let args = arg({}, { argv: process.argv.slice(2), stopAtPositional: true });
 if (args._[0] === "dev") {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
 } else {


### PR DESCRIPTION
Related issue #12606 
Introduced in release v7.1.0 with the changes required to have NODE_ENV correctly set-up for React 19.

In this file the optional args are not necessary but it shouldn't crash if present. The fixe handle that situation by not parsing positional args in this file.