### PR TITLE
docs: Added guide on combining `configure routes` and `file routes`

### DIFF
--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -49,8 +49,7 @@ export default [
 ] satisfies RouteConfig;
 ```
 
-If you prefer to define your routes via file naming conventions rather than configuration, the `@react-router/fs-routes` package provides a [file system routing convention.][file-route-conventions]
-These approaches can also be combined, as shown below:
+If you prefer to define your routes via file naming conventions rather than configuration, the `@react-router/fs-routes` package provides a [file system routing convention][file-route-conventions]. You can even combine different routing conventions if you like:
 
 ```ts filename=app/routes.ts
 import { type RouteConfig, route } from "@react-router/dev/routes";

--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -50,6 +50,18 @@ export default [
 ```
 
 If you prefer to define your routes via file naming conventions rather than configuration, the `@react-router/fs-routes` package provides a [file system routing convention.][file-route-conventions]
+These approaches can also be combined, as shown below:
+
+```ts filename=app/routes.ts
+import { type RouteConfig, route } from "@react-router/dev/routes";
+import { flatRoutes } from "@react-router/fs-routes";
+
+export default = [
+  route("/", "./home.tsx"),
+
+  ...await flatRoutes(),
+] satisfies RouteConfig;
+```
 
 ## Route Modules
 


### PR DESCRIPTION
# Motivation

The use of `config routes` and `file routes` in combination is explained in the [PR](https://github.com/remix-run/react-router/pull/11773) where `routes.ts` was added, but it was missing from the guide.
I added it because I thought it would be more useful and cover the use cases by documenting it in the guide.