### PR TITLE
fix(dev): resolve optimizeDeps entries properly on Windows

### DIFF
--- a/.changeset/gentle-carrots-appear.md
+++ b/.changeset/gentle-carrots-appear.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Properly resolve Windows file paths to scan for Vite's dependency optimization when using the `unstable_optimizeDeps` future flag.

--- a/contributors.yml
+++ b/contributors.yml
@@ -321,6 +321,7 @@
 - willemarcel
 - williamsdyyz
 - willsawyerrrr
+- wkovacs64
 - xavier-lc
 - xcsnowcity
 - yionr

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -812,9 +812,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           optimizeDeps: {
             entries: ctx.reactRouterConfig.future.unstable_optimizeDeps
               ? [
-                  ctx.entryClientFilePath,
+                  vite.normalizePath(ctx.entryClientFilePath),
                   ...Object.values(ctx.reactRouterConfig.routes).map((route) =>
-                    path.join(ctx.reactRouterConfig.appDirectory, route.file)
+                    resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
                   ),
                 ]
               : [],


### PR DESCRIPTION
TL;DR - [`unstable_optimizeDeps` doesn't work well on Windows due to path resolution issues](https://github.com/remix-run/remix/issues/10156). This fixes it. All credit goes to @sebastien-comeau for https://github.com/remix-run/remix/pull/10258 (which still needs merged for the Windows folks still on Remix v2, btw).