### PR TITLE
chore: remove deprecated @types/cookie package

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -330,3 +330,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- abdrahmanrizk

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -80,7 +80,6 @@
     }
   },
   "dependencies": {
-    "@types/cookie": "^0.6.0",
     "cookie": "^1.0.1",
     "set-cookie-parser": "^2.6.0",
     "turbo-stream": "2.4.0"


### PR DESCRIPTION
Removed deprecated @types/cookie package.

The @types/cookie package is no longer needed as the cookie package now provides its own type definitions.
