### PR TITLE
Fix configuring resolve conditions for Vite v6

### DIFF
--- a/.changeset/afraid-jeans-drive.md
+++ b/.changeset/afraid-jeans-drive.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix default external conditions in Vite v6. This fixes resolution issues with certain npm packages.

--- a/contributors.yml
+++ b/contributors.yml
@@ -268,6 +268,7 @@
 - shamsup
 - shihanng
 - shivamsinghchahar
+- silvenon
 - SimenB
 - SkayuX
 - skratchdot
@@ -330,4 +331,3 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
-- silvenon

--- a/contributors.yml
+++ b/contributors.yml
@@ -330,3 +330,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- silvenon

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -4,7 +4,7 @@ import { type Plugin } from "vite";
 import { type GetPlatformProxyOptions, type PlatformProxy } from "wrangler";
 
 import { fromNodeRequest, toNodeRequest } from "./node-adapter";
-import { preloadViteEsm, importViteEsmSync } from "./import-vite-esm-sync";
+import { preloadVite, getVite } from "./vite";
 
 let serverBuildId = "virtual:react-router/server-build";
 
@@ -44,9 +44,9 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
 
   return {
     name: PLUGIN_NAME,
-    config: async (userConfig) => {
-      await preloadViteEsm();
-      const vite = importViteEsmSync();
+    config: async () => {
+      await preloadVite();
+      const vite = getVite();
       // a compatibility layer from Vite v6+ and below because
       // Vite v6 overrides the default resolve.conditions, so we have to import them
       // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -51,8 +51,10 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
       // Vite v6 overrides the default resolve.conditions, so we have to import them
       // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
       // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
-      const serverConditions =
-        "defaultServerConditions" in vite ? vite.defaultServerConditions : [];
+      const serverConditions: string[] =
+        "defaultServerConditions" in vite
+          ? [...vite.defaultServerConditions]
+          : [];
 
       return {
         ssr: {

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -47,9 +47,13 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
     config: async () => {
       await preloadVite();
       const vite = getVite();
-      // a compatibility layer from Vite v6+ and below because
-      // Vite v6 overrides the default resolve.conditions, so we have to import them
-      // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
+      // This is a compatibility layer for Vite 5. Default conditions were
+      // automatically added to any custom conditions in Vite 5, but Vite 6
+      // removed this behavior. Instead, the default conditions are overridden
+      // by any custom conditions. If we wish to retain the default
+      // conditions, we need to manually merge them using the provided default
+      // conditions arrays exported from Vite. In Vite 5, these default
+      // conditions arrays do not exist.
       // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
       const serverConditions: string[] = [
         ...(vite.defaultServerConditions ?? []),

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -51,10 +51,9 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
       // Vite v6 overrides the default resolve.conditions, so we have to import them
       // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
       // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
-      const serverConditions: string[] =
-        "defaultServerConditions" in vite
-          ? [...vite.defaultServerConditions]
-          : [];
+      const serverConditions: string[] = [
+        ...(vite.defaultServerConditions ?? []),
+      ];
 
       return {
         ssr: {

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -47,6 +47,10 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
     config: async (userConfig) => {
       await preloadViteEsm();
       const vite = importViteEsmSync();
+      // a compatibility layer from Vite v6+ and below because
+      // Vite v6 overrides the default resolve.conditions, so we have to import them
+      // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
+      // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
       const serverConditions =
         userConfig.ssr?.resolve?.externalConditions ??
         "defaultServerConditions" in vite

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -52,10 +52,7 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
       // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
       // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
       const serverConditions =
-        userConfig.ssr?.resolve?.externalConditions ??
-        "defaultServerConditions" in vite
-          ? vite.defaultServerConditions
-          : [];
+        "defaultServerConditions" in vite ? vite.defaultServerConditions : [];
 
       return {
         ssr: {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -743,12 +743,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
         // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
         let viteClientConditions: string[] =
-          viteUserConfig.resolve?.conditions ??
           "defaultClientConditions" in vite
             ? Array.from(vite.defaultClientConditions)
             : [];
         let viteServerConditions: string[] =
-          viteUserConfig.ssr?.resolve?.conditions ??
           "defaultServerConditions" in vite
             ? Array.from(vite.defaultServerConditions)
             : [];

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -738,9 +738,13 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         viteConfigEnv = _viteConfigEnv;
         viteCommand = viteConfigEnv.command;
 
-        // a compatibility layer from Vite v6+ and below because
-        // Vite v6 overrides the default resolve.conditions, so we have to import them
-        // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
+        // This is a compatibility layer for Vite 5. Default conditions were
+        // automatically added to any custom conditions in Vite 5, but Vite 6
+        // removed this behavior. Instead, the default conditions are overridden
+        // by any custom conditions. If we wish to retain the default
+        // conditions, we need to manually merge them using the provided default
+        // conditions arrays exported from Vite. In Vite 5, these default
+        // conditions arrays do not exist.
         // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
         let viteClientConditions: string[] = [
           ...(vite.defaultClientConditions ?? []),

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -742,14 +742,12 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         // Vite v6 overrides the default resolve.conditions, so we have to import them
         // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
         // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
-        let viteClientConditions: string[] =
-          "defaultClientConditions" in vite
-            ? [...vite.defaultClientConditions]
-            : [];
-        let viteServerConditions: string[] =
-          "defaultServerConditions" in vite
-            ? [...vite.defaultServerConditions]
-            : [];
+        let viteClientConditions: string[] = [
+          ...(vite.defaultClientConditions ?? []),
+        ];
+        let viteServerConditions: string[] = [
+          ...(vite.defaultServerConditions ?? []),
+        ];
 
         logger = vite.createLogger(viteUserConfig.logLevel, {
           prefix: "[react-router]",

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -744,11 +744,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
         let viteClientConditions: string[] =
           "defaultClientConditions" in vite
-            ? Array.from(vite.defaultClientConditions)
+            ? [...vite.defaultClientConditions]
             : [];
         let viteServerConditions: string[] =
           "defaultServerConditions" in vite
-            ? Array.from(vite.defaultServerConditions)
+            ? [...vite.defaultServerConditions]
             : [];
 
         logger = vite.createLogger(viteUserConfig.logLevel, {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -738,6 +738,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         viteConfigEnv = _viteConfigEnv;
         viteCommand = viteConfigEnv.command;
 
+        // a compatibility layer from Vite v6+ and below because
+        // Vite v6 overrides the default resolve.conditions, so we have to import them
+        // and if the export doesn't exist, it means that we're in Vite v5, so an empty array should be used
+        // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
         let viteClientConditions: string[] =
           viteUserConfig.resolve?.conditions ??
           "defaultClientConditions" in vite

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -738,6 +738,17 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         viteConfigEnv = _viteConfigEnv;
         viteCommand = viteConfigEnv.command;
 
+        let viteClientConditions: string[] =
+          viteUserConfig.resolve?.conditions ??
+          "defaultClientConditions" in vite
+            ? Array.from(vite.defaultClientConditions)
+            : [];
+        let viteServerConditions: string[] =
+          viteUserConfig.ssr?.resolve?.conditions ??
+          "defaultServerConditions" in vite
+            ? Array.from(vite.defaultServerConditions)
+            : [];
+
         logger = vite.createLogger(viteUserConfig.logLevel, {
           prefix: "[react-router]",
         });
@@ -804,9 +815,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           ssr: {
             external: ssrExternals,
             resolve: {
-              conditions: viteCommand === "build" ? [] : ["development"],
+              conditions:
+                viteCommand === "build"
+                  ? viteServerConditions
+                  : ["development", ...viteServerConditions],
               externalConditions:
-                viteCommand === "build" ? [] : ["development"],
+                viteCommand === "build"
+                  ? viteServerConditions
+                  : ["development", ...viteServerConditions],
             },
           },
           optimizeDeps: {
@@ -853,7 +869,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
               "react-router/dom",
               "react-router-dom",
             ],
-            conditions: viteCommand === "build" ? [] : ["development"],
+            conditions:
+              viteCommand === "build"
+                ? viteClientConditions
+                : ["development", ...viteClientConditions],
           },
           base: viteUserConfig.base,
 


### PR DESCRIPTION
Configuring `resolve.conditions`/`resolve.externalConditions` in Vite v6 has changed: https://vite.dev/guide/migration.html#default-value-for-resolve-conditions

The configured conditions are no longer added to the default values, they now _replace_ the defaults. This was causing problems with resolving packages like `@prisma/client` during SSR.

This fix adds the missing default values if the default values exist, and they only exist in Vite v6, otherwise it preserves the previous behavior in order to (hopefully) maintain the same behavior with Vite v5.

Fixes #12610.