### PR TITLE
Export `defineConfig` helper from `@react-router/dev/config`

### DIFF
--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -167,6 +167,10 @@ export type ReactRouterConfig = {
   ssr?: boolean;
 };
 
+export function defineConfig(config: ReactRouterConfig): ReactRouterConfig {
+  return config;
+}
+
 export type ResolvedReactRouterConfig = Readonly<{
   /**
    * The absolute path to the application source directory.


### PR DESCRIPTION
Simple convenience helper for defining configuration, following the same approach used by other tooling such as `vite`. Currently just a simple identity function.

## Before:

```ts
// react-router.config.ts
import type { Config } from '@react-router/dev/config';

export default {
  ssr: true,
  // etc...
} satisfies Config;
```

## After:

```ts
// react-router.config.ts
import { defineConfig } from '@react-router/dev/config';

export default defineConfig({
  ssr: true,
  // etc...
});
```
