### PR TITLE
docs(how-to/suspense): update

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -109,6 +109,7 @@
 - gowthamvbhat
 - GraxMonzo
 - GuptaSiddhant
+- guppy0356
 - haivuw
 - hampelm
 - harshmangalam

--- a/docs/how-to/suspense.md
+++ b/docs/how-to/suspense.md
@@ -53,7 +53,6 @@ export default function MyComponent({
         <Await resolve={nonCriticalData}>
           {(value) => <h3>Non critical value: {value}</h3>}
         </Await>
-        <NonCriticalUI p={nonCriticalData} />
       </React.Suspense>
     </div>
   );


### PR DESCRIPTION
This PR removes the unnecessary rendering of NonCriticalUI when the Await component is used.

Since the Await component handles loading states and delays rendering of its children until the awaited resource is ready, rendering NonCriticalUI is redundant.