### PR TITLE
Update package.json to fix issue #12642

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -330,3 +330,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- briankb

--- a/tutorials/address-book/package.json
+++ b/tutorials/address-book/package.json
@@ -14,7 +14,7 @@
     "match-sorter": "^8.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "7.1.1",
+    "react-router": "*",
     "sort-by": "^1.2.0",
     "tiny-invariant": "^1.3.3"
   },

--- a/tutorials/address-book/package.json
+++ b/tutorials/address-book/package.json
@@ -14,7 +14,7 @@
     "match-sorter": "^8.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "7.0.2",
+    "react-router": "7.1.1",
     "sort-by": "^1.2.0",
     "tiny-invariant": "^1.3.3"
   },


### PR DESCRIPTION
This PR resolves issue #12642 that would cause npm install to fail during setup of the address-book example code. 

using the fix provided by [dev001hajipro](https://github.com/dev001hajipro)

- changed live 17 from 7.0.2 to 7.1.1