### PR TITLE
Fix react-refresh source maps

### DIFF
--- a/.changeset/polite-clocks-shake.md
+++ b/.changeset/polite-clocks-shake.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Fixes react-refresh source maps
+Fix react-refresh source maps

--- a/.changeset/polite-clocks-shake.md
+++ b/.changeset/polite-clocks-shake.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fixes react-refresh source maps

--- a/contributors.yml
+++ b/contributors.yml
@@ -275,6 +275,7 @@
 - soartec-lab
 - sorrycc
 - souzasmatheus
+- soxtoby
 - srmagura
 - SsongQ-92
 - stasundr

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1678,30 +1678,12 @@ function addRefreshWrapper(
       ]
     : [];
   return (
-    "\n\n" +
-    withCommentBoundaries(
-      "REACT REFRESH HEADER",
-      REACT_REFRESH_HEADER.replaceAll("__SOURCE__", JSON.stringify(id))
-    ) +
-    "\n\n" +
-    withCommentBoundaries("REACT REFRESH BODY", code) +
-    "\n\n" +
-    withCommentBoundaries(
-      "REACT REFRESH FOOTER",
-      REACT_REFRESH_FOOTER.replaceAll("__SOURCE__", JSON.stringify(id))
-        .replaceAll("__ACCEPT_EXPORTS__", JSON.stringify(acceptExports))
-        .replaceAll("__ROUTE_ID__", JSON.stringify(route?.id))
-    ) +
-    "\n"
+    REACT_REFRESH_HEADER.replaceAll("__SOURCE__", JSON.stringify(id)) +
+    code +
+    REACT_REFRESH_FOOTER.replaceAll("__SOURCE__", JSON.stringify(id))
+      .replaceAll("__ACCEPT_EXPORTS__", JSON.stringify(acceptExports))
+      .replaceAll("__ROUTE_ID__", JSON.stringify(route?.id))
   );
-}
-
-function withCommentBoundaries(label: string, text: string) {
-  let begin = `// [BEGIN] ${label} `;
-  begin += "-".repeat(80 - begin.length);
-  let end = `// [END] ${label} `;
-  end += "-".repeat(80 - end.length);
-  return `${begin}\n${text}\n${end}`;
 }
 
 const REACT_REFRESH_HEADER = `
@@ -1724,7 +1706,7 @@ if (import.meta.hot && !inWebWorker) {
     RefreshRuntime.register(type, __SOURCE__ + " " + id)
   };
   window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
-}`.trim();
+}`.replaceAll("\n", ""); // Header is all on one line so source maps aren't affected
 
 const REACT_REFRESH_FOOTER = `
 if (import.meta.hot && !inWebWorker) {
@@ -1739,7 +1721,7 @@ if (import.meta.hot && !inWebWorker) {
       if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
     });
   });
-}`.trim();
+}`;
 
 function getRoute(
   pluginConfig: ResolvedReactRouterConfig,


### PR DESCRIPTION
Resolves #12483

The `react-router:react-refresh-babel` transform was wrapping the code with big chunks of code that completely threw off the source maps. I've changed the wrapping code to use babel to maintain the source maps, and split it off into a new transform step so the source maps from the previous transform flow through.