### PR TITLE
Add prerender SPA mode bug report test

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -218,6 +218,7 @@
 - mspiess
 - mtendekuyokwa19
 - mtliendo
+- namoscato
 - ned-park
 - nikeee
 - nilubisan


### PR DESCRIPTION
The Single Page App (SPA) guide [notes pre-rendering can be configured](https://reactrouter.com/how-to/spa#3-pre-rendering), but a build-time error is always thrown when a [route `loader`](https://reactrouter.com/start/framework/route-module#loader) is defined in SPA mode (`ssr: false`):

```
[react-router:route-exports] SPA Mode: 1 invalid route export(s) in `routes/home.tsx`: `loader`. See https://remix.run/guides/spa-mode for more information.
```

Am I misunderstanding SPA pre-rendering?