### PR TITLE
Remove module-sync from node exports map

### DIFF
--- a/.changeset/tiny-cooks-warn.md
+++ b/.changeset/tiny-cooks-warn.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Remove the `exports.node.module-sync` config from `package.json` to avoid ESM/CJS mismatches on Node 22+

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -25,7 +25,6 @@
     ".": {
       "node": {
         "types": "./dist/development/index.d.ts",
-        "module-sync": "./dist/development/index.mjs",
         "default": "./dist/development/index.js"
       },
       "import": {


### PR DESCRIPTION
This removes the `module-sync` export from `react-router` which currently points to the ESM build.

From the [Node docs](https://nodejs.org/docs/latest-v22.x/api/packages.html#conditional-exports):

> "module-sync" - matches no matter the package is loaded via import, import() or require(). The format is expected to be ES modules that does not contain top-level await in its module graph - if it does, ERR_REQUIRE_ASYNC_MODULE will be thrown when the module is require()-ed.

It sounds like this would definitely cause issues for us to tell node to _always_ load the ESM version - since if anything else loaded the CJS version we'd immediately have a mismatch?

Right now, we can run into issues like this on Node 22+ ([repro](https://stackblitz.com/edit/github-k5nghg)) where we load the CJS and ESM versions during dev:

![Screenshot 2025-01-08 at 10 46 21 AM](https://github.com/user-attachments/assets/6dde309f-0562-4c2a-87f8-2d1145cd2e98)

Prior to this PR I wasn't aware of `module-sync`, or if there was a specific reason we included it - so I'd like to get @jacob-ebey 's eyes on this as well before merging.

Closes #12475