### PR TITLE
docs: add additional JSDocs to NavigateOptions

### DIFF
--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -128,11 +128,17 @@ export const AwaitContext = React.createContext<TrackedPromise | null>(null);
 AwaitContext.displayName = "Await";
 
 export interface NavigateOptions {
+  /** Replace the current entry in the history stack instead of pushing a new one */
   replace?: boolean;
+  /** Adds persistent client side routing state to the next location */
   state?: any;
+  /** If you are using {@link https://api.reactrouter.com/v7/functions/react_router.ScrollRestoration.html <ScrollRestoration>}, prevent the scroll position from being reset to the top of the window when navigating */
   preventScrollReset?: boolean;
+  /** Defines the relative path behavior for the link. "route" will use the route hierarchy so ".." will remove all URL segments of the current route pattern while "path" will use the URL path so ".." will remove one URL segment. */
   relative?: RelativeRoutingType;
+  /** Wraps the initial state update for this navigation in a {@link https://react.dev/reference/react-dom/flushSync ReactDOM.flushSync} call instead of the default {@link https://react.dev/reference/react/startTransition React.startTransition} */
   flushSync?: boolean;
+  /** Enables a {@link https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API View Transition} for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the {@link https://api.reactrouter.com/v7/functions/react_router.useViewTransitionState.html useViewTransitionState()} hook.  */
   viewTransition?: boolean;
 }
 


### PR DESCRIPTION
These should appear both in VS Code and other IDEs, as well as in the reference docs website.