### PR TITLE
fix: use vite to load react-router runtime in bundler plugin

### DIFF
--- a/.changeset/gorgeous-numbers-trade.md
+++ b/.changeset/gorgeous-numbers-trade.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+use vite to load react-router runtime in bundler plugin to make sure it's the proper one for the environment we are running in

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -5,6 +5,7 @@ import { type GetPlatformProxyOptions, type PlatformProxy } from "wrangler";
 
 import { fromNodeRequest, toNodeRequest } from "./node-adapter";
 import { preloadVite, getVite } from "./vite";
+import { virtual } from "./plugin";
 
 let serverBuildId = "virtual:react-router/server-build";
 
@@ -97,7 +98,7 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
 
               const { createRequestHandler } =
                 (await viteDevServer.ssrLoadModule(
-                  "react-router"
+                  virtual.reactRouterReexport.id
                 )) as typeof rr;
               let handler = createRequestHandler(build, "development");
               let req = fromNodeRequest(nodeReq, nodeRes);

--- a/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
+++ b/packages/react-router-dev/vite/cloudflare-dev-proxy.ts
@@ -1,5 +1,5 @@
-import { createRequestHandler } from "react-router";
-import { type AppLoadContext, type ServerBuild } from "react-router";
+import type * as rr from "react-router";
+import type { AppLoadContext, ServerBuild } from "react-router";
 import { type Plugin } from "vite";
 import { type GetPlatformProxyOptions, type PlatformProxy } from "wrangler";
 
@@ -95,6 +95,10 @@ export const cloudflareDevProxyVitePlugin = <Env, Cf extends CfProperties>(
                 serverBuildId
               )) as ServerBuild;
 
+              const { createRequestHandler } =
+                (await viteDevServer.ssrLoadModule(
+                  "react-router"
+                )) as typeof rr;
               let handler = createRequestHandler(build, "development");
               let req = fromNodeRequest(nodeReq, nodeRes);
               let loadContext = getLoadContext

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -176,6 +176,7 @@ let virtual = {
   serverBuild: VirtualModule.create("server-build"),
   serverManifest: VirtualModule.create("server-manifest"),
   browserManifest: VirtualModule.create("browser-manifest"),
+  reactRouterReexport: VirtualModule.create("react-router-reexport"),
 };
 
 let invalidateVirtualModules = (viteDevServer: Vite.ViteDevServer) => {
@@ -1073,7 +1074,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           unstable_setDevServerHooks: setDevServerHooks,
           createRequestHandler,
           matchRoutes,
-        } = (await viteDevServer.ssrLoadModule("react-router")) as typeof rr;
+        } = (await viteDevServer.ssrLoadModule(
+          virtual.reactRouterReexport.id
+        )) as typeof rr;
 
         setDevServerHooks({
           // Give the request handler access to the critical CSS in dev to avoid a
@@ -1335,6 +1338,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             });
 
             return `window.__reactRouterManifest=${reactRouterManifestString};`;
+          }
+          case virtual.reactRouterReexport.resolvedId: {
+            return `export * from "react-router";`;
           }
         }
       },

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -172,7 +172,7 @@ const resolveRelativeRouteFilePath = (
   return vite.normalizePath(fullPath);
 };
 
-let virtual = {
+export let virtual = {
   serverBuild: VirtualModule.create("server-build"),
   serverManifest: VirtualModule.create("server-manifest"),
   browserManifest: VirtualModule.create("browser-manifest"),

--- a/packages/react-router-dev/vite/styles.ts
+++ b/packages/react-router-dev/vite/styles.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import type { ServerBuild } from "react-router";
-import { matchRoutes } from "react-router";
+import type * as rr from "react-router";
 import type { ModuleNode, ViteDevServer } from "vite";
 
 import type { ResolvedReactRouterConfig } from "../config/config";
@@ -224,6 +224,7 @@ export const getStylesForUrl = async ({
   cssModulesManifest,
   build,
   url,
+  matchRoutes,
 }: {
   viteDevServer: ViteDevServer;
   rootDirectory: string;
@@ -232,6 +233,7 @@ export const getStylesForUrl = async ({
   cssModulesManifest: Record<string, string>;
   build: ServerBuild;
   url: string | undefined;
+  matchRoutes: typeof rr.matchRoutes;
 }): Promise<string | undefined> => {
   if (url === undefined || url.includes("?_data=")) {
     return undefined;


### PR DESCRIPTION
this makes sure it's the proper one for the environment we are running in