### PR TITLE
draft: typesafety

### DIFF
--- a/integration/helpers/vite-5-template/tsconfig.json
+++ b/integration/helpers/vite-5-template/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "include": [
-    "env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".react-router/types/**/*.d.ts"
-  ],
+  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", ".react-router/types/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "verbatimModuleSyntax": true,

--- a/integration/helpers/vite-6-template/tsconfig.json
+++ b/integration/helpers/vite-6-template/tsconfig.json
@@ -1,10 +1,5 @@
 {
-  "include": [
-    "env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".react-router/types/**/*.d.ts"
-  ],
+  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", ".react-router/types/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "verbatimModuleSyntax": true,

--- a/integration/helpers/vite-cloudflare-template/tsconfig.json
+++ b/integration/helpers/vite-cloudflare-template/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["env.d.ts", "**/*.ts", "**/*.tsx", ".react-router/types/**/*.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["vite/client"],

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -1,122 +1,38 @@
 import ts from "dedent";
-import * as Path from "pathe";
-import * as Pathe from "pathe/utils";
 
-import { type RouteManifest, type RouteManifestEntry } from "../config/routes";
-import { type Context } from "./context";
-import { getTypesPath } from "./paths";
+import { type RouteManifestEntry } from "../config/routes";
 
-export function generate(ctx: Context, route: RouteManifestEntry): string {
-  const lineage = getRouteLineage(ctx.config.routes, route);
-  const urlpath = lineage.map((route) => route.path).join("/");
-  const typesPath = getTypesPath(ctx, route);
-
-  const parents = lineage.slice(0, -1);
-  const parentTypeImports = parents
-    .map((parent, i) => {
-      const rel = Path.relative(
-        Path.dirname(typesPath),
-        getTypesPath(ctx, parent)
-      );
-
-      const indent = i === 0 ? "" : "  ".repeat(2);
-      let source = noExtension(rel);
-      if (!source.startsWith("../")) source = "./" + source;
-      return `${indent}import type { Info as Parent${i} } from "${source}.js"`;
-    })
-    .join("\n");
-
+export function generate(route: RouteManifestEntry): string {
   return ts`
     // React Router generated types for route:
     // ${route.file}
 
-    import type * as T from "react-router/route-module"
+    import type { RouteExports, Routes } from "react-router/types";
 
-    ${parentTypeImports}
+    type RouteId = "${route.id}"
+    export type Info = Routes[RouteId];
 
-    type Module = typeof import("../${Pathe.filename(route.file)}.js")
-
-    export type Info = {
-      parents: [${parents.map((_, i) => `Parent${i}`).join(", ")}],
-      id: "${route.id}"
-      file: "${route.file}"
-      path: "${route.path}"
-      params: {${formatParamProperties(
-        urlpath
-      )}} & { [key: string]: string | undefined }
-      module: Module
-      loaderData: T.CreateLoaderData<Module>
-      actionData: T.CreateActionData<Module>
-    }
+    type Exports = RouteExports[RouteId];
 
     export namespace Route {
-      export type LinkDescriptors = T.LinkDescriptors
-      export type LinksFunction = () => LinkDescriptors
+      export type LinkDescriptors = Exports["links"]["return"];
+      export type LinksFunction = () => LinkDescriptors;
 
-      export type MetaArgs = T.CreateMetaArgs<Info>
-      export type MetaDescriptors = T.MetaDescriptors
-      export type MetaFunction = (args: MetaArgs) => MetaDescriptors
+      export type MetaArgs = Exports["meta"]["args"];
+      export type MetaDescriptors = Exports["meta"]["return"];
+      export type MetaFunction = (args: MetaArgs) => MetaDescriptors;
 
-      export type HeadersArgs = T.HeadersArgs
-      export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit
+      export type HeadersArgs = Exports["headers"]["args"];
+      export type HeadersFunction = (args: HeadersArgs) => Headers | HeadersInit;
 
-      export type LoaderArgs = T.CreateServerLoaderArgs<Info>
-      export type ClientLoaderArgs = T.CreateClientLoaderArgs<Info>
-      export type ActionArgs = T.CreateServerActionArgs<Info>
-      export type ClientActionArgs = T.CreateClientActionArgs<Info>
+      export type LoaderArgs = Exports["loader"]["args"];
+      export type ClientLoaderArgs = Exports["clientLoader"]["args"];
+      export type ActionArgs = Exports["action"]["args"];
+      export type ClientActionArgs = Exports["clientAction"]["args"];
 
-      export type HydrateFallbackProps = T.CreateHydrateFallbackProps<Info>
-      export type ComponentProps = T.CreateComponentProps<Info>
-      export type ErrorBoundaryProps = T.CreateErrorBoundaryProps<Info>
+      export type HydrateFallbackProps = Exports["HydrateFallback"]["args"];
+      export type ComponentProps = Exports["default"]["args"];
+      export type ErrorBoundaryProps = Exports["ErrorBoundary"]["args"];
     }
   `;
-}
-
-const noExtension = (path: string) =>
-  Path.join(Path.dirname(path), Pathe.filename(path));
-
-function getRouteLineage(routes: RouteManifest, route: RouteManifestEntry) {
-  const result: RouteManifestEntry[] = [];
-  while (route) {
-    result.push(route);
-    if (!route.parentId) break;
-    route = routes[route.parentId];
-  }
-  result.reverse();
-  return result;
-}
-
-function formatParamProperties(urlpath: string) {
-  const params = parseParams(urlpath);
-  const properties = Object.entries(params).map(([name, values]) => {
-    if (values.length === 1) {
-      const isOptional = values[0];
-      return isOptional ? `"${name}"?: string` : `"${name}": string`;
-    }
-    const items = values.map((isOptional) =>
-      isOptional ? "string | undefined" : "string"
-    );
-    return `"${name}": [${items.join(", ")}]`;
-  });
-  return properties.join("; ");
-}
-
-function parseParams(urlpath: string) {
-  const result: Record<string, boolean[]> = {};
-
-  let segments = urlpath.split("/");
-  segments.forEach((segment) => {
-    const match = segment.match(/^:([\w-]+)(\?)?/);
-    if (!match) return;
-    const param = match[1];
-    const isOptional = match[2] !== undefined;
-
-    result[param] ??= [];
-    result[param].push(isOptional);
-    return;
-  });
-
-  const hasSplat = segments.at(-1) === "*";
-  if (hasSplat) result["*"] = [false];
-  return result;
 }

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -107,15 +107,13 @@ async function writeAll(ctx: Context): Promise<void> {
           }
         }
 
-        // DEBUG
-        import type { Routes } from "react-router/types"
-        type X = Routes
+        export {}
     `
   );
 
   Object.values(ctx.config.routes).forEach((route) => {
     const typesPath = getTypesPath(ctx, route);
-    const content = generate(ctx, route);
+    const content = generate(route);
     fs.mkdirSync(Path.dirname(typesPath), { recursive: true });
     fs.writeFileSync(typesPath, content);
   });

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -9,6 +9,7 @@ import { createConfigLoader } from "../config/config";
 import { generate } from "./generate";
 import type { Context } from "./context";
 import { getTypesDir, getTypesPath } from "./paths";
+import type { RouteManifest, RouteManifestEntry } from "../config/routes";
 
 export async function run(rootDirectory: string) {
   const ctx = await createContext({ rootDirectory, watch: false });
@@ -71,10 +72,110 @@ async function createContext({
   };
 }
 
-async function writeAll(ctx: Context): Promise<void> {
-  const typegenDir = getTypesDir(ctx);
+// TODO:
+// 1. commit as wip
+// 2. normalized data per route
 
+function getRouteLineage(routes: RouteManifest, route: RouteManifestEntry) {
+  const result: RouteManifestEntry[] = [];
+  while (route) {
+    result.push(route);
+    if (!route.parentId) break;
+    route = routes[route.parentId];
+  }
+  result.reverse();
+  return result;
+}
+
+function parseParams(urlpath: string) {
+  const result: Record<string, boolean> = {};
+
+  let segments = urlpath.split("/");
+  segments.forEach((segment) => {
+    const match = segment.match(/^:([\w-]+)(\?)?/);
+    if (!match) return;
+    const param = match[1];
+    const isRequired = match[2] === undefined;
+
+    result[param] ||= isRequired;
+    return;
+  });
+
+  const hasSplat = segments.at(-1) === "*";
+  if (hasSplat) result["*"] = true;
+  return result;
+}
+
+type Route = {
+  id: string;
+  path: string;
+  file: string;
+  parent?: string;
+};
+
+function formatRoute({ id, path, parent }: Route) {
+  let params = parseParams(path);
+  return [
+    `"${path}": {`,
+    `  path: "${path}"`,
+    `  params: ${formatParams(params)}`,
+    `  module: typeof import("./app/${id}.js")`,
+    `  parent: ${JSON.stringify(parent)}`,
+    `}`,
+  ]
+    .map((line) => `  ${line}`)
+    .join("\n");
+}
+
+function formatParams(params: Record<string, boolean>) {
+  let entries = Object.entries(params);
+  if (entries.length === 0) return `{}`;
+  return [
+    "{",
+    ...entries.map(
+      ([param, isRequired]) =>
+        `  ${JSON.stringify(param)}${isRequired ? "" : "?"}: string`
+    ),
+    "}",
+  ]
+    .map((line, index) => (index === 0 ? line : `    ${line}`))
+    .join("\n");
+}
+
+async function writeAll(ctx: Context): Promise<void> {
+  let routes = Object.values(ctx.config.routes);
+
+  let paths = new Map<string, string>();
+  for (let route of routes) {
+    let lineage = getRouteLineage(ctx.config.routes, route);
+    let path = lineage.map((route) => route.path).join("/");
+    if (path === "") path = "<root>";
+    paths.set(route.id, path);
+  }
+
+  const typegenDir = getTypesDir(ctx);
   fs.rmSync(typegenDir, { recursive: true, force: true });
+
+  let types: Array<Route> = [];
+  for (let route of routes) {
+    let path = paths.get(route.id);
+    if (path === undefined) throw new Error();
+
+    types.push({
+      id: route.id,
+      path,
+      file: route.file,
+      parent: route.parentId && paths.get(route.parentId),
+    });
+  }
+
+  const newTypes = Path.join(typegenDir, "routes.ts");
+  fs.mkdirSync(Path.dirname(newTypes), { recursive: true });
+  fs.writeFileSync(
+    newTypes,
+    `export type Routes = {\n${types.map(formatRoute).join("\n")}\n}`
+  );
+
   Object.values(ctx.config.routes).forEach((route) => {
     const typesPath = getTypesPath(ctx, route);
     const content = generate(ctx, route);
@@ -82,3 +183,29 @@ async function writeAll(ctx: Context): Promise<void> {
     fs.writeFileSync(typesPath, content);
   });
 }
+
+/*
+type GetParents<T extends keyof Routes> = Routes[T] extends {
+  parent: infer P extends keyof Routes;
+}
+  ? [...GetParents<P>, P]
+  : [];
+
+type P1 = GetParents<"/products/:id/blah/:id?">;
+
+type _GetChildren<T extends keyof Routes> = {
+  [K in keyof Routes]: Routes[K] extends { parent: T }
+    ? [K, ..._GetChildren<K>]
+    : [];
+}[keyof Routes];
+type GetChildren<T extends keyof Routes> = Exclude<_GetChildren<T>, []>;
+
+type C1 = GetChildren<"<root>">;
+
+type GetBranches<T extends keyof Routes> = [
+  ...GetParents<T>,
+  T,
+  ...GetChildren<T>
+];
+type B1 = GetBranches<"<root>">;
+*/

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1,4 +1,4 @@
-// We can only import types from Vite at the top level since we're in a CJS
+//  We can only import types from Vite at the top level since we're in a CJS
 // context but want to use Vite's ESM build to avoid deprecation warnings
 import type * as Vite from "vite";
 import { type BinaryLike, createHash } from "node:crypto";

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -59,6 +59,7 @@ export {
 export {
   data,
   generatePath,
+  href,
   isRouteErrorResponse,
   matchPath,
   matchRoutes,

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1,3 +1,4 @@
+import type { Register } from "../types";
 import type { Equal, Expect } from "../types/utils";
 import type { Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";
@@ -1469,4 +1470,31 @@ export function isRouteErrorResponse(error: any): error is ErrorResponse {
     typeof error.internal === "boolean" &&
     "data" in error
   );
+}
+
+type AnyPaths = Record<string, Record<string, string | undefined>>;
+type Paths = Register extends { paths: infer TPaths extends AnyPaths }
+  ? TPaths
+  : AnyPaths;
+type HrefArgs<Params extends Record<string, string | undefined>> = Equal<
+  Params,
+  {}
+> extends true
+  ? []
+  : [Params];
+
+export function href<Path extends keyof Paths>(
+  path: Path,
+  ...args: HrefArgs<Paths[Path]>
+): string {
+  let params = args[0];
+  return path
+    .split("/")
+    .map((segment) => {
+      const match = segment.match(/^:([\w-]+)(\?)?/);
+      if (!match) return segment;
+      const param = match[1];
+      return params[param];
+    })
+    .join("/");
 }

--- a/packages/react-router/lib/types/index.ts
+++ b/packages/react-router/lib/types/index.ts
@@ -1,4 +1,7 @@
 import type { MetaDescriptor } from "../dom/ssr/routeModules";
+import type { LinkDescriptor } from "../router/links";
+import type { AppLoadContext } from "../server-runtime/data";
+import type { ServerDataFrom } from "./route-data";
 import type {
   CreateActionData,
   CreateLoaderData,
@@ -117,6 +120,7 @@ type Matches = {
 
 export type Routes = {
   [Id in RouteId]: {
+    module: UserRoutes[Id]["module"];
     params: Params[Id];
     loaderData: Data[Id]["loaderData"];
     actionData: Data[Id]["actionData"];
@@ -124,6 +128,104 @@ export type Routes = {
     matches: Matches[Id]["matches"];
   };
 };
+
+type AnyRoute = {
+  module: RouteModule;
+  params: Record<string, string | undefined>;
+  loaderData: unknown;
+  actionData: unknown;
+  metaMatches: Array<MetaMatch<RouteId>>;
+  matches: Array<Match<RouteId>>;
+};
+
+type RouteExport<Route extends AnyRoute> = {
+  links: {
+    return: Array<LinkDescriptor>;
+  };
+
+  meta: {
+    args: {
+      location: Location;
+      params: Route["params"];
+      data: Route["loaderData"];
+      error?: unknown;
+      matches: Route["metaMatches"];
+    };
+    return: Array<MetaDescriptor>;
+  };
+
+  headers: {
+    args: {
+      loaderHeaders: Headers;
+      parentHeaders: Headers;
+      actionHeaders: Headers;
+      errorHeaders: Headers | undefined;
+    };
+    return: Headers | HeadersInit;
+  };
+
+  loader: {
+    args: {
+      context: AppLoadContext;
+      request: Request;
+      params: Route["params"];
+    };
+  };
+
+  clientLoader: {
+    args: {
+      request: Request;
+      params: Route["params"];
+      serverLoader: () => Promise<ServerDataFrom<Route["module"]["loader"]>>;
+    };
+  };
+
+  action: {
+    args: {
+      context: AppLoadContext;
+      request: Request;
+      params: Route["params"];
+    };
+  };
+
+  clientAction: {
+    args: {
+      request: Request;
+      params: Route["params"];
+      serverAction: () => Promise<ServerDataFrom<Route["module"]["action"]>>;
+    };
+  };
+
+  HydrateFallback: {
+    args: {
+      params: Route["params"];
+    };
+  };
+
+  default: {
+    args: {
+      params: Route["params"];
+      loaderData: Route["loaderData"];
+      actionData?: Route["actionData"];
+      matches: Route["matches"];
+    };
+  };
+
+  ErrorBoundary: {
+    args: {
+      params: Route["params"];
+      loaderData?: Route["loaderData"];
+      actionData?: Route["actionData"];
+      error: unknown;
+    };
+  };
+};
+
+export type RouteExports = {
+  [Id in RouteId]: RouteExport<Routes[Id]>;
+};
+
+// --- PARSE PARAM ---
 
 // prettier-ignore
 type Regex_az = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"

--- a/packages/react-router/lib/types/index.ts
+++ b/packages/react-router/lib/types/index.ts
@@ -1,0 +1,173 @@
+import type { MetaDescriptor } from "../dom/ssr/routeModules";
+import type {
+  CreateActionData,
+  CreateLoaderData,
+  RouteModule,
+} from "./route-module";
+import type { Pretty } from "./utils";
+
+export interface Register {
+  // routes
+}
+
+type AnyRoutes = Record<
+  string,
+  {
+    parentId: string | undefined;
+    path: string | undefined;
+    module: RouteModule;
+  }
+>;
+
+type UserRoutes = Register extends {
+  routes: infer TRoutes extends AnyRoutes;
+}
+  ? TRoutes
+  : AnyRoutes;
+
+type RouteId = keyof UserRoutes;
+
+type GetParents<Id extends RouteId> = UserRoutes[Id] extends {
+  parentId: infer P extends RouteId;
+}
+  ? [...GetParents<P>, P]
+  : [];
+
+type _GetChildren<Id extends RouteId> = {
+  [K in RouteId]: UserRoutes[K] extends { parentId: Id }
+    ? [K, ..._GetChildren<K>]
+    : [];
+}[RouteId];
+type GetChildren<Id extends RouteId> = _GetChildren<Id> extends []
+  ? []
+  : Exclude<_GetChildren<Id>, []>;
+
+type GetBranch<Id extends RouteId> = [
+  ...GetParents<Id>,
+  Id,
+  ...GetChildren<Id>
+];
+
+// path vs full path
+// params vs page params?
+
+type Data = {
+  [Id in RouteId]: {
+    loaderData: CreateLoaderData<UserRoutes[Id]["module"]>;
+    actionData: CreateActionData<UserRoutes[Id]["module"]>;
+  };
+};
+
+type Branches = {
+  [Id in RouteId]: GetBranch<Id>;
+};
+
+type PartialParams = {
+  [Id in RouteId]: UserRoutes[Id]["path"] extends string
+    ? ParseParams<UserRoutes[Id]["path"]>
+    : {};
+};
+type BranchParams<Branch extends Array<RouteId>> = Branch extends [
+  infer Id extends RouteId,
+  ...infer Ids extends Array<RouteId>
+]
+  ? PartialParams[Id] & BranchParams<Ids>
+  : {};
+type Params = {
+  [Id in RouteId]: Pretty<BranchParams<Branches[Id]>>;
+};
+
+type MetaMatch<Id extends RouteId> = Pretty<{
+  id: Id;
+  params: Params[Id];
+  pathname: string;
+  meta: MetaDescriptor[];
+  data: Data[Id]["loaderData"];
+  handle?: unknown;
+  error?: unknown;
+}>;
+type BranchMetaMatches<Branch extends Array<RouteId>> = Branch extends [
+  infer Id extends RouteId,
+  ...infer Ids extends Array<RouteId>
+]
+  ? [MetaMatch<Id>, ...BranchMetaMatches<Ids>]
+  : [];
+
+type Match<Id extends RouteId> = {
+  id: Id;
+  params: Params[Id];
+  pathname: string;
+  data: Data[Id]["loaderData"];
+  handle: unknown;
+};
+
+type BranchMatches<Branch extends Array<RouteId>> = Branch extends [
+  infer Id extends RouteId,
+  ...infer Ids extends Array<RouteId>
+]
+  ? [Match<Id>, ...BranchMatches<Ids>]
+  : [];
+
+type Matches = {
+  [Id in RouteId]: {
+    metaMatches: BranchMetaMatches<Branches[Id]>;
+    matches: BranchMatches<Branches[Id]>;
+  };
+};
+
+export type Routes = {
+  [Id in RouteId]: {
+    params: Params[Id];
+    loaderData: Data[Id]["loaderData"];
+    actionData: Data[Id]["actionData"];
+    metaMatches: Matches[Id]["metaMatches"];
+    matches: Matches[Id]["matches"];
+  };
+};
+
+// prettier-ignore
+type Regex_az = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"
+// prettier-ignore
+type Regez_AZ = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+type Regex_09 = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type Regex_w = Regex_az | Regez_AZ | Regex_09 | "_";
+type ParamChar = Regex_w | "-";
+
+// Emulates regex `+`
+type RegexMatchPlus<
+  CharPattern extends string,
+  T extends string
+> = T extends `${infer First}${infer Rest}`
+  ? First extends CharPattern
+    ? RegexMatchPlus<CharPattern, Rest> extends never
+      ? First
+      : `${First}${RegexMatchPlus<CharPattern, Rest>}`
+    : never
+  : never;
+
+// Recursive helper for finding path parameters in the absence of wildcards
+type _PathParam<Path extends string> =
+  // split path into individual path segments
+  Path extends `${infer L}/${infer R}`
+    ? _PathParam<L> & _PathParam<R>
+    : // find params after `:`
+    Path extends `:${infer Param}`
+    ? Param extends `${infer Optional}?${string}`
+      ? RegexMatchPlus<ParamChar, Optional> extends infer Id extends string
+        ? { [K in Id]?: string }
+        : {}
+      : RegexMatchPlus<ParamChar, Param> extends infer Id extends string
+      ? { [K in Id]: string }
+      : {}
+    : // otherwise, there aren't any params present
+      {};
+
+type ParseParams<Path extends string> =
+  // check if path is just a wildcard
+  Path extends "*" | "/*"
+    ? "*"
+    : // look for wildcard at the end of the path
+    Path extends `${infer Rest}/*`
+    ? Pretty<_PathParam<Rest> & { "*": string }>
+    : // look for params in the absence of wildcards
+      Pretty<_PathParam<Path>>;

--- a/packages/react-router/lib/types/index.ts
+++ b/packages/react-router/lib/types/index.ts
@@ -9,7 +9,14 @@ import type {
 } from "./route-module";
 import type { Pretty } from "./utils";
 
+// TODO: refactor
+// - do we need `route-module` anymore?
+// - should `Register` be its own file?
+// - comment for why `export {}` is necessary
+// - probably name generated `routes.ts` differently?
+
 export interface Register {
+  // paths
   // routes
 }
 

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -27,8 +27,6 @@ type RouteInfo = {
   parents: RouteInfo[];
   module: RouteModule;
   id: unknown;
-  file: string;
-  path: string;
   params: unknown;
   loaderData: unknown;
   actionData: unknown;

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -7,7 +7,7 @@ import type { Equal, Expect, Func, Pretty } from "./utils";
 
 type IsDefined<T> = Equal<T, undefined> extends true ? false : true;
 
-type RouteModule = {
+export type RouteModule = {
   meta?: Func;
   links?: Func;
   headers?: Func;

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -37,6 +37,14 @@
         "default": "./dist/development/index.js"
       }
     },
+    "./types": {
+      "import": {
+        "types": "./dist/development/lib/types/index.d.mts"
+      },
+      "default": {
+        "types": "./dist/development/lib/types/index.d.ts"
+      }
+    },
     "./route-module": {
       "import": {
         "types": "./dist/development/lib/types/route-module.d.mts"

--- a/packages/react-router/tsup.config.ts
+++ b/packages/react-router/tsup.config.ts
@@ -5,7 +5,12 @@ import { createBanner } from "../../build.utils.js";
 
 import pkg from "./package.json";
 
-const entry = ["index.ts", "dom-export.ts", "lib/types/route-module.ts"];
+const entry = [
+  "index.ts",
+  "dom-export.ts",
+  "lib/types/route-module.ts",
+  "lib/types/index.ts",
+];
 
 const config = (enableDevWarnings: boolean) =>
   defineConfig([


### PR DESCRIPTION
Fixes #12373

This PR refactors typegen to be "route ID centric" based on the route manifest produced by `routes.ts`.
This architecture better supports the fixes/features also added in this PR:

- [x] Fix: `matches` are typed to be precise for child routes
- [x] Feature: Type-safe paths via`href`
- [ ] Feature: Type-safe access for other routes via `useRoute`

## TODO
- [ ] decide if requiring `{}` for paths that have _only_ optional params is good or bad
- [ ] clean up the old `route-modules`, `register.ts`, etc.
- [x] support custom app dir (no hardcoded `app/`)
- [ ] type-safe `handle` within `matches`
- [ ] `loaderData` with `hydrate = true` respects `HydrateFallback` set in parent routes
- [ ] try it with a huge app (1000+ routes)
- [ ] tests
- [ ] changeset

## href

Construct type-safe paths for navigation with `href`:

```tsx
import { href } from "react-router"

const home = href("/home")
const productUrl = href("/products/:id", { id: "asdf" })
<Link to={href("/foo/:bar/", { bar: "baz" })
```