### PR TITLE
Export node-adapter’s fromNodeRequest and toNodeRequest from @react-router/dev/vite/cloudflare

### DIFF
--- a/.changeset/early-oranges-shake.md
+++ b/.changeset/early-oranges-shake.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": minor
+---
+
+Export node-adapter’s fromNodeRequest and toNodeRequest utility functions from @react-router/dev/vite/cloudflare

--- a/packages/react-router-dev/vite/cloudflare.ts
+++ b/packages/react-router-dev/vite/cloudflare.ts
@@ -1,1 +1,2 @@
 export { cloudflareDevProxyVitePlugin as cloudflareDevProxy } from "./cloudflare-dev-proxy";
+export { fromNodeRequest, toNodeRequest } from "./node-adapter";


### PR DESCRIPTION
there’s a great project called [Superflare](https://superflare.dev) that describes itself as a “full-stack toolkit for Cloudflare Workers” and offers user auth, an ORM and DB migration management for D1, and a bunch of other useful things. it provides a package specifically for integrating with Remix, which exports a vite dev proxy plugin that is a drop-in replacement for the `cloudflareDevProxy` plugin provided by Remix/RR v7 to automatically handle sessions and auth and provide it to the app load context. that plugin uses the `fromNodeRequest` and `toNodeRequest` utils from the vite/node-adapter.ts file ([imported here](https://github.com/jplhomer/superflare/blob/main/packages/superflare-remix/dev.ts#L2-L5)).

i am currently working on making Superflare compatible with React Router v7, but the node-adapter.ts file is not available in the published `dist/` directory of `@react-router/dev`. this one-line change to the `vite/cloudflare.ts` file will enable importing everything we need for the cloudflare dev proxy plugin in @superflare/remix like so:

```ts
import {
  cloudflareDevProxy,
  fromNodeRequest,
  toNodeRequest,
} from "@react-router/dev/vite/cloudflare";
```

i hope this change is amenable to you all. regardless, thank you all for such a great project/community resource! the greatly improved types for route files from RR v7 are most excellent, and more generally, i’ve found working with Remix and now RR v7 truly a pleasure.