### PR TITLE
docs: fix syntax error in routing.md

### DIFF
--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -55,7 +55,7 @@ If you prefer to define your routes via file naming conventions rather than conf
 import { type RouteConfig, route } from "@react-router/dev/routes";
 import { flatRoutes } from "@react-router/fs-routes";
 
-export default = [
+export default [
   route("/", "./home.tsx"),
 
   ...await flatRoutes(),


### PR DESCRIPTION
Fix syntax error in `routing.md` by removing incorrect assignment operator.