### PR TITLE
docs: Remove redundant awaits from formData examples

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -279,6 +279,7 @@
 - skratchdot
 - smithki
 - soartec-lab
+- sorokya
 - sorrycc
 - souzasmatheus
 - soxtoby

--- a/docs/how-to/status.md
+++ b/docs/how-to/status.md
@@ -16,7 +16,7 @@ export async function action({
   request,
 }: Route.ActionArgs) {
   let formData = await request.formData();
-  let title = await formData.get("title");
+  let title = formData.get("title");
   if (!title) {
     return data(
       { message: "Invalid title" },

--- a/docs/start/framework/actions.md
+++ b/docs/start/framework/actions.md
@@ -23,7 +23,7 @@ export async function clientAction({
   request,
 }: Route.ClientActionArgs) {
   let formData = await request.formData();
-  let title = await formData.get("title");
+  let title = formData.get("title");
   let project = await someApi.updateProject({ title });
   return project;
 }
@@ -60,7 +60,7 @@ export async function action({
   request,
 }: Route.ActionArgs) {
   let formData = await request.formData();
-  let title = await formData.get("title");
+  let title = formData.get("title");
   let project = await fakeDb.updateProject({ title });
   return project;
 }


### PR DESCRIPTION
Noticed while going through the actions tutorial that these weren't needed.

<img width="986" alt="image" src="https://github.com/user-attachments/assets/26dc9117-d31b-4b11-8c9c-7a747ae3f036" />
