### PR TITLE
Properly bubble headers when throwing a data result

### DIFF
--- a/.changeset/proud-stingrays-wink.md
+++ b/.changeset/proud-stingrays-wink.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Properly bubble headers when throwing a `data()` result

--- a/packages/router/router.ts
+++ b/packages/router/router.ts
@@ -5052,15 +5052,25 @@ async function convertDataStrategyResultToDataResult(
           type: ResultType.error,
           error: result.data,
           statusCode: result.init?.status,
+          headers: result.init?.headers
+            ? new Headers(result.init.headers)
+            : undefined,
         };
       }
 
       // Convert thrown data() to ErrorResponse instances
-      result = new ErrorResponseImpl(
-        result.init?.status || 500,
-        undefined,
-        result.data
-      );
+      return {
+        type: ResultType.error,
+        error: new ErrorResponseImpl(
+          result.init?.status || 500,
+          undefined,
+          result.data
+        ),
+        statusCode: isRouteErrorResponse(result) ? result.status : undefined,
+        headers: result.init?.headers
+          ? new Headers(result.init.headers)
+          : undefined,
+      };
     }
     return {
       type: ResultType.error,


### PR DESCRIPTION
Sibling for https://github.com/remix-run/remix/pull/10424