### PR TITLE
Bug report: Calling navigate more than once causes 404 error

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -59,7 +59,8 @@ test.beforeAll(async () => {
     ////////////////////////////////////////////////////////////////////////////
     files: {
       "app/routes/_index.tsx": js`
-        import { useLoaderData, Link } from "react-router";
+        import { useEffect } from "react";
+        import { useLoaderData, Link, useNavigate } from "react-router";
 
         export function loader() {
           return "pizza";
@@ -67,6 +68,13 @@ test.beforeAll(async () => {
 
         export default function Index() {
           let data = useLoaderData();
+
+          const navigate = useNavigate();
+          useEffect(() => {
+            navigate("/burgers");
+            navigate("/burgers");
+          }, []);
+
           return (
             <div>
               {data}
@@ -97,7 +105,9 @@ test.afterAll(() => {
 // add a good description for what you expect Remix to do 👇🏽
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("should not show 404 page on multiple navigate calls", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
   // You can test any request your app might get using `fixture`.
   let response = await fixture.requestDocument("/");
@@ -105,8 +115,10 @@ test("[description of what you expect it to do]", async ({ page }) => {
 
   // If you need to test interactivity use the `app`
   await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
+  await page.waitForURL("**/burgers");
+  // await app.poke(20);
+  await expect(page.locator("text=Not Found")).not.toBeVisible();
+  await expect(page.locator("text=cheeseburger")).toBeVisible();
 
   // If you're not sure what's going on, you can "poke" the app, it'll
   // automatically open up in your browser for 20 seconds, so be quick!


### PR DESCRIPTION
When calling the `navigate` functions multiple times immediately after the initial rendering in a `useEffect` hook, the website shows a 404 error even though the route exists. This does not happen, if the calls to navigate are delayed.

![image](https://github.com/user-attachments/assets/e47a78ed-3799-4bea-83d0-5337775ae024)

This is very likely to happen in dev mode with strict mode enabled, since then React executes the useEffect hook twice. I do not know how to do this with your test template, so to simulate a similar behavior I just called the `navigate` function twice.

![image](https://github.com/user-attachments/assets/fe40d8c9-93bb-4c05-ab0f-d5458f1af394)

I did not have this problem with Remix v2.