### PR TITLE
Contributing docs fix

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -77,6 +77,7 @@
 - dauletbaev
 - david-bezero
 - david-crespo
+- davidbielik
 - dcblair
 - decadentsavant
 - dgrijuela

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -26,10 +26,14 @@ git clone https://github.com/<your_github_username>/react-router.git
 cd react-router
 
 # if you are making *any* code changes, make sure to checkout the dev branch
-git checkout dev
+git checkout -b dev
 ```
 
 3. Install dependencies and build. React Router uses [pnpm](https://pnpm.io), so you should too. If you install using `npm`, unnecessary `package-lock.json` files will be generated.
+
+```bash
+pnpm install
+```
 
 ## Think You Found a Bug?
 

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -22,7 +22,7 @@ The following steps will get you set up to contribute changes to this repo:
 
 ```bash
 # in a terminal, cd to parent directory where you want your clone to be, then
-git clone https://github.com/<your_github_username>/react-router.git
+git clone git@github.com:<your_github_username>/react-router.git
 cd react-router
 
 # if you are making *any* code changes, make sure to checkout the dev branch


### PR DESCRIPTION
1. git checkout command doesn't work since `dev` branch won't exist
2. https instead of ssh isn't industry standard (and caused an error trying to push a branch)
3. added command for those not familiar with `pnpm`