### PR TITLE
Added the keyword "async" to the asynchronous anonymous function

### DIFF
--- a/docs/start/framework/custom.md
+++ b/docs/start/framework/custom.md
@@ -59,7 +59,7 @@ Routes can take most of their definition lazily with the `lazy` property.
 createBrowserRouter([
   {
     path: "/show/:showId",
-    lazy: () => {
+    lazy: async () => {
       let [loader, action, Component] = await Promise.all([
         import("./show.action.js"),
         import("./show.loader.js"),


### PR DESCRIPTION
You forgot to add the keyword "async" in the anonymous function of the "lazy" method, I decided so because the keyword "await" is used inside the anonymous function