### PR TITLE
Improve prefetch perf for CSS side effects

### DIFF
--- a/.changeset/stupid-mirrors-prove.md
+++ b/.changeset/stupid-mirrors-prove.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Improve prefetch performance of CSS side effects in framework mode


### PR DESCRIPTION
CSS side effects are currently treated as if they were defined as part of a route's `links` function. While this kept things conceptually simple, it meant that we're blocking on the route module being loaded before we begin prefetching these styles on navigation.

We can do better than this since we already know about them up front in the manifest as `route.css` before loading the route module, so this PR hoists the prefetching of CSS side effect links up to run in parallel to the loading of the route module.