### PR TITLE
Remove redundant Vite preview SPA build config

### DIFF
--- a/playground/framework-spa/package.json
+++ b/playground/framework-spa/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@react-router/node": "workspace:*",
+    "isbot": "^5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1155,6 +1155,9 @@ importers:
       '@react-router/node':
         specifier: workspace:*
         version: link:../../packages/react-router-node
+      isbot:
+        specifier: ^5
+        version: 5.1.11
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
The build config can be streamlined a bit since the client build was already providing the same config as our `vite preview` overrides. This meant that a `resolveBuildOptions` function was no longer needed since it's simple enough to inline the build config fallback now.

I've manually tested this in the `framework-spa` playground to ensure that `vite preview` still works.