### PR TITLE
Fix CLI arg parsing to allow usage with no arguments

### DIFF
--- a/.changeset/fast-olives-invent.md
+++ b/.changeset/fast-olives-invent.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix CLI parsing to allow argumentless `npx react-router` usage

--- a/packages/react-router-dev/bin.js
+++ b/packages/react-router-dev/bin.js
@@ -5,7 +5,7 @@ let arg = require("arg");
 // default `NODE_ENV` so React loads the proper version in it's CJS entry script.
 // We have to do this before importing `run.ts` since that is what imports
 // `react` (indirectly via `react-router`)
-let args = arg({}, { argv: process.argv.slice(2), stopAtPositional: true });
+let args = arg({}, { argv: process.argv.slice(2), permissive: true });
 if (args._[0] === "dev") {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
 } else {

--- a/packages/react-router-dev/bin.js
+++ b/packages/react-router-dev/bin.js
@@ -6,7 +6,7 @@ let arg = require("arg");
 // We have to do this before importing `run.ts` since that is what imports
 // `react` (indirectly via `react-router`)
 let args = arg({}, { argv: process.argv.slice(2), permissive: true });
-if (args._[0] === "dev") {
+if (args._.length === 0 || args._[0] === "dev") {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
 } else {
   process.env.NODE_ENV = process.env.NODE_ENV ?? "production";


### PR DESCRIPTION
See https://github.com/vercel/arg#permissive

Closes #12606 