### PR TITLE
docs(tutorial): remove line breaks in new route definitions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -71,6 +71,7 @@
 - coryhouse
 - ctnelson1997
 - cvbuelow
+- dadamssg
 - damianstasik
 - danielberndt
 - daniilguit

--- a/docs/tutorials/address-book.md
+++ b/docs/tutorials/address-book.md
@@ -987,15 +987,13 @@ touch app/routes/edit-contact.tsx
 
 Don't forget to add the route to `app/routes.ts`:
 
-```tsx filename=app/routes.ts lines=[5-8]
+<!-- prettier-ignore -->
+```tsx filename=app/routes.ts lines=[5]
 export default [
   layout("layouts/sidebar.tsx", [
     index("routes/home.tsx"),
     route("contacts/:contactId", "routes/contact.tsx"),
-    route(
-      "contacts/:contactId/edit",
-      "routes/edit-contact.tsx"
-    ),
+    route("contacts/:contactId/edit", "routes/edit-contact.tsx"),
   ]),
   route("about", "routes/about.tsx"),
 ] satisfies RouteConfig;
@@ -1336,14 +1334,12 @@ At this point you should know everything you need to know to make the delete but
 touch app/routes/destroy-contact.tsx
 ```
 
-```tsx filename=app/routes.ts lines=[3-6]
+<!-- prettier-ignore -->
+```tsx filename=app/routes.ts lines=[3]
 export default [
-  // existing routes
-  route(
-    "contacts/:contactId/destroy",
-    "routes/destroy-contact.tsx"
-  ),
-  // existing routes
+    // existing routes
+    route("contacts/:contactId/destroy", "routes/destroy-contact.tsx"),
+    // existing routes
 ] satisfies RouteConfig;
 ```
 


### PR DESCRIPTION
Every time I saw the route config additions where the `route()` arguments were broken across two lines it took me _way_ too long to realize I was only looking at a single route. I would suggest not breaking. I know this will be worse for mobile but it's a bit jarring.

```diff
export default [
  layout("layouts/sidebar.tsx", [
    index("routes/home.tsx"),
    route("contacts/:contactId", "routes/contact.tsx"),
--  route(
--    "contacts/:contactId/edit",
--    "routes/edit-contact.tsx"
--  ),
++  route("contacts/:contactId/edit", "routes/edit-contact.tsx"),
  ]),
  route("about", "routes/about.tsx"),
] satisfies RouteConfig;

```

```diff
export default [
  // existing routes
--  route(
--    "contacts/:contactId/destroy",
--    "routes/destroy-contact.tsx"
--  ),
++  route("contacts/:contactId/destroy", "routes/destroy-contact.tsx"),
  // existing routes
] satisfies RouteConfig;
```