### PR TITLE
Fix custom SSR environment build entry

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3000,7 +3000,9 @@ export async function getEnvironmentOptionsResolvers(
           outDir: getServerBuildDirectory(ctx),
           rollupOptions: {
             input:
-              viteUserConfig.build?.rollupOptions?.input ??
+              (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
+                ? viteUserConfig.environments?.ssr?.build?.rollupOptions?.input
+                : viteUserConfig.build?.rollupOptions?.input) ??
               virtual.serverBuild.id,
           },
         },


### PR DESCRIPTION
When using the Environment API, a custom SSR build entry should be configured in the SSR environment, not the base `build` config.