### PR TITLE
docs: add tiny info to redirect

### DIFF
--- a/docs/start/framework/navigating.md
+++ b/docs/start/framework/navigating.md
@@ -126,7 +126,7 @@ Forms with `<Form method="post" />` will also navigate to the action prop but wi
 
 ## redirect
 
-Inside of route loaders and actions, you can `redirect` to another URL.
+Inside of route loaders and actions, you can `redirect` to another URL. Note: the `return` statement is mandatory.
 
 ```tsx
 import { redirect } from "react-router";


### PR DESCRIPTION
Using another framework before, where it was not mandatory to return the redirect, I stumbled into a bug not using it in React Router. So at least for me, that would have been an useful hint.