### PR TITLE
Lazy load Cloudflare platform proxy

### DIFF
--- a/.changeset/slow-coats-arrive.md
+++ b/.changeset/slow-coats-arrive.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Lazy load Cloudflare platform proxy on first dev server request when using the `cloudflareDevProxy` Vite plugin to avoid creating unnecessary workerd processes


### PR DESCRIPTION
Fixes: #12973

This change ensures that the side effect of creating the Cloudflare platform proxy doesn't happen when this plugin is used outside of a dev server context, e.g. our child compiler.