### PR TITLE
Only import the root route when SSRing SPA mode's index.html

### DIFF
--- a/.changeset/modern-forks-ring.md
+++ b/.changeset/modern-forks-ring.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Stub all routes except root in "SPA Mode" server builds to avoid issues when route modules or their dependencies import non-SSR-friendly modules

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -1125,7 +1125,7 @@ test.describe("SPA Mode", () => {
           import { logImport } from "../routeImportTracker";
           logImport("app/routes/_index.tsx");
 
-          // This should not cause an error on SSr because the module is not loaded
+          // This should not cause an error on SSR because the module is not loaded
           console.log(window);
 
           export default function Component() {
@@ -1137,7 +1137,7 @@ test.describe("SPA Mode", () => {
           import { logImport } from "../routeImportTracker";
           logImport("app/routes/about.tsx");
 
-          // This should not cause an error on SSr because the module is not loaded
+          // This should not cause an error on SSR because the module is not loaded
           console.log(window);
 
           export default function Component() {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -631,7 +631,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       .map((key, index) => {
         let route = routes[key]!;
         if (isSpaMode && key !== "root") {
-          // In SPA mode, we only pre-render to the root route and it's `HydrateFallback`.
+          // In SPA mode, we only pre-render the root route and its `HydrateFallback`.
           // Therefore, we can stub all other routes with an empty module as they
           // (and their deps) may not be compatible with server-side rendering.
           // This also helps keep the build fast.


### PR DESCRIPTION
Since we only SSR the root route in SPA mode, we don't need to import any other routes in the server bundle; the bundle is solely used to generate the index.html file, and is subsequently discarded.

This should speed up SPA mode builds and make them less error prone; often times apps use libraries that are not SSR-capable (e.g. referencing window in the module scope). By excluding all other routes (and their deps), we make the index.html render more likely to be successful and less likely to require a bunch of shenanigans in vite.config.js.

cc @brophdawg11 

Closes https://github.com/remix-run/react-router/discussions/12360