### PR TITLE
Fix: Accessing Invalid Route with Loader present fails to show ErrorElement

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -23,6 +23,7 @@
 - amitdahan
 - AmRo045
 - amsal
+- amubushar
 - andreasottosson-polestar
 - andreiduca
 - antonmontrezor

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1091,7 +1091,7 @@ export function createRouter(init: RouterInit): Router {
     // in the normal navigation flow.  For SSR it's expected that lazy modules are
     // resolved prior to router creation since we can't go into a fallback
     // UI for SSR'd apps
-    if (!state.initialized) {
+    if (!state.initialized && state.errors === null) {
       startNavigation(NavigationType.Pop, state.location, {
         initialHydration: true,
       });


### PR DESCRIPTION
Currently, if you access an Invalid Route directly with a Loader present it will fail to display the ErrorElement as mentioned in #12995.

This is due to it continuing to navigate with loader errors and assuming a hydrationError, then when it hydrates subsequently it ends up displaying an empty page instead without falling back to the nearest parent error boundary correctly. 

To fix it, we now check for state.errors early & skip navigating to an Invalid Route.