### PR TITLE
docs: Fix useFetchers type inference usage example

### DIFF
--- a/docs/how-to/fetchers.md
+++ b/docs/how-to/fetchers.md
@@ -219,7 +219,7 @@ export function UserSearchCombobox() {
 
 ```tsx lines=[2,5]
 import { useFetcher } from "react-router";
-import type { Search } from "./search-users";
+import type * as Search from "./search-users";
 
 export function UserSearchCombobox() {
   let fetcher = useFetcher<typeof Search.action>();


### PR DESCRIPTION
the guide suggests to import the types of the suggested `./search-users.tsx` file as:

```ts
import type { Search } from "./search-users";
```

and makes a special note to “Ensure you use `import type` so you only import the types.” which is an important note, except that there is no `Search` export from the `/search-users.tsx` file, so it won’t work as written. my guess is that the intention was to import all of the exports as a type to enable the `useFetcher<typeof Search.action>()` usage in the component, which works if you do a wildcard type import:
```ts
import type * as Search from "./search-users";
```