### PR TITLE
fix(react-router-dev): add --save-dev command on md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -349,3 +349,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- otabekshoyimov

--- a/packages/react-router-dev/README.md
+++ b/packages/react-router-dev/README.md
@@ -1,5 +1,5 @@
 Dev tools and CLI for React Router that enables framework features through bundler integration like server rendering, code splitting, HMR, etc.
 
 ```sh
-npm install @react-router/dev
+npm install @react-router/dev --save-dev
 ```


### PR DESCRIPTION
Right now markdown file suggests installing react-router-dev as a runtime dependency instead of dev dependency