### PR TITLE
Scope helper environment to only handle CSS

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -979,7 +979,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         cssMod !== null &&
         "default" in cssMod &&
         typeof cssMod.default === "string",
-      `Failed to load CSS for ${dep.url}`
+      `Failed to load CSS for ${dep.file ?? dep.url}`
     );
 
     return cssMod.default;

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -967,11 +967,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     if (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi) {
       const cssDevHelperEnvironment =
         viteDevServer.environments[CSS_DEV_HELPER_ENVIRONMENT_NAME];
-      invariant(
-        cssDevHelperEnvironment &&
-          vite.isRunnableDevEnvironment(cssDevHelperEnvironment),
-        "Missing CSS dev helper environment"
-      );
+      invariant(cssDevHelperEnvironment, "Missing CSS dev helper environment");
+      invariant(vite.isRunnableDevEnvironment(cssDevHelperEnvironment));
       cssMod = await cssDevHelperEnvironment.runner.import(url);
     } else {
       cssMod = await viteDevServer.ssrLoadModule(url);

--- a/packages/react-router-dev/vite/styles.ts
+++ b/packages/react-router-dev/vite/styles.ts
@@ -4,9 +4,8 @@ import { matchRoutes } from "react-router";
 import type { ModuleNode, ViteDevServer } from "vite";
 
 import type { ResolvedReactRouterConfig } from "../config/config";
+import type { LoadCssContents } from "./plugin";
 import { resolveFileUrl } from "./resolve-file-url";
-import { getVite } from "./vite";
-import type { LoadModule } from "./plugin";
 
 type ServerRouteManifest = ServerBuild["routes"];
 type ServerRoute = ServerRouteManifest[string];
@@ -50,25 +49,17 @@ export const isCssUrlWithoutSideEffects = (url: string) => {
   return false;
 };
 
-const injectQuery = (url: string, query: string) =>
-  url.includes("?") ? url.replace("?", `?${query}&`) : `${url}?${query}`;
-
 const getStylesForFiles = async ({
   viteDevServer,
   rootDirectory,
-  cssModulesManifest,
+  loadCssContents,
   files,
-  loadModule,
 }: {
   viteDevServer: ViteDevServer;
   rootDirectory: string;
-  cssModulesManifest: Record<string, string>;
+  loadCssContents: LoadCssContents;
   files: string[];
-  loadModule: LoadModule;
 }): Promise<string | undefined> => {
-  let vite = getVite();
-  let viteMajor = parseInt(vite.version.split(".")[0], 10);
-
   let styles: Record<string, string> = {};
   let deps = new Set<ModuleNode>();
 
@@ -111,24 +102,7 @@ const getStylesForFiles = async ({
       !isCssUrlWithoutSideEffects(dep.url) // Ignore styles that resolved as URLs, inline or raw. These shouldn't get injected.
     ) {
       try {
-        let css = isCssModulesFile(dep.file)
-          ? cssModulesManifest[dep.file]
-          : (
-              await loadModule(
-                viteDevServer,
-                // We need the ?inline query in Vite v6 when loading CSS in SSR
-                // since it does not expose the default export for CSS in a
-                // server environment. This is to align with non-SSR
-                // environments. For backwards compatibility with v5 we keep
-                // using the URL without ?inline query because the HMR code was
-                // relying on the implicit SSR-client module graph relationship.
-                viteMajor >= 6 ? injectQuery(dep.url, "inline") : dep.url
-              )
-            ).default;
-
-        if (css === undefined) {
-          throw new Error();
-        }
+        let css = await loadCssContents(viteDevServer, dep);
 
         styles[dep.url] = css;
       } catch {
@@ -225,19 +199,17 @@ export const getStylesForUrl = async ({
   rootDirectory,
   reactRouterConfig,
   entryClientFilePath,
-  cssModulesManifest,
+  loadCssContents,
   build,
   url,
-  loadModule,
 }: {
   viteDevServer: ViteDevServer;
   rootDirectory: string;
   reactRouterConfig: Pick<ResolvedReactRouterConfig, "appDirectory" | "routes">;
   entryClientFilePath: string;
-  cssModulesManifest: Record<string, string>;
+  loadCssContents: LoadCssContents;
   build: ServerBuild;
   url: string | undefined;
-  loadModule: LoadModule;
 }): Promise<string | undefined> => {
   if (url === undefined || url.includes("?_data=")) {
     return undefined;
@@ -253,14 +225,13 @@ export const getStylesForUrl = async ({
   let styles = await getStylesForFiles({
     viteDevServer,
     rootDirectory,
-    cssModulesManifest,
+    loadCssContents,
     files: [
       // Always include the client entry file when crawling the module graph for CSS
       path.relative(rootDirectory, entryClientFilePath),
       // Then include any styles from the matched routes
       ...documentRouteFiles,
     ],
-    loadModule,
   });
 
   return styles;

--- a/packages/react-router-dev/vite/styles.ts
+++ b/packages/react-router-dev/vite/styles.ts
@@ -102,11 +102,9 @@ const getStylesForFiles = async ({
       !isCssUrlWithoutSideEffects(dep.url) // Ignore styles that resolved as URLs, inline or raw. These shouldn't get injected.
     ) {
       try {
-        let css = await loadCssContents(viteDevServer, dep);
-
-        styles[dep.url] = css;
+        styles[dep.url] = await loadCssContents(viteDevServer, dep);
       } catch {
-        console.warn(`Could not load ${dep.file}`);
+        console.warn(`Failed to load CSS for ${dep.file}`);
         // this can happen with dynamically imported modules, I think
         // because the Vite module graph doesn't distinguish between
         // static and dynamic imports? TODO investigate, submit fix


### PR DESCRIPTION
This is a follow-up to #13008.

This PR makes the following refactors:
- Ensure the helper environment is only used for CSS. This is because the helper environment is Node-based and may differ from the `ssr` environment, e.g. when using vite-plugin-cloudflare. CSS is handled the same regardless of environment so it's safe to load from another environment, but we don't want to be loading arbitrary modules.
- In order to scope the helper environment to CSS, the server manifest is no longer loaded from the module graph during HMR. Instead, we now keep a reference to the current server manifest in memory.
- Hoists the CSS dev helper environment up to site alongside the other environments rather than being added on separately within the plugin.