### PR TITLE
Avoid `ssrLoadModule` usage with Vite Environment API

### DIFF
--- a/.changeset/new-houses-hug.md
+++ b/.changeset/new-houses-hug.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Fix `future.unstable_viteEnvironmentApi` when the `ssr` environment has been configured by another plugin to be a custom `Vite.DevEnvironment` rather than a `Vite.RunnableDevEnvironment`
+Fix errors with `future.unstable_viteEnvironmentApi` when the `ssr` environment has been configured by another plugin to be a custom `Vite.DevEnvironment` rather than the default `Vite.RunnableDevEnvironment`

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1393,9 +1393,21 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           if (!viteDevServer.config.server.middlewareMode) {
             viteDevServer.middlewares.use(async (req, res, next) => {
               try {
-                let build = (await viteDevServer.ssrLoadModule(
-                  virtual.serverBuild.id
-                )) as ServerBuild;
+                let build: ServerBuild;
+                if (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi) {
+                  let vite = getVite();
+                  let ssrEnvironment = viteDevServer.environments.ssr;
+                  if (!vite.isRunnableDevEnvironment(ssrEnvironment)) {
+                    return;
+                  }
+                  build = (await ssrEnvironment.runner.import(
+                    virtual.serverBuild.id
+                  )) as ServerBuild;
+                } else {
+                  build = (await viteDevServer.ssrLoadModule(
+                    virtual.serverBuild.id
+                  )) as ServerBuild;
+                }
 
                 let handler = createRequestHandler(build, "development");
                 let nodeHandler: NodeRequestHandler = async (


### PR DESCRIPTION
We had one remaining usage of `ssrLoadModule` which I've now swapped for `environments.ssr.runner.import` when the Environment API future flag is enabled. This also means we now explicitly handle the case when the `ssr` environment has been defined by another plugin (e.g. vite-plugin-cloudflare) to be a custom `Vite.DevEnvironment` rather than a `Vite.RunnableDevEnvironment`. In this case, our middleware bails out and doesn't attempt to handle the request, assuming that it's going to be handled by the plugin that defined the custom `Vite.DevEnvironment`.

This also better prepares our codebase for future Vite releases where `ssrLoadModule` is not available.