### PR TITLE
Detect lazy route discovery manifest version mismatches and trigger reloads

### DIFF
--- a/.changeset/real-adults-protect.md
+++ b/.changeset/real-adults-protect.md
@@ -1,0 +1,9 @@
+---
+"react-router": minor
+---
+
+Add `fetcherKey` as a parameter to `patchRoutesOnNavigation`
+
+- In framework mode, Lazy Route Discovery will now detect manifest version mismatches after a new deploy
+- On navigations to undiscovered routes, this mismatch will trigger a document reload of the destination path
+- On `fetcher` calls to undiscovered routes, this mismatch will trigger a document reload of the current path

--- a/.changeset/tall-lamps-think.md
+++ b/.changeset/tall-lamps-think.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Detect manifest version mismatches after new deploys and trigger hard reloads on subsequent navigations in active sessions

--- a/.changeset/tall-lamps-think.md
+++ b/.changeset/tall-lamps-think.md
@@ -1,5 +1,0 @@
----
-"react-router": patch
----
-
-Detect manifest version mismatches after new deploys and trigger hard reloads on subsequent navigations in active sessions

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2225,7 +2225,8 @@ export function createRouter(init: RouterInit): Router {
       let discoverResult = await discoverRoutes(
         requestMatches,
         path,
-        fetchRequest.signal
+        fetchRequest.signal,
+        key
       );
 
       if (discoverResult.type === "aborted") {
@@ -2509,7 +2510,8 @@ export function createRouter(init: RouterInit): Router {
       let discoverResult = await discoverRoutes(
         matches,
         path,
-        fetchRequest.signal
+        fetchRequest.signal,
+        key
       );
 
       if (discoverResult.type === "aborted") {
@@ -3168,7 +3170,8 @@ export function createRouter(init: RouterInit): Router {
   async function discoverRoutes(
     matches: AgnosticDataRouteMatch[],
     pathname: string,
-    signal: AbortSignal
+    signal: AbortSignal,
+    fetcherKey?: string
   ): Promise<DiscoverRoutesResult> {
     if (!patchRoutesOnNavigationImpl) {
       return { type: "success", matches };
@@ -3184,6 +3187,7 @@ export function createRouter(init: RouterInit): Router {
           signal,
           path: pathname,
           matches: partialMatches,
+          fetcherKey,
           patch: (routeId, children) => {
             if (signal.aborted) return;
             patchRoutesImpl(

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -285,6 +285,7 @@ export type AgnosticPatchRoutesOnNavigationFunctionArgs<
   signal: AbortSignal;
   path: string;
   matches: M[];
+  fetcherKey: string | undefined;
   patch: (routeId: string | null, children: O[]) => void;
 };
 

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -296,6 +296,15 @@ async function handleManifestRequest(
   routes: ServerRoute[],
   url: URL
 ) {
+  if (build.assets.version !== url.searchParams.get("version")) {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "X-Remix-Reload-Document": "true",
+      },
+    });
+  }
+
   let patches: Record<string, EntryRoute> = {};
 
   if (url.searchParams.has("p")) {


### PR DESCRIPTION
This adds manifest version mismatch detection and forces a hard reload to get the user session onto the updated deployed version.  Similar concept that we use when we hard reload on a route module asset 404.

Closes #10455 
Closes https://github.com/remix-run/react-router/discussions/12951 