### PR TITLE
feat(express): support Express v5

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -265,6 +265,7 @@
 - robbtraister
 - RobHannay
 - robinvdvleuten
+- rossipedia
 - rtmann
 - rtzll
 - rubeonline

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -63,7 +63,7 @@
     "wireit": "0.14.9"
   },
   "peerDependencies": {
-    "express": "^4.17.1",
+    "express": "^4.17.1 || ^5",
     "react-router": "workspace:*",
     "typescript": "^5.1.0"
   },


### PR DESCRIPTION
`express@5` is out, and is mostly compatible with `express@4` (see [the migration guide](https://expressjs.com/en/guide/migrating-5.html)). At least for React Router usage the differences should be immaterial.

This would allow users to integrate React Router into their existing `express@5` apps, or use `express@5` as a hosting server, without having to fiddle with `--legacy-peer-deps` or similar.