### PR TITLE
docs(CHANGELOG): fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ export default function Component() {
 }
 ```
 
-You'll now get type errors if you pass a path path value or a bad param value:
+You'll now get type errors if you pass a bad path value or a bad param value:
 
 ```ts
 const badPath = href("/not/a/valid/path");

--- a/contributors.yml
+++ b/contributors.yml
@@ -222,6 +222,7 @@
 - minthulim
 - mjackson
 - mlewando
+- mm-jpoole
 - modex98
 - morleytatro
 - ms10596


### PR DESCRIPTION
The changelog for 7.2.0 has a minor typo. `path path` -> `bad path`