### PR TITLE
Fix critical CSS with custom `Vite.DevEnvironment`

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1401,7 +1401,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           }
         );
 
-        return () => {
+        if (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi) {
           viteDevServer.middlewares.use(async (req, res, next) => {
             let [reqPathname, reqSearch] = (req.url ?? "").split("?");
             if (reqPathname === "/@react-router/critical.css") {
@@ -1423,7 +1423,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
               next();
             }
           });
+        }
 
+        return () => {
           // Let user servers handle SSR requests in middleware mode,
           // otherwise the Vite plugin will handle the request
           if (!viteDevServer.config.server.middlewareMode) {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -36,7 +36,7 @@ import type { Cache } from "./cache";
 import { generate, parse } from "./babel";
 import type { NodeRequestHandler } from "./node-adapter";
 import { fromNodeRequest, toNodeRequest } from "./node-adapter";
-import { getStylesForUrl, isCssModulesFile } from "./styles";
+import { getStylesForPathname, isCssModulesFile } from "./styles";
 import * as VirtualModule from "./virtual-module";
 import { resolveFileUrl } from "./resolve-file-url";
 import { combineURLs } from "./combine-urls";
@@ -622,20 +622,20 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     );
 
     return `
-    import * as entryServer from ${JSON.stringify(
-      resolveFileUrl(ctx, ctx.entryServerFilePath)
-    )};
-    ${Object.keys(routes)
-      .map((key, index) => {
-        let route = routes[key]!;
-        return `import * as route${index} from ${JSON.stringify(
-          resolveFileUrl(
-            ctx,
-            resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
-          )
-        )};`;
-      })
-      .join("\n")}
+      import * as entryServer from ${JSON.stringify(
+        resolveFileUrl(ctx, ctx.entryServerFilePath)
+      )};
+      ${Object.keys(routes)
+        .map((key, index) => {
+          let route = routes[key]!;
+          return `import * as route${index} from ${JSON.stringify(
+            resolveFileUrl(
+              ctx,
+              resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
+            )
+          )};`;
+        })
+        .join("\n")}
       export { default as assets } from ${JSON.stringify(
         `${virtual.serverManifest.id}${
           routeIds ? `?route-ids=${routeIds.join(",")}` : ""
@@ -668,7 +668,22 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }`;
           })
           .join(",\n  ")}
-      };`;
+      };
+      ${
+        ctx.reactRouterConfig.future.unstable_viteEnvironmentApi &&
+        viteCommand === "serve"
+          ? `
+              export const getCriticalCss = ({ pathname }) => {
+                return {
+                  rel: "stylesheet",
+                  href: "${
+                    viteUserConfig.base ?? "/"
+                  }@react-router/critical.css?pathname=" + pathname,
+                };
+              }
+            `
+          : ""
+      }`;
   };
 
   let loadViteManifest = async (directory: string) => {
@@ -1331,15 +1346,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         setDevServerHooks({
           // Give the request handler access to the critical CSS in dev to avoid a
           // flash of unstyled content since Vite injects CSS file contents via JS
-          getCriticalCss: async (build, url) => {
-            return getStylesForUrl({
+          getCriticalCss: async (pathname) => {
+            return getStylesForPathname({
               rootDirectory: ctx.rootDirectory,
               entryClientFilePath: ctx.entryClientFilePath,
               reactRouterConfig: ctx.reactRouterConfig,
               viteDevServer,
               loadCssContents,
-              build,
-              url,
+              pathname,
             });
           },
           // If an error is caught within the request handler, let Vite fix the
@@ -1388,6 +1402,28 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         );
 
         return () => {
+          viteDevServer.middlewares.use(async (req, res, next) => {
+            let [reqPathname, reqSearch] = (req.url ?? "").split("?");
+            if (reqPathname === "/@react-router/critical.css") {
+              let pathname = new URLSearchParams(reqSearch).get("pathname");
+              if (!pathname) {
+                return next("No pathname provided");
+              }
+              let css = await getStylesForPathname({
+                rootDirectory: ctx.rootDirectory,
+                entryClientFilePath: ctx.entryClientFilePath,
+                reactRouterConfig: ctx.reactRouterConfig,
+                viteDevServer,
+                loadCssContents,
+                pathname,
+              });
+              res.setHeader("Content-Type", "text/css");
+              res.end(css);
+            } else {
+              next();
+            }
+          });
+
           // Let user servers handle SSR requests in middleware mode,
           // otherwise the Vite plugin will handle the request
           if (!viteDevServer.config.server.middlewareMode) {

--- a/packages/react-router/lib/dom/global.ts
+++ b/packages/react-router/lib/dom/global.ts
@@ -1,11 +1,11 @@
 import type { HydrationState, Router as DataRouter } from "../router/router";
-import type { AssetsManifest, FutureConfig } from "./ssr/entry";
+import type { AssetsManifest, CriticalCss, FutureConfig } from "./ssr/entry";
 import type { RouteModules } from "./ssr/routeModules";
 
 export type WindowReactRouterContext = {
   basename?: string;
   state: HydrationState;
-  criticalCss?: string;
+  criticalCss?: CriticalCss;
   future: FutureConfig;
   ssr: boolean;
   isSpaMode: boolean;

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -241,8 +241,11 @@ export function Links() {
 
   return (
     <>
-      {criticalCss ? (
+      {typeof criticalCss === "string" ? (
         <style dangerouslySetInnerHTML={{ __html: criticalCss }} />
+      ) : null}
+      {typeof criticalCss === "object" ? (
+        <link rel="stylesheet" href={criticalCss.href} />
       ) : null}
       {keyedLinks.map(({ key, link }) =>
         isPageLinkDescriptor(link) ? (

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -13,7 +13,7 @@ type SerializedError = {
 export interface FrameworkContextObject {
   manifest: AssetsManifest;
   routeModules: RouteModules;
-  criticalCss?: string;
+  criticalCss?: CriticalCss;
   serverHandoffString?: string;
   future: FutureConfig;
   ssr: boolean;
@@ -42,6 +42,8 @@ export interface EntryContext extends FrameworkContextObject {
 }
 
 export interface FutureConfig {}
+
+export type CriticalCss = string | { rel: "stylesheet"; href: string };
 
 export interface AssetsManifest {
   entry: {

--- a/packages/react-router/lib/server-runtime/build.ts
+++ b/packages/react-router/lib/server-runtime/build.ts
@@ -1,11 +1,14 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "../router/utils";
 import type {
   AssetsManifest,
+  CriticalCss,
   EntryContext,
   FutureConfig,
 } from "../dom/ssr/entry";
 import type { ServerRouteManifest } from "./routes";
 import type { AppLoadContext } from "./data";
+
+type OptionalCriticalCss = CriticalCss | undefined;
 
 /**
  * The output of the compiler for the server build.
@@ -21,6 +24,9 @@ export interface ServerBuild {
   assetsBuildDirectory: string;
   future: FutureConfig;
   ssr: boolean;
+  getCriticalCss?: (args: {
+    pathname: string;
+  }) => OptionalCriticalCss | Promise<OptionalCriticalCss>;
   /**
    * @deprecated This is now done via a custom header during prerendering
    */

--- a/packages/react-router/lib/server-runtime/dev.ts
+++ b/packages/react-router/lib/server-runtime/dev.ts
@@ -1,10 +1,5 @@
-import type { ServerBuild } from "./build";
-
 type DevServerHooks = {
-  getCriticalCss?: (
-    build: ServerBuild,
-    pathname: string
-  ) => Promise<string | undefined>;
+  getCriticalCss?: (pathname: string) => Promise<string | undefined>;
   processRequestError?: (error: unknown) => void;
 };
 

--- a/packages/react-router/lib/server-runtime/serverHandoff.ts
+++ b/packages/react-router/lib/server-runtime/serverHandoff.ts
@@ -1,5 +1,5 @@
 import type { HydrationState } from "../router/router";
-import type { FutureConfig } from "../dom/ssr/entry";
+import type { CriticalCss, FutureConfig } from "../dom/ssr/entry";
 import { escapeHtml } from "./markup";
 
 type ValidateShape<T, Shape> =
@@ -18,7 +18,7 @@ export function createServerHandoffString<T>(serverHandoff: {
   // Don't allow StaticHandlerContext to be passed in verbatim, since then
   // we'd end up including duplicate info
   state?: ValidateShape<T, HydrationState>;
-  criticalCss?: string;
+  criticalCss?: CriticalCss;
   basename: string | undefined;
   future: FutureConfig;
   ssr: boolean;


### PR DESCRIPTION
Our current mechanism for rendering critical CSS in dev assumes that the SSR environment is running in the same Node process as the Vite dev server. If you're using a plugin that defines a non-Node SSR environment (e.g. vite-plugin-cloudflare) this mechanism fails to work. To fix this, when `future.unstable_viteEnvironmentApi` is enabled, we now manage critical CSS via a dynamic CSS file on the Vite dev server (available via `/@react-router/critical.css?pathname=...`) rather than trying to render the string of CSS inline. This ensures that the logic for calculating the critical CSS is always running within the same context as the Vite dev server.