### PR TITLE
Fix support for custom `build.assetsDir`

### DIFF
--- a/.changeset/gold-insects-remain.md
+++ b/.changeset/gold-insects-remain.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix support for custom `build.assetsDir`

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3248,7 +3248,10 @@ export async function getEnvironmentOptionsResolvers(
                 let routeChunkSuffix = routeChunkName
                   ? `-${kebabCase(routeChunkName)}`
                   : "";
-                return `assets/[name]${routeChunkSuffix}-[hash].js`;
+                return path.posix.join(
+                  viteUserConfig.build?.assetsDir ?? "assets",
+                  `[name]${routeChunkSuffix}-[hash].js`
+                );
               },
             },
           },


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13071.