### PR TITLE
Fix usage of `prerender` option with `serverBundles`

### DIFF
--- a/.changeset/dry-impalas-live.md
+++ b/.changeset/dry-impalas-live.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix usage of `prerender` option when `serverBundles` option has been configured or provided by a preset, e.g. `vercelPreset` from `@vercel/react-router`


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13069.

Since the server build virtual module now includes a query string when using the `serverBundles` option (e.g. `virtual:react-router/server-build?route-ids=home,about`), we need to ensure that we factor this into any logic that tries to find this virtual module in the Vite manifest.

Note that this issue actually highlighted a previously hidden issue where the build would have broken if you generate than 1 server bundle when using the `prerender` option. This is now also handled correctly.