### PR TITLE
Add failing tests for ReadonlyMap and ReadonlySet

### DIFF
--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -108,6 +108,25 @@ type __tests = [
     >
   >,
   Expect<Equal<ServerDataFrom<() => { a: string } | Response>, { a: string }>>,
+  Expect<
+    Equal<
+      ServerDataFrom<
+        () => {
+          map: Map<string, number>;
+          readonlyMap: ReadonlyMap<string, number>;
+        }
+      >,
+      { map: Map<string, number>; readonlyMap: ReadonlyMap<string, number> }
+    >
+  >,
+  Expect<
+    Equal<
+      ServerDataFrom<
+        () => { set: Set<string>; readonlySet: ReadonlySet<string> }
+      >,
+      { set: Set<string>; readonlySet: ReadonlySet<string> }
+    >
+  >,
 
   // ClientDataFrom
   Expect<Equal<ClientDataFrom<any>, undefined>>,


### PR DESCRIPTION
`ReadonlyMap` and `ReadonlySet` are regular `Map` and `Set` objects, but their types omit the mutation methods that the `Map` and `Set` types have, similar to the way `ReadonlyArray` and `Array` work. However, `ReadonlyMap` and `ReadonlySet` do not extend `Map` and `Set`, so their types do not serialize correctly when coming from the server.

This is related to the discussion in https://github.com/remix-run/react-router/discussions/13043