### PR TITLE
docs(pending-ui): optimistic ui type mismatch fix

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -354,3 +354,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- liborgabrhel

--- a/docs/start/framework/pending-ui.md
+++ b/docs/start/framework/pending-ui.md
@@ -111,7 +111,7 @@ function Task({ task }) {
 
   let isComplete = task.status === "complete";
   if (fetcher.formData) {
-    isComplete = fetcher.formData.get("status");
+    isComplete = fetcher.formData.get("status") === "complete";
   }
 
   return (


### PR DESCRIPTION
# Fix Type Mismatch in Task Component

## Problem
Currently, the Task component has a type mismatch when handling form data. The `isComplete` variable is used as a boolean, but it's being directly assigned a string value from `formData.get()`, which causes inconsistent behavior when comparing states.

Before:
```tsx
isComplete = fetcher.formData.get("status");  // Returns string
```
After:
```tsx
isComplete = fetcher.formData.get("status") === "complete";  // Returns boolean
```
