### PR TITLE
Fix custom client `build.rollupOptions.output.entryFileNames`

### DIFF
--- a/.changeset/afraid-tigers-promise.md
+++ b/.changeset/afraid-tigers-promise.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Fix support for custom client `build.rollupOptions.output`
+Fix support for custom client `build.rollupOptions.output.entryFileNames`

--- a/.changeset/afraid-tigers-promise.md
+++ b/.changeset/afraid-tigers-promise.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix support for custom client `build.rollupOptions.output`

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3308,8 +3308,11 @@ export async function getEnvironmentOptionsResolvers(
                 }
               ),
             ],
-            output: {
-              entryFileNames({ moduleIds }) {
+            output: (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
+              ? viteUserConfig?.environments?.client?.build?.rollupOptions
+                  ?.output
+              : viteUserConfig?.build?.rollupOptions?.output) ?? {
+              entryFileNames: ({ moduleIds }) => {
                 let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
                 let routeChunkName = routeChunkModuleId
                   ? getRouteChunkNameFromModuleId(routeChunkModuleId)
@@ -3318,7 +3321,9 @@ export async function getEnvironmentOptionsResolvers(
                   ? `-${kebabCase(routeChunkName)}`
                   : "";
                 return path.posix.join(
-                  viteUserConfig.build?.assetsDir ?? "assets",
+                  (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
+                    ? viteUserConfig?.environments?.client?.build?.assetsDir
+                    : viteUserConfig?.build?.assetsDir) ?? "assets",
                   `[name]${routeChunkSuffix}-[hash].js`
                 );
               },


### PR DESCRIPTION
Fixes #13091.

With the introduction of `future.unstable_splitRouteModules`, we added our own `build.rollupOptions.output.entryFileNames` config so that route chunk names would end up in the output (e.g. `assets/route-client-loader-HASH.js`). This took precedence over any user provided config.

This PR fixes this so any user-provided value for `build.rollupOptions.output.entryFileNames` takes precedence. It's worth calling out that our config is not required for the app to work, it's simply to make it easier to tell the chunks apart when debugging.