### PR TITLE
Fix custom SSR build input with `serverBundles`

### DIFF
--- a/.changeset/pretty-flies-crash.md
+++ b/.changeset/pretty-flies-crash.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix support for custom SSR build input when `serverBundles` option has been configured

--- a/.changeset/pretty-flies-crash.md
+++ b/.changeset/pretty-flies-crash.md
@@ -3,3 +3,5 @@
 ---
 
 Fix support for custom SSR build input when `serverBundles` option has been configured
+
+Note that for consumers using the `future.unstable_viteEnvironmentApi` and `serverBundles` options together, hyphens are no longer supported in server bundle IDs since they also need to be valid Vite environment names.

--- a/integration/vite-server-bundles-test.ts
+++ b/integration/vite-server-bundles-test.ts
@@ -57,21 +57,21 @@ const TEST_ROUTES = [
   "_index.tsx",
 
   // Bundle A has an index route
-  "bundle-a.tsx",
-  "bundle-a._index.tsx",
-  "bundle-a.route-a.tsx",
-  "bundle-a.route-b.tsx",
+  "bundle_a.tsx",
+  "bundle_a._index.tsx",
+  "bundle_a.route_a.tsx",
+  "bundle_a.route_b.tsx",
 
   // Bundle B doesn't have an index route
-  "bundle-b.tsx",
-  "bundle-b.route-a.tsx",
-  "bundle-b.route-b.tsx",
+  "bundle_b.tsx",
+  "bundle_b.route_a.tsx",
+  "bundle_b.route_b.tsx",
 
   // Bundle C is nested in a pathless route
   "_pathless.tsx",
-  "_pathless.bundle-c.tsx",
-  "_pathless.bundle-c.route-a.tsx",
-  "_pathless.bundle-c.route-b.tsx",
+  "_pathless.bundle_c.tsx",
+  "_pathless.bundle_c.route_a.tsx",
+  "_pathless.bundle_c.route_b.tsx",
 ];
 
 const files = {
@@ -151,16 +151,16 @@ test.describe("Server bundles", () => {
                     return "root";
                   }
 
-                  if (branch.some((route) => route.id === "routes/bundle-a")) {
-                    return "bundle-a";
+                  if (branch.some((route) => route.id === "routes/bundle_a")) {
+                    return "bundle_a";
                   }
 
-                  if (branch.some((route) => route.id === "routes/bundle-b")) {
-                    return "bundle-b";
+                  if (branch.some((route) => route.id === "routes/bundle_b")) {
+                    return "bundle_b";
                   }
 
-                  if (branch.some((route) => route.id === "routes/_pathless.bundle-c")) {
-                    return "bundle-c";
+                  if (branch.some((route) => route.id === "routes/_pathless.bundle_c")) {
+                    return "bundle_c";
                   }
 
                   throw new Error("No bundle defined for route " + branch[branch.length - 1].id);
@@ -199,19 +199,19 @@ test.describe("Server bundles", () => {
           await page.goto(`http://localhost:${port}/`);
           await expectRenderedRoutes(page, ["_index.tsx"]);
 
-          await page.goto(`http://localhost:${port}/bundle-a`);
+          await page.goto(`http://localhost:${port}/bundle_a`);
           await expectRenderedRoutes(page, [
-            "bundle-a.tsx",
-            "bundle-a._index.tsx",
+            "bundle_a.tsx",
+            "bundle_a._index.tsx",
           ]);
 
-          await page.goto(`http://localhost:${port}/bundle-b`);
-          await expectRenderedRoutes(page, ["bundle-b.tsx"]);
+          await page.goto(`http://localhost:${port}/bundle_b`);
+          await expectRenderedRoutes(page, ["bundle_b.tsx"]);
 
-          await page.goto(`http://localhost:${port}/bundle-c`);
+          await page.goto(`http://localhost:${port}/bundle_c`);
           await expectRenderedRoutes(page, [
             "_pathless.tsx",
-            "_pathless.bundle-c.tsx",
+            "_pathless.bundle_c.tsx",
           ]);
 
           expect(pageErrors).toEqual([]);
@@ -243,84 +243,84 @@ test.describe("Server bundles", () => {
             await page.goto(`http://localhost:${port}/`);
             await expectRenderedRoutes(page, ["_index.tsx"]);
 
-            let _404s = ["/bundle-a", "/bundle-b", "/bundle-c"];
+            let _404s = ["/bundle_a", "/bundle_b", "/bundle_c"];
             for (let path of _404s) {
               let response = await page.goto(`http://localhost:${port}${path}`);
               expect(response?.status()).toBe(404);
             }
           });
 
-          await withBundleServer(cwd, "bundle-a", async (port) => {
-            await page.goto(`http://localhost:${port}/bundle-a`);
+          await withBundleServer(cwd, "bundle_a", async (port) => {
+            await page.goto(`http://localhost:${port}/bundle_a`);
             await expectRenderedRoutes(page, [
-              "bundle-a.tsx",
-              "bundle-a._index.tsx",
+              "bundle_a.tsx",
+              "bundle_a._index.tsx",
             ]);
 
-            await page.goto(`http://localhost:${port}/bundle-a/route-a`);
+            await page.goto(`http://localhost:${port}/bundle_a/route_a`);
             await expectRenderedRoutes(page, [
-              "bundle-a.tsx",
-              "bundle-a.route-a.tsx",
+              "bundle_a.tsx",
+              "bundle_a.route_a.tsx",
             ]);
 
-            await page.goto(`http://localhost:${port}/bundle-a/route-b`);
+            await page.goto(`http://localhost:${port}/bundle_a/route_b`);
             await expectRenderedRoutes(page, [
-              "bundle-a.tsx",
-              "bundle-a.route-b.tsx",
+              "bundle_a.tsx",
+              "bundle_a.route_b.tsx",
             ]);
 
-            let _404s = ["/bundle-b", "/bundle-c"];
+            let _404s = ["/bundle_b", "/bundle_c"];
             for (let path of _404s) {
               let response = await page.goto(`http://localhost:${port}${path}`);
               expect(response?.status()).toBe(404);
             }
           });
 
-          await withBundleServer(cwd, "bundle-b", async (port) => {
-            await page.goto(`http://localhost:${port}/bundle-b`);
-            await expectRenderedRoutes(page, ["bundle-b.tsx"]);
+          await withBundleServer(cwd, "bundle_b", async (port) => {
+            await page.goto(`http://localhost:${port}/bundle_b`);
+            await expectRenderedRoutes(page, ["bundle_b.tsx"]);
 
-            await page.goto(`http://localhost:${port}/bundle-b/route-a`);
+            await page.goto(`http://localhost:${port}/bundle_b/route_a`);
             await expectRenderedRoutes(page, [
-              "bundle-b.tsx",
-              "bundle-b.route-a.tsx",
+              "bundle_b.tsx",
+              "bundle_b.route_a.tsx",
             ]);
 
-            await page.goto(`http://localhost:${port}/bundle-b/route-b`);
+            await page.goto(`http://localhost:${port}/bundle_b/route_b`);
             await expectRenderedRoutes(page, [
-              "bundle-b.tsx",
-              "bundle-b.route-b.tsx",
+              "bundle_b.tsx",
+              "bundle_b.route_b.tsx",
             ]);
 
-            let _404s = ["/bundle-a", "/bundle-c"];
+            let _404s = ["/bundle_a", "/bundle_c"];
             for (let path of _404s) {
               let response = await page.goto(`http://localhost:${port}${path}`);
               expect(response?.status()).toBe(404);
             }
           });
 
-          await withBundleServer(cwd, "bundle-c", async (port) => {
-            await page.goto(`http://localhost:${port}/bundle-c`);
+          await withBundleServer(cwd, "bundle_c", async (port) => {
+            await page.goto(`http://localhost:${port}/bundle_c`);
             await expectRenderedRoutes(page, [
               "_pathless.tsx",
-              "_pathless.bundle-c.tsx",
+              "_pathless.bundle_c.tsx",
             ]);
 
-            await page.goto(`http://localhost:${port}/bundle-c/route-a`);
+            await page.goto(`http://localhost:${port}/bundle_c/route_a`);
             await expectRenderedRoutes(page, [
               "_pathless.tsx",
-              "_pathless.bundle-c.tsx",
-              "_pathless.bundle-c.route-a.tsx",
+              "_pathless.bundle_c.tsx",
+              "_pathless.bundle_c.route_a.tsx",
             ]);
 
-            await page.goto(`http://localhost:${port}/bundle-c/route-b`);
+            await page.goto(`http://localhost:${port}/bundle_c/route_b`);
             await expectRenderedRoutes(page, [
               "_pathless.tsx",
-              "_pathless.bundle-c.tsx",
-              "_pathless.bundle-c.route-b.tsx",
+              "_pathless.bundle_c.tsx",
+              "_pathless.bundle_c.route_b.tsx",
             ]);
 
-            let _404s = ["/bundle-a", "/bundle-b"];
+            let _404s = ["/bundle_a", "/bundle_b"];
             for (let path of _404s) {
               let response = await page.goto(`http://localhost:${port}${path}`);
               expect(response?.status()).toBe(404);
@@ -344,9 +344,9 @@ test.describe("Server bundles", () => {
         test("Vite manifests", () => {
           [
             ["client"],
-            ["server", "bundle-a"],
-            ["server", "bundle-b"],
-            ["server", "bundle-c"],
+            ["server", "bundle_a"],
+            ["server", "bundle_b"],
+            ["server", "bundle_c"],
             ["server", "root"],
           ].forEach((buildPaths) => {
             let viteManifestFiles = fs.readdirSync(
@@ -360,17 +360,17 @@ test.describe("Server bundles", () => {
           let manifestPath = path.join(cwd, "build", "test-manifest.json");
           expect(JSON.parse(fs.readFileSync(manifestPath, "utf8"))).toEqual({
             serverBundles: {
-              "bundle-c": {
-                id: "bundle-c",
-                file: "build/server/bundle-c/index.js",
+              bundle_c: {
+                id: "bundle_c",
+                file: "build/server/bundle_c/index.js",
               },
-              "bundle-a": {
-                id: "bundle-a",
-                file: "build/server/bundle-a/index.js",
+              bundle_a: {
+                id: "bundle_a",
+                file: "build/server/bundle_a/index.js",
               },
-              "bundle-b": {
-                id: "bundle-b",
-                file: "build/server/bundle-b/index.js",
+              bundle_b: {
+                id: "bundle_b",
+                file: "build/server/bundle_b/index.js",
               },
               root: {
                 id: "root",
@@ -378,15 +378,15 @@ test.describe("Server bundles", () => {
               },
             },
             routeIdToServerBundleId: {
-              "routes/_pathless.bundle-c.route-a": "bundle-c",
-              "routes/_pathless.bundle-c.route-b": "bundle-c",
-              "routes/_pathless.bundle-c": "bundle-c",
-              "routes/bundle-a.route-a": "bundle-a",
-              "routes/bundle-a.route-b": "bundle-a",
-              "routes/bundle-b.route-a": "bundle-b",
-              "routes/bundle-b.route-b": "bundle-b",
-              "routes/bundle-a._index": "bundle-a",
-              "routes/bundle-b": "bundle-b",
+              "routes/_pathless.bundle_c.route_a": "bundle_c",
+              "routes/_pathless.bundle_c.route_b": "bundle_c",
+              "routes/_pathless.bundle_c": "bundle_c",
+              "routes/bundle_a.route_a": "bundle_a",
+              "routes/bundle_a.route_b": "bundle_a",
+              "routes/bundle_b.route_a": "bundle_b",
+              "routes/bundle_b.route_b": "bundle_b",
+              "routes/bundle_a._index": "bundle_a",
+              "routes/bundle_b": "bundle_b",
               "routes/_index": "root",
             },
             routes: {
@@ -395,69 +395,69 @@ test.describe("Server bundles", () => {
                 id: "root",
                 file: "app/root.tsx",
               },
-              "routes/_pathless.bundle-c.route-a": {
-                file: "app/routes/_pathless.bundle-c.route-a.tsx",
-                id: "routes/_pathless.bundle-c.route-a",
-                path: "route-a",
-                parentId: "routes/_pathless.bundle-c",
+              "routes/_pathless.bundle_c.route_a": {
+                file: "app/routes/_pathless.bundle_c.route_a.tsx",
+                id: "routes/_pathless.bundle_c.route_a",
+                path: "route_a",
+                parentId: "routes/_pathless.bundle_c",
               },
-              "routes/_pathless.bundle-c.route-b": {
-                file: "app/routes/_pathless.bundle-c.route-b.tsx",
-                id: "routes/_pathless.bundle-c.route-b",
-                path: "route-b",
-                parentId: "routes/_pathless.bundle-c",
+              "routes/_pathless.bundle_c.route_b": {
+                file: "app/routes/_pathless.bundle_c.route_b.tsx",
+                id: "routes/_pathless.bundle_c.route_b",
+                path: "route_b",
+                parentId: "routes/_pathless.bundle_c",
               },
-              "routes/_pathless.bundle-c": {
-                file: "app/routes/_pathless.bundle-c.tsx",
-                id: "routes/_pathless.bundle-c",
-                path: "bundle-c",
+              "routes/_pathless.bundle_c": {
+                file: "app/routes/_pathless.bundle_c.tsx",
+                id: "routes/_pathless.bundle_c",
+                path: "bundle_c",
                 parentId: "routes/_pathless",
               },
-              "routes/bundle-a.route-a": {
-                file: "app/routes/bundle-a.route-a.tsx",
-                id: "routes/bundle-a.route-a",
-                path: "route-a",
-                parentId: "routes/bundle-a",
+              "routes/bundle_a.route_a": {
+                file: "app/routes/bundle_a.route_a.tsx",
+                id: "routes/bundle_a.route_a",
+                path: "route_a",
+                parentId: "routes/bundle_a",
               },
-              "routes/bundle-a.route-b": {
-                file: "app/routes/bundle-a.route-b.tsx",
-                id: "routes/bundle-a.route-b",
-                path: "route-b",
-                parentId: "routes/bundle-a",
+              "routes/bundle_a.route_b": {
+                file: "app/routes/bundle_a.route_b.tsx",
+                id: "routes/bundle_a.route_b",
+                path: "route_b",
+                parentId: "routes/bundle_a",
               },
-              "routes/bundle-b.route-a": {
-                file: "app/routes/bundle-b.route-a.tsx",
-                id: "routes/bundle-b.route-a",
-                path: "route-a",
-                parentId: "routes/bundle-b",
+              "routes/bundle_b.route_a": {
+                file: "app/routes/bundle_b.route_a.tsx",
+                id: "routes/bundle_b.route_a",
+                path: "route_a",
+                parentId: "routes/bundle_b",
               },
-              "routes/bundle-b.route-b": {
-                file: "app/routes/bundle-b.route-b.tsx",
-                id: "routes/bundle-b.route-b",
-                path: "route-b",
-                parentId: "routes/bundle-b",
+              "routes/bundle_b.route_b": {
+                file: "app/routes/bundle_b.route_b.tsx",
+                id: "routes/bundle_b.route_b",
+                path: "route_b",
+                parentId: "routes/bundle_b",
               },
-              "routes/bundle-a._index": {
-                file: "app/routes/bundle-a._index.tsx",
-                id: "routes/bundle-a._index",
+              "routes/bundle_a._index": {
+                file: "app/routes/bundle_a._index.tsx",
+                id: "routes/bundle_a._index",
                 index: true,
-                parentId: "routes/bundle-a",
+                parentId: "routes/bundle_a",
               },
               "routes/_pathless": {
                 file: "app/routes/_pathless.tsx",
                 id: "routes/_pathless",
                 parentId: "root",
               },
-              "routes/bundle-a": {
-                file: "app/routes/bundle-a.tsx",
-                id: "routes/bundle-a",
-                path: "bundle-a",
+              "routes/bundle_a": {
+                file: "app/routes/bundle_a.tsx",
+                id: "routes/bundle_a",
+                path: "bundle_a",
                 parentId: "root",
               },
-              "routes/bundle-b": {
-                file: "app/routes/bundle-b.tsx",
-                id: "routes/bundle-b",
-                path: "bundle-b",
+              "routes/bundle_b": {
+                file: "app/routes/bundle_b.tsx",
+                id: "routes/bundle_b",
+                path: "bundle_b",
                 parentId: "root",
               },
               "routes/_index": {

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -168,6 +168,7 @@ async function viteBuild(
     let environmentBuildContext: EnvironmentBuildContext = {
       name: environmentName,
       resolveOptions,
+      buildManifest,
     };
 
     await vite.build({

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -189,11 +189,9 @@ async function viteBuild(
     });
   }
 
-  let { reactRouterConfig } = ctx;
-  let buildManifest = await getBuildManifest(ctx);
+  let { reactRouterConfig, buildManifest } = ctx;
   let environmentOptionsResolvers = await getEnvironmentOptionsResolvers(
     ctx,
-    buildManifest,
     "build"
   );
   let environmentsOptions = resolveEnvironmentsOptions(

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -9,7 +9,6 @@ import {
   extractPluginContext,
   cleanBuildDirectory,
   cleanViteManifests,
-  getBuildManifest,
   getEnvironmentOptionsResolvers,
   resolveEnvironmentsOptions,
   getServerEnvironmentKeys,
@@ -149,7 +148,7 @@ async function viteBuild(
       },
     ],
   });
-  let ctx = await extractPluginContext(viteConfig);
+  let ctx = extractPluginContext(viteConfig);
 
   if (!ctx) {
     console.error(
@@ -168,7 +167,6 @@ async function viteBuild(
     let environmentBuildContext: EnvironmentBuildContext = {
       name: environmentName,
       resolveOptions,
-      buildManifest,
     };
 
     await vite.build({
@@ -185,11 +183,16 @@ async function viteBuild(
       optimizeDeps: { force },
       clearScreen,
       logLevel,
-      ...{ __reactRouterEnvironmentBuildContext: environmentBuildContext },
+      ...{
+        __reactRouterPluginContext: ctx,
+        __reactRouterEnvironmentBuildContext: environmentBuildContext,
+      },
     });
   }
 
   let { reactRouterConfig, buildManifest } = ctx;
+  invariant(buildManifest, "Expected build manifest to be present");
+
   let environmentOptionsResolvers = await getEnvironmentOptionsResolvers(
     ctx,
     "build"
@@ -206,8 +209,8 @@ async function viteBuild(
 
   // Then run Vite SSR builds in parallel
   let serverEnvironmentNames = getServerEnvironmentKeys(
-    environmentOptionsResolvers,
-    buildManifest
+    ctx,
+    environmentOptionsResolvers
   );
 
   await Promise.all(serverEnvironmentNames.map(buildEnvironment));

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -727,7 +727,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       })
       .join("\n")}
       export { default as assets } from ${JSON.stringify(
-        `${virtual.serverManifest.id}`
+        virtual.serverManifest.id
       )};
       export const assetsBuildDirectory = ${JSON.stringify(
         path.relative(

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1116,9 +1116,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         });
 
         await updatePluginContext();
-        buildManifest = ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
-          ? await getBuildManifest(ctx)
-          : ctx.environmentBuildContext?.buildManifest;
+        buildManifest =
+          ctx.reactRouterConfig.future.unstable_viteEnvironmentApi ||
+          viteCommand === "serve"
+            ? await getBuildManifest(ctx)
+            : ctx.environmentBuildContext?.buildManifest;
         invariant(buildManifest);
 
         Object.assign(

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -524,15 +524,15 @@ let getServerBundleRouteIds = (
   vitePluginContext: Vite.Rollup.PluginContext,
   ctx: ReactRouterPluginContext
 ): string[] | undefined => {
+  if (!ctx.buildManifest) {
+    return undefined;
+  }
+
   let environmentName = ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
     ? vitePluginContext.environment.name
     : ctx.environmentBuildContext?.name;
 
-  if (
-    !ctx.buildManifest ||
-    !environmentName ||
-    !isSsrBundleEnvironmentName(environmentName)
-  ) {
+  if (!environmentName || !isSsrBundleEnvironmentName(environmentName)) {
     return undefined;
   }
 

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -163,6 +163,7 @@ type EnvironmentOptionsResolvers = Partial<
 export type EnvironmentBuildContext = {
   name: EnvironmentName;
   resolveOptions: EnvironmentOptionsResolver;
+  buildManifest: BuildManifest;
 };
 
 function isSeverBundleEnvironmentName(
@@ -236,6 +237,7 @@ export type ServerBundleBuildConfig = {
 type ResolvedEnvironmentBuildContext = {
   name: EnvironmentName;
   options: EnvironmentOptions;
+  buildManifest: BuildManifest;
 };
 
 type ReactRouterPluginContext = {
@@ -501,6 +503,7 @@ const resolveEnvironmentBuildContext = ({
   let resolvedBuildContext: ResolvedEnvironmentBuildContext = {
     name: buildContext.name,
     options: buildContext.resolveOptions({ viteUserConfig }),
+    buildManifest: buildContext.buildManifest,
   };
 
   return resolvedBuildContext;
@@ -1113,7 +1116,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         });
 
         await updatePluginContext();
-        buildManifest = await getBuildManifest(ctx);
+        buildManifest = ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
+          ? await getBuildManifest(ctx)
+          : ctx.environmentBuildContext?.buildManifest;
+        invariant(buildManifest);
 
         Object.assign(
           process.env,


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13104.

This fixes two issues:
- Since moving to the Vite Environment API, if a custom `build.rollupOptions.input` value was provided in the SSR build, this was not honoured when `serverBundles` were configured. This PR ensures that all SSR builds honour this value.
- Since the custom server entry imports `virtual:react-router/server-build`, this fails to account for the query string used to support `serverBundles` (e.g. `virtual:react-router/server-build?route-ids=foo,bar,baz`. This PR alters the logic for getting the route IDs of a server bundle build so they're no longer encoded in the query string. Instead, the server bundle ID is extracted from the environment name, and this is then used to look up its routes in the React Router build manifest.