### PR TITLE
do not typegen params for layout routes with a corresponding index

### DIFF
--- a/.changeset/yellow-glasses-sort.md
+++ b/.changeset/yellow-glasses-sort.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix duplicated entries in typegen for layout routes and their corresponding index route

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -117,6 +117,7 @@ function register(ctx: Context) {
         .map((route) => {
           // filter out pathless (layout) routes
           if (route.id !== "root" && !route.path) return undefined;
+
           // filter out layout routes that have a corresponding index
           if (!route.index && indexPaths.has(route.path)) return undefined;
 

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -103,6 +103,12 @@ function register(ctx: Context) {
 
   const { t } = Babel;
 
+  const indexPaths = new Set(
+    Object.values(ctx.config.routes)
+      .filter((route) => route.index)
+      .map((route) => route.path)
+  );
+
   const typeParams = t.tsTypeAliasDeclaration(
     t.identifier("Params"),
     null,
@@ -111,6 +117,8 @@ function register(ctx: Context) {
         .map((route) => {
           // filter out pathless (layout) routes
           if (route.id !== "root" && !route.path) return undefined;
+          // filter out layout routes that have a corresponding index
+          if (!route.index && indexPaths.has(route.path)) return undefined;
 
           const lineage = Route.lineage(ctx.config.routes, route);
           const fullpath = Route.fullpath(lineage);


### PR DESCRIPTION
Given the following file-system routes:
```ls
routes/base._index.tsx
routes/base._layout.tsx
routes/base._layout.child.tsx
```

The current typegen algorithm will create 2 entries for `"base": {}`, 1 each for the index and the layout, which is a type error.

This PR adds a filter to the Params generation to ignore layouts if a corresponding index is defined.

Addresses https://github.com/remix-run/react-router/issues/13059
