### PR TITLE
Switch server.hot to server.ws for vite

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1952,7 +1952,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           }
         }
 
-        server.hot.send({
+        server.ws.send({
           type: "custom",
           event: "react-router:hmr",
           data: hmrEventData,


### PR DESCRIPTION
Honestly, I don't know what I'm doing here. However, the ViteDevServer (https://vite.dev/guide/api-javascript.html#vitedevserver) doesn't seem to have a `hot` attribute, only `ws`. and this change fixes the error I was seeing (specifically, `Cannot read properties of undefined (reading 'send')`), so :man_shrugging: here's a PR!