### PR TITLE
docs(start/library/routing): fix component name

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -302,6 +302,7 @@
 - stmtk1
 - sukvvon
 - swalker326
+- szhsin
 - tanayv
 - thecode00
 - theostavrides

--- a/docs/start/library/routing.md
+++ b/docs/start/library/routing.md
@@ -162,7 +162,7 @@ You can have multiple dynamic segments in one route path:
 ```tsx filename=app/category-product.tsx
 import { useParams } from "react-router";
 
-export default function Team() {
+export default function CategoryProduct() {
   let { categoryId, productId } = useParams();
   // ...
 }


### PR DESCRIPTION
Fix the component name in the dynamic segment documentation.