### PR TITLE
Fix duplicated entries in typegen for layout routes and their corresponding index route

### DIFF
--- a/.changeset/yellow-glasses-sort.md
+++ b/.changeset/yellow-glasses-sort.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix duplicated entries in typegen for layout routes and their corresponding index route

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -103,6 +103,12 @@ function register(ctx: Context) {
 
   const { t } = Babel;
 
+  const indexPaths = new Set(
+    Object.values(ctx.config.routes)
+      .filter((route) => route.index)
+      .map((route) => route.path)
+  );
+
   const typeParams = t.tsTypeAliasDeclaration(
     t.identifier("Params"),
     null,
@@ -111,6 +117,9 @@ function register(ctx: Context) {
         .map((route) => {
           // filter out pathless (layout) routes
           if (route.id !== "root" && !route.path) return undefined;
+
+          // filter out layout routes that have a corresponding index
+          if (!route.index && indexPaths.has(route.path)) return undefined;
 
           const lineage = Route.lineage(ctx.config.routes, route);
           const fullpath = Route.fullpath(lineage);


### PR DESCRIPTION
Cherry-picking commit from #13131 into `dev` since that PR was (accidentally) merged into `main`