### PR TITLE
docs(tutorials/address-book): fix `Type Safety` code example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -79,6 +79,7 @@
 - david-bezero
 - david-crespo
 - davidbielik
+- dbredden
 - dcblair
 - decadentsavant
 - developit

--- a/docs/tutorials/address-book.md
+++ b/docs/tutorials/address-book.md
@@ -472,7 +472,7 @@ import type { Route } from "./+types/root";
 // existing imports & exports
 
 export default function App({
-  loaderData,
+  loaderData = { contacts: [] },
 }: Route.ComponentProps) {
   const { contacts } = loaderData;
 


### PR DESCRIPTION
Added a TypeError resolution to destructure property 'contacts' of 'loaderData' as it is null.