### PR TITLE
Support optional static segments and splats in `href()` util

### DIFF
--- a/.changeset/clean-frogs-clean.md
+++ b/.changeset/clean-frogs-clean.md
@@ -1,0 +1,6 @@
+---
+"@react-router/dev": minor
+"react-router": minor
+---
+
+Support optional static segments and splats in href() util

--- a/contributors.yml
+++ b/contributors.yml
@@ -340,6 +340,7 @@
 - vikingviolinist
 - vishwast03
 - vitekzach
+- vjee
 - vladinator1000
 - vonagam
 - WalkAlone0325

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -81,8 +81,9 @@ const noExtension = (path: string) =>
 
 function formatParamProperties(fullpath: string) {
   const params = Params.parse(fullpath);
-  const properties = Object.entries(params).map(([name, isRequired]) =>
-    isRequired ? `"${name}": string` : `"${name}"?: string`
+  const properties = Object.entries(params).map(
+    ([name, { type, isRequired }]) =>
+      isRequired ? `"${name}": ${type}` : `"${name}"?: ${type}`
   );
   return properties.join("; ");
 }

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -131,10 +131,14 @@ function register(ctx: Context) {
             t.stringLiteral(fullpath),
             t.tsTypeAnnotation(
               t.tsTypeLiteral(
-                Object.entries(params).map(([param, isRequired]) => {
+                Object.entries(params).map(([param, { type, isRequired }]) => {
                   const property = t.tsPropertySignature(
                     t.stringLiteral(param),
-                    t.tsTypeAnnotation(t.tsStringKeyword())
+                    t.tsTypeAnnotation(
+                      type === "string"
+                        ? t.tsStringKeyword()
+                        : t.tsBooleanKeyword()
+                    )
                   );
                   property.optional = !isRequired;
                   return property;

--- a/packages/react-router-dev/typegen/params.ts
+++ b/packages/react-router-dev/typegen/params.ts
@@ -1,18 +1,29 @@
 export function parse(fullpath: string) {
-  const result: Record<string, boolean> = {};
+  const result: Record<
+    string,
+    { type: "string" | "boolean"; isRequired: boolean }
+  > = {};
 
   let segments = fullpath.split("/");
   segments.forEach((segment) => {
-    const match = segment.match(/^:([\w-]+)(\?)?/);
-    if (!match) return;
-    const param = match[1];
-    const isRequired = match[2] === undefined;
+    const match = segment.match(/^\*$|^(:)?([\w-]+)(\?)?$/);
+    if (!match) return segment;
 
-    result[param] ||= isRequired;
-    return;
+    const isSplat = match[0] === "*";
+    const param = isSplat ? "*" : match[2];
+    const isDynamic = isSplat ? true : match[1] === ":";
+    const isOptional = isSplat ? false : match[3] === "?";
+
+    if (isDynamic) {
+      result[param] ||= { type: "string", isRequired: !isOptional };
+      return;
+    }
+
+    if (!isDynamic && isOptional) {
+      result[param] ||= { type: "boolean", isRequired: false };
+      return;
+    }
   });
 
-  const hasSplat = segments.at(-1) === "*";
-  if (hasSplat) result["*"] = true;
   return result;
 }

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -17,7 +17,7 @@ describe("href", () => {
     );
   });
 
-  it("works with optional segments", () => {
+  it("works with optional static segments", () => {
     expect(href("/a/b?/:c", { c: "hello" })).toBe("/a/hello");
     expect(href("/a/b?/:c", { b: true, c: "hello" })).toBe("/a/b/hello");
   });

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -17,9 +17,22 @@ describe("href", () => {
     );
   });
 
+  it("works with optional segments", () => {
+    expect(href("/a/b?/:c", { c: "hello" })).toBe("/a/hello");
+    expect(href("/a/b?/:c", { b: true, c: "hello" })).toBe("/a/b/hello");
+  });
+
+  it("works with slpats", () => {
+    expect(href("/a/*", { "*": "hello" })).toBe("/a/hello");
+    expect(href("/a/*", { "*": "hello/world" })).toBe("/a/hello/world");
+  });
+
   it("throws when required params are missing", () => {
     expect(() => href("/a/:b")).toThrow(
       `Path '/a/:b' requires param 'b' but it was not provided`
+    );
+    expect(() => href("/a/*")).toThrow(
+      `Path '/a/*' requires param '*' but it was not provided`
     );
   });
 });

--- a/packages/react-router/lib/href.ts
+++ b/packages/react-router/lib/href.ts
@@ -1,7 +1,7 @@
 import type { Register } from "./types/register";
 import type { Equal } from "./types/utils";
 
-type AnyParams = Record<string, Record<string, string | undefined>>;
+type AnyParams = Record<string, Record<string, string | boolean | undefined>>;
 type Params = Register extends {
   params: infer RegisteredParams extends AnyParams;
 }
@@ -26,6 +26,9 @@ type ToArgs<T> =
   const h = href("/:lang?/about", { lang: "en" })
   // -> `/en/about`
 
+  const h = href("/users/:userId/edit?", { userId: "abc123", edit: true })
+  // -> `/users/abc123/edit`
+
   <Link to={href("/products/:id", { id: "abc123" })} />
   ```
  */
@@ -37,18 +40,30 @@ export function href<Path extends keyof Args>(
   return path
     .split("/")
     .map((segment) => {
-      const match = segment.match(/^:([\w-]+)(\?)?/);
+      const match = segment.match(/^\*$|^(:)?([\w-]+)(\?)?$/);
       if (!match) return segment;
-      const param = match[1];
-      const value = params ? params[param] : undefined;
 
-      const isRequired = match[2] === undefined;
-      if (isRequired && value === undefined) {
-        throw Error(
-          `Path '${path}' requires param '${param}' but it was not provided`
-        );
+      const isSplat = match[0] === "*";
+      const param = isSplat ? "*" : match[2];
+      const isDynamic = isSplat ? true : match[1] === ":";
+      const isOptional = isSplat ? false : match[3] === "?";
+
+      if (isDynamic) {
+        const value = params ? params[param] : undefined;
+        if (!isOptional && value === undefined) {
+          throw Error(
+            `Path '${path}' requires param '${param}' but it was not provided`
+          );
+        }
+        return value;
+      } else {
+        if (isOptional) {
+          const include = params ? params[param] === true : false;
+          return include ? param : undefined;
+        } else {
+          return param;
+        }
       }
-      return value;
     })
     .filter((segment) => segment !== undefined)
     .join("/");


### PR DESCRIPTION
Fixes #13055
Fixes #13166

This PR adds support for optional static segments and splats to the `href()` util.

## Optional static segments

For optional static segments, `true` can be passed as param value to enable the segment. Not providing the param, or passing a falsy value ignores the segment.
```ts
href("/users/:userId/edit?", { userId: "abc123" }) // "/users/abc123"
href("/users/:userId/edit?", { userId: "abc123", edit: true }) // "/users/abc123/edit"
```

## Splats

A splat value can be provided with a `"*"` param.
```ts
href("/a/*", { "*": "hello" }) // "/a/hello"
href("/a/*", { "*": "hello/world" }) // "/a/hello/world"
```
