### PR TITLE
Respect configured assetsDir for all assets

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- danieltroger
 - 0xEddie
 - aarbi
 - abdallah-nour

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3146,7 +3146,7 @@ export async function getEnvironmentOptionsResolvers(
                 let routeChunkSuffix = routeChunkName
                   ? `-${kebabCase(routeChunkName)}`
                   : "";
-                return `assets/[name]${routeChunkSuffix}-[hash].js`;
+                return path.join(viteUserConfig.build.assetsDir ?? "assets", `[name]${routeChunkSuffix}-[hash].js`);
               },
             },
           },


### PR DESCRIPTION
Since upgrading to the latest stable version of react-router we saw some output assets no longer being in `build/client/lite`, what we have configured in `vite.config.ts`, but instead in `build/client/assets`,  for example `MultiStoreBoundary` of the ones shown below.

Due to reasons all client assets must be in a folder called `lite` in our setup or they won't be accessible, so upgrading react-router brought down our app, in the condition that one entered it on a route that needed the files that were suddenly in `assets` (additional to only happening in prod due to complicated reverse proxy setup but not dev when testing).

This fixes the issue, by changing the hardcoded `assets` folder in the `react-router` vite plugin to instead respect the `build.assetDir` from the users' `vite.config.ts` file.

![bild](https://github.com/user-attachments/assets/caea3af0-3885-4081-84a6-ba7e213d1724)


```
build/client/lite/TabMenuHorizontal-Cj00gGiI.js                          1.93 kB │ gzip:   0.94 kB │ map:     5.79 kB
build/client/lite/LazySpline-CuWQDOoW.js                                 1.98 kB │ gzip:   1.02 kB │ map:     5.29 kB
build/client/lite/CompactButton-DG38KrCW.js                              2.05 kB │ gzip:   0.85 kB │ map:     5.14 kB
build/client/lite/Banner-CFLqHPHd.js                                     2.16 kB │ gzip:   1.07 kB │ map:     6.05 kB
build/client/lite/List-CkfHjRHN.js                                       2.20 kB │ gzip:   0.80 kB │ map:     4.78 kB
build/client/lite/Copy-CvE0E__T.js                                       2.29 kB │ gzip:   0.87 kB │ map:     4.86 kB
build/client/assets/MultiStoreCollectionMappingView-Koj_yuKa.js          2.38 kB │ gzip:   0.97 kB │ map:     0.12 kB
build/client/lite/useMultiStore-BOJOA2nD.js                              2.38 kB │ gzip:   0.97 kB │ map:     8.17 kB
build/client/lite/CaretUpDown-DRnmhLNr.js                                2.56 kB │ gzip:   1.02 kB │ map:     5.16 kB
build/client/assets/MultiStoreBoundary-LW1DRoMB.js                       2.58 kB │ gzip:   1.16 kB │ map:     4.46 kB
build/client/lite/CheckCircle-Ch1UKKx0.js                                2.59 kB │ gzip:   0.98 kB │ map:     5.20 kB
```