### PR TITLE
Remove Vite server hooks in child compiler plugins

### DIFF
--- a/.changeset/eleven-oranges-cheat.md
+++ b/.changeset/eleven-oranges-cheat.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+The `configureServer` and `configurePreviewServer` hooks are now removed in child compiler plugins to avoid conflicts with the main dev server.

--- a/.changeset/eleven-oranges-cheat.md
+++ b/.changeset/eleven-oranges-cheat.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-The `configureServer` and `configurePreviewServer` hooks are now removed in child compiler plugins to avoid conflicts with the main dev server.
+Fix conflicts with other Vite plugins that use the `configureServer` and/or `configurePreviewServer` hooks


### PR DESCRIPTION
This removes the `configureServer` and `configurePreviewServer` hooks in child compiler plugins to avoid conflicts with the main dev server. In @cloudflare/vite-plugin, for example, this prevents creating an additional Miniflare instance. Removing `configurePreviewServer` isn't strictly necessary but seems worth doing for consistency.