### PR TITLE
fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,7 +391,7 @@ function unstable_getContext() {
 
 #### Middleware (unstable)
 
-Middleware is implemented behind a `future.unstable_middleware` flag. To enable, you must enable the flag and the types in your `react-router-config.ts` file:
+Middleware is implemented behind a `future.unstable_middleware` flag. To enable, you must enable the flag and the types in your `react-router.config.ts` file:
 
 ```ts
 import type { Config } from "@react-router/dev/config";

--- a/contributors.yml
+++ b/contributors.yml
@@ -265,6 +265,7 @@
 - pwdcd
 - pyitphyoaung
 - refusado
+- renyu-io
 - reyronald
 - rifaidev
 - rimian

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -3487,7 +3487,7 @@ export function createStaticHandler(
       invariant(
         requestContext instanceof unstable_RouterContextProvider,
         "When using middleware in `staticHandler.query()`, any provided " +
-          "`requestContext` must bean instance of `unstable_RouterContextProvider`"
+          "`requestContext` must be an instance of `unstable_RouterContextProvider`"
       );
       try {
         let renderedStaticContext: StaticHandlerContext | undefined;


### PR DESCRIPTION
it should be `react-router.config.ts` instead of `react-router-config.ts`

I am migrating from remix v2, and this typo causes me hours.