### PR TITLE
Fix `RequestHandler` `loadContext` type when middleware is enabled

### DIFF
--- a/.changeset/few-months-begin.md
+++ b/.changeset/few-months-begin.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix `RequestHandler` `loadContext` parameter type when middleware is enabled

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -41,7 +41,7 @@ import type { MiddlewareEnabled } from "../types/future";
 export type RequestHandler = (
   request: Request,
   loadContext?: MiddlewareEnabled extends true
-    ? unstable_RouterContextProvider
+    ? unstable_InitialContext
     : AppLoadContext
 ) => Promise<Response>;
 


### PR DESCRIPTION
Closes #13158