### PR TITLE
feat: Support setting state through redirect header

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -296,6 +296,7 @@
 - silvenon
 - SimenB
 - SkayuX
+- skovhus
 - skratchdot
 - smithki
 - soartec-lab

--- a/packages/react-router/__tests__/router/redirects-test.ts
+++ b/packages/react-router/__tests__/router/redirects-test.ts
@@ -208,6 +208,29 @@ describe("redirects", () => {
       },
       errors: null,
     });
+    expect(t.history.location.state).toEqual({
+      _isRedirect: true,
+    });
+  });
+
+  it("supports setting location state through a header when redirecting", async () => {
+    let t = setup({ routes: REDIRECT_ROUTES });
+
+    const stateObj = { obj: { type: "bar" }, count: 42 };
+
+    let fetch = await t.fetch("/parent/child?index");
+    let nav = await fetch.loaders.index.redirectReturn(
+      "..",
+      undefined,
+      { State: JSON.stringify(stateObj) },
+      ["parent"]
+    );
+
+    await nav.loaders.parent.resolve("PARENT");
+    expect(t.router.state.location.state).toEqual({
+      ...stateObj,
+      _isRedirect: true,
+    });
   });
 
   it("supports . redirects", async () => {

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2681,7 +2681,10 @@ export function createRouter(init: RouterInit): Router {
       new URL(request.url),
       basename
     );
+    let serializedState = redirect.response.headers.get("State");
+    let redirectState = serializedState ? JSON.parse(serializedState) : {};
     let redirectLocation = createLocation(state.location, location, {
+      ...redirectState,
       _isRedirect: true,
     });
 


### PR DESCRIPTION
Enable setting a `State` header when redirecting using data loaders similar to how you can set state when using the `useNavigate` hook. 

https://github.com/remix-run/react-router/discussions/11274