### PR TITLE
docs: use an unified let/const code style

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -159,6 +159,7 @@
 - JeraldVin
 - JesusTheHun
 - jimniels
+- jirkavrba
 - jmargeta
 - jmjpro
 - johnpangalos

--- a/docs/api/components/Await.md
+++ b/docs/api/components/Await.md
@@ -123,8 +123,8 @@ Takes a promise returned from a [LoaderFunction](../Other/LoaderFunction) value 
 import { useLoaderData, Await } from "react-router";
 
 export async function loader() {
-  let reviews = getReviews(); // not awaited
-  let book = await getBook();
+  const reviews = getReviews(); // not awaited
+  const book = await getBook();
   return {
     book,
     reviews, // this is a promise

--- a/docs/api/data-routers/RouterProvider.md
+++ b/docs/api/data-routers/RouterProvider.md
@@ -19,7 +19,7 @@ import {
   createBrowserRouter,
 } from "react-router";
 import { createRoot } from "react-dom/client";
-let router = createBrowserRouter();
+const router = createBrowserRouter();
 createRoot(document.getElementById("root")).render(
   <RouterProvider router={router} />
 );

--- a/docs/api/hooks/unstable_usePrompt.md
+++ b/docs/api/hooks/unstable_usePrompt.md
@@ -16,7 +16,7 @@ The `unstable_` flag will not be removed because this technique has a lot of rou
 
 ```tsx
 function ImportantForm() {
-  let [value, setValue] = React.useState("");
+  const [value, setValue] = React.useState("");
 
   // Block navigating elsewhere when data has been entered into the input
   unstable_usePrompt({

--- a/docs/api/hooks/useFetcher.md
+++ b/docs/api/hooks/useFetcher.md
@@ -18,7 +18,7 @@ Fetchers track their own, independent state and can be used to load data, submit
 import { useFetcher } from "react-router"
 
 function SomeComponent() {
-  let fetcher = useFetcher()
+  const fetcher = useFetcher()
 
   // states are available on the fetcher
   fetcher.state // "idle" | "loading" | "submitting"

--- a/docs/api/hooks/useFormAction.md
+++ b/docs/api/hooks/useFormAction.md
@@ -19,10 +19,10 @@ import { useFormAction } from "react-router";
 
 function SomeComponent() {
   // closest route URL
-  let action = useFormAction();
+  const action = useFormAction();
 
   // closest route URL + "destroy"
-  let destroyAction = useFormAction("destroy");
+  const destroyAction = useFormAction("destroy");
 }
 ```
 

--- a/docs/api/hooks/useHref.md
+++ b/docs/api/hooks/useHref.md
@@ -16,7 +16,7 @@ Resolves a URL against the current location.
 import { useHref } from "react-router";
 
 function SomeComponent() {
-  let href = useHref("some/where");
+  const href = useHref("some/where");
   // "/resolved/some/where"
 }
 ```

--- a/docs/api/hooks/useLoaderData.md
+++ b/docs/api/hooks/useLoaderData.md
@@ -20,7 +20,7 @@ export async function loader() {
 }
 
 export default function Invoices() {
-  let invoices = useLoaderData<typeof loader>();
+  const invoices = useLoaderData<typeof loader>();
   // ...
 }
 ```

--- a/docs/api/hooks/useLocation.md
+++ b/docs/api/hooks/useLocation.md
@@ -17,7 +17,7 @@ import * as React from 'react'
 import { useLocation } from 'react-router'
 
 function SomeComponent() {
-  let location = useLocation()
+  const location = useLocation()
 
   React.useEffect(() => {
     // Google Analytics

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -16,7 +16,7 @@ Returns a function that lets you navigate programmatically in the browser in res
 import { useNavigate } from "react-router";
 
 function SomeComponent() {
-  let navigate = useNavigate();
+  const navigate = useNavigate();
   return (
     <button
       onClick={() => {

--- a/docs/api/hooks/useNavigation.md
+++ b/docs/api/hooks/useNavigation.md
@@ -16,7 +16,7 @@ Returns the current navigation, defaulting to an "idle" navigation when no navig
 import { useNavigation } from "react-router";
 
 function SomeComponent() {
-  let navigation = useNavigation();
+  const navigation = useNavigation();
   navigation.state;
   navigation.formData;
   // etc.

--- a/docs/api/hooks/useParams.md
+++ b/docs/api/hooks/useParams.md
@@ -16,7 +16,7 @@ Returns an object of key/value pairs of the dynamic params from the current URL 
 import { useParams } from "react-router"
 
 function SomeComponent() {
-  let params = useParams()
+  const params = useParams()
   params.postId
 }
 ```

--- a/docs/api/hooks/useResolvedPath.md
+++ b/docs/api/hooks/useResolvedPath.md
@@ -17,7 +17,7 @@ import { useResolvedPath } from "react-router";
 
 function SomeComponent() {
   // if the user is at /dashboard/profile
-  let path = useResolvedPath("../accounts");
+  const path = useResolvedPath("../accounts");
   path.pathname; // "/dashboard/accounts"
   path.search; // ""
   path.hash; // ""

--- a/docs/api/hooks/useRoutes.md
+++ b/docs/api/hooks/useRoutes.md
@@ -19,7 +19,7 @@ import * as React from "react";
 import { useRoutes } from "react-router";
 
 function App() {
-  let element = useRoutes([
+  const element = useRoutes([
     {
       path: "/",
       element: <Dashboard />,

--- a/docs/api/utils/createSearchParams.md
+++ b/docs/api/utils/createSearchParams.md
@@ -20,7 +20,7 @@ values for a given key, but don't want to use an array initializer.
 For example, instead of:
 
 ```tsx
-let searchParams = new URLSearchParams([
+const searchParams = new URLSearchParams([
   ["sort", "name"],
   ["sort", "price"],
 ]);
@@ -29,7 +29,7 @@ let searchParams = new URLSearchParams([
 you can do:
 
 ```
-let searchParams = createSearchParams({
+const searchParams = createSearchParams({
   sort: ['name', 'price']
 });
 ```

--- a/docs/start/data/custom.md
+++ b/docs/start/data/custom.md
@@ -17,7 +17,7 @@ It takes an array of route objects that support loaders, actions, error boundari
 ```tsx
 import { createBrowserRouter } from "react-router";
 
-let router = createBrowserRouter([
+const router = createBrowserRouter([
   {
     path: "/",
     Component: Root,
@@ -107,7 +107,7 @@ Turn your routes into a request handler with `createStaticHandler`:
 import { createStaticHandler } from "react-router";
 import routes from "./some-routes";
 
-let { query, dataRoutes } = createStaticHandler(routes);
+const { query, dataRoutes } = createStaticHandler(routes);
 ```
 
 ### 3. Get Routing Context and Render
@@ -126,11 +126,11 @@ import {
 
 import routes from "./some-routes.js";
 
-let { query, dataRoutes } = createStaticHandler(routes);
+const { query, dataRoutes } = createStaticHandler(routes);
 
 export async function handler(request: Request) {
   // 1. run actions/loaders to get the routing context with `query`
-  let context = await query(request);
+  const context = await query(request);
 
   // If `query` returns a Response, send it raw (a route probably a redirected)
   if (context instanceof Response) {
@@ -138,10 +138,10 @@ export async function handler(request: Request) {
   }
 
   // 2. Create a static router for SSR
-  let router = createStaticRouter(dataRoutes, context);
+  const router = createStaticRouter(dataRoutes, context);
 
   // 3. Render everything with StaticRouterProvider
-  let html = renderToString(
+  const html = renderToString(
     <StaticRouterProvider
       router={router}
       context={context}
@@ -149,12 +149,12 @@ export async function handler(request: Request) {
   );
 
   // Setup headers from action and loaders from deepest match
-  let leaf = context.matches[context.matches.length - 1];
-  let actionHeaders = context.actionHeaders[leaf.route.id];
-  let loaderHeaders = context.loaderHeaders[leaf.route.id];
-  let headers = new Headers(actionHeaders);
+  const leaf = context.matches[context.matches.length - 1];
+  const actionHeaders = context.actionHeaders[leaf.route.id];
+  const loaderHeaders = context.loaderHeaders[leaf.route.id];
+  const headers = new Headers(actionHeaders);
   if (loaderHeaders) {
-    for (let [key, value] of loaderHeaders.entries()) {
+    for (const [key, value] of loaderHeaders.entries()) {
       headers.append(key, value);
     }
   }
@@ -180,7 +180,7 @@ import { RouterProvider } from "react-router/dom";
 import routes from "./app/routes.js";
 import { createBrowserRouter } from "react-router";
 
-let router = createBrowserRouter(routes, {
+const router = createBrowserRouter(routes, {
   hydrationData: window.__staticRouterHydrationData,
 });
 

--- a/docs/start/declarative/routing.md
+++ b/docs/start/declarative/routing.md
@@ -145,7 +145,7 @@ If a path segment starts with `:` then it becomes a "dynamic segment". When the 
 import { useParams } from "react-router";
 
 export default function Team() {
-  let params = useParams();
+  const params = useParams();
   // params.teamId
 }
 ```
@@ -163,7 +163,7 @@ You can have multiple dynamic segments in one route path:
 import { useParams } from "react-router";
 
 export default function CategoryProduct() {
-  let { categoryId, productId } = useParams();
+  const { categoryId, productId } = useParams();
   // ...
 }
 ```
@@ -193,15 +193,15 @@ Also known as "catchall" and "star" segments. If a route path pattern ends with 
 ```
 
 ```tsx
-let params = useParams();
+const params = useParams();
 // params["*"] will contain the remaining URL after files/
-let filePath = params["*"];
+const filePath = params["*"];
 ```
 
 You can destructure the `*`, you just have to assign it a new name. A common name is `splat`:
 
 ```tsx
-let { "*": splat } = useParams();
+const { "*": splat } = useParams();
 ```
 
 ## Linking

--- a/docs/start/modes.md
+++ b/docs/start/modes.md
@@ -39,7 +39,7 @@ import {
   RouterProvider,
 } from "react-router";
 
-let router = createBrowserRouter([
+const router = createBrowserRouter([
   {
     path: "/",
     Component: Root,

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -85,7 +85,7 @@ Instead of importing your route modules directly, lazy load and convert them to 
 Not only does your route definition now conform to the Route Module API, but you also get the benefits of code-splitting your routes.
 
 ```diff filename=src/main.tsx
-let router = createBrowserRouter([
+const router = createBrowserRouter([
   // ... other routes
   {
     path: "about",


### PR DESCRIPTION
This PR unifies the code style regarding `let`/`const` usage in the docs.

In most cases the `let` keyword can be replaced by `const` which is the preferred style of most React codebases.

I've reviewed all `let` usages and only kept those that are necessary.