### PR TITLE
Do not throw if the url hash is not a valid URI component

### DIFF
--- a/.changeset/proud-scissors-tickle.md
+++ b/.changeset/proud-scissors-tickle.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Do not throw if the url hash is not a valid URI component

--- a/contributors.yml
+++ b/contributors.yml
@@ -415,8 +415,4 @@
 - zeevick10
 - zeromask1337
 - zheng-chuang
-<<<<<<< HEAD
 - zxTomw
-=======
-
->>>>>>> 83cf8b8b8 (add to contributors.yml)

--- a/contributors.yml
+++ b/contributors.yml
@@ -386,6 +386,7 @@
 - ValiantCat
 - vdusart
 - vesan
+- vezaynk
 - VictorElHajj
 - vijaypushkin
 - vikingviolinist
@@ -414,4 +415,8 @@
 - zeevick10
 - zeromask1337
 - zheng-chuang
+<<<<<<< HEAD
 - zxTomw
+=======
+
+>>>>>>> 83cf8b8b8 (add to contributors.yml)

--- a/contributors.yml
+++ b/contributors.yml
@@ -415,4 +415,8 @@
 - zeevick10
 - zeromask1337
 - zheng-chuang
+<<<<<<< HEAD
 - zxTomw
+=======
+
+>>>>>>> 83cf8b8b8 (add to contributors.yml)

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2090,14 +2090,21 @@ export function useScrollRestoration({
       }
 
       // try to scroll to the hash
-      if (location.hash) {
-        let el = document.getElementById(
-          decodeURIComponent(location.hash.slice(1))
-        );
-        if (el) {
-          el.scrollIntoView();
-          return;
+      try {
+        if (location.hash) {
+          let el = document.getElementById(
+            decodeURIComponent(location.hash.slice(1))
+          );
+          if (el) {
+            el.scrollIntoView();
+            return;
+          }
         }
+      } catch {
+        warning(
+            false,
+            `"${location.hash.slice(1)}" is not a decodable element ID. The view will not scroll to it.`
+          );
       }
 
       // Don't reset if this navigation opted out


### PR DESCRIPTION
Some tooling might pass arbitrary strings in the `window.location.hash`. React Router should not crash if the value is not decodable.

In our case, for example, a user interacted with a URL that Datadog injected some tracking info into and the call turned to:

```ts
decodeURIComponent("targetindividualusers---input-raw%20:9999%20--output-http%20OVERRIDE_TARGET|OVERRIDE_PERCENT%%20--http-rewrite-url%20v5/onboarding:v6/interstitials%20--http-set-header%20X-Datadog-Parent-Id:%20--http-set-header%20X-Datadog-Trace-Id:%20--http-set-header%20X-Datadog-Sampling-Priority:1%20--http-allow-url%20/content/v5/onboarding")
```

...which crashed the view with the following error:

```
Uncaught URIError: malformed URI sequence
```

To avoid this in the future, I would like to suggest that a failure to decode the portion of the URL be preventing from throwing, by wrapping in a `try-catch`.