### PR TITLE
Fix path in prerender error message

### DIFF
--- a/.changeset/clever-waves-drum.md
+++ b/.changeset/clever-waves-drum.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix path in prerender error messages

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2710,7 +2710,7 @@ async function prerenderData(
   if (response.status !== 200) {
     throw new Error(
       `Prerender (data): Received a ${response.status} status code from ` +
-        `\`entry.server.tsx\` while prerendering the \`${path}\` ` +
+        `\`entry.server.tsx\` while prerendering the \`${prerenderPath}\` ` +
         `path.\n${normalizedPath}`
     );
   }


### PR DESCRIPTION
This error message includes `[Object object]` as the path because `path` is actually Node's path module. It should be using `prerenderPath` instead.