### PR TITLE
Dedupe calls to `route.lazy` functions

### DIFF
--- a/.changeset/green-windows-itch.md
+++ b/.changeset/green-windows-itch.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Dedupe calls to `route.lazy` functions

--- a/packages/react-router/__tests__/router/lazy-test.ts
+++ b/packages/react-router/__tests__/router/lazy-test.ts
@@ -2,7 +2,12 @@ import { createMemoryHistory } from "../../lib/router/history";
 import { createRouter, createStaticHandler } from "../../lib/router/router";
 
 import type { TestRouteObject } from "./utils/data-router-setup";
-import { cleanup, createDeferred, setup } from "./utils/data-router-setup";
+import {
+  cleanup,
+  createDeferred,
+  createLazyStub,
+  setup,
+} from "./utils/data-router-setup";
 import {
   createFormData,
   createRequest,
@@ -23,19 +28,6 @@ describe("lazily loaded route modules", () => {
     // @ts-ignore
     console.warn.mockReset();
   });
-
-  const createLazyStub = (): {
-    lazyStub: jest.Mock;
-    lazyDeferred: ReturnType<typeof createDeferred>;
-  } => {
-    let lazyDeferred = createDeferred();
-    let lazyStub = jest.fn(() => lazyDeferred.promise);
-
-    return {
-      lazyStub,
-      lazyDeferred,
-    };
-  };
 
   const createBasicLazyRoutes = (): {
     routes: TestRouteObject[];

--- a/packages/react-router/__tests__/router/utils/data-router-setup.ts
+++ b/packages/react-router/__tests__/router/utils/data-router-setup.ts
@@ -168,6 +168,19 @@ export function createDeferred<T = any>() {
   };
 }
 
+export function createLazyStub(): {
+  lazyStub: jest.Mock;
+  lazyDeferred: ReturnType<typeof createDeferred>;
+} {
+  let lazyDeferred = createDeferred();
+  let lazyStub = jest.fn(() => lazyDeferred.promise);
+
+  return {
+    lazyStub,
+    lazyDeferred,
+  };
+}
+
 export function getFetcherData(router: Router) {
   let fetcherData = new Map<string, unknown>();
   router.subscribe((state, { deletedFetchers }) => {

--- a/packages/react-router/__tests__/router/utils/data-router-setup.ts
+++ b/packages/react-router/__tests__/router/utils/data-router-setup.ts
@@ -34,9 +34,8 @@ import { isRedirect, tick } from "./utils";
 // by our test harness
 export type TestIndexRouteObject = Pick<
   AgnosticIndexRouteObject,
-  "id" | "index" | "path" | "shouldRevalidate" | "handle"
+  "id" | "index" | "path" | "shouldRevalidate" | "handle" | "lazy"
 > & {
-  lazy?: boolean;
   loader?: boolean;
   action?: boolean;
   hasErrorBoundary?: boolean;
@@ -44,9 +43,8 @@ export type TestIndexRouteObject = Pick<
 
 export type TestNonIndexRouteObject = Pick<
   AgnosticNonIndexRouteObject,
-  "id" | "index" | "path" | "shouldRevalidate" | "handle"
+  "id" | "index" | "path" | "shouldRevalidate" | "handle" | "lazy"
 > & {
-  lazy?: boolean;
   loader?: boolean;
   action?: boolean;
   hasErrorBoundary?: boolean;
@@ -86,7 +84,6 @@ export type Helpers = InternalHelpers & {
 // control and assertions over the loaders/actions
 export type NavigationHelpers = {
   navigationId: number;
-  lazy: Record<string, Helpers>;
   loaders: Record<string, Helpers>;
   actions: Record<string, Helpers>;
 };
@@ -148,11 +145,11 @@ type SetupOpts = {
 
 // We use a slightly modified version of createDeferred here that includes the
 // tick() calls to let the router finish updating
-export function createDeferred() {
-  let resolve: (val?: any) => Promise<void>;
+export function createDeferred<T = any>() {
+  let resolve: (val: T) => Promise<void>;
   let reject: (error?: Error) => Promise<void>;
-  let promise = new Promise((res, rej) => {
-    resolve = async (val: any) => {
+  let promise = new Promise<T>((res, rej) => {
+    resolve = async (val: T) => {
       res(val);
       await tick();
       await promise;
@@ -225,37 +222,11 @@ export function setup({
       let enhancedRoute: AgnosticDataRouteObject = {
         unstable_middleware: undefined,
         ...r,
-        lazy: undefined,
         loader: undefined,
         action: undefined,
         children: undefined,
         id: r.id || `route-${guid++}`,
       };
-      if (r.lazy) {
-        // @ts-expect-error
-        enhancedRoute.lazy = (args) => {
-          // This is maybe not ideal, but works for now :).  We don't really know
-          // which key to look for so we resolve the earliest one we find and
-          // remove it such that subsequent calls resolve the later ones.
-          const sortedIds = [
-            activeLoaderNavigationId,
-            activeActionNavigationId,
-            activeLoaderFetchId,
-            activeActionFetchId,
-          ].sort();
-          let helperKey = sortedIds
-            .map((id) => `${id}:lazy:${enhancedRoute.id}`)
-            .find((k) => activeHelpers.has(k));
-          invariant(helperKey != null, `No helperKey found`);
-          let helpers = activeHelpers.get(helperKey);
-          invariant(helpers, `No helpers found for: ${helperKey}`);
-          helpers.stub(args);
-          return helpers.dfd.promise.then((def) => {
-            activeHelpers.delete(helperKey!);
-            return def;
-          });
-        };
-      }
       if (r.loader) {
         enhancedRoute.loader = (...args) => {
           let navigationId =
@@ -457,13 +428,6 @@ export function setup({
     );
     let matches = matchRoutes(inFlightRoutes || currentRouter.routes, href);
 
-    // Generate helpers for all route matches that contain loaders
-    let lazyHelpers = getHelpers(
-      (matches || []).filter((m) => m.route.lazy),
-      navigationId,
-      (routeId, helpers) =>
-        activeHelpers.set(`${navigationId}:lazy:${routeId}`, helpers)
-    );
     let loaderHelpers = getHelpers(
       (matches || []).filter((m) => m.route.loader),
       navigationId,
@@ -485,7 +449,6 @@ export function setup({
 
     return {
       navigationId,
-      lazy: lazyHelpers,
       loaders: loaderHelpers,
       actions: actionHelpers,
     };
@@ -517,7 +480,6 @@ export function setup({
           invariant(currentRouter, "No currentRouter available");
           return currentRouter.getFetcher(key);
         },
-        lazy: {},
         loaders: {},
         actions: {},
       };
@@ -545,13 +507,6 @@ export function setup({
       }
     }
 
-    // Generate helpers for all route matches that contain loaders
-    let lazyHelpers = getHelpers(
-      match.route.lazy ? [match] : [],
-      navigationId,
-      (routeId, helpers) =>
-        activeHelpers.set(`${navigationId}:lazy:${routeId}`, helpers)
-    );
     let loaderHelpers = getHelpers(
       activeLoaderMatches.filter((m) => m.route.loader),
       navigationId,
@@ -575,7 +530,6 @@ export function setup({
           data: fetcherData.get(key),
         };
       },
-      lazy: lazyHelpers,
       loaders: loaderHelpers,
       actions: actionHelpers,
     };

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -4868,10 +4868,15 @@ async function loadLazyRouteModule(
     return;
   }
 
+  // We use `.then` to chain additional logic to the lazy route promise so that
+  // the consumer's lazy route logic is coupled to our logic for updating the
+  // route in place in a single task. This ensures that the cached promise
+  // contains all logic for managing the lazy route. This chained promise is
+  // then awaited so that consumers of this function see the updated route.
   let lazyRoutePromise = route.lazy().then((lazyRoute) => {
-    // Update the route in place.  This should be safe because there's no way
-    // we could yet be sitting on this route as we can't get there without
-    // resolving lazy() first.
+    // Here we update the route in place.  This should be safe because there's
+    // no way we could yet be sitting on this route as we can't get there
+    // without resolving lazy() first.
     //
     // This is different than the HMR "update" use-case where we may actively be
     // on the route being updated.  The main concern boils down to "does this

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -20,7 +20,6 @@ import type {
   FormMethod,
   HTMLFormMethod,
   DataStrategyResult,
-  LazyRouteFunctionCache,
   UnsupportedLazyRouteFunctionKey,
   MapRoutePropertiesFunction,
   MaybePromise,
@@ -4840,7 +4839,10 @@ function isSameRoute(
   );
 }
 
-const lazyRouteFunctionCache: LazyRouteFunctionCache = new WeakMap();
+const lazyRouteFunctionCache = new WeakMap<
+  AgnosticDataRouteObject,
+  Promise<void>
+>();
 
 /**
  * Execute route.lazy() methods to lazily load route modules (loader, action,

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -429,10 +429,6 @@ export interface LazyRouteFunction<R extends AgnosticRouteObject> {
   (): Promise<RequireOne<Omit<R, UnsupportedLazyRouteFunctionKey>>>;
 }
 
-export type LazyRouteFunctionCache<
-  R extends AgnosticRouteObject = AgnosticRouteObject
-> = WeakMap<R, Promise<void>>;
-
 interface LazyMiddlewareFunction {
   (): Promise<unstable_MiddlewareFunction[]>;
 }

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -392,7 +392,7 @@ export interface MapRoutePropertiesFunction {
  * onto the route. Either they're meaningful to the router, or they'll get
  * ignored.
  */
-export type ImmutableRouteKey =
+export type UnsupportedLazyRouteFunctionKey =
   | "lazy"
   | "caseSensitive"
   | "path"
@@ -402,16 +402,17 @@ export type ImmutableRouteKey =
   | "unstable_lazyMiddleware"
   | "children";
 
-export const immutableRouteKeys = new Set<ImmutableRouteKey>([
-  "lazy",
-  "caseSensitive",
-  "path",
-  "id",
-  "index",
-  "unstable_middleware",
-  "unstable_lazyMiddleware",
-  "children",
-]);
+export const unsupportedLazyRouteFunctionKeys =
+  new Set<UnsupportedLazyRouteFunctionKey>([
+    "lazy",
+    "caseSensitive",
+    "path",
+    "id",
+    "index",
+    "unstable_middleware",
+    "unstable_lazyMiddleware",
+    "children",
+  ]);
 
 type RequireOne<T, Key = keyof T> = Exclude<
   {
@@ -425,8 +426,12 @@ type RequireOne<T, Key = keyof T> = Exclude<
  * related properties to a route
  */
 export interface LazyRouteFunction<R extends AgnosticRouteObject> {
-  (): Promise<RequireOne<Omit<R, ImmutableRouteKey>>>;
+  (): Promise<RequireOne<Omit<R, UnsupportedLazyRouteFunctionKey>>>;
 }
+
+export type LazyRouteFunctionCache<
+  R extends AgnosticRouteObject = AgnosticRouteObject
+> = WeakMap<R, Promise<void>>;
 
 interface LazyMiddlewareFunction {
   (): Promise<unstable_MiddlewareFunction[]>;


### PR DESCRIPTION
This PR is in preparation for more granular `route.lazy` support. This updates the existing logic to ensure calls to `route.lazy` are deduped, which is how the more granular object-based API is intended to work. This also means that the tests are now updated to be more flexible in terms of the types for `route.lazy`, rather than testing using the `lazy: true` flag on the `TestRouteObject` type. This will make introducing object-based `route.lazy` tests much easier.