### PR TITLE
Fix links in the document

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -345,6 +345,7 @@
 - turansky
 - tyankatsu0105
 - underager
+- uskey512
 - valerii15298
 - ValiantCat
 - vdusart

--- a/docs/api/components/Await.md
+++ b/docs/api/components/Await.md
@@ -117,7 +117,7 @@ via [useRouteError](../hooks/useRouteError) hook.
 
 [modes: framework, data]
 
-Takes a promise returned from a [LoaderFunction](../Other/LoaderFunction) value to be resolved and rendered.
+Takes a promise returned from a [LoaderFunction](../other/LoaderFunction) value to be resolved and rendered.
 
 ```jsx
 import { useLoaderData, Await } from "react-router";

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -149,7 +149,7 @@ This state is inaccessible on the server as it is implemented on top of [`histor
 
 [modes: framework, data, declarative]
 
-Can be a string or a partial [Path](../Other/Path):
+Can be a string or a partial [Path](../other/Path):
 
 ```tsx
 <Link to="/some/path" />

--- a/docs/api/components/NavLink.md
+++ b/docs/api/components/NavLink.md
@@ -20,7 +20,7 @@ import { NavLink } from "react-router";
 <NavLink to="/message" />;
 ```
 
-States are available through the className, style, and children render props. See [NavLinkRenderProps](../Other/NavLinkRenderProps).
+States are available through the className, style, and children render props. See [NavLinkRenderProps](../other/NavLinkRenderProps).
 
 ```tsx
 <NavLink
@@ -233,7 +233,7 @@ Note that `pending` is only available with Framework and Data modes.
 
 [modes: framework, data, declarative]
 
-Can be a string or a partial [Path](../Other/Path):
+Can be a string or a partial [Path](../other/Path):
 
 ```tsx
 <Link to="/some/path" />

--- a/docs/api/hooks/useLoaderData.md
+++ b/docs/api/hooks/useLoaderData.md
@@ -10,7 +10,7 @@ title: useLoaderData
 
 [Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.useLoaderData.html)
 
-Returns the data from the closest route [LoaderFunction](../Other/LoaderFunction) or [ClientLoaderFunction](../Other/ClientLoaderFunction).
+Returns the data from the closest route [LoaderFunction](../other/LoaderFunction) or [ClientLoaderFunction](../other/ClientLoaderFunction).
 
 ```tsx
 import { useLoaderData } from "react-router";

--- a/docs/api/hooks/useLocation.md
+++ b/docs/api/hooks/useLocation.md
@@ -10,7 +10,7 @@ title: useLocation
 
 [Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.useLocation.html)
 
-Returns the current [Location]([../Other/Location](https://api.reactrouter.com/v7/interfaces/react_router.Location.html)). This can be useful if you'd like to perform some side effect whenever it changes.
+Returns the current [Location]([../other/Location](https://api.reactrouter.com/v7/interfaces/react_router.Location.html)). This can be useful if you'd like to perform some side effect whenever it changes.
 
 ```tsx
 import * as React from 'react'

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -27,7 +27,7 @@ function SomeComponent() {
 }
 ```
 
-It's often better to use [redirect](../Utils/redirect) in [ActionFunction](../Other/ActionFunction) and [LoaderFunction](../Other/LoaderFunction) than this hook.
+It's often better to use [redirect](../utils/redirect) in [ActionFunction](../other/ActionFunction) and [LoaderFunction](../other/LoaderFunction) than this hook.
 
 ## Signature
 

--- a/docs/api/hooks/useResolvedPath.md
+++ b/docs/api/hooks/useResolvedPath.md
@@ -10,7 +10,7 @@ title: useResolvedPath
 
 [Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.useResolvedPath.html)
 
-Resolves the pathname of the given `to` value against the current location. Similar to [useHref](../hooks/useHref), but returns a [Path](../Other/Path) instead of a string.
+Resolves the pathname of the given `to` value against the current location. Similar to [useHref](../hooks/useHref), but returns a [Path](../other/Path) instead of a string.
 
 ```tsx
 import { useResolvedPath } from "react-router";

--- a/docs/api/hooks/useRouteError.md
+++ b/docs/api/hooks/useRouteError.md
@@ -10,7 +10,7 @@ title: useRouteError
 
 [Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.useRouteError.html)
 
-Accesses the error thrown during an [ActionFunction](../Other/ActionFunction), [LoaderFunction](../Other/LoaderFunction), or component render to be used in a route module Error Boundary.
+Accesses the error thrown during an [ActionFunction](../other/ActionFunction), [LoaderFunction](../other/LoaderFunction), or component render to be used in a route module Error Boundary.
 
 ```tsx
 export function ErrorBoundary() {


### PR DESCRIPTION
Relative path links containing capitalized paths such as `Other` or `Util` in the URL are not working properly.

For example, the problem exists in the following pages
- https://reactrouter.com/api/hooks/useRouteError
- https://reactrouter.com/api/hooks/useNavigate