### PR TITLE
Remove `react-router:override-optimize-deps` plugin

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1445,26 +1445,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 configureServer: undefined,
                 configurePreviewServer: undefined,
               })),
-            {
-              name: "react-router:override-optimize-deps",
-              config(userConfig) {
-                // Prevent unnecessary dependency optimization in the child compiler
-                if (
-                  ctx.reactRouterConfig.future.unstable_viteEnvironmentApi &&
-                  userConfig.environments
-                ) {
-                  for (const environmentName of Object.keys(
-                    userConfig.environments
-                  )) {
-                    userConfig.environments[environmentName].optimizeDeps = {
-                      noDiscovery: true,
-                    };
-                  }
-                } else {
-                  userConfig.optimizeDeps = { noDiscovery: true };
-                }
-              },
-            },
           ],
         });
         await viteChildCompiler.pluginContainer.buildStart({});


### PR DESCRIPTION
I previously added this plugin so that the child compiler wouldn't duplicate all the dependency optimization work that is done in the main Vite server. This has resulted in issues, however, as reported in https://github.com/cloudflare/workers-sdk/issues/8678. The best option, for now, is to remove it. It would be good to look at possible alternatives in future.