### PR TITLE
Updated the upgrade from remix guide to use the correct vite plugin

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -370,3 +370,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- Cmoen11

--- a/docs/upgrading/remix.md
+++ b/docs/upgrading/remix.md
@@ -198,7 +198,7 @@ export default defineConfig({
 -     ssr: true,
 -     future: {/* all the v3 flags */}
 -   }),
-+   remix(),
++   reactRouter(),
     tsconfigPaths(),
   ],
 });


### PR DESCRIPTION
In the upgrade guide it specified to use remix plugin, however this is incorrect, the correct plugin to use is reactRouter().
