### PR TITLE
feat(dev): expose `setReactRouterDevLoadContext`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -16,6 +16,7 @@
 - akamfoad
 - alany411
 - alberto
+- albertusdev
 - Aleuck
 - alexandernanberg
 - alexanderson1993

--- a/packages/react-router-dev/vite.ts
+++ b/packages/react-router-dev/vite.ts
@@ -1,1 +1,4 @@
-export { reactRouterVitePlugin as reactRouter } from "./vite/plugin";
+export {
+  reactRouterVitePlugin as reactRouter,
+  setReactRouterDevLoadContext,
+} from "./vite/plugin";


### PR DESCRIPTION
## Purpose

This PR exposes the `setReactRouterDevLoadContext` function from the vite plugin, allowing developers to easily set a custom load context for the dev server without requiring a custom server entrypoint.

## Problem

Currently, to provide a custom "load context" for server-side loaders and actions during development, developers must either:

1. Set up a custom server entrypoint with more complex configuration, as shown in [Vercel's documentation](https://vercel.com/docs/frameworks/react-router#using-a-custom-server-entrypoint):

```ts
// vite.config.ts
export default defineConfig(({ isSsrBuild }) => ({
  build: {
    rollupOptions: isSsrBuild
      ? {
          input: './server/app.ts',
        }
      : undefined,
  },
  plugins: [reactRouter(), /* other plugins */],
}));

// server/app.ts
export default app.fetch;
```

2. Or even goes to the length of implementing a custom server & dev server as seen in https://github.com/remix-run/react-router-templates/tree/main/node-custom-server

Both approaches require additional configuration and setup just to supply environment variables or other data to loaders and actions during development.

## Solution

By exposing the existing `setReactRouterDevLoadContext` function, developers can achieve the same result with a much simpler approach:

```js
// vite.config.ts
import { reactRouter, setReactRouterDevLoadContext } from '@react-router/dev/vite';

// Set a custom load context for the dev server
setReactRouterDevLoadContext((request) => {
  return {
    env: {
      API_KEY: process.env.API_KEY,
      // Other environment variables
    },
    // Other context data
  };
});

export default {
  plugins: [
    reactRouter(),
    // Other plugins
  ],
};
```

