### PR TITLE
Fix virtual module type to properly handle optional properties

### DIFF
--- a/.changeset/tiny-gifts-wash.md
+++ b/.changeset/tiny-gifts-wash.md
@@ -1,0 +1,7 @@
+---
+"@react-router/dev": patch
+---
+
+Fix virtual module type to properly handle optional properties.
+
+The virtual module `virtual:react-router/server-build` now deliberately implements CommonJS `export =` syntax to correctly support optional properties in the `ServerBuild` type, ensuring proper TypeScript compatibility with `exactOptionalPropertyTypes`.

--- a/.changeset/tiny-gifts-wash.md
+++ b/.changeset/tiny-gifts-wash.md
@@ -2,6 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Fix virtual module type to properly handle optional properties.
-
-The virtual module `virtual:react-router/server-build` now deliberately implements CommonJS `export =` syntax to correctly support optional properties in the `ServerBuild` type, ensuring proper TypeScript compatibility with `exactOptionalPropertyTypes`.
+Update generated types for `virtual:react-router/server-build` to ensure compatibility with TypeScript's `exactOptionalPropertyTypes` option

--- a/.changeset/tiny-gifts-wash.md
+++ b/.changeset/tiny-gifts-wash.md
@@ -1,5 +1,5 @@
 ---
-"@react-router/dev": patch
+"react-router": patch
 ---
 
-Update generated types for `virtual:react-router/server-build` to ensure compatibility with TypeScript's `exactOptionalPropertyTypes` option
+Update `ServerBuild` type to ensure compatibility with TypeScript's `exactOptionalPropertyTypes` option

--- a/contributors.yml
+++ b/contributors.yml
@@ -303,6 +303,7 @@
 - SkayuX
 - skratchdot
 - smithki
+- smorimoto
 - soartec-lab
 - sorokya
 - sorrycc

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -490,6 +490,31 @@ test.describe("typegen", () => {
       expect(proc.status).toBe(0);
     });
 
+
+    test("works with tsconfig 'exactOptionalPropertyTypes' set to 'true'", async () => {
+      const cwd = await createProject({
+        "vite.config.ts": viteConfig,
+        "app/routes.ts": tsx`
+          import { type RouteConfig } from "@react-router/dev/routes";
+          export default [] satisfies RouteConfig;
+        `,
+        "app/handler.ts": tsx`
+          import { createRequestHandler } from "react-router";
+          import * as serverBuild from "virtual:react-router/server-build";
+          export default createRequestHandler(serverBuild);
+        `,
+      });
+
+      const tsconfig = await fse.readJson(path.join(cwd, "tsconfig.json"));
+      tsconfig.compilerOptions.exactOptionalPropertyTypes = true;
+      await fse.writeJson(path.join(cwd, "tsconfig.json"), tsconfig);
+
+      const proc = typecheck(cwd);
+      expect(proc.stdout.toString()).toBe("");
+      expect(proc.stderr.toString()).toBe("");
+      expect(proc.status).toBe(0);
+    });
+
     test("dynamic import matches 'createRequestHandler' function argument type", async () => {
       const cwd = await createProject({
         "vite.config.ts": viteConfig,

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -490,7 +490,6 @@ test.describe("typegen", () => {
       expect(proc.status).toBe(0);
     });
 
-
     test("works with tsconfig 'exactOptionalPropertyTypes' set to 'true'", async () => {
       const cwd = await createProject({
         "vite.config.ts": viteConfig,

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -152,18 +152,17 @@ function register(ctx: Context) {
 
 const virtual = ts`
   declare module "virtual:react-router/server-build" {
-    import type { ServerBuild } from "react-router";
-    // Whilst this uses the CommonJS 'export =' syntax, which is technically not
-    // ESM-compliant, it is intentionally implemented this way to properly support
-    // optional properties in the ServerBuild type.
-    //
-    // TypeScript's type system does not provide an elegant solution for defining
-    // optional exports at the module level in ESM syntax, so this approach offers
-    // the most accurate type definitions for maintainability.
-    //
-    // This ensures all properties of ServerBuild, including optional ones, are
-    // properly type-checked when using this module.
-    const serverBuild: ServerBuild;
-    export = serverBuild;
+    import type { ServerBuild } from "react-router";    import { ServerBuild } from "react-router";
+    export const assets: ServerBuild["assets"];
+    export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"];
+    export const basename: ServerBuild["basename"];
+    export const entry: ServerBuild["entry"];
+    export const future: ServerBuild["future"];
+    export const isSpaMode: ServerBuild["isSpaMode"];
+    export const prerender: ServerBuild["prerender"];
+    export const publicPath: ServerBuild["publicPath"];
+    export const routes: ServerBuild["routes"];
+    export const ssr: ServerBuild["ssr"];
+    export const unstable_getCriticalCss: ServerBuild["unstable_getCriticalCss"];
   }
 `;

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -152,17 +152,18 @@ function register(ctx: Context) {
 
 const virtual = ts`
   declare module "virtual:react-router/server-build" {
-    import { ServerBuild } from "react-router";
-    export const assets: ServerBuild["assets"];
-    export const assetsBuildDirectory: ServerBuild["assetsBuildDirectory"];
-    export const basename: ServerBuild["basename"];
-    export const entry: ServerBuild["entry"];
-    export const future: ServerBuild["future"];
-    export const isSpaMode: ServerBuild["isSpaMode"];
-    export const prerender: ServerBuild["prerender"];
-    export const publicPath: ServerBuild["publicPath"];
-    export const routes: ServerBuild["routes"];
-    export const ssr: ServerBuild["ssr"];
-    export const unstable_getCriticalCss: ServerBuild["unstable_getCriticalCss"];
+    import type { ServerBuild } from "react-router";
+    // Whilst this uses the CommonJS 'export =' syntax, which is technically not
+    // ESM-compliant, it is intentionally implemented this way to properly support
+    // optional properties in the ServerBuild type.
+    //
+    // TypeScript's type system does not provide an elegant solution for defining
+    // optional exports at the module level in ESM syntax, so this approach offers
+    // the most accurate type definitions for maintainability.
+    //
+    // This ensures all properties of ServerBuild, including optional ones, are
+    // properly type-checked when using this module.
+    const serverBuild: ServerBuild;
+    export = serverBuild;
   }
 `;

--- a/packages/react-router/lib/server-runtime/build.ts
+++ b/packages/react-router/lib/server-runtime/build.ts
@@ -24,14 +24,20 @@ export interface ServerBuild {
   };
   routes: ServerRouteManifest;
   assets: AssetsManifest;
-  basename?: string;
+  // `| undefined` is required to ensure compatibility with TypeScript's
+  // `exactOptionalPropertyTypes` option
+  basename?: string | undefined;
   publicPath: string;
   assetsBuildDirectory: string;
   future: FutureConfig;
   ssr: boolean;
-  unstable_getCriticalCss?: (args: {
-    pathname: string;
-  }) => OptionalCriticalCss | Promise<OptionalCriticalCss>;
+  unstable_getCriticalCss?:
+    | ((args: {
+        pathname: string;
+      }) => OptionalCriticalCss | Promise<OptionalCriticalCss>)
+    // `| undefined` is required to ensure compatibility with TypeScript's
+    // `exactOptionalPropertyTypes` option
+    | undefined;
   /**
    * @deprecated This is now done via a custom header during prerendering
    */


### PR DESCRIPTION
## Overview

This PR fixes the TypeScript type definition for the virtual module `virtual:react-router/server-build` to properly handle optional properties in the `ServerBuild` interface. The change moves from named exports to a CommonJS-style `export =` syntax to ensure better TypeScript compatibility, especially with `exactOptionalPropertyTypes` enabled.

## Potential Issues or Risks

- Migration impact: The change from named exports to a default export might require modifications in code that specifically imports individual properties from the virtual module
- ESM compatibility: As noted in the comments, this approach isn't strictly ESM-compliant, which is a conscious tradeoff made for better typing support

## Conclusion

This PR provides a solid solution to type compatibility issues with optional properties in the `ServerBuild` interface. The approach is well-reasoned and properly tested. The change should improve type-checking accuracy, especially in projects using strict TypeScript configurations.