### PR TITLE
fix wrong url in useNavigate.md 

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -371,3 +371,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- nenene3

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -27,7 +27,7 @@ function SomeComponent() {
 }
 ```
 
-It's often better to use [redirect](../Utils/redirect) in [ActionFunction](../Other/ActionFunction) and [LoaderFunction](../Other/LoaderFunction) than this hook.
+It's often better to use [redirect](../utils/redirect) in [ActionFunction](../Other/ActionFunction) and [LoaderFunction](../Other/LoaderFunction) than this hook.
 
 ## Signature
 


### PR DESCRIPTION
I found that the URL for the redirect  in the React Router documentation was incorrect. The original URL was:
https://reactrouter.com/api/Utils/redirect

It has been updated to the correct URL:
https://reactrouter.com/api/utils/redirect

