### PR TITLE
Make element returned by useOutlet have stable reference

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -320,12 +320,15 @@ export function useOutletContext<Context = unknown>(): Context {
  */
 export function useOutlet(context?: unknown): React.ReactElement | null {
   let outlet = React.useContext(RouteContext).outlet;
-  if (outlet) {
-    return (
-      <OutletContext.Provider value={context}>{outlet}</OutletContext.Provider>
-    );
-  }
-  return outlet;
+  return React.useMemo(
+    () =>
+      outlet && (
+        <OutletContext.Provider value={context}>
+          {outlet}
+        </OutletContext.Provider>
+      ),
+    [outlet, context]
+  );
 }
 
 /**


### PR DESCRIPTION
I was trying to accomplish an exit animation for routes rendered in `<Outlet />`s. I need to hold onto the previous value of outlet until it finishes its animation.

```jsx
const outlet = useOutlet()
const [heldOntoNode, setHeldOntoNode] = useState(outlet)

// If outlet changes to null, don't discard `heldOntoNode`.
// Otherwise, heldOntoNode should reflect the latest value of the outlet
if (outlet && heldOntoNode !== outlet) {
  // Calling setState in render body will discard the current render
  // and schedule a new one immediately
  setHeldOntoNode(outlet)
  return null
}

if (!heldOntoNode) return null

return (
  <Modal 
    // outlet set to null means we have to hide the modal
    // aka. trigger it's exit animation.
    open={!!outlet} 
    onExitAnimationEnd={() => setHeldOntoNode(null)}
  >
    {heldOntoNode}
  </Modal>
)
```

Calling setState in render is THE way to capture the previous value. Reading refs in render isn't _really_ allowed.

Since `useOutlet` wraps the `<RenderedRoute />` in `<OutletContext.Provider />`, the reference to the outer `<OutletContext.Provider />` is always different on every re-render. And the code above triggers an infinite render loop.

This PR just wraps the resulting element in `useMemo`. That's it.

The workaround for me currently involves asserting that the element is in fact the react context, and grabbing the stable `children` prop.

I'm not sure we can guarantee stable references from `useOutlet` going forward, but that would be nice.