### PR TITLE
Support Vite's --configLoader parameter.

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -242,6 +242,7 @@
 - mtliendo
 - namoscato
 - ned-park
+- neochief
 - nikeee
 - nilubisan
 - Nismit

--- a/packages/react-router-dev/cli/run.ts
+++ b/packages/react-router-dev/cli/run.ts
@@ -19,7 +19,8 @@ ${colors.blueBright("react-router")}
   \`build\` Options:
     --assetsInlineLimit Static asset base64 inline threshold in bytes (default: 4096) (number)
     --clearScreen       Allow/disable clear screen when logging (boolean)
-    --config, -c        Use specified config file (string)
+    --config, -c        Use specified Vite config file (string)
+    --configLoader      Load config file with specified Vite config loader (string)
     --emptyOutDir       Force empty outDir when it's outside of root (boolean)
     --logLevel, -l      Info | warn | error | silent (string)
     --minify            Enable/disable minification, or specify minifier to use (default: "esbuild") (boolean | "terser" | "esbuild")
@@ -29,7 +30,8 @@ ${colors.blueBright("react-router")}
     --sourcemapServer   Output source maps for server build (default: false) (boolean | "inline" | "hidden")
   \`dev\` Options:
     --clearScreen       Allow/disable clear screen when logging (boolean)
-    --config, -c        Use specified config file (string)
+    --config, -c        Use specified Vite config file (string)
+    --configLoader      Load config file with specified Vite config loader (string)
     --cors              Enable CORS (boolean)
     --force             Force the optimizer to ignore the cache and re-bundle (boolean)
     --host              Specify hostname (string)
@@ -41,9 +43,11 @@ ${colors.blueBright("react-router")}
     --strictPort        Exit if specified port is already in use (boolean)
   \`routes\` Options:
     --config, -c        Use specified Vite config file (string)
+    --configLoader      Load config file with specified Vite config loader (string)
     --json              Print the routes as JSON
   \`reveal\` Options:
     --config, -c        Use specified Vite config file (string)
+    --configLoader      Load config file with specified Vite config loader (string)
     --no-typescript     Generate plain JavaScript files
   \`typegen\` Options:
     --watch             Automatically regenerate types whenever route config (\`routes.ts\`) or route modules change
@@ -117,6 +121,7 @@ export async function run(argv: string[] = process.argv.slice(2)) {
       "-p": "--port",
       "--config": String,
       "-c": "--config",
+      "--configLoader": String,
       "--assetsInlineLimit": Number,
       "--clearScreen": Boolean,
       "--cors": Boolean,

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -19,6 +19,7 @@ export interface ViteBuildOptions {
   assetsInlineLimit?: number;
   clearScreen?: boolean;
   config?: string;
+  configLoader?: 'bundle' | 'runner' | 'native';
   emptyOutDir?: boolean;
   force?: boolean;
   logLevel?: Vite.LogLevel;
@@ -62,6 +63,7 @@ async function viteAppBuild(
     assetsInlineLimit,
     clearScreen,
     config: configFile,
+    configLoader,
     emptyOutDir,
     force,
     logLevel,
@@ -76,6 +78,7 @@ async function viteAppBuild(
     root,
     mode,
     configFile,
+    configLoader,
     build: {
       assetsInlineLimit,
       emptyOutDir,
@@ -125,6 +128,7 @@ async function viteBuild(
     assetsInlineLimit,
     clearScreen,
     config: configFile,
+    configLoader,
     emptyOutDir,
     force,
     logLevel,
@@ -137,6 +141,7 @@ async function viteBuild(
   let viteUserConfig: Vite.UserConfig = {};
   let viteConfig = await resolveViteConfig({
     configFile,
+    configLoader,
     mode,
     root,
     plugins: [
@@ -173,6 +178,7 @@ async function viteBuild(
       root,
       mode,
       configFile,
+      configLoader,
       build: {
         assetsInlineLimit,
         emptyOutDir,

--- a/packages/react-router-dev/vite/dev.ts
+++ b/packages/react-router-dev/vite/dev.ts
@@ -7,6 +7,7 @@ import * as profiler from "./profiler";
 export interface ViteDevOptions {
   clearScreen?: boolean;
   config?: string;
+  configLoader?: 'bundle' | 'runner' | 'native';
   cors?: boolean;
   force?: boolean;
   host?: boolean | string;
@@ -23,6 +24,7 @@ export async function dev(
   {
     clearScreen,
     config: configFile,
+    configLoader,
     cors,
     force,
     host,
@@ -42,6 +44,7 @@ export async function dev(
     root,
     mode,
     configFile,
+    configLoader,
     server: { open, cors, host, port, strictPort },
     optimizeDeps: { force },
     clearScreen,


### PR DESCRIPTION
I use the `--configLoader runner` to debug my `vite.config.ts` and any plugin using the step-by-step debugger of the WebStorm IDE. Naturally, this is impossible with the current version of react-router, because it has its own way of handling vite config under the hood, where clientLoader is always default (bundler).

---

From Vite docs (https://vite.dev/config/):

> By default, Vite uses esbuild to bundle the config into a temporary file and load it. This may cause issues when importing TypeScript files in a monorepo. If you encounter any issues with this approach, you can specify --configLoader runner to use the [module runner](https://vite.dev/guide/api-environment-runtimes#modulerunner) instead, which will not create a temporary config and will transform any files on the fly.