### PR TITLE
Remove missing react-router exports in tests

### DIFF
--- a/integration/action-test.ts
+++ b/integration/action-test.ts
@@ -74,8 +74,7 @@ test.describe("actions", () => {
         `,
 
         [`app/routes/${THROWS_REDIRECT}.jsx`]: js`
-          import { redirect } from "react-router";
-          import { Form } from "react-router";
+          import { redirect, Form } from "react-router";
 
           export function action() {
             throw redirect("/${REDIRECT_TARGET}")

--- a/integration/blocking-test.ts
+++ b/integration/blocking-test.ts
@@ -40,7 +40,7 @@ test("handles synchronous proceeding correctly", async ({ page }) => {
       `,
       "app/routes/b.tsx": js`
       import * as React from "react";
-      import { Form, useAction, useBlocker } from "react-router";
+      import { Form, useBlocker } from "react-router";
         export default function Component() {
           return (
             <div>

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -335,7 +335,6 @@ test.describe("Client Data", () => {
               }),
               "app/routes/parent.child.tsx": js`
                 import * as React from 'react';
-                import { json } from "react-router"
                 import { Await, useLoaderData } from "react-router"
                 export function loader() {
                   return {
@@ -685,7 +684,6 @@ test.describe("Client Data", () => {
                 }),
                 "app/routes/parent.child.tsx": js`
                   import * as React from 'react';
-                  import { json } from "react-router";
                   import { useLoaderData, useRevalidator } from "react-router";
                   let isFirstCall = true;
                   export async function loader({ serverLoader }) {
@@ -763,7 +761,7 @@ test.describe("Client Data", () => {
                     childClientLoaderHydrate: false,
                   }),
                   "app/routes/parent.child.tsx": js`
-                    import { ClientLoaderFunctionArgs, useRouteError } from "react-router";
+                    import { useRouteError } from "react-router";
 
                     export function loader() {
                       throw new Error("Broken!")
@@ -1286,7 +1284,6 @@ test.describe("Client Data", () => {
                 }),
                 "app/routes/parent.child.tsx": js`
                   import * as React from 'react';
-                  import { json } from "react-router";
                   import { Form, useRouteError } from "react-router";
                   export async function clientAction({ serverAction }) {
                     return await serverAction();
@@ -1508,7 +1505,6 @@ test.describe("Client Data", () => {
                 }),
                 "app/routes/parent.child.tsx": js`
                   import * as React from 'react';
-                  import { json } from "react-router";
                   import { Form, useRouteError } from "react-router";
                   export async function clientAction({ serverAction }) {
                     return await serverAction();

--- a/integration/error-boundary-test.ts
+++ b/integration/error-boundary-test.ts
@@ -971,7 +971,6 @@ test("Allows back-button out of an error boundary after a hard reload", async ({
         `,
 
       "app/routes/boom.tsx": js`
-          import { json } from "react-router";
           export function loader() { return boom(); }
           export default function() { return <b>my page</b>; }
         `,

--- a/integration/fetch-globals-test.ts
+++ b/integration/fetch-globals-test.ts
@@ -14,7 +14,6 @@ test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
       "app/routes/_index.tsx": js`
-        import { json } from "react-router";
         import { useLoaderData } from "react-router";
         export async function loader() {
           const resp = await fetch('https://reqres.in/api/users?page=2');

--- a/integration/fetcher-test.ts
+++ b/integration/fetcher-test.ts
@@ -23,7 +23,6 @@ test.describe("useFetcher", () => {
     fixture = await createFixture({
       files: {
         "app/routes/resource-route-action-only.ts": js`
-          import { json } from "react-router";
           export function action() {
             return new Response("${CHEESESTEAK}");
           }

--- a/integration/link-test.ts
+++ b/integration/link-test.ts
@@ -357,8 +357,7 @@ test.describe("route module link export", () => {
         `,
 
         "app/routes/gists.$username.tsx": js`
-          import { data, redirect } from "react-router";
-          import { Link, useLoaderData, useParams } from "react-router";
+          import { data, redirect, Link, useLoaderData, useParams } from "react-router";
           export async function loader({ params }) {
             let { username } = params;
             if (username === "mjijackson") {

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -16,8 +16,7 @@ test.describe("pathless layout routes", () => {
       await createFixture({
         files: {
           "app/routes/_index.tsx": js`
-            import { data, redirect } from "react-router";
-            import { Form, useActionData } from "react-router";
+            import { data, redirect, Form, useActionData } from "react-router";
 
             export let loader = async () => {
               let headers = new Headers();

--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -35,8 +35,7 @@ test.describe("redirects", () => {
         `,
 
         "app/routes/absolute._index.tsx": js`
-          import { redirect } from "react-router";
-          import { Form } from "react-router";
+          import { redirect, Form } from "react-router";
 
           export async function action({ request }) {
             return redirect(new URL(request.url).origin + "/absolute/landing");

--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -114,7 +114,6 @@ test.describe("loader in an app", async () => {
           }
         `,
         "app/routes/$.tsx": js`
-          import { json } from "react-router";
           import { useRouteError } from "react-router";
           export function loader({ request }) {
             throw Response.json({

--- a/integration/revalidate-test.ts
+++ b/integration/revalidate-test.ts
@@ -46,8 +46,7 @@ test.describe("Revalidation", () => {
             `,
 
           "app/routes/parent.tsx": js`
-              import { data } from "react-router";
-              import { Outlet, useLoaderData } from "react-router";
+              import { data, Outlet, useLoaderData } from "react-router";
 
               export async function loader({ request }) {
                 let header = request.headers.get('Cookie') || '';
@@ -86,8 +85,7 @@ test.describe("Revalidation", () => {
             `,
 
           "app/routes/parent.child.tsx": js`
-              import { data } from "react-router";
-              import { Form, useLoaderData, useRevalidator } from "react-router";
+              import { data, Form, useLoaderData, useRevalidator } from "react-router";
 
               export async function action() {
                 return { action: 'data' }

--- a/integration/scroll-test.ts
+++ b/integration/scroll-test.ts
@@ -15,8 +15,7 @@ test.beforeAll(async () => {
   fixture = await createFixture({
     files: {
       "app/routes/_index.tsx": js`
-        import { redirect } from "react-router";
-        import { Form } from "react-router";
+        import { redirect, Form } from "react-router";
 
         export function action() {
           return redirect("/test");

--- a/integration/transition-test.ts
+++ b/integration/transition-test.ts
@@ -139,8 +139,7 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/gh-1691.tsx": js`
-          import { json, redirect } from "react-router";
-          import { useFetcher} from "react-router";
+          import { redirect, useFetcher } from "react-router";
 
           export const action = async ( ) => {
             return redirect("/gh-1691");
@@ -195,8 +194,7 @@ test.describe("rendering", () => {
         `,
 
         "app/routes/parent.child.tsx": js`
-          import { redirect } from "react-router";
-          import { useFetcher} from "react-router";
+          import { redirect, useFetcher } from "react-router";
 
           export const action = async ({ request }) => {
             return redirect("/parent");


### PR DESCRIPTION
Some of our tests have unused imports from React Router that are no longer exported, leftover from the Remix migration. Vite builds with these without any issues, but `rolldown-vite` is more strict. This PR fixes the tests to help ensure `vite-ecosystem-ci` can pass against `vite-rolldown` without having to suppress these errors in Rolldown.