### PR TITLE
Add `unstable_runClientMiddleware` API for `dataStrategy`

### DIFF
--- a/.changeset/silent-snakes-mix.md
+++ b/.changeset/silent-snakes-mix.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-UNSTABLE: Add a new `unstable_runMiddleware` argument to `dataStrategy` to enable middleware execution in custom `dataStrategy` implementations
+UNSTABLE: Add a new `unstable_runClientMiddleware` argument to `dataStrategy` to enable middleware execution in custom `dataStrategy` implementations

--- a/.changeset/silent-snakes-mix.md
+++ b/.changeset/silent-snakes-mix.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+UNSTABLE: Add a new `unstable_runMiddleware` argument to `dataStrategy` to enable middleware execution in custom `dataStrategy` implementations

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -160,7 +160,7 @@ export function getSingleFetchDataStrategy(
     basename,
     getRouter
   );
-  return async (args) => args.unstable_runMiddleware(dataStrategy);
+  return async (args) => args.unstable_runClientMiddleware(dataStrategy);
 }
 
 export function getSingleFetchDataStrategyImpl(

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -5565,10 +5565,10 @@ async function callDataStrategyImpl(
     context: scopedContext,
     matches,
   };
-  let unstable_runMiddleware = isStaticHandler
+  let unstable_runClientMiddleware = isStaticHandler
     ? () => {
         throw new Error(
-          "You cannot call `unstable_runMiddleware()` from a static handler " +
+          "You cannot call `unstable_runClientMiddleware()` from a static handler " +
             "`dataStrategy`. Middleware is run outside of `dataStrategy` during " +
             "SSR in order to bubble up the Response.  You can enable middleware " +
             "via the `respond` API in `query`/`queryRoute`"
@@ -5588,10 +5588,10 @@ async function callDataStrategyImpl(
             cb({
               ...typedDataStrategyArgs,
               fetcherKey,
-              unstable_runMiddleware: () => {
+              unstable_runClientMiddleware: () => {
                 throw new Error(
-                  "Cannot call `unstable_runMiddleware()` from within an " +
-                    "`unstable_runMiddleware` handler"
+                  "Cannot call `unstable_runClientMiddleware()` from within an " +
+                    "`unstable_runClientMiddleware` handler"
                 );
               },
             }),
@@ -5604,7 +5604,7 @@ async function callDataStrategyImpl(
   let results = await dataStrategyImpl({
     ...dataStrategyArgs,
     fetcherKey,
-    unstable_runMiddleware,
+    unstable_runClientMiddleware,
   });
 
   // Wait for all routes to load here but swallow the error since we want

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -361,7 +361,7 @@ export interface DataStrategyMatch
 export interface DataStrategyFunctionArgs<Context = DefaultContext>
   extends DataFunctionArgs<Context> {
   matches: DataStrategyMatch[];
-  unstable_runMiddleware: (
+  unstable_runClientMiddleware: (
     cb: DataStrategyFunction<Context>
   ) => Promise<Record<string, DataStrategyResult>>;
   fetcherKey: string | null;

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -347,7 +347,6 @@ export interface DataStrategyMatch
   shouldLoad: boolean;
   // This can be null for actions calls and for initial hydration calls
   unstable_shouldRevalidateArgs: ShouldRevalidateFunctionArgs | null;
-  // TODO: Figure out a good name for this or use `shouldLoad` and add a future flag
   // This function will use a scoped version of `shouldRevalidateArgs` because
   // they are read-only but let the user provide an optional override value for
   // `defaultShouldRevalidate` if they choose
@@ -362,8 +361,9 @@ export interface DataStrategyMatch
 export interface DataStrategyFunctionArgs<Context = DefaultContext>
   extends DataFunctionArgs<Context> {
   matches: DataStrategyMatch[];
-  // TODO: Implement
-  // runMiddleware: () => unknown,
+  unstable_runMiddleware: (
+    cb: DataStrategyFunction<Context>
+  ) => Promise<Record<string, DataStrategyResult>>;
   fetcherKey: string | null;
 }
 


### PR DESCRIPTION
Add the `unstable_runClientMiddleware` API to `dataStrategy` to allow users to run middleware inside of custom `dataStrategy` implementations