### PR TITLE
chore(react-router): remove `@types/cookie` dependency

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -81,7 +81,6 @@
     }
   },
   "dependencies": {
-    "@types/cookie": "^0.6.0",
     "cookie": "^1.0.1",
     "set-cookie-parser": "^2.6.0",
     "turbo-stream": "2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,9 +733,6 @@ importers:
 
   packages/react-router:
     dependencies:
-      '@types/cookie':
-        specifier: ^0.6.0
-        version: 0.6.0
       cookie:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3985,9 +3982,6 @@ packages:
 
   '@types/cookie@0.4.1':
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
-
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
@@ -11693,8 +11687,6 @@ snapshots:
       '@types/node': 20.11.30
 
   '@types/cookie@0.4.1': {}
-
-  '@types/cookie@0.6.0': {}
 
   '@types/cookiejar@2.1.5': {}
 


### PR DESCRIPTION
Types are includes as of `cookie@1.0.0`, so adding the extra types package is obsolete

References:
- https://github.com/jshttp/cookie/releases/tag/v1.0.0
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70892

---

Re-submission of @abdrahmanrizk's #12640