### PR TITLE
Add timeout section to streaming wiki

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -366,6 +366,7 @@
 - willemarcel
 - williamsdyyz
 - willsawyerrrr
+- willsmithte
 - wkovacs64
 - xavier-lc
 - xcsnowcity

--- a/docs/how-to/suspense.md
+++ b/docs/how-to/suspense.md
@@ -75,3 +75,12 @@ function NonCriticalUI({ p }: { p: Promise<string> }) {
   return <h3>Non critical value {value}</h3>;
 }
 ```
+
+## Timeouts
+
+By default, loaders and actions reject any outstanding promises after 4950ms. You can control this by exporting a `streamTimeout` numerical value from your `entry.server.tsx`.
+
+```ts filename=entry.server.tsx
+// Reject all pending promises from handler functions after 10 seconds
+export const streamTimeout = 10_000;
+```


### PR DESCRIPTION
Mostly copied from the remix docs: https://remix.run/docs/en/main/guides/single-fetch#streaming-timeout

Discussed in an issue: https://github.com/remix-run/react-router/issues/12467