### PR TITLE
fix(dev): fix `setTimeout` leaks in default `entry.server.tsx`

### DIFF
--- a/.changeset/funny-suns-explain.md
+++ b/.changeset/funny-suns-explain.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Cancel aborts timeouts created in the default entry.server.tsx file

--- a/contributors.yml
+++ b/contributors.yml
@@ -342,3 +342,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- remorses


### PR DESCRIPTION
If you don't cancel the setTimeout all the closure context is kept in memory until the timeout is called, in this case the whole React tree. This can cause massive memory usage if you are serving many requests