### PR TITLE
docs: fix install link for Declarative Mode

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -269,6 +269,7 @@
 - printfn
 - promet99
 - proshunsuke
+- pruszel
 - pwdcd
 - pyitphyoaung
 - refusado

--- a/docs/start/modes.md
+++ b/docs/start/modes.md
@@ -117,7 +117,7 @@ Every mode supports any architecture and deployment target, so the question isn'
 - have a data layer that either skips pending states (like local first, background data replication/sync) or has its own abstractions for them
 - are coming from Create React App (you may want to consider framework mode though)
 
-[→ Get Started with Declarative Mode](./library/installation).
+[→ Get Started with Declarative Mode](./declarative/installation).
 
 ## API + Mode Availability Table
 


### PR DESCRIPTION
The current link: `./library/installation` returns a `404`.

The new link: `./declarative/installation` correctly routes to the installation guide for Declarative Mode.