### PR TITLE
Update React Router Documentation Links to Version-Specific URLs

### DIFF
--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1298,7 +1298,7 @@ enum DataRouterStateHook {
 function getDataRouterConsoleError(
   hookName: DataRouterHook | DataRouterStateHook
 ) {
-  return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
+  return `${hookName} must be used within a data router.  See https://reactrouter.com/6.30.0/routers/picking-a-router.`;
 }
 
 function useDataRouterContext(hookName: DataRouterHook) {

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -961,7 +961,7 @@ enum DataRouterStateHook {
 function getDataRouterConsoleError(
   hookName: DataRouterHook | DataRouterStateHook
 ) {
-  return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
+  return `${hookName} must be used within a data router.  See https://reactrouter.com/6.30.0/routers/picking-a-router.`;
 }
 
 function useDataRouterContext(hookName: DataRouterHook) {


### PR DESCRIPTION
Fix: Replace outdated documentation links with version-specific URLs (6.38.0) in error messages

Updated the error message URLs in both `lib.tax` and `hooks.tax` files to point to the correct version (6.38.0) of the React Router documentation instead of the placeholder/en/masia path. This ensures users are directed to the appropriate documentation when encountering router-related errors.