### PR TITLE
fix: better flush assets as they are discovered for a flatter network.

### DIFF
--- a/packages/react-router/tsup.config.rsc.ts
+++ b/packages/react-router/tsup.config.rsc.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
 
 // @ts-ignore - out of scope
 import { createBanner } from "../../build.utils.js";
@@ -43,10 +43,9 @@ const config = (enableDevWarnings: boolean) =>
       },
       treeshake: true,
     },
-  ]);
+  ]) as Options[];
 
 export default defineConfig([
-  // @ts-expect-error
   ...config(false),
   ...config(true),
 ]);

--- a/packages/react-router/tsup.config.ts
+++ b/packages/react-router/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
 
 // @ts-ignore - out of scope
 import { createBanner } from "../../build.utils.js";
@@ -38,10 +38,9 @@ const config = (enableDevWarnings: boolean) =>
         __DEV__: JSON.stringify(enableDevWarnings),
       },
     },
-  ]);
+  ]) as Options[];
 
 export default defineConfig([
-  // @ts-expect-error
   ...config(false),
   ...config(true),
 ]);

--- a/playground/rsc-vite/src/ssr/entry.ssr.tsx
+++ b/playground/rsc-vite/src/ssr/entry.ssr.tsx
@@ -22,9 +22,9 @@ export default {
         request,
         callServer,
         (body) => RSD.createFromReadableStream(body, manifest),
-        async (payload) => {
+        async (getPayload) => {
           return await RDS.renderToReadableStream(
-            <RSCStaticRouter payload={payload} />,
+            <RSCStaticRouter getPayload={getPayload} />,
             {
               bootstrapModules,
               signal: request.signal,


### PR DESCRIPTION
Delay decoding of the stream until we are inside of a "render to html" context. This allows React to use async localstorage to collect and flush assets for client components as they are discovered.

Before:
![image](https://github.com/user-attachments/assets/1a267adb-8ed6-4532-b094-17ae64ea75a6)

After:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/5b046e94-556f-4680-b2bb-459c624cc177" />
