### PR TITLE
Fix root directory resolution logic

### DIFF
--- a/.changeset/bright-experts-grab.md
+++ b/.changeset/bright-experts-grab.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Support project root directories without a `package.json` if it exists in a parent directory

--- a/.changeset/cold-seals-count.md
+++ b/.changeset/cold-seals-count.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+When providing a custom Vite config path via the CLI `--config`/`-c` flag, default the project root directory to the directory containing the Vite config when not explicitly provided

--- a/.changeset/forty-ants-teach.md
+++ b/.changeset/forty-ants-teach.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Ensure consistent project root directory resolution logic in CLI commands


### PR DESCRIPTION
Fixes #12390

This PR fixes a few issues that were raised by the issue linked above:

- When providing a custom Vite config via the CLI (e.g. `react-router dev --config apps/my-app/vite.config.ts`), the React Router project directory would still be `cwd`. This meant that you'd get an error about a missing root route even if it's present in the directory containing the Vite config. To fix this, if a custom Vite config path is provided, we now default the React Router project root to be the directory containing the custom Vite config.
- The logic for resolving the project root directory was duplicated across different commands. This PR introduces a `resolveRootDirectory` util which is used consistently across all commands. This gives us a central place to implement the fix mentioned above. This issue wasn't explicitly raised, but was highlighted when fixing the above issue.
- When your React Router root directory doesn't contain a `package.json` but a parent directory has one, an error is thrown because we try to read the non-existent `package.json` from root. To fix this, we now also walk parent directories to find `package.json`. If none of the parent directories contain a `package.json`, you'll still see the same error as before.

Note that I've opted not to test this logic specifically. I've manually tested in one of our playgrounds, moving all app code into a subdirectory and ensuring I can do the following:

- Run with a custom root, e.g. `react-router dev apps/my-app`.
- Run with a custom Vite config in a root directory, e.g. `react-router dev --config apps/my-app/vite.config.ts`

I've also tried to ensure this doesn't break any usages that inadvertently work today (e.g. having config files in a `config` dir and the `app` directory in the root), but this just showed me that too much of our code assumes everything is in the root directory. If the Vite config is in a `config` dir, a `react-router.config.ts` file next to it doesn't get picked up. In this scenario, we also generate a `.react-router` dir in the `config` dir. This makes me much more confident that it's safe to infer the root directory from the Vite config location since it currently doesn't seem to work otherwise.