### PR TITLE
Don't trigger error boundary prior to lazy route discovery manifest mismatch reload

### DIFF
--- a/.changeset/silly-ligers-dress.md
+++ b/.changeset/silly-ligers-dress.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Don't trigger an `ErrorBoundary` UI before the reload when we detect a manifest verison mismatch in Lazy Route Discovery

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -254,7 +254,13 @@ export async function fetchAndApplyManifestPatches(
 
       sessionStorage.setItem(MANIFEST_VERSION_STORAGE_KEY, manifest.version);
       window.location.href = errorReloadPath;
-      throw new Error("Detected manifest version mismatch, reloading...");
+      console.warn("Detected manifest version mismatch, reloading...");
+
+      // Stall here and let the browser reload and avoid triggering a flash of
+      // an ErrorBoundary if we threw (same thing we do in `loadRouteModule()`)
+      await new Promise(() => {
+        // check out of this hook cause the DJs never gonna re[s]olve this
+      });
     } else if (res.status >= 400) {
       throw new Error(await res.text());
     }


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/13332