### PR TITLE
[Proposal] add gitmcp badge for documentation access

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [npm]: https://www.npmjs.org/package/react-router-dom
 [build-badge]: https://img.shields.io/github/actions/workflow/status/remix-run/react-router/test.yml?branch=dev&style=square
 [build]: https://github.com/remix-run/react-router/actions/workflows/test.yml
-[gitmcp-badge]: https://img.shields.io/endpoint?url=https://gitmcp.io/badge/remix-run/react-router
+[gitmcp-badge]: https://img.shields.io/endpoint?url=https://gitmcp.io/badge/remix-run/react-router "Documentation compatible with GitMCP"
 [gitmcp]: https://gitmcp.io/remix-run/react-router
 
 React Router is a multi-strategy router for React bridging the gap from React 18 to React 19. You can use it maximally as a React framework or minimally as a library with your own architecture.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-[![npm package][npm-badge]][npm] [![build][build-badge]][build]
+[![npm package][npm-badge]][npm] [![build][build-badge]][build] [![GitMCP][gitmcp-badge]][gitmcp]
 
 [npm-badge]: https://img.shields.io/npm/v/react-router-dom.svg
 [npm]: https://www.npmjs.org/package/react-router-dom
 [build-badge]: https://img.shields.io/github/actions/workflow/status/remix-run/react-router/test.yml?branch=dev&style=square
 [build]: https://github.com/remix-run/react-router/actions/workflows/test.yml
+[gitmcp-badge]: https://img.shields.io/endpoint?url=https://gitmcp.io/badge/remix-run/react-router
+[gitmcp]: https://gitmcp.io/remix-run/react-router
 
 React Router is a multi-strategy router for React bridging the gap from React 18 to React 19. You can use it maximally as a React framework or minimally as a library with your own architecture.
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -380,3 +380,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- idosal


### PR DESCRIPTION
Hey,
[gitmcp.io](https://gitmcp.io) provides easy access to the latest React Router docs through a remote, free, open-source MCP.  It enables two access points -
- Empower AI agents (e.g., Cursor) with live documentation context to prevent hallucinations
- Chat with the documentation in the browser via the embedded chat

This PR proposes adding a new badge to help users make the most of React Router's documentation with GitMCP. The badge is [customizable](https://github.com/idosal/git-mcp?tab=readme-ov-file#-gitmcp-badge).

[![GitMCP](https://img.shields.io/endpoint?url=https://gitmcp.io/badge/remix-run/react-router)](https://gitmcp.io/remix-run/react-router)

We look forward to hearing your thoughts!