### PR TITLE
Ensure `vite-node` doesn't load PostCSS config

### DIFF
--- a/.changeset/little-cups-deliver.md
+++ b/.changeset/little-cups-deliver.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+When executing `react-router.config.ts` and `routes.ts` with `vite-node`, ensure that PostCSS config files are ignored

--- a/packages/react-router-dev/vite/vite-node.ts
+++ b/packages/react-router-dev/vite/vite-node.ts
@@ -36,6 +36,15 @@ export async function createContext({
     optimizeDeps: {
       noDiscovery: true,
     },
+    css: {
+      // This empty PostCSS config object prevents the PostCSS config file from
+      // being loaded. We don't need it in a React Router config context, and
+      // there's also an issue in Vite 5 when using a .ts PostCSS config file in
+      // an ESM project: https://github.com/vitejs/vite/issues/15869. Consumers
+      // can work around this in their own Vite config file, but they can't
+      // configure this internal usage of vite-node.
+      postcss: {},
+    },
     configFile: false,
     envFile: false,
     plugins: [],


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/12472.

tl;dr: Adding `css: { postcss: {} }` to our vite-node config is the equivalent of `configFile: false` but for PostCSS config files.