### PR TITLE
Fix `assetsDir` in `entryFileNames` with Vite Env API

### DIFF
--- a/.changeset/rude-cobras-warn.md
+++ b/.changeset/rude-cobras-warn.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+When `future.unstable_viteEnvironmentApi` is enabled, ensure that `build.assetsDir` in Vite config is respected when `environments.client.build.assetsDir` is not configured

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3541,10 +3541,14 @@ export async function getEnvironmentOptionsResolvers(
                 let routeChunkSuffix = routeChunkName
                   ? `-${kebabCase(routeChunkName)}`
                   : "";
-                return path.posix.join(
+                let assetsDir =
                   (ctx.reactRouterConfig.future.unstable_viteEnvironmentApi
                     ? viteUserConfig?.environments?.client?.build?.assetsDir
-                    : viteUserConfig?.build?.assetsDir) ?? "assets",
+                    : null) ??
+                  viteUserConfig?.build?.assetsDir ??
+                  "assets";
+                return path.posix.join(
+                  assetsDir,
                   `[name]${routeChunkSuffix}-[hash].js`
                 );
               },


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13430

When `future.unstable_viteEnvironmentApi` is enabled, we were respecting the value for `environments.client.build.assetsDir` when configuring `build.rollupOptions.output.entryFileNames`, but we weren't falling back to the top-level `build.assetsDir` if it was missing.

This PR updates the logic so that the `assetsDir` value falls back to `build.assetsDir` if `environments.client.build.assetsDir` is not provided, before finally falling back to the default value of `"assets"`.