### PR TITLE
Get critical CSS in dev from client env

### DIFF
--- a/.changeset/proud-needles-destroy.md
+++ b/.changeset/proud-needles-destroy.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+When extracting critical CSS during development, ensure it's loaded from the client environment to avoid issues with plugins that handle the SSR environment differently


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13379

When we extract critical CSS during dev, we're currently doing this from the SSR environment, or a custom environment when using Vite's Environment API to support non-Node SSR environments. This seems to cause issues if the SSR environment differs from the client environment in terms of resolving CSS files. In the case of the linked issue above, our critical CSS extraction logic doesn't work for the virtual CSS modules that Pigment CSS introduces.

To fix this issue, we now request the same CSS that the browser does by passing the CSS URL to `viteDevServer.transformRequest`. The only down side of this approach is that it returns a string of JS code with the CSS embedded within it as a string (along with HMR code etc.). To work around this, we use Babel to parse the JS and find the value for the `__vite__css` variable.