### PR TITLE
Include react-router/dom APIs in typedoc

### DIFF
--- a/packages/react-router-dom/index.ts
+++ b/packages/react-router-dom/index.ts
@@ -1,9 +1,12 @@
-import type { RouterProviderProps } from "react-router/dom";
+import type {
+  HydratedRouterProps,
+  RouterProviderProps,
+} from "react-router/dom";
 import { HydratedRouter, RouterProvider } from "react-router/dom";
 
 // TODO: Confirm if this causes tree-shaking issues and if so, convert to named exports
 export type * from "react-router";
 export * from "react-router";
 
-export type { RouterProviderProps };
+export type { HydratedRouterProps, RouterProviderProps };
 export { HydratedRouter, RouterProvider };

--- a/packages/react-router/dom-export.ts
+++ b/packages/react-router/dom-export.ts
@@ -1,3 +1,4 @@
 export type { RouterProviderProps } from "./lib/dom-export/dom-router-provider";
 export { RouterProvider } from "./lib/dom-export/dom-router-provider";
+export type { HydratedRouterProps } from "./lib/dom-export/hydrated-router";
 export { HydratedRouter } from "./lib/dom-export/hydrated-router";

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -208,7 +208,7 @@ function createHydratedRouter({
   return router;
 }
 
-interface HydratedRouterProps {
+export interface HydratedRouterProps {
   /**
    * Context object to passed through to `createBrowserRouter` and made available
    * to `clientLoader`/`clientActon` functions

--- a/packages/react-router/typedoc.json
+++ b/packages/react-router/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["./index.ts"],
+  "entryPoints": ["./index.ts", "./dom-export.ts"],
   "categoryOrder": [
     "Components",
     "Hooks",


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/13450

This doesn't work as well as I'd hoped - maybe we should just inline the docs now for `react-router/dom` exports?