### PR TITLE
Skip unused `routes.ts` eval before Vite build

### DIFF
--- a/.changeset/ten-pears-wash.md
+++ b/.changeset/ten-pears-wash.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Skip unnecessary `routes.ts` evaluation before Vite build is started

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -38,6 +38,9 @@ export async function build(root: string, viteBuildOptions: ViteBuildOptions) {
   let configResult = await loadConfig({
     rootDirectory: root,
     mode: viteBuildOptions.mode ?? "production",
+    // In this scope we only need future flags, so we can skip evaluating
+    // routes.ts until we're within the Vite build context
+    skipRoutes: true,
   });
 
   if (!configResult.ok) {


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13078

We currently load the React Router config before starting the Vite build, but this is only done to load the future flags so we know whether to use the Vite Environment API powered build process or not. However, our config loading logic also evaluates `routes.ts`.

As a slight performance improvement and to keep the order of operations as similar as possible to `react-router dev` and `vite build`, we now skip evaluating `routes.ts` when loading future flags before the Vite build is started.