### PR TITLE
Preserve status code on clientAction throw data() results

### DIFF
--- a/.changeset/late-hats-yell.md
+++ b/.changeset/late-hats-yell.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Preserve status code if a `clientAction` throws a `data()` result in framework mode

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { decode } from "../../../vendor/turbo-stream-v2/turbo-stream";
 import type { Router as DataRouter } from "../../router/router";
-import { isResponse } from "../../router/router";
+import { isDataWithResponseInit, isResponse } from "../../router/router";
 import type {
   DataStrategyFunction,
   DataStrategyFunctionArgs,
@@ -289,7 +289,11 @@ async function singleFetchActionStrategy(
     return result;
   });
 
-  if (isResponse(result.result) || isRouteErrorResponse(result.result)) {
+  if (
+    isResponse(result.result) ||
+    isRouteErrorResponse(result.result) ||
+    isDataWithResponseInit(result.result)
+  ) {
     return { [actionMatch.route.id]: result };
   }
 


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/12919