### PR TITLE
Properly escape :params in generatePath

### DIFF
--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -45,10 +45,8 @@ describe("generatePath", () => {
       ).toBe("/courses/foo*");
     });
     it("handles a 0 parameter", () => {
-      // @ts-expect-error
       // incorrect usage but worked in 6.3.0 so keep it to avoid the regression
       expect(generatePath("/courses/:id", { id: 0 })).toBe("/courses/0");
-      // @ts-expect-error
       // incorrect usage but worked in 6.3.0 so keep it to avoid the regression
       expect(generatePath("/courses/*", { "*": 0 })).toBe("/courses/0");
     });

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -133,6 +133,14 @@ describe("generatePath", () => {
     });
   });
 
+  describe("with a param that contains a /", () => {
+    it("properly encodes the slash", () => {
+      expect(generatePath("/courses/:id/grades", { id: "a/b" })).toBe(
+        "/courses/a%2Fb/grades"
+      );
+    });
+  });
+
   it("throws only on on missing named parameters, but not missing splat params", () => {
     expect(() => generatePath(":foo")).toThrow();
     expect(() => generatePath("/:foo")).toThrow();

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -908,7 +908,7 @@ export function generatePath<Path extends string>(
         const [, key, optional] = keyMatch;
         let param = params[key as PathParam<Path>];
         invariant(optional === "?" || param != null, `Missing ":${key}" param`);
-        return stringify(param);
+        return encodeURIComponent(stringify(param));
       }
 
       // Remove any optional markers from optional static segments


### PR DESCRIPTION
I believe this should fix #11940, but I'd love to get a 2nd opinion here.