### PR TITLE
Add longer timeout for windows E2E CI runs

### DIFF
--- a/.github/workflows/integration-pr-windows-macos.yml
+++ b/.github/workflows/integration-pr-windows-macos.yml
@@ -32,6 +32,7 @@ jobs:
       os: "windows-latest"
       node_version: "[22]"
       browser: '["msedge"]'
+      timeout: 60
 
   integration-webkit:
     name: "👀 Integration Test"

--- a/.github/workflows/shared-integration.yml
+++ b/.github/workflows/shared-integration.yml
@@ -18,6 +18,10 @@ on:
         # but we want to pass an array (browser: "['chromium', 'firefox']"),
         # so we'll need to manually stringify it for now
         type: string
+      timeout:
+        required: false
+        type: number
+        default: 30
 
 env:
   CI: true
@@ -62,4 +66,4 @@ jobs:
 
       - name: 👀 Run Integration Tests ${{ matrix.browser }}
         run: "pnpm test:integration --project=${{ matrix.browser }}"
-        timeout-minutes: 40
+        timeout-minutes: ${{inputs.timeout}}


### PR DESCRIPTION
Attempt to fix timed out jobs such as https://github.com/remix-run/react-router/actions/runs/14783281251/job/41506683463