### PR TITLE
Remove matchRoutes optimization from render pass

### DIFF
--- a/.changeset/flat-seas-own.md
+++ b/.changeset/flat-seas-own.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Partially revert optimization added in `7.1.4` to reduce calls to `matchRoutes` because it surfaced other issues

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -32,7 +32,6 @@ import type {
 } from "./router/router";
 import { IDLE_BLOCKER } from "./router/router";
 import type {
-  AgnosticRouteMatch,
   ParamParseKey,
   Params,
   PathMatch,
@@ -445,7 +444,7 @@ export function useRoutesImpl(
     `useRoutes() may be used only in the context of a <Router> component.`
   );
 
-  let { navigator, static: isStatic } = React.useContext(NavigationContext);
+  let { navigator } = React.useContext(NavigationContext);
   let { matches: parentMatches } = React.useContext(RouteContext);
   let routeMatch = parentMatches[parentMatches.length - 1];
   let parentParams = routeMatch ? routeMatch.params : {};
@@ -532,17 +531,7 @@ export function useRoutesImpl(
     remainingPathname = "/" + segments.slice(parentSegments.length).join("/");
   }
 
-  // Use data router matches when available to avoid another match routes call.
-  // Skip this during SSR because the matches coming in from StaticHandlerContext
-  // might be UI agnostic and we want the matches from the createStaticRouter's
-  // routes
-  let matches =
-    !isStatic &&
-    dataRouterState &&
-    dataRouterState.matches &&
-    dataRouterState.matches.length > 0
-      ? (dataRouterState.matches as AgnosticRouteMatch<string, RouteObject>[])
-      : matchRoutes(routes, { pathname: remainingPathname });
+  let matches = matchRoutes(routes, { pathname: remainingPathname });
 
   if (ENABLE_DEV_WARNINGS) {
     warning(


### PR DESCRIPTION
Partial revert of #12800/#12882

Closes https://github.com/remix-run/react-router/issues/13118, https://github.com/remix-run/react-router/issues/13159