### PR TITLE
Update Route.MetaArgs to reflect optional data

### DIFF
--- a/.changeset/big-ladybugs-brush.md
+++ b/.changeset/big-ladybugs-brush.md
@@ -1,0 +1,7 @@
+---
+"react-router": patch
+---
+
+Update `Route.MetaArgs` to reflect that `data` can be potentially `undefined`
+
+This is primarily for cases where a route `loader` threw an error to it's own `ErrorBoundary`. but it also arises in the case of a 404 which renders the root `ErrorBoundary`/`meta` but the root loader did not run because not routes matched.

--- a/packages/react-router/lib/types/route-module.ts
+++ b/packages/react-router/lib/types/route-module.ts
@@ -61,7 +61,7 @@ type CreateMetaArgs<T extends RouteInfo> = {
   /** {@link https://reactrouter.com/start/framework/routing#dynamic-segments Dynamic route params} for the current route. */
   params: T["params"];
   /** The return value for this route's server loader function */
-  data: T["loaderData"];
+  data: T["loaderData"] | undefined;
   /** Thrown errors that trigger error boundaries will be passed to the meta function. This is useful for generating metadata for error pages. */
   error?: unknown;
   /** An array of the current {@link https://api.reactrouter.com/v7/interfaces/react_router.UIMatch.html route matches}, including parent route matches. */


### PR DESCRIPTION
Small miss in the new types that we had in Remix v2: https://github.com/remix-run/remix/pull/6231.  See the changeset for scenarios.

Closes #13541 