### PR TITLE
Bug Report: Process crash when suspense route faster than layout

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -387,3 +387,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- richardszalay


### PR DESCRIPTION
If a route:

1. Uses suspense
2. Has a layout that also has a loader (non-suspense)
3. The route's suspense promise rejects before the layout's loader completes

Then the promise is uncaught and the entire node process exits.

The issue does not occur if any of the following are true:
1. The route's suspense promise does not reject until after the layout's loader complete
2. The layout does not define a loader