### PR TITLE
Escape paths passed to `optimizeDeps.entries`

### DIFF
--- a/.changeset/lovely-walls-exist.md
+++ b/.changeset/lovely-walls-exist.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Escape paths passed to `optimizeDeps.entries` to ensure special characters don't accidentally trigger pattern matching

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -89,6 +89,7 @@
     "react-refresh": "^0.14.0",
     "semver": "^7.3.7",
     "set-cookie-parser": "^2.6.0",
+    "tinyglobby": "^0.2.13",
     "valibot": "^0.41.0",
     "vite-node": "3.0.0-beta.2"
   },

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -27,6 +27,7 @@ import pick from "lodash/pick";
 import jsesc from "jsesc";
 import colors from "picocolors";
 import kebabCase from "lodash/kebabCase";
+import { convertPathToPattern } from "tinyglobby";
 
 import * as Typegen from "../typegen";
 import type { RouteManifestEntry, RouteManifest } from "../config/routes";
@@ -1224,7 +1225,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                   ...Object.values(ctx.reactRouterConfig.routes).map((route) =>
                     resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
                   ),
-                ]
+                ].map(convertPathToPattern)
               : [],
             include: [
               // Pre-bundle React dependencies to avoid React duplicates,
@@ -1361,7 +1362,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                             ctx.reactRouterConfig
                           )
                       ),
-                    ],
+                    ].map(convertPathToPattern),
                     include: [
                       "react",
                       "react/jsx-dev-runtime",

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -27,7 +27,7 @@ import pick from "lodash/pick";
 import jsesc from "jsesc";
 import colors from "picocolors";
 import kebabCase from "lodash/kebabCase";
-import { convertPathToPattern } from "tinyglobby";
+import { escapePath as escapePathAsGlob } from "tinyglobby";
 
 import * as Typegen from "../typegen";
 import type { RouteManifestEntry, RouteManifest } from "../config/routes";
@@ -1225,7 +1225,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                   ...Object.values(ctx.reactRouterConfig.routes).map((route) =>
                     resolveRelativeRouteFilePath(route, ctx.reactRouterConfig)
                   ),
-                ].map(convertPathToPattern)
+                ].map(escapePathAsGlob)
               : [],
             include: [
               // Pre-bundle React dependencies to avoid React duplicates,
@@ -1362,7 +1362,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                             ctx.reactRouterConfig
                           )
                       ),
-                    ].map(convertPathToPattern),
+                    ].map(escapePathAsGlob),
                     include: [
                       "react",
                       "react/jsx-dev-runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,9 @@ importers:
       set-cookie-parser:
         specifier: ^2.6.0
         version: 2.6.0
+      tinyglobby:
+        specifier: ^0.2.13
+        version: 0.2.13
       valibot:
         specifier: ^0.41.0
         version: 0.41.0(typescript@5.4.5)
@@ -5678,6 +5681,14 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.4.4:
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -8401,6 +8412,10 @@ packages:
 
   tinyglobby@0.2.12:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.9:
@@ -13928,6 +13943,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fdir@6.4.4(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.0.4
@@ -16808,7 +16827,7 @@ snapshots:
       picomatch: 4.0.2
       postcss: 8.5.3
       rolldown: 1.0.0-beta.7-commit.7452fa0(@oxc-project/runtime@0.61.2)(typescript@5.4.5)
-      tinyglobby: 0.2.12
+      tinyglobby: 0.2.13
     optionalDependencies:
       '@types/node': 20.11.30
       esbuild: 0.25.0
@@ -17447,6 +17466,11 @@ snapshots:
   tinyglobby@0.2.12:
     dependencies:
       fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  tinyglobby@0.2.13:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinyglobby@0.2.9:


### PR DESCRIPTION
The values passed to `optimizeDeps.entries` are expected to be [tinyglobby](https://www.npmjs.com/package/tinyglobby) patterns, not file paths. We're currently passing file paths which means that any special matching characters in file names will accidentally trigger pattern matching.

To fix this, we now pass all paths through [escapePath](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#escapepathpath).

In terms of versioning, I've ensured we depend on the same tinyglobby version range as Vite: https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L93

Note that in Vite v5, the globs are passed to [fast-glob](https://www.npmjs.com/package/fast-glob) instead of tinyglobby, but since tinyglobby is a drop-in replacement, we don't need to do any version detection.