### PR TITLE
docs(start/data/data-loading): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -387,3 +387,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- 3fuyang

--- a/docs/start/data/data-loading.md
+++ b/docs/start/data/data-loading.md
@@ -15,7 +15,7 @@ Data is provided to route components from route loaders:
 createBrowserRouter([
   {
     path: "/",
-    loader: () => {
+    loader: async () => {
       // return data from here
       return { records: await getSomeRecords() };
     },


### PR DESCRIPTION
Added the missing `async` keyword