### PR TITLE
correct import and export error in index.ts (located at react-router-dom/packages/react-router-dom/index.ts)

### DIFF
--- a/packages/react-router-dom/index.ts
+++ b/packages/react-router-dom/index.ts
@@ -1,9 +1,9 @@
-import type { RouterProviderProps } from "react-router-dom";
-import { HydratedRouter, RouterProvider } from "react-router-dom";
+import type { RouterProviderProps } from "react-router";
+import { RouterProvider } from "react-router";
 
 // TODO: Confirm if this causes tree-shaking issues and if so, convert to named exports
 export type * from "react-router";
 export * from "react-router";
 
 export type { RouterProviderProps };
-export { HydratedRouter, RouterProvider };
+export { RouterProvider };

--- a/packages/react-router-dom/index.ts
+++ b/packages/react-router-dom/index.ts
@@ -1,5 +1,5 @@
-import type { RouterProviderProps } from "react-router/dom";
-import { HydratedRouter, RouterProvider } from "react-router/dom";
+import type { RouterProviderProps } from "react-router-dom";
+import { HydratedRouter, RouterProvider } from "react-router-dom";
 
 // TODO: Confirm if this causes tree-shaking issues and if so, convert to named exports
 export type * from "react-router";


### PR DESCRIPTION
there is an import error as well as export error in the file react-router-dom/packages/react-router-dom/index.ts
the error have raised the errors(screenshot attached) after correcting it the error resolved'

Removed `HydratedRouter` Export
The "HydratedRouter" export does not exist in "react-router-dom@7.6.0" (or "react-router@7.6.0"). Including it in "index.ts" was causing the compiled "dist/index.mjs" to fail, which in turn broke the "RouterProvider" export.
   - Removed both the import ("import { HydratedRouter, RouterProvider } from "react-router-dom";") and export ("export { HydratedRouter, RouterProvider };") of "HydratedRouter".



![Screenshot from 2025-05-11 23-31-07](https://github.com/user-attachments/assets/67c400f2-ccc2-4e91-bf9f-62a87e276df9)

![react-error](https://github.com/user-attachments/assets/026b2716-321e-41e6-8ff3-6dd2b0af2cc6)
