### PR TITLE
Remove `RefreshRuntime` imports in react-router vite plugin

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -388,3 +388,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- edenworky

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2142,7 +2142,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         if (id !== virtualInjectHmrRuntime.resolvedId) return;
 
         return [
-          `import RefreshRuntime from "${virtualHmrRuntime.id}"`,
           "RefreshRuntime.injectIntoGlobalHook(window)",
           "window.$RefreshReg$ = () => {}",
           "window.$RefreshSig$ = () => (type) => type",
@@ -2349,8 +2348,6 @@ function addRefreshWrapper(
 }
 
 const REACT_REFRESH_HEADER = `
-import RefreshRuntime from "${virtualHmrRuntime.id}";
-
 const inWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
 let prevRefreshReg;
 let prevRefreshSig;


### PR DESCRIPTION
These lines are throwing an error for me as `RefreshRuntime` is already being imported by `@vitejs/plugin-react`. If/when this PR is approved I can generate a changeset, but this seems somewhat drastic, but as stated currently I can't run the plugin.