### PR TITLE
Fix Parcel RSC playground

### DIFF
--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -290,11 +290,7 @@ export type {
 export { createCallServer, RSCHydratedRouter } from "./lib/rsc/browser";
 export { routeRSCServerRequest, RSCStaticRouter } from "./lib/rsc/server.ssr";
 export { getServerStream } from "./lib/rsc/html-stream/browser";
-export {
-  WithRouteComponentProps as UNSAFE_WithRouteComponentProps,
-  WithHydrateFallbackProps as UNSAFE_WithHydrateFallbackProps,
-  WithErrorBoundaryProps as UNSAFE_WithErrorBoundaryProps,
-} from "./lib/components";
+export { ClientComponentPropsProvider as unstable_ClientComponentPropsProvider } from "./lib/components";
 
 ///////////////////////////////////////////////////////////////////////////////
 // DANGER! PLEASE READ ME!

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1147,7 +1147,7 @@ export type RouteComponentProps = {
   matches: ReturnType<typeof useMatches>;
 };
 
-export function WithRouteComponentProps({
+function RouteComponentPropsProvider({
   children,
 }: {
   children: React.ReactElement;
@@ -1167,7 +1167,7 @@ export type HydrateFallbackProps = {
   params: ReturnType<typeof useParams>;
 };
 
-export function WithHydrateFallbackProps({
+function HydrateFallbackPropsProvider({
   children,
 }: {
   children: React.ReactElement;
@@ -1187,7 +1187,7 @@ export type ErrorBoundaryProps = {
   error: ReturnType<typeof useRouteError>;
 };
 
-export function WithErrorBoundaryProps({
+function ErrorBoundaryPropsProvider({
   children,
 }: {
   children: React.ReactElement;
@@ -1200,6 +1200,31 @@ export function WithErrorBoundaryProps({
   };
   return React.cloneElement(children, props);
 }
+
+const clientComponentPropsProvidersByType = {
+  Component: RouteComponentPropsProvider,
+  ErrorBoundary: ErrorBoundaryPropsProvider,
+  HydrateFallback: HydrateFallbackPropsProvider,
+} as const;
+
+export function ClientComponentPropsProvider({
+  __type: type,
+  children,
+}: {
+  __type: keyof typeof clientComponentPropsProvidersByType;
+  children: React.ReactElement;
+}) {
+  const Provider = clientComponentPropsProvidersByType[type];
+
+  if (!Provider) {
+    throw new Error(`Invalid type: ${type}`);
+  }
+
+  return <Provider>{children}</Provider>;
+}
+
+export type ClientComponentPropsProviderType =
+  typeof ClientComponentPropsProvider;
 
 ///////////////////////////////////////////////////////////////////////////////
 // UTILS

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -156,7 +156,7 @@ export async function matchRSCServerRequest({
   request,
   routes,
   generateResponse,
-  ClientComponentPropsProvider,
+  unstable_ClientComponentPropsProvider: ClientComponentPropsProvider,
 }: {
   decodeCallServer?: DecodeCallServerFunction;
   decodeFormAction?: DecodeFormActionFunction;
@@ -164,7 +164,7 @@ export async function matchRSCServerRequest({
   request: Request;
   routes: ServerRouteObject[];
   generateResponse: (match: ServerMatch) => Response;
-  ClientComponentPropsProvider?: ClientComponentPropsProviderType;
+  unstable_ClientComponentPropsProvider?: ClientComponentPropsProviderType;
 }): Promise<Response> {
   const url = new URL(request.url);
 

--- a/playground/rsc-parcel/src/entry.rsc.ts
+++ b/playground/rsc-parcel/src/entry.rsc.ts
@@ -12,7 +12,7 @@ import {
   type DecodeFormActionFunction,
   matchRSCServerRequest,
 } from "react-router/rsc";
-import { unstable_ClientComponentPropsProvider as ClientComponentPropsProvider } from "react-router" assert { env: "client" };
+import { unstable_ClientComponentPropsProvider } from "react-router" assert { env: "client" };
 
 import { routes } from "./routes";
 
@@ -35,7 +35,7 @@ export function callServer(request: Request) {
     request,
     // @ts-expect-error
     routes,
-    ClientComponentPropsProvider,
+    unstable_ClientComponentPropsProvider,
     generateResponse(match) {
       return new Response(renderToReadableStream(match.payload), {
         status: match.statusCode,

--- a/playground/rsc-parcel/src/entry.rsc.ts
+++ b/playground/rsc-parcel/src/entry.rsc.ts
@@ -1,22 +1,42 @@
 "use server-entry";
 
-import "./entry.browser";
-
-import { matchRSCServerRequest } from "react-router/rsc";
-// @ts-expect-error
-import { renderToReadableStream } from "react-server-dom-parcel/server.edge";
+import {
+  decodeAction,
+  decodeReply,
+  loadServerAction,
+  renderToReadableStream,
+  // @ts-expect-error
+} from "react-server-dom-parcel/server.edge";
+import {
+  type DecodeCallServerFunction,
+  type DecodeFormActionFunction,
+  matchRSCServerRequest,
+} from "react-router/rsc";
+import { unstable_ClientComponentPropsProvider as ClientComponentPropsProvider } from "react-router" assert { env: "client" };
 
 import { routes } from "./routes";
 
+import "./entry.browser.tsx";
+
+const decodeCallServer: DecodeCallServerFunction = async (actionId, reply) => {
+  const args = await decodeReply(reply);
+  const action = await loadServerAction(actionId);
+  return action.bind(null, ...args);
+};
+
+const decodeFormAction: DecodeFormActionFunction = async (formData) => {
+  return await decodeAction(formData);
+};
+
 export function callServer(request: Request) {
   return matchRSCServerRequest({
+    decodeCallServer,
+    decodeFormAction,
     request,
+    // @ts-expect-error
     routes,
+    ClientComponentPropsProvider,
     generateResponse(match) {
-      if (match instanceof Response) {
-        return match;
-      }
-
       return new Response(renderToReadableStream(match.payload), {
         status: match.statusCode,
         headers: match.headers,

--- a/playground/rsc-parcel/src/entry.ssr.tsx
+++ b/playground/rsc-parcel/src/entry.ssr.tsx
@@ -1,45 +1,38 @@
 import { createRequestListener } from "@mjackson/node-fetch-server";
 import express from "express";
-
+// @ts-expect-error - no types
+import { renderToReadableStream as renderHTMLToReadableStream } from "react-dom/server.edge" assert { env: "react-client" };
+import {
+  routeRSCServerRequest,
+  RSCStaticRouter,
+} from "react-router" assert { env: "react-client" };
 // @ts-expect-error
-import { createFromReadableStream } from "react-server-dom-parcel/client.edge" with {
-	env: "react-client",
-};
-// @ts-expect-error
-import { renderToReadableStream as renderHTMLToReadableStream } from "react-dom/server.edge" with {
-	env: "react-client",
-};
+import { createFromReadableStream } from "react-server-dom-parcel/client.edge" assert { env: "react-client" };
 
-import { routeRSCServerRequest, RSCStaticRouter } from "react-router" with {
-	env: "react-client",
-};
-
-import { callServer } from "./entry.rsc" with {
-	env: "react-server",
-};
+import { callServer } from "./entry.rsc" assert { env: "react-server" };
 
 const app = express();
 
-app.use(express.static("dist"));
+app.use("/client", express.static("dist/client"));
 
 app.use(
-	createRequestListener(async (request) => {
-		return routeRSCServerRequest(
-			request,
-			callServer,
-			createFromReadableStream,
-			async (payload) => {
-				return await renderHTMLToReadableStream(
-					<RSCStaticRouter payload={payload} />,
-					{
-						bootstrapScriptContent: (
-							callServer as unknown as { bootstrapScript: string }
-						).bootstrapScript,
-					},
-				);
-			}
-		);
-	}),
+  createRequestListener(async (request) => {
+    return routeRSCServerRequest(
+      request,
+      callServer,
+      createFromReadableStream,
+      async (getPayload) => {
+        return await renderHTMLToReadableStream(
+          <RSCStaticRouter getPayload={getPayload} />,
+          {
+            bootstrapScriptContent: (
+              callServer as unknown as { bootstrapScript: string }
+            ).bootstrapScript,
+          }
+        );
+      }
+    );
+  })
 );
 
 const server = app.listen(3001);
@@ -47,9 +40,9 @@ console.log("Server listening on port 3001");
 
 // Restart the server when it changes.
 if (module.hot) {
-	module.hot.dispose(() => {
-		server.close();
-	});
+  module.hot.dispose(() => {
+    server.close();
+  });
 
-	module.hot.accept();
+  module.hot.accept();
 }

--- a/playground/rsc-parcel/src/routes.ts
+++ b/playground/rsc-parcel/src/routes.ts
@@ -1,19 +1,20 @@
-import type { ServerRouteObject } from "react-router";
+import type { ServerRouteObject } from "react-router/rsc";
 
 export const routes = [
   {
     id: "root",
-    // requiredCSS: ["/index.css"],
     lazy: () => import("./routes/root/root"),
     children: [
       {
         id: "home",
         index: true,
+        // @ts-expect-error
         lazy: () => import("./routes/home/home"),
       },
       {
         id: "about",
         path: "about",
+        // @ts-expect-error
         lazy: () => import("./routes/about/about"),
       },
     ],

--- a/playground/rsc-parcel/tsconfig.json
+++ b/playground/rsc-parcel/tsconfig.json
@@ -1,12 +1,12 @@
 {
-	"compilerOptions": {
-		"strict": true,
-		"jsx": "react-jsx",
-		"allowSyntheticDefaultImports": true,
-		"moduleResolution": "node",
-		"module": "esnext",
-		"isolatedModules": true,
-		"esModuleInterop": true,
-		"target": "es2022"
-	}
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react-jsx",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "bundler",
+    "module": "esnext",
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "target": "es2022"
+  }
 }


### PR DESCRIPTION
The Parcel RSC playground currently isn't working in the `rsc` branch. To fix this, this PR updates all of the RSC entry code to use the latest APIs. However, this surfaced an issue with our use of client component imports within `react-router/rsc` (importing `UNSAFE_WithRouteComponentProps`, `UNSAFE_WithHydrateFallbackProps` and `UNSAFE_WithErrorBoundaryProps`).

For some reason this doesn't seem to work within this monorepo. The errors seem to indicate that Parcel isn't honouring the `"use client"` directive at the top of our `react-router` entry point when resolved within `react-router/rsc`. Since I already had a feeling this might fail in other scenarios (e.g. unbundled Vite dev server), I've modified the API a bit to handle this.

We now have a single component for wrapping route-level client components called `ClientComponentPropsProvider`. By making it a single component, it's now ergonomic for consumers to import this client component in their app code and pass it to `matchRSCServerRequest`. This way, if `"use client"` isn't supported within `node_modules`, consumers now have a way to work around it. This is the approach we now use in `playground/rsc-parcel/src/entry.rsc.ts`.

Update: We've decided this is a temporary fix. This is a good sign that we shouldn't rely on this behaviour. Instead, client component props will be provided at the framework layer, not in library mode, but that doesn't need to block this fix.