### PR TITLE
Normalize `dirent` entry path across node versions when generating SRI manifest

### DIFF
--- a/.changeset/odd-hounds-ring.md
+++ b/.changeset/odd-hounds-ring.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Normalize dirent entry path across node versions when generating SRI manifest

--- a/.changeset/odd-hounds-ring.md
+++ b/.changeset/odd-hounds-ring.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Normalize dirent entry path across node versions when generating SRI manifest
+[UNSTABLE] Normalize dirent entry path across node versions when generating SRI manifest

--- a/contributors.yml
+++ b/contributors.yml
@@ -267,6 +267,7 @@
 - parveen232
 - paulsmithkc
 - pavsoldatov
+- pawelblaszczyk5
 - pcattori
 - penx
 - petersendidit

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -810,10 +810,15 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     let sriManifest: ReactRouterManifest["sri"] = {};
     for (const entry of entries) {
       if (entry.isFile() && entry.name.endsWith(".js")) {
+        const entryNormalizedPath =
+          "parentPath" in entry && typeof entry.parentPath === "string"
+            ? entry.parentPath
+            : entry.path;
+
         let contents;
         try {
           contents = await fse.readFile(
-            path.join(entry.path, entry.name),
+            path.join(entryNormalizedPath, entry.name),
             "utf-8"
           );
         } catch (e) {
@@ -825,7 +830,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           .digest()
           .toString("base64");
         let filepath = getVite().normalizePath(
-          path.relative(clientBuildDirectory, path.join(entry.path, entry.name))
+          path.relative(clientBuildDirectory, path.join(entryNormalizedPath, entry.name))
         );
         sriManifest[`${ctx.publicPath}${filepath}`] = `sha384-${hash}`;
       }


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/13590

`entry.path` on `Dirent` is deprecated since a few versions and removed as of Node version 24 https://github.com/nodejs/node/pull/55548

![image](https://github.com/user-attachments/assets/b07b1363-41ff-40d2-8ad1-a3de20e2b869)

https://nodejs.org/docs/latest-v23.x/api/fs.html#direntpath

Since RR declares engines as working with any minor/patch version above 20.x.x - I can’t just directly use the `parentPath` which is recommended now. I normalize it so it works also in few minors that have `dirent.path` but don't have `dirent.parentPath`. Also a bit of gymnastics for TS is needed because installed version of types for node doesn’t include the `parentPath`