### PR TITLE
Remove dynamic `react-router` import from RSC code

### DIFF
--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as reactRouterClient from "react-router";
 
 import type {
   ClientActionFunction,
@@ -403,7 +404,7 @@ async function generateStaticContextResponse(
   isSubmission: boolean,
   actionResult: Promise<unknown> | undefined,
   staticContext: StaticHandlerContext,
-  ClientComponentPropsProviderArg?: ClientComponentPropsProviderType
+  ClientComponentPropsProvider: ClientComponentPropsProviderType = reactRouterClient.unstable_ClientComponentPropsProvider
 ): Promise<Response> {
   statusCode = staticContext.statusCode ?? statusCode;
 
@@ -443,10 +444,6 @@ async function generateStaticContextResponse(
     loaderData: staticContext.loaderData,
     location: staticContext.location,
   };
-
-  const ClientComponentPropsProvider =
-    ClientComponentPropsProviderArg ??
-    (await import("react-router")).unstable_ClientComponentPropsProvider;
 
   // Short circuit without matches on submissions
   if (isSubmission) {


### PR DESCRIPTION
The dynamic import from `react-router` within `react-router/rsc` is being used to load the client component that wraps all route-level client components. This works within the context of the playground in this repo, but fails in the context of apps installing the package. Instead, we now statically import from `react-router` to get the fallback value. I've confirmed that this works in both the playground and as an experimental release.