### PR TITLE
docs(upgrading/future): fix `v7_relativeSplatPath` code diff

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,4 +1,5 @@
 - 0xEddie
+- aasensios
 - abdallah-nour
 - abeadam
 - abhi-kr-2100

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -57,7 +57,6 @@ Split any multi-segment splat `<Route>` into a parent route with the path and a 
   <Route path="/" element={<Home />} />
 -  <Route path="dashboard/*" element={<Dashboard />} />
 +  <Route path="dashboard">
-+    <Route index element={<Dashboard />} />
 +    <Route path="*" element={<Dashboard />} />
 +  </Route>
 </Routes>


### PR DESCRIPTION
In the diff code snippet of [v7_relativeSplatPath](https://reactrouter.com/6.30.0/upgrading/future#v7_relativesplatpath), the index Route instance is causing navigation failure on v6.30.0.

This PR removes that line from the example.

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/215a6ac1-c79d-41a8-a766-d8f5e214fa6b" />
