### PR TITLE
fix: Respect `X-Forwarded-Proto` header when creating Remix request

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -165,6 +165,7 @@
 - jimniels
 - jmargeta
 - jmjpro
+- jobveldhuis
 - johnpangalos
 - jonkoops
 - jrakotoharisoa

--- a/packages/react-router-express/__tests__/server-test.ts
+++ b/packages/react-router-express/__tests__/server-test.ts
@@ -241,4 +241,40 @@ describe("express createRemixRequest", () => {
     expect(remixRequest.headers.get("host")).toBe("localhost:3000");
     expect(remixRequest.url).toBe("http://localhost:3000/foo/bar");
   });
+
+  it("respects forwarded protocol if allowed", async () => {
+    let expressRequest = createRequest({
+      url: "/foo/bar",
+      method: "GET",
+      protocol: "http",
+      hostname: "localhost",
+      headers: {
+        "X-Forwarded-Proto": "https",
+        Host: "localhost:3000",
+      },
+    });
+    let expressResponse = createResponse();
+
+    let remixRequest = createRemixRequest(expressRequest, expressResponse);
+
+    expect(remixRequest.url).toBe("https://localhost:3000/foo/bar");
+  });
+
+  it("defaults to the original request protocol if the forwarded protocol is not allowed", async () => {
+    let expressRequest = createRequest({
+      url: "/foo/bar",
+      method: "GET",
+      protocol: "http",
+      hostname: "localhost",
+      headers: {
+        "X-Forwarded-Proto": "ws",
+        Host: "localhost:3000",
+      },
+    });
+    let expressResponse = createResponse();
+
+    let remixRequest = createRemixRequest(expressRequest, expressResponse);
+
+    expect(remixRequest.url).toBe("http://localhost:3000/foo/bar");
+  });
 });

--- a/packages/react-router-express/server.ts
+++ b/packages/react-router-express/server.ts
@@ -109,8 +109,13 @@ export function createRemixRequest(
     : "";
   // Use req.hostname here as it respects the "trust proxy" setting
   let resolvedHost = `${req.hostname}${port ? `:${port}` : ""}`;
+  // Only allow http and https protocols to avoid security issues with forwarding protocol
+  const allowedProtocols = new Set(["http", "https"]);
+  const forwardedProtocol = req.get("X-Forwarded-Proto") ?? req.protocol;
+  // Fall back to default protocol if the requested protocol is not allowed
+  const protocol = allowedProtocols.has(forwardedProtocol) ? forwardedProtocol : req.protocol;
   // Use `req.originalUrl` so Remix is aware of the full path
-  let url = new URL(`${req.protocol}://${resolvedHost}${req.originalUrl}`);
+  let url = new URL(`${protocol}://${resolvedHost}${req.originalUrl}`);
 
   // Abort action/loaders once we can no longer write a response
   let controller: AbortController | null = new AbortController();


### PR DESCRIPTION
Previously, the `X-Forwarded-Proto` header was ignored when creating a new RemixRequest instance. This PR changes that to respect the `X-Forwarded-Proto` header if the forwarded protocol is either `http` or `https`. In all other cases, it will default to the original request protocol.

Fixes #13544 