### PR TITLE
Fix href function return empty string

### DIFF
--- a/packages/react-router/lib/href.ts
+++ b/packages/react-router/lib/href.ts
@@ -23,6 +23,9 @@ type ToArgs<T> =
   Returns a resolved URL path for the specified route.
 
   ```tsx
+  const h = href("/:lang?", {})
+  // -> `/`
+
   const h = href("/:lang?/about", { lang: "en" })
   // -> `/en/about`
 
@@ -51,5 +54,5 @@ export function href<Path extends keyof Args>(
       return value;
     })
     .filter((segment) => segment !== undefined)
-    .join("/");
+    .join("/") || "/";
 }


### PR DESCRIPTION
if href function return empty string, the url don't change when click the link.