### PR TITLE
chore: export `DefineRouteFunction` type from remix adapter

### DIFF
--- a/packages/react-router-remix-routes-option-adapter/defineRoutes.ts
+++ b/packages/react-router-remix-routes-option-adapter/defineRoutes.ts
@@ -28,7 +28,7 @@ interface DefineRouteChildren {
   (): void;
 }
 
-interface DefineRouteFunction {
+export interface DefineRouteFunction {
   (
     /**
      * The path this route uses to match the URL pathname.

--- a/packages/react-router-remix-routes-option-adapter/index.ts
+++ b/packages/react-router-remix-routes-option-adapter/index.ts
@@ -1,9 +1,9 @@
 import { type RouteConfigEntry } from "@react-router/dev/routes";
 
 import { routeManifestToRouteConfig } from "./manifest";
-import { defineRoutes, type DefineRoutesFunction } from "./defineRoutes";
+import { defineRoutes, type DefineRoutesFunction, type DefineRouteFunction } from "./defineRoutes";
 
-export type { DefineRoutesFunction };
+export type { DefineRoutesFunction, DefineRouteFunction };
 
 /**
  * Adapts routes defined using [Remix's `routes` config


### PR DESCRIPTION
Hello together,

in the remix days i used the type `DefineRouteFunction` to structure and reuse my route functions. Now with React Router 7 and the `remix-routes-option-adapter` this type is not exported anymore.

This merge request exports it again.

Thanks for your great work
bmsuseluda