### PR TITLE
setSearchParams should not navigate if the state is unchanged

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -366,6 +366,7 @@
 - valerii15298
 - ValiantCat
 - vdusart
+- vezaynk
 - VictorElHajj
 - vijaypushkin
 - vikingviolinist
@@ -389,3 +390,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1427,8 +1427,11 @@ export function useSearchParams(
       const newSearchParams = createSearchParams(
         typeof nextInit === "function" ? nextInit(searchParams) : nextInit
       );
+
+      if (newSearchParams === searchParams) return Promise.resolve();
       hasSetSearchParamsRef.current = true;
-      navigate("?" + newSearchParams, navigateOptions);
+
+      return navigate("?" + newSearchParams, navigateOptions);
     },
     [navigate, searchParams]
   );
@@ -2270,3 +2273,4 @@ export function useViewTransitionState(
 }
 
 //#endregion
+

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1429,7 +1429,9 @@ export function useSearchParams(
       );
 
       const unchanged = newSearchParams === searchParams || newSearchParams.toString() === searchParams.toString()
-      if (unchanged) return Promise.resolve();
+      // Do not trigger a navigation for unchanged searchParams 
+      // unless if it is meant to update state OR it is used for a flushSync
+      if (unchanged && navigateOptions.state === undefined && !navigateOptions.flushSync) return Promise.resolve();
       hasSetSearchParamsRef.current = true;
 
       return navigate("?" + newSearchParams, navigateOptions);

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1428,7 +1428,8 @@ export function useSearchParams(
         typeof nextInit === "function" ? nextInit(searchParams) : nextInit
       );
 
-      if (newSearchParams === searchParams) return Promise.resolve();
+      const unchanged = newSearchParams === searchParams || newSearchParams.toString() === searchParams.toString()
+      if (unchanged) return Promise.resolve();
       hasSetSearchParamsRef.current = true;
 
       return navigate("?" + newSearchParams, navigateOptions);


### PR DESCRIPTION
I'd like to be able to write code like this to avoid unnecessary navigation events:

```ts
  setSearchParams((searchParams) => {
      const nextParams = computeNextParams(searchParams, nextData);
      // This should avoid the rerender, but apparently it doesn't.
      if (nextParams.toString() === searchParams.toString()) {
        // skip update due to reference
        return searchParams;
      }
      return nextParams;
    });
```

With this change, I should also be able to write this:

```ts
  setSearchParams((searchParams) => {
      const nextParams = computeNextParams(searchParams, nextData);
      // skip update due to value
      return nextParams;
    });
```

Additionally, I've made `setSearchParams` return a Promise to be consistent with `navigate`, since both are async actions.