### PR TITLE
docs(start/framework/route-module): clarify the behaviour of multiple `meta` functions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -382,6 +382,7 @@
 - willsawyerrrr
 - willsmithte
 - wkovacs64
+- woodywoodsta
 - xavier-lc
 - xcsnowcity
 - xdaxer

--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -309,9 +309,9 @@ export default function Root() {
 
 ## `meta`
 
-Route meta defines meta tags to be rendered in the `<head>` of the document.
+Route meta defines meta tags to be rendered in the `<Meta />` component, usually placed in the `<head>`.
 
-```tsx
+```tsx filename=app/product.tsx
 export function meta() {
   return [
     { title: "Very cool app" },
@@ -326,10 +326,7 @@ export function meta() {
   ];
 }
 ```
-
-All routes' meta will be aggregated and rendered through the `<Meta />` component, usually rendered in your app root:
-
-```tsx
+```tsx filename=app/root.tsx
 import { Meta } from "react-router";
 
 export default function Root() {
@@ -344,6 +341,8 @@ export default function Root() {
   );
 }
 ```
+
+The meta of the last matching route is used, allowing you to override parent routes' meta. It's important to note that the entire meta descriptor array is replaced, not merged. This gives you the flexibility to build your own meta composition logic across pages at different levels.
 
 **See also**
 


### PR DESCRIPTION
Fixes #13633 