### PR TITLE
feat(react-router): make `useRouteError`'s return type generic

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -389,3 +389,4 @@
 - yuleicul
 - zeromask1337
 - zheng-chuang
+- Kymesa

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1167,7 +1167,7 @@ export function useActionData<T = any>(): SerializeFrom<T> | undefined {
 
   @category Hooks
  */
-export function useRouteError(): unknown {
+export function useRouteError<T = unknown>(): T {
   let error = React.useContext(RouteErrorContext);
   let state = useDataRouterState(DataRouterStateHook.UseRouteError);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseRouteError);


### PR DESCRIPTION
Hi, I use this function useRouteError in React and React Native, but typescript always has problems.
![Captura de pantalla 2025-05-20 a las 11 54 29 a  m](https://github.com/user-attachments/assets/b9218971-e801-42b8-ac14-8332d1803593)
![Captura de pantalla 2025-05-20 a las 11 55 22 a  m](https://github.com/user-attachments/assets/42e102f7-bb83-4b49-aa0e-33c73134d00b)
