### PR TITLE
fix: move `with-props` runtime logic to core library

### DIFF
--- a/.changeset/calm-pants-film.md
+++ b/.changeset/calm-pants-film.md
@@ -1,0 +1,6 @@
+---
+"@react-router/dev": patch
+"react-router": patch
+---
+
+Avoid additional `with-props` chunk in Framework Mode by moving route module component prop logic from the Vite plugin to `react-router`

--- a/integration/prefetch-test.ts
+++ b/integration/prefetch-test.ts
@@ -166,10 +166,6 @@ test.describe("prefetch", () => {
           // These 2 are common and duped for both - but they've already loaded on
           // page load so they don't trigger network requests
           await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/with-props-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
             // Look for either Rollup or Rolldown chunks
             [
               "link[rel='modulepreload'][href^='/assets/index-']",
@@ -179,7 +175,7 @@ test.describe("prefetch", () => {
           );
 
           // Ensure no other links in the #nav element
-          expect(await page.locator("link").count()).toBe(7);
+          expect(await page.locator("link").count()).toBe(5);
         });
       });
 
@@ -226,29 +222,6 @@ test.describe("prefetch", () => {
             { state: "attached" }
           );
           await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/with-props-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
-            // Look for either Rollup or Rolldown chunks
-            [
-              "link[rel='modulepreload'][href^='/assets/index-']",
-              "link[rel='modulepreload'][href^='/assets/jsx-runtime-']",
-            ].join(","),
-            { state: "attached" }
-          );
-          expect(await page.locator("link").count()).toBe(4);
-
-          await page.hover("a[href='/prefetch-without-loader']");
-          await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/prefetch-without-loader-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/with-props-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
             // Look for either Rollup or Rolldown chunks
             [
               "link[rel='modulepreload'][href^='/assets/index-']",
@@ -257,6 +230,21 @@ test.describe("prefetch", () => {
             { state: "attached" }
           );
           expect(await page.locator("link").count()).toBe(3);
+
+          await page.hover("a[href='/prefetch-without-loader']");
+          await page.waitForSelector(
+            "link[rel='modulepreload'][href^='/assets/prefetch-without-loader-']",
+            { state: "attached" }
+          );
+          await page.waitForSelector(
+            // Look for either Rollup or Rolldown chunks
+            [
+              "link[rel='modulepreload'][href^='/assets/index-']",
+              "link[rel='modulepreload'][href^='/assets/jsx-runtime-']",
+            ].join(","),
+            { state: "attached" }
+          );
+          expect(await page.locator("link").count()).toBe(2);
         });
 
         test("removes prefetch tags after navigating to/from the page", async ({
@@ -268,7 +256,7 @@ test.describe("prefetch", () => {
           // Links added on hover
           await page.hover("a[href='/prefetch-with-loader']");
           await page.waitForSelector("link", { state: "attached" });
-          expect(await page.locator("link").count()).toBe(4);
+          expect(await page.locator("link").count()).toBe(3);
 
           // Links removed upon navigating to the page
           await page.click("a[href='/prefetch-with-loader']");
@@ -335,29 +323,6 @@ test.describe("prefetch", () => {
             { state: "attached" }
           );
           await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/with-props-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
-            // Look for either Rollup or Rolldown chunks
-            [
-              "link[rel='modulepreload'][href^='/assets/index-']",
-              "link[rel='modulepreload'][href^='/assets/jsx-runtime-']",
-            ].join(","),
-            { state: "attached" }
-          );
-          expect(await page.locator("link").count()).toBe(4);
-
-          await page.focus("a[href='/prefetch-without-loader']");
-          await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/prefetch-without-loader-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
-            "link[rel='modulepreload'][href^='/assets/with-props-']",
-            { state: "attached" }
-          );
-          await page.waitForSelector(
             // Look for either Rollup or Rolldown chunks
             [
               "link[rel='modulepreload'][href^='/assets/index-']",
@@ -366,6 +331,21 @@ test.describe("prefetch", () => {
             { state: "attached" }
           );
           expect(await page.locator("link").count()).toBe(3);
+
+          await page.focus("a[href='/prefetch-without-loader']");
+          await page.waitForSelector(
+            "link[rel='modulepreload'][href^='/assets/prefetch-without-loader-']",
+            { state: "attached" }
+          );
+          await page.waitForSelector(
+            // Look for either Rollup or Rolldown chunks
+            [
+              "link[rel='modulepreload'][href^='/assets/index-']",
+              "link[rel='modulepreload'][href^='/assets/jsx-runtime-']",
+            ].join(","),
+            { state: "attached" }
+          );
+          expect(await page.locator("link").count()).toBe(2);
         });
       });
 

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -69,7 +69,7 @@ import {
   resolveEntryFiles,
   configRouteToBranchRoute,
 } from "../config/config";
-import * as WithProps from "./with-props";
+import { decorateComponentExportsWithProps } from "./with-props";
 
 export type LoadCssContents = (
   viteDevServer: Vite.ViteDevServer,
@@ -2149,7 +2149,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }
       },
     },
-    WithProps.plugin,
     {
       name: "react-router:route-exports",
       async transform(code, id, options) {
@@ -2201,7 +2200,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         if (!options?.ssr) {
           removeExports(ast, SERVER_ONLY_ROUTE_EXPORTS);
         }
-        WithProps.transform(ast);
+        decorateComponentExportsWithProps(ast);
         return generate(ast, {
           sourceMaps: true,
           filename: id,

--- a/packages/react-router-dev/vite/with-props.ts
+++ b/packages/react-router-dev/vite/with-props.ts
@@ -1,70 +1,22 @@
-import type { Plugin } from "vite";
-import dedent from "dedent";
-
 import type { Babel, NodePath, ParseResult } from "./babel";
 import { traverse, t } from "./babel";
-import * as VirtualModule from "./virtual-module";
 
-const vmod = VirtualModule.create("with-props");
+const namedComponentExports = ["HydrateFallback", "ErrorBoundary"] as const;
+type NamedComponentExport = (typeof namedComponentExports)[number];
+function isNamedComponentExport(name: string): name is NamedComponentExport {
+  return namedComponentExports.includes(name as NamedComponentExport);
+}
 
-const NAMED_COMPONENT_EXPORTS = ["HydrateFallback", "ErrorBoundary"];
+type HocName =
+  | "UNSAFE_withComponentProps"
+  | "UNSAFE_withHydrateFallbackProps"
+  | "UNSAFE_withErrorBoundaryProps";
 
-export const plugin: Plugin = {
-  name: "react-router-with-props",
-  enforce: "pre",
-  resolveId(id) {
-    if (id === vmod.id) return vmod.resolvedId;
-  },
-  async load(id) {
-    if (id !== vmod.resolvedId) return;
-
-    // Note: If you make changes to these implementations, please also update
-    // the corresponding functions in packages/react-router/lib/dom/ssr/routes-test-stub.tsx
-    return dedent`
-      import { createElement as h } from "react";
-      import { useActionData, useLoaderData, useMatches, useParams, useRouteError } from "react-router";
-
-      export function withComponentProps(Component) {
-        return function Wrapped() {
-          const props = {
-            params: useParams(),
-            loaderData: useLoaderData(),
-            actionData: useActionData(),
-            matches: useMatches(),
-          };
-          return h(Component, props);
-        };
-      }
-
-      export function withHydrateFallbackProps(HydrateFallback) {
-        return function Wrapped() {
-          const props = {
-            params: useParams(),
-            loaderData: useLoaderData(),
-            actionData: useActionData(),
-          };
-          return h(HydrateFallback, props);
-        };
-      }
-
-      export function withErrorBoundaryProps(ErrorBoundary) {
-        return function Wrapped() {
-          const props = {
-            params: useParams(),
-            loaderData: useLoaderData(),
-            actionData: useActionData(),
-            error: useRouteError(),
-          };
-          return h(ErrorBoundary, props);
-        };
-      }
-    `;
-  },
-};
-
-export const transform = (ast: ParseResult<Babel.File>) => {
+export const decorateComponentExportsWithProps = (
+  ast: ParseResult<Babel.File>
+) => {
   const hocs: Array<[string, Babel.Identifier]> = [];
-  function getHocUid(path: NodePath, hocName: string) {
+  function getHocUid(path: NodePath, hocName: HocName) {
     const uid = path.scope.generateUidIdentifier(hocName);
     hocs.push([hocName, uid]);
     return uid;
@@ -80,7 +32,7 @@ export const transform = (ast: ParseResult<Babel.File>) => {
           declaration.isFunctionDeclaration() ? toFunctionExpression(declaration.node) :
           undefined
         if (expr) {
-          const uid = getHocUid(path, "withComponentProps");
+          const uid = getHocUid(path, "UNSAFE_withComponentProps");
           declaration.replaceWith(t.callExpression(uid, [expr]));
         }
         return;
@@ -97,9 +49,8 @@ export const transform = (ast: ParseResult<Babel.File>) => {
             if (!expr) return;
             if (!id.isIdentifier()) return;
             const { name } = id.node;
-            if (!NAMED_COMPONENT_EXPORTS.includes(name)) return;
-
-            const uid = getHocUid(path, `with${name}Props`);
+            if (!isNamedComponentExport(name)) return;
+            const uid = getHocUid(path, `UNSAFE_with${name}Props`);
             init.replaceWith(t.callExpression(uid, [expr]));
           });
           return;
@@ -109,9 +60,9 @@ export const transform = (ast: ParseResult<Babel.File>) => {
           const { id } = decl.node;
           if (!id) return;
           const { name } = id;
-          if (!NAMED_COMPONENT_EXPORTS.includes(name)) return;
+          if (!isNamedComponentExport(name)) return;
 
-          const uid = getHocUid(path, `with${name}Props`);
+          const uid = getHocUid(path, `UNSAFE_with${name}Props`);
           decl.replaceWith(
             t.variableDeclaration("const", [
               t.variableDeclarator(
@@ -131,7 +82,7 @@ export const transform = (ast: ParseResult<Babel.File>) => {
         hocs.map(([name, identifier]) =>
           t.importSpecifier(identifier, t.identifier(name))
         ),
-        t.stringLiteral(vmod.id)
+        t.stringLiteral("react-router")
       )
     );
   }

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -320,6 +320,9 @@ export {
 export {
   hydrationRouteProperties as UNSAFE_hydrationRouteProperties,
   mapRouteProperties as UNSAFE_mapRouteProperties,
+  withComponentProps as UNSAFE_withComponentProps,
+  withHydrateFallbackProps as UNSAFE_withHydrateFallbackProps,
+  withErrorBoundaryProps as UNSAFE_withErrorBoundaryProps,
 } from "./lib/components";
 
 /** @internal */

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -53,11 +53,16 @@ import {
 } from "./context";
 import {
   _renderMatches,
+  useActionData,
   useAsyncValue,
   useInRouterContext,
+  useLoaderData,
   useLocation,
+  useMatches,
   useNavigate,
   useOutlet,
+  useParams,
+  useRouteError,
   useRoutes,
   useRoutesImpl,
 } from "./hooks";
@@ -1228,4 +1233,59 @@ export function renderMatches(
   matches: RouteMatch[] | null
 ): React.ReactElement | null {
   return _renderMatches(matches);
+}
+
+export type RouteComponentType = React.ComponentType<{
+  params: ReturnType<typeof useParams>;
+  loaderData: ReturnType<typeof useLoaderData>;
+  actionData: ReturnType<typeof useActionData>;
+  matches: ReturnType<typeof useMatches>;
+}>;
+
+export function withComponentProps(Component: RouteComponentType) {
+  return function WithComponentProps() {
+    const props = {
+      params: useParams(),
+      loaderData: useLoaderData(),
+      actionData: useActionData(),
+      matches: useMatches(),
+    };
+    return React.createElement(Component, props);
+  };
+}
+
+export type HydrateFallbackType = React.ComponentType<{
+  params: ReturnType<typeof useParams>;
+  loaderData: ReturnType<typeof useLoaderData>;
+  actionData: ReturnType<typeof useActionData>;
+}>;
+
+export function withHydrateFallbackProps(HydrateFallback: HydrateFallbackType) {
+  return function WithHydrateFallbackProps() {
+    const props = {
+      params: useParams(),
+      loaderData: useLoaderData(),
+      actionData: useActionData(),
+    };
+    return React.createElement(HydrateFallback, props);
+  };
+}
+
+export type ErrorBoundaryType = React.ComponentType<{
+  params: ReturnType<typeof useParams>;
+  loaderData: ReturnType<typeof useLoaderData>;
+  actionData: ReturnType<typeof useActionData>;
+  error: ReturnType<typeof useRouteError>;
+}>;
+
+export function withErrorBoundaryProps(ErrorBoundary: ErrorBoundaryType) {
+  return function WithErrorBoundaryProps() {
+    const props = {
+      params: useParams(),
+      loaderData: useLoaderData(),
+      actionData: useActionData(),
+      error: useRouteError(),
+    };
+    return React.createElement(ErrorBoundary, props);
+  };
 }

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -18,35 +18,24 @@ import type {
   FutureConfig,
   FrameworkContextObject,
 } from "./entry";
-import { Outlet, RouterProvider, createMemoryRouter } from "../../components";
+import {
+  type RouteComponentType,
+  type HydrateFallbackType,
+  type ErrorBoundaryType,
+  Outlet,
+  RouterProvider,
+  createMemoryRouter,
+  withComponentProps,
+  withErrorBoundaryProps,
+  withHydrateFallbackProps,
+} from "../../components";
 import type { EntryRoute } from "./routes";
 import { FrameworkContext } from "./components";
-import {
-  useParams,
-  useLoaderData,
-  useActionData,
-  useMatches,
-  useRouteError,
-} from "../../hooks";
 
 interface StubRouteExtensions {
-  Component?: React.ComponentType<{
-    params: ReturnType<typeof useParams>;
-    loaderData: ReturnType<typeof useLoaderData>;
-    actionData: ReturnType<typeof useActionData>;
-    matches: ReturnType<typeof useMatches>;
-  }>;
-  HydrateFallback?: React.ComponentType<{
-    params: ReturnType<typeof useParams>;
-    loaderData: ReturnType<typeof useLoaderData>;
-    actionData: ReturnType<typeof useActionData>;
-  }>;
-  ErrorBoundary?: React.ComponentType<{
-    params: ReturnType<typeof useParams>;
-    loaderData: ReturnType<typeof useLoaderData>;
-    actionData: ReturnType<typeof useActionData>;
-    error: ReturnType<typeof useRouteError>;
-  }>;
+  Component?: RouteComponentType;
+  HydrateFallback?: HydrateFallbackType;
+  ErrorBoundary?: ErrorBoundaryType;
   loader?: LoaderFunction;
   action?: ActionFunction;
   children?: StubRouteObject[];
@@ -174,41 +163,6 @@ export function createRoutesStub(
         <RouterProvider router={routerRef.current} />
       </FrameworkContext.Provider>
     );
-  };
-}
-
-// Implementations copied from packages/react-router-dev/vite/with-props.ts
-function withComponentProps(Component: React.ComponentType<any>) {
-  return function Wrapped() {
-    return React.createElement(Component, {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-      matches: useMatches(),
-    });
-  };
-}
-
-function withHydrateFallbackProps(HydrateFallback: React.ComponentType<any>) {
-  return function Wrapped() {
-    const props = {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-    };
-    return React.createElement(HydrateFallback, props);
-  };
-}
-
-function withErrorBoundaryProps(ErrorBoundary: React.ComponentType<any>) {
-  return function Wrapped() {
-    const props = {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-      error: useRouteError(),
-    };
-    return React.createElement(ErrorBoundary, props);
   };
 }
 


### PR DESCRIPTION
This change was initially designed to expose these utils for use in the preview RSC Parcel plugin, but I realised this is a useful change to ship immediately since it results in 1 fewer network requests on page load. It also cleans up the internals quite a bit and removes some duplication between `react-router` and `@react-router/dev`.

Before:

<img width="207" alt="Screenshot 2025-05-21 at 5 38 42 pm" src="https://github.com/user-attachments/assets/cba9f56f-ebd7-4ab7-9091-8acf565f61e7" />

After:

<img width="205" alt="Screenshot 2025-05-21 at 5 39 10 pm" src="https://github.com/user-attachments/assets/d27f9396-22f7-442a-a934-78e2be736521" />