### PR TITLE
chore: mark new APIs as unstable

### DIFF
--- a/integration/helpers/rsc-parcel/src/entry.browser.tsx
+++ b/integration/helpers/rsc-parcel/src/entry.browser.tsx
@@ -3,9 +3,9 @@
 import * as React from "react";
 import { hydrateRoot } from "react-dom/client";
 import {
-  createCallServer,
-  getServerStream,
-  RSCHydratedRouter,
+  unstable_createCallServer as createCallServer,
+  unstable_getServerStream as getServerStream,
+  unstable_RSCHydratedRouter as RSCHydratedRouter,
 } from "react-router";
 import type { ServerPayload } from "react-router/rsc";
 import {

--- a/integration/helpers/rsc-parcel/src/entry.rsc.ts
+++ b/integration/helpers/rsc-parcel/src/entry.rsc.ts
@@ -10,7 +10,7 @@ import {
 import {
   type DecodeCallServerFunction,
   type DecodeFormActionFunction,
-  matchRSCServerRequest,
+  unstable_matchRSCServerRequest as matchRSCServerRequest,
 } from "react-router/rsc";
 
 import { routes } from "./routes";

--- a/integration/helpers/rsc-parcel/src/entry.ssr.tsx
+++ b/integration/helpers/rsc-parcel/src/entry.ssr.tsx
@@ -4,8 +4,8 @@ import express from "express";
 // @ts-expect-error - no types
 import { renderToReadableStream as renderHTMLToReadableStream } from "react-dom/server.edge" assert { env: "react-client" };
 import {
-  routeRSCServerRequest,
-  RSCStaticRouter,
+  unstable_routeRSCServerRequest as routeRSCServerRequest,
+  unstable_RSCStaticRouter as RSCStaticRouter,
 } from "react-router" assert { env: "react-client" };
 // @ts-expect-error
 import { createFromReadableStream } from "react-server-dom-parcel/client.edge" assert { env: "react-client" };

--- a/integration/helpers/rsc-vite/src/entry.browser.tsx
+++ b/integration/helpers/rsc-vite/src/entry.browser.tsx
@@ -11,9 +11,9 @@ import { manifest } from "virtual:react-manifest";
 import {
   type DecodeServerResponseFunction,
   type EncodeActionFunction,
-  createCallServer,
-  getServerStream,
-  RSCHydratedRouter,
+  unstable_createCallServer as createCallServer,
+  unstable_getServerStream as getServerStream,
+  unstable_RSCHydratedRouter as RSCHydratedRouter,
 } from "react-router";
 import { type ServerPayload } from "react-router/rsc";
 

--- a/integration/helpers/rsc-vite/src/entry.rsc.tsx
+++ b/integration/helpers/rsc-vite/src/entry.rsc.tsx
@@ -1,7 +1,7 @@
 /// <reference types="@cloudflare/workers-types" />
 import {
   type DecodeCallServerFunction,
-  matchRSCServerRequest,
+  unstable_matchRSCServerRequest as matchRSCServerRequest,
 } from "react-router/rsc";
 // @ts-expect-error - no types yet
 import { manifest } from "virtual:react-manifest";

--- a/integration/helpers/rsc-vite/src/entry.ssr.tsx
+++ b/integration/helpers/rsc-vite/src/entry.ssr.tsx
@@ -7,7 +7,10 @@ import RDS from "react-dom/server.edge";
 // @ts-expect-error
 import { bootstrapModules, manifest } from "virtual:react-manifest";
 
-import { routeRSCServerRequest, RSCStaticRouter } from "react-router";
+import {
+  unstable_routeRSCServerRequest as routeRSCServerRequest,
+  unstable_RSCStaticRouter as RSCStaticRouter,
+} from "react-router";
 
 type CloudflareEnv = {
   ASSETS: Fetcher;

--- a/packages/react-router/dom-export.ts
+++ b/packages/react-router/dom-export.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export type { RouterProviderProps } from "./lib/dom-export/dom-router-provider";
 export { RouterProvider } from "./lib/dom-export/dom-router-provider";
 export { HydratedRouter } from "./lib/dom-export/hydrated-router";

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -287,9 +287,15 @@ export type {
   DecodeServerResponseFunction,
   EncodeActionFunction,
 } from "./lib/rsc/browser";
-export { createCallServer, RSCHydratedRouter } from "./lib/rsc/browser";
-export { routeRSCServerRequest, RSCStaticRouter } from "./lib/rsc/server.ssr";
-export { getServerStream } from "./lib/rsc/html-stream/browser";
+export {
+  createCallServer as unstable_createCallServer,
+  RSCHydratedRouter as unstable_RSCHydratedRouter,
+} from "./lib/rsc/browser";
+export {
+  routeRSCServerRequest as unstable_routeRSCServerRequest,
+  RSCStaticRouter as unstable_RSCStaticRouter,
+} from "./lib/rsc/server.ssr";
+export { getServerStream as unstable_getServerStream } from "./lib/rsc/html-stream/browser";
 
 ///////////////////////////////////////////////////////////////////////////////
 // DANGER! PLEASE READ ME!

--- a/packages/react-router/rsc-export.ts
+++ b/packages/react-router/rsc-export.ts
@@ -50,4 +50,4 @@ export type {
   ServerRouteMatch,
   ServerRouteObject,
 } from "./lib/rsc/server.rsc";
-export { matchRSCServerRequest } from "./lib/rsc/server.rsc";
+export { matchRSCServerRequest as unstable_matchRSCServerRequest } from "./lib/rsc/server.rsc";

--- a/playground/rsc-parcel/src/entry.browser.tsx
+++ b/playground/rsc-parcel/src/entry.browser.tsx
@@ -3,9 +3,9 @@
 import * as React from "react";
 import { hydrateRoot } from "react-dom/client";
 import {
-  createCallServer,
-  getServerStream,
-  RSCHydratedRouter,
+  unstable_createCallServer as createCallServer,
+  unstable_getServerStream as getServerStream,
+  unstable_RSCHydratedRouter as RSCHydratedRouter,
 } from "react-router";
 import type { ServerPayload } from "react-router/rsc";
 import {

--- a/playground/rsc-parcel/src/entry.rsc.ts
+++ b/playground/rsc-parcel/src/entry.rsc.ts
@@ -10,7 +10,7 @@ import {
 import {
   type DecodeCallServerFunction,
   type DecodeFormActionFunction,
-  matchRSCServerRequest,
+  unstable_matchRSCServerRequest as matchRSCServerRequest,
 } from "react-router/rsc";
 
 import { routes } from "./routes";

--- a/playground/rsc-parcel/src/entry.ssr.tsx
+++ b/playground/rsc-parcel/src/entry.ssr.tsx
@@ -3,8 +3,8 @@ import express from "express";
 // @ts-expect-error - no types
 import { renderToReadableStream as renderHTMLToReadableStream } from "react-dom/server.edge" assert { env: "react-client" };
 import {
-  routeRSCServerRequest,
-  RSCStaticRouter,
+  unstable_routeRSCServerRequest as routeRSCServerRequest,
+  unstable_RSCStaticRouter as RSCStaticRouter,
 } from "react-router" assert { env: "react-client" };
 // @ts-expect-error
 import { createFromReadableStream } from "react-server-dom-parcel/client.edge" assert { env: "react-client" };

--- a/playground/rsc-vite/src/browser/entry.browser.tsx
+++ b/playground/rsc-vite/src/browser/entry.browser.tsx
@@ -11,9 +11,9 @@ import { manifest } from "virtual:react-manifest";
 import {
   type DecodeServerResponseFunction,
   type EncodeActionFunction,
-  createCallServer,
-  getServerStream,
-  RSCHydratedRouter,
+  unstable_createCallServer as createCallServer,
+  unstable_getServerStream as getServerStream,
+  unstable_RSCHydratedRouter as RSCHydratedRouter,
 } from "react-router";
 import { type ServerPayload } from "react-router/rsc";
 

--- a/playground/rsc-vite/src/rsc/entry.rsc.tsx
+++ b/playground/rsc-vite/src/rsc/entry.rsc.tsx
@@ -6,7 +6,7 @@ import { manifest } from "virtual:react-manifest";
 
 import {
   type DecodeCallServerFunction,
-  matchRSCServerRequest,
+  unstable_matchRSCServerRequest as matchRSCServerRequest,
 } from "react-router/rsc";
 
 import { routes } from "../routes";

--- a/playground/rsc-vite/src/ssr/entry.ssr.tsx
+++ b/playground/rsc-vite/src/ssr/entry.ssr.tsx
@@ -7,7 +7,10 @@ import RDS from "react-dom/server.edge";
 // @ts-expect-error
 import { bootstrapModules, manifest } from "virtual:react-manifest";
 
-import { routeRSCServerRequest, RSCStaticRouter } from "react-router";
+import {
+  unstable_routeRSCServerRequest as routeRSCServerRequest,
+  unstable_RSCStaticRouter as RSCStaticRouter,
+} from "react-router";
 
 type CloudflareEnv = {
   ASSETS: Fetcher;


### PR DESCRIPTION
chore: add `use client` directive to dom-export