### PR TITLE
wire thrown redirects from actions into the transition lifecycle

### DIFF
--- a/integration/rsc/rsc-test.ts
+++ b/integration/rsc/rsc-test.ts
@@ -657,14 +657,13 @@ implementations.forEach((implementation) => {
           `http://localhost:${port}/?redirected=true`
         );
 
+        expect(await page.locator("[data-count]").textContent()).toBe(
+          "Count: 0"
+        );
         // Validate things are still interactive after redirect
         await page.click("[data-count]");
         expect(await page.locator("[data-count]").textContent()).toBe(
-          "Count: 2"
-        );
-        await page.click("[data-count]");
-        expect(await page.locator("[data-count]").textContent()).toBe(
-          "Count: 3"
+          "Count: 1"
         );
 
         // Ensure this is using RSC

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -894,6 +894,9 @@ export function _renderMatches(
       } else {
         children = outlet;
       }
+
+      children = <RedirectBoundary>{children}</RedirectBoundary>;
+
       return (
         <RenderedRoute
           match={match}
@@ -923,6 +926,21 @@ export function _renderMatches(
       getChildren()
     );
   }, null as React.ReactElement | null);
+}
+
+class RedirectBoundary extends React.Component<{ children?: React.ReactNode }> {
+  // If the error is Symbol.for("react-router.redirect"), keep rendering children.
+  // If it's anything else, re-throw to bubble it up.
+  static getDerivedStateFromError(error: any) {
+    if (error === Symbol.for("react-router.redirect")) {
+      return null; // Keep rendering children
+    }
+    throw error; // Re-throw to bubble up
+  }
+
+  render() {
+    return this.props.children;
+  }
 }
 
 enum DataRouterHook {

--- a/playground/rsc-vite/src/routes/home/home.client.tsx
+++ b/playground/rsc-vite/src/routes/home/home.client.tsx
@@ -41,3 +41,16 @@ export function HomeForm({ fn }: { fn: () => unknown }) {
     </form>
   );
 }
+
+export function RedirectForm({ fn }: { fn: () => unknown }) {
+  const [state, formAction, isPending] = React.useActionState(fn, null);
+
+  return (
+    <form action={formAction}>
+      <button type="submit">
+        Redirect{isPending ? " (pending)" : null}
+      </button>
+      {state ? <p>Action state: {state}</p> : null}
+    </form>
+  );
+}

--- a/playground/rsc-vite/src/routes/home/home.tsx
+++ b/playground/rsc-vite/src/routes/home/home.tsx
@@ -1,17 +1,21 @@
-import { HomeForm } from "./home.client";
+import { HomeForm, RedirectForm } from "./home.client";
 export { clientLoader } from "./home.client";
 
 import { Counter } from "../../counter";
+import { redirect } from "react-router/rsc";
+import type { LoaderFunctionArgs } from "react-router";
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
   await new Promise((r) => setTimeout(r, 500));
   return {
     message: `Home route loader ran at ${new Date().toISOString()}`,
+    wasRedirected:
+      new URL(request.url).searchParams.get("redirected") === "true",
   };
 }
 
 export default function Home({
-  loaderData,
+  loaderData: { message, wasRedirected },
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;
 }) {
@@ -19,16 +23,28 @@ export default function Home({
     "use server";
     await new Promise((r) => setTimeout(r, 500));
     console.log("Running action on server!");
-    console.log(`  data to prove that scoped vars work: ${loaderData.message}`);
+    console.log(
+      `  data to prove that scoped vars work: ${message} and it is now ${new Date().toISOString()}`
+    );
     return new Date().toISOString();
+  };
+
+  const redirectOnServer = async () => {
+    "use server";
+    await new Promise((r) => setTimeout(r, 500));
+    if (wasRedirected) {
+      throw redirect("/");
+    }
+    throw redirect("/?redirected=true");
   };
 
   return (
     <div style={{ border: "1px solid black", padding: "10px" }}>
       <h2>Home Route</h2>
-      <p>Loader data: {loaderData.message}</p>
+      <p>Loader data: {message}</p>
       <Counter />
       <HomeForm fn={logOnServer} />
+      <RedirectForm fn={redirectOnServer} />
     </div>
   );
 }


### PR DESCRIPTION
Suppress the internal thrown symbol as best as possible from error logs