### PR TITLE
feat(react-router): rename RSC `default` route property to `Component`

### DIFF
--- a/integration/helpers/rsc-parcel/src/routes/home.tsx
+++ b/integration/helpers/rsc-parcel/src/routes/home.tsx
@@ -1,3 +1,3 @@
-export default function ServerComponent() {
+export function Component() {
   return <h2>Home</h2>;
 }

--- a/integration/rsc/rsc-test.ts
+++ b/integration/rsc/rsc-test.ts
@@ -109,7 +109,7 @@ implementations.forEach((implementation) => {
               export function loader() {
                 return { message: "Loader Data" };
               }
-              export default function ServerComponent({ loaderData }) {
+              export function Component({ loaderData }) {
                 return <h2 data-home>Home: {loaderData.message}</h2>;
               }
             `,
@@ -141,7 +141,7 @@ implementations.forEach((implementation) => {
                 return { message: "Loader Data" };
               }
 
-              export default function ServerComponent({ loaderData }) {
+              export function Component({ loaderData }) {
                 return (
                   <div>
                     <h2 data-home>Home: {loaderData.message}</h2>
@@ -236,7 +236,7 @@ implementations.forEach((implementation) => {
                 return { message: "Home Page Data" };
               }
 
-              export default function Home({ loaderData }) {
+              export function Component({ loaderData }) {
                 return (
                   <div>
                     <h1 data-page="home">Home Page</h1>
@@ -251,7 +251,7 @@ implementations.forEach((implementation) => {
                 return { count: 1 };
               }
 
-              export { Dashboard as default } from "./dashboard.client";
+              export { Component } from "./dashboard.client";
             `,
             "src/routes/dashboard.client.tsx": js`
               "use client";
@@ -260,7 +260,7 @@ implementations.forEach((implementation) => {
               import { Link } from "react-router";
 
               // Export the entire route as a client component
-              export function Dashboard({ loaderData }) {
+              export function Component({ loaderData }) {
                 const [count, setCount] = useState(loaderData.count);
 
                 return (
@@ -367,7 +367,7 @@ implementations.forEach((implementation) => {
                 return { message: "Home Page Data" };
               }
 
-              export default function Home({ loaderData }) {
+              export function Component({ loaderData }) {
                 return (
                   <div>
                     <h1 data-page="home">Home Page</h1>
@@ -382,7 +382,7 @@ implementations.forEach((implementation) => {
                 return { count: 1 };
               }
 
-              export { Dashboard as default } from "./dashboard.client";
+              export { Dashboard as Component } from "./dashboard.client";
             `,
             "src/routes/dashboard.client.tsx": js`
               "use client";
@@ -477,13 +477,16 @@ implementations.forEach((implementation) => {
               }
             `,
             "src/routes/home.tsx": js`
+              export { Component } from "./home.client";
+            `,
+            "src/routes/home.client.tsx": js`
               "use client";
 
               import { useActionState } from "react";
 
               import { incrementCounter } from "./home.actions";
 
-              export default function ClientComponent() {
+              export function Component() {
                 const [count, incrementCounterAction, incrementing] = useActionState(incrementCounter, 0);
 
                 return (
@@ -544,7 +547,7 @@ implementations.forEach((implementation) => {
                 return { name, count };
               }
 
-              export default function ServerComponent({ loaderData }) {
+              export function Component({ loaderData }) {
                 const updateCounter = async (formData: FormData) => {
                   "use server";
                   name = formData.get("name");
@@ -621,7 +624,7 @@ implementations.forEach((implementation) => {
               import { redirectAction } from "./home.actions";
               import { Counter } from "./home.client";
 
-              export default function ServerComponent(props) {
+              export function Component(props) {
                 console.log({props});
                 return (
                   <div>
@@ -694,7 +697,7 @@ implementations.forEach((implementation) => {
                 throw new Error("Intentional error from loader");
               }
 
-              export default function Home() {
+              export function Component() {
                 return <h2>This shouldn't render</h2>;
               }
 

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -586,7 +586,7 @@ async function getServerRouteMatch(
   }
 
   const Layout = (match.route as any).Layout || React.Fragment;
-  const Component = (match.route as any).default;
+  const Component = (match.route as any).Component;
   const ErrorBoundary = (match.route as any).ErrorBoundary;
   const HydrateFallback = (match.route as any).HydrateFallback;
   const loaderData = staticContext.loaderData[match.route.id];

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -33,7 +33,7 @@ type ServerRouteObjectBase = {
   action?: ActionFunction;
   clientAction?: ClientActionFunction;
   clientLoader?: ClientLoaderFunction;
-  default?: React.ComponentType<any>;
+  Component?: React.ComponentType<any>;
   ErrorBoundary?: React.ComponentType<any>;
   handle?: any;
   headers?: HeadersFunction;

--- a/playground/rsc-parcel/src/routes/about/about.client.tsx
+++ b/playground/rsc-parcel/src/routes/about/about.client.tsx
@@ -15,7 +15,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
   };
 }
 
-export default function About() {
+export function Component() {
   const { client, message } = useLoaderData<typeof clientLoader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/about/about.tsx
+++ b/playground/rsc-parcel/src/routes/about/about.tsx
@@ -1,4 +1,4 @@
-export { clientLoader, default } from "./about.client";
+export { clientLoader, Component } from "./about.client";
 
 export function loader() {
   return {

--- a/playground/rsc-parcel/src/routes/fetcher/fetcher.client.tsx
+++ b/playground/rsc-parcel/src/routes/fetcher/fetcher.client.tsx
@@ -3,7 +3,7 @@
 import { useFetcher } from "react-router";
 import type { loader } from "../resource/resource";
 
-export default function Fetcher() {
+export function Component() {
   const fetcher = useFetcher<typeof loader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/fetcher/fetcher.ts
+++ b/playground/rsc-parcel/src/routes/fetcher/fetcher.ts
@@ -1,1 +1,1 @@
-export { default } from "./fetcher.client";
+export { Component } from "./fetcher.client";

--- a/playground/rsc-parcel/src/routes/home/home.client.tsx
+++ b/playground/rsc-parcel/src/routes/home/home.client.tsx
@@ -15,7 +15,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
   };
 }
 
-export default function Home() {
+export function Component() {
   const { client, message } = useLoaderData<typeof clientLoader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/home/home.tsx
+++ b/playground/rsc-parcel/src/routes/home/home.tsx
@@ -1,4 +1,4 @@
-export { clientLoader, default } from "./home.client";
+export { clientLoader, Component } from "./home.client";
 
 export function loader() {
   return {

--- a/playground/rsc-parcel/src/routes/root/root.client.tsx
+++ b/playground/rsc-parcel/src/routes/root/root.client.tsx
@@ -27,7 +27,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function Root() {
+export function Component() {
   const { counter, message } = useLoaderData<typeof loader>();
   return (
     <>

--- a/playground/rsc-parcel/src/routes/root/root.tsx
+++ b/playground/rsc-parcel/src/routes/root/root.tsx
@@ -1,4 +1,4 @@
-export { default, ErrorBoundary, Layout } from "./root.client";
+export { Component, ErrorBoundary, Layout } from "./root.client";
 
 import { Counter } from "../../counter";
 

--- a/playground/rsc-vite/src/routes/about/about.client.tsx
+++ b/playground/rsc-vite/src/routes/about/about.client.tsx
@@ -31,7 +31,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
 
 clientLoader.hydrate = true;
 
-export default function About() {
+export function Component() {
   const loaderData = useLoaderData<typeof clientLoader>();
   const actionData = useActionData<typeof clientAction>();
 

--- a/playground/rsc-vite/src/routes/about/about.tsx
+++ b/playground/rsc-vite/src/routes/about/about.tsx
@@ -5,7 +5,7 @@ export {
   // clientLazy,
   clientLoader,
   clientAction,
-  default,
+  Component,
 } from "./about.client";
 
 export function headers({

--- a/playground/rsc-vite/src/routes/child/child.tsx
+++ b/playground/rsc-vite/src/routes/child/child.tsx
@@ -5,7 +5,7 @@ async function loader() {
   };
 }
 
-export default async function Component() {
+export async function Component() {
   let loaderData = await loader();
   return (
     <div style={{ border: "1px solid black", padding: "10px" }}>

--- a/playground/rsc-vite/src/routes/home/home.tsx
+++ b/playground/rsc-vite/src/routes/home/home.tsx
@@ -14,7 +14,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-export default function Home({
+export function Component({
   loaderData: { message, wasRedirected },
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/parent-index/parent-index.tsx
+++ b/playground/rsc-vite/src/routes/parent-index/parent-index.tsx
@@ -5,7 +5,7 @@ export async function loader() {
   };
 }
 
-export default function Component({
+export function Component({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/parent/parent.tsx
+++ b/playground/rsc-vite/src/routes/parent/parent.tsx
@@ -6,7 +6,7 @@ export function loader() {
   };
 }
 
-export default function Component({
+export function Component({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/root/root.tsx
+++ b/playground/rsc-vite/src/routes/root/root.tsx
@@ -27,7 +27,7 @@ export async function loader() {
   };
 }
 
-export default function Root({
+export function Component({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;


### PR DESCRIPTION
This brings it in line with the existing Data Mode API, making `default` more of a Framework Mode opinion.