### PR TITLE
refactor(create-react-router): use native Node.js instead of `recursive-readdir`

### DIFF
--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -43,7 +43,6 @@
     "gunzip-maybe": "^1.4.2",
     "log-update": "^5.0.1",
     "proxy-agent": "^6.3.0",
-    "recursive-readdir": "^2.2.3",
     "semver": "^7.3.7",
     "sisteransi": "^1.0.5",
     "sort-package-json": "^1.55.0",

--- a/packages/create-react-router/utils.ts
+++ b/packages/create-react-router/utils.ts
@@ -1,11 +1,11 @@
+import fs from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import os from "node:os";
-import fs from "node:fs";
 import { type Key as ActionKey } from "node:readline";
 import { erase, cursor } from "sisteransi";
 import chalk from "chalk";
-import recursiveReaddir from "recursive-readdir";
 
 // https://no-color.org/
 const SUPPORTS_COLOR = chalk.supportsColor && !process.env.NO_COLOR;
@@ -292,14 +292,11 @@ export function stripDirectoryFromPath(dir: string, filePath: string) {
 export const IGNORED_TEMPLATE_DIRECTORIES = [".git", "node_modules"];
 
 export async function getDirectoryFilesRecursive(dir: string) {
-  let files = await recursiveReaddir(dir, [
-    (file) => {
-      let strippedFile = stripDirectoryFromPath(dir, file);
-      let parts = strippedFile.split(path.sep);
-      return (
-        parts.length > 1 && IGNORED_TEMPLATE_DIRECTORIES.includes(parts[0])
-      );
-    },
-  ]);
-  return files.map((f) => stripDirectoryFromPath(dir, f));
+  return (await readdir(dir, { recursive: true })).filter((file) => {
+    let parts = file.split(path.sep);
+
+    return (
+      parts.length <= 1 || !IGNORED_TEMPLATE_DIRECTORIES.includes(parts[0])
+    );
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,9 +734,6 @@ importers:
       proxy-agent:
         specifier: ^6.3.0
         version: 6.4.0
-      recursive-readdir:
-        specifier: ^2.2.3
-        version: 2.2.3
       semver:
         specifier: ^7.3.7
         version: 7.7.1
@@ -7646,10 +7643,6 @@ packages:
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
-
-  recursive-readdir@2.2.3:
-    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
-    engines: {node: '>=6.0.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -16308,10 +16301,6 @@ snapshots:
   rechoir@0.6.2:
     dependencies:
       resolve: 1.22.8
-
-  recursive-readdir@2.2.3:
-    dependencies:
-      minimatch: 3.1.2
 
   redent@3.0.0:
     dependencies:


### PR DESCRIPTION
I'm sure people from the wider @e18e ecosystem cleanup (like @43081j, @benmccann & @outslept) will be very happy to see these kind of changes as well