### PR TITLE
perf: use `replaceAll` for slash normalisation

### DIFF
--- a/.changeset/tasty-peas-retire.md
+++ b/.changeset/tasty-peas-retire.md
@@ -1,0 +1,6 @@
+---
+"@react-router/remix-routes-option-adapter": patch
+"@react-router/fs-routes": patch
+---
+
+Use `replaceAll` for normalising windows file system slashes.

--- a/contributors.yml
+++ b/contributors.yml
@@ -1,5 +1,6 @@
 - 0xEddie
 - 3fuyang
+- 43081j
 - aarbi
 - abdallah-nour
 - abeadam

--- a/packages/react-router-fs-routes/normalizeSlashes.ts
+++ b/packages/react-router-fs-routes/normalizeSlashes.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
 
 export function normalizeSlashes(file: string) {
-  return file.split(path.win32.sep).join("/");
+  return file.replaceAll(path.win32.sep, "/");
 }

--- a/packages/react-router-remix-routes-option-adapter/normalizeSlashes.ts
+++ b/packages/react-router-remix-routes-option-adapter/normalizeSlashes.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
 
 export function normalizeSlashes(file: string) {
-  return file.split(path.win32.sep).join("/");
+  return file.replaceAll(path.win32.sep, "/");
 }


### PR DESCRIPTION
Splitting and joining is slow and results in garbage collection each time. We can instead use a string `replaceAll` for a small perf gain.