### PR TITLE
fix(dev/config): skip `package.json` resolution with custom `server.entry`

### DIFF
--- a/.changeset/large-points-arrive.md
+++ b/.changeset/large-points-arrive.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Skip `package.json` resolution checks when a custom `entry.server.(j|t)sx` file is provided.

--- a/contributors.yml
+++ b/contributors.yml
@@ -223,6 +223,7 @@
 - marc2332
 - markdalgleish
 - markivancho
+- markmals
 - maruffahmed
 - marvinruder
 - mathpaquette

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -855,7 +855,7 @@ export async function resolveEntryFiles({
 
     if (!packageJsonPath) {
       throw new Error(
-        `Could not find package.json in ${rootDirectory} or any of its parent directories`
+        `Could not find package.json in ${rootDirectory} or any of its parent directories. Please add a package.json, or provide a custom entry.server.tsx/jsx file in your app directory.`
       );
     }
 

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -844,25 +844,25 @@ export async function resolveEntryFiles({
   let entryServerFile: string;
   let entryClientFile = userEntryClientFile || "entry.client.tsx";
 
-  let packageJsonPath = findEntry(rootDirectory, "package", {
-    extensions: [".json"],
-    absolute: true,
-    walkParents: true,
-  });
-
-  if (!packageJsonPath) {
-    throw new Error(
-      `Could not find package.json in ${rootDirectory} or any of its parent directories`
-    );
-  }
-
-  let packageJsonDirectory = Path.dirname(packageJsonPath);
-  let pkgJson = await PackageJson.load(packageJsonDirectory);
-  let deps = pkgJson.content.dependencies ?? {};
-
   if (userEntryServerFile) {
     entryServerFile = userEntryServerFile;
   } else {
+    let packageJsonPath = findEntry(rootDirectory, "package", {
+      extensions: [".json"],
+      absolute: true,
+      walkParents: true,
+    });
+
+    if (!packageJsonPath) {
+      throw new Error(
+        `Could not find package.json in ${rootDirectory} or any of its parent directories`
+      );
+    }
+
+    let packageJsonDirectory = Path.dirname(packageJsonPath);
+    let pkgJson = await PackageJson.load(packageJsonDirectory);
+    let deps = pkgJson.content.dependencies ?? {};
+
     if (!deps["@react-router/node"]) {
       throw new Error(
         `Could not determine server runtime. Please install @react-router/node, or provide a custom entry.server.tsx/jsx file in your app directory.`


### PR DESCRIPTION
Skip `package.json` file checks when a user-supplied entry.server file is present