### PR TITLE
fix(dev/vite): properly handle `https` protocol in dev mode

### DIFF
--- a/.changeset/calm-swans-tap.md
+++ b/.changeset/calm-swans-tap.md
@@ -1,5 +1,5 @@
 ---
-"@react-router/dev": minor
+"@react-router/dev": patch
 ---
 
 Detect HTTPS protocol

--- a/.changeset/calm-swans-tap.md
+++ b/.changeset/calm-swans-tap.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Detect HTTPS protocol
+Properly handle `https` protocol in dev mode

--- a/.changeset/calm-swans-tap.md
+++ b/.changeset/calm-swans-tap.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": minor
+---
+
+Detect HTTPS protocol

--- a/packages/react-router-dev/vite/node-adapter.ts
+++ b/packages/react-router-dev/vite/node-adapter.ts
@@ -1,5 +1,6 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
 import { once } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { TLSSocket } from "node:tls";
 import { Readable } from "node:stream";
 import { splitCookiesString } from "set-cookie-parser";
 import { createReadableStreamFromReadable } from "@react-router/node";
@@ -48,10 +49,14 @@ export function fromNodeRequest(
   nodeReq: Vite.Connect.IncomingMessage,
   nodeRes: ServerResponse<Vite.Connect.IncomingMessage>
 ): Request {
+  let protocol =
+    nodeReq.socket instanceof TLSSocket && nodeReq.socket.encrypted
+      ? "https"
+      : "http";
   let origin =
     nodeReq.headers.origin && "null" !== nodeReq.headers.origin
       ? nodeReq.headers.origin
-      : `http://${nodeReq.headers.host}`;
+      : `${protocol}://${nodeReq.headers.host}`;
   // Use `req.originalUrl` so React Router is aware of the full path
   invariant(
     nodeReq.originalUrl,


### PR DESCRIPTION
Resubmission of @TrySound's https://github.com/remix-run/remix/pull/10199

> We use https for development at Webstudio.
> While setup we found some requests always have "http" protocol. Turns out origin is not sent with get requests and node-adapter falls back into "http".
>
> Here added https detection based on express internals.