### PR TITLE
chore: fix "⚙️ Deduplicate lock file" workflow

### DIFF
--- a/.github/workflows/deduplicate-lock-file.yml
+++ b/.github/workflows/deduplicate-lock-file.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - dev
     paths:
-      - ./pnpm-lock.yaml
+      - pnpm-lock.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This way we don't have to do PRs like #13674 manually anymore