### PR TITLE
fix(cloudflare): remove `tsup` from `peerDependencies`

### DIFF
--- a/.changeset/silent-boxes-sell.md
+++ b/.changeset/silent-boxes-sell.md
@@ -1,0 +1,5 @@
+---
+"@react-router/cloudflare": patch
+---
+
+Remove `tsup` from `peerDependencies`

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -54,7 +54,6 @@
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
     "react-router": "workspace:^",
-    "tsup": "^8.3.0",
     "typescript": "^5.1.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
I guess this was added by accident in @jacob-ebey's #12136

---

I'm sure people from the wider @e18e ecosystem cleanup (like @43081j & @outslept) will be very happy to see these kind of changes as well