### PR TITLE
Support RSC lazy `default` export as `Component` fallback

### DIFF
--- a/integration/helpers/rsc-parcel/src/routes/home.tsx
+++ b/integration/helpers/rsc-parcel/src/routes/home.tsx
@@ -1,3 +1,3 @@
-export function Component() {
+export default function HomeRoute() {
   return <h2>Home</h2>;
 }

--- a/integration/rsc/rsc-test.ts
+++ b/integration/rsc/rsc-test.ts
@@ -109,7 +109,7 @@ implementations.forEach((implementation) => {
               export function loader() {
                 return { message: "Loader Data" };
               }
-              export function Component({ loaderData }) {
+              export default function HomeRoute({ loaderData }) {
                 return <h2 data-home>Home: {loaderData.message}</h2>;
               }
             `,
@@ -141,7 +141,7 @@ implementations.forEach((implementation) => {
                 return { message: "Loader Data" };
               }
 
-              export function Component({ loaderData }) {
+              export default function HomeRoute({ loaderData }) {
                 return (
                   <div>
                     <h2 data-home>Home: {loaderData.message}</h2>
@@ -236,7 +236,7 @@ implementations.forEach((implementation) => {
                 return { message: "Home Page Data" };
               }
 
-              export function Component({ loaderData }) {
+              export default function HomeRoute({ loaderData }) {
                 return (
                   <div>
                     <h1 data-page="home">Home Page</h1>
@@ -251,7 +251,7 @@ implementations.forEach((implementation) => {
                 return { count: 1 };
               }
 
-              export { Component } from "./dashboard.client";
+              export { default } from "./dashboard.client";
             `,
             "src/routes/dashboard.client.tsx": js`
               "use client";
@@ -260,7 +260,7 @@ implementations.forEach((implementation) => {
               import { Link } from "react-router";
 
               // Export the entire route as a client component
-              export function Component({ loaderData }) {
+              export default function DashboardRoute({ loaderData }) {
                 const [count, setCount] = useState(loaderData.count);
 
                 return (
@@ -367,7 +367,7 @@ implementations.forEach((implementation) => {
                 return { message: "Home Page Data" };
               }
 
-              export function Component({ loaderData }) {
+              export default function HomeRoute({ loaderData }) {
                 return (
                   <div>
                     <h1 data-page="home">Home Page</h1>
@@ -477,7 +477,7 @@ implementations.forEach((implementation) => {
               }
             `,
             "src/routes/home.tsx": js`
-              export { Component } from "./home.client";
+              export { default } from "./home.client";
             `,
             "src/routes/home.client.tsx": js`
               "use client";
@@ -486,7 +486,7 @@ implementations.forEach((implementation) => {
 
               import { incrementCounter } from "./home.actions";
 
-              export function Component() {
+              export default function HomeRoute() {
                 const [count, incrementCounterAction, incrementing] = useActionState(incrementCounter, 0);
 
                 return (
@@ -547,7 +547,7 @@ implementations.forEach((implementation) => {
                 return { name, count };
               }
 
-              export function Component({ loaderData }) {
+              export default function HomeRoute({ loaderData }) {
                 const updateCounter = async (formData: FormData) => {
                   "use server";
                   name = formData.get("name");
@@ -624,7 +624,7 @@ implementations.forEach((implementation) => {
               import { redirectAction } from "./home.actions";
               import { Counter } from "./home.client";
 
-              export function Component(props) {
+              export default function HomeRoute(props) {
                 console.log({props});
                 return (
                   <div>
@@ -697,7 +697,7 @@ implementations.forEach((implementation) => {
                 throw new Error("Intentional error from loader");
               }
 
-              export function Component() {
+              export default function HomeRoute() {
                 return <h2>This shouldn't render</h2>;
               }
 

--- a/playground/rsc-parcel/src/routes/about/about.client.tsx
+++ b/playground/rsc-parcel/src/routes/about/about.client.tsx
@@ -15,7 +15,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
   };
 }
 
-export function Component() {
+export default function AboutRoute() {
   const { client, message } = useLoaderData<typeof clientLoader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/about/about.tsx
+++ b/playground/rsc-parcel/src/routes/about/about.tsx
@@ -1,4 +1,4 @@
-export { clientLoader, Component } from "./about.client";
+export { clientLoader, default } from "./about.client";
 
 export function loader() {
   return {

--- a/playground/rsc-parcel/src/routes/fetcher/fetcher.client.tsx
+++ b/playground/rsc-parcel/src/routes/fetcher/fetcher.client.tsx
@@ -3,7 +3,7 @@
 import { useFetcher } from "react-router";
 import type { loader } from "../resource/resource";
 
-export function Component() {
+export default function FetcherRoute() {
   const fetcher = useFetcher<typeof loader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/fetcher/fetcher.ts
+++ b/playground/rsc-parcel/src/routes/fetcher/fetcher.ts
@@ -1,1 +1,1 @@
-export { Component } from "./fetcher.client";
+export { default } from "./fetcher.client";

--- a/playground/rsc-parcel/src/routes/home/home.client.tsx
+++ b/playground/rsc-parcel/src/routes/home/home.client.tsx
@@ -15,7 +15,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
   };
 }
 
-export function Component() {
+export default function HomeRoute() {
   const { client, message } = useLoaderData<typeof clientLoader>();
 
   return (

--- a/playground/rsc-parcel/src/routes/home/home.tsx
+++ b/playground/rsc-parcel/src/routes/home/home.tsx
@@ -1,4 +1,4 @@
-export { clientLoader, Component } from "./home.client";
+export { clientLoader, default } from "./home.client";
 
 export function loader() {
   return {

--- a/playground/rsc-parcel/src/routes/root/root.client.tsx
+++ b/playground/rsc-parcel/src/routes/root/root.client.tsx
@@ -27,7 +27,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function Component() {
+export default function RootRoute() {
   const { counter, message } = useLoaderData<typeof loader>();
   return (
     <>

--- a/playground/rsc-parcel/src/routes/root/root.tsx
+++ b/playground/rsc-parcel/src/routes/root/root.tsx
@@ -1,4 +1,4 @@
-export { Component, ErrorBoundary, Layout } from "./root.client";
+export { default, ErrorBoundary, Layout } from "./root.client";
 
 import { Counter } from "../../counter";
 

--- a/playground/rsc-vite/src/routes/about/about.client.tsx
+++ b/playground/rsc-vite/src/routes/about/about.client.tsx
@@ -31,7 +31,7 @@ export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
 
 clientLoader.hydrate = true;
 
-export function Component() {
+export default function AboutRoute() {
   const loaderData = useLoaderData<typeof clientLoader>();
   const actionData = useActionData<typeof clientAction>();
 

--- a/playground/rsc-vite/src/routes/home/home.tsx
+++ b/playground/rsc-vite/src/routes/home/home.tsx
@@ -14,7 +14,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-export function Component({
+export default function HomeRoute({
   loaderData: { message, wasRedirected },
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/parent-index/parent-index.tsx
+++ b/playground/rsc-vite/src/routes/parent-index/parent-index.tsx
@@ -5,7 +5,7 @@ export async function loader() {
   };
 }
 
-export function Component({
+export default function ParentIndexRoute({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/parent/parent.tsx
+++ b/playground/rsc-vite/src/routes/parent/parent.tsx
@@ -6,7 +6,7 @@ export function loader() {
   };
 }
 
-export function Component({
+export default function ParentRoute({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;

--- a/playground/rsc-vite/src/routes/root/root.tsx
+++ b/playground/rsc-vite/src/routes/root/root.tsx
@@ -27,7 +27,7 @@ export async function loader() {
   };
 }
 
-export function Component({
+export default function RootRoute({
   loaderData,
 }: {
   loaderData: Awaited<ReturnType<typeof loader>>;


### PR DESCRIPTION
This is a follow-up to https://github.com/remix-run/react-router/pull/13726, adding back support to `default` exports from lazy route modules, but only as a fallback for `Component`. The top-level route property is still `Component` rather than `default`.