### PR TITLE
docs(start/framework/routing): add 404 route instructions

### DIFF
--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -314,8 +314,6 @@ export default [
 ```
 
 
-If you use the `flatRoutes` convention, create a route file named `$.tsx`.
-
 ## Component Routes
 
 You can also use components that match the URL to elements anywhere in the component tree:

--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -301,9 +301,18 @@ You can destructure the `*`, you just have to assign it a new name. A common nam
 const { "*": splat } = params;
 ```
 
-## 404 Catch-All Route
+You can also use a splat to catch requests that don't match any route:
 
-To create a route to catch non-matching routes, you can use the `route("*", "file-path")` route helper.
+```ts filename=app/routes.ts lines=[6]
+import { type RouteConfig, route,  index } from "@react-router/dev/routes";
+
+export default [
+  index("./home.tsx"),
+  route("about", "./about.tsx"),
+  route("*", "./404.tsx")
+] satisfies RouteConfig;
+```
+
 
 If you use the `flatRoutes` convention, create a route file named `$.tsx`.
 

--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -313,7 +313,6 @@ export default [
 ] satisfies RouteConfig;
 ```
 
-
 ## Component Routes
 
 You can also use components that match the URL to elements anywhere in the component tree:

--- a/docs/start/framework/routing.md
+++ b/docs/start/framework/routing.md
@@ -301,6 +301,12 @@ You can destructure the `*`, you just have to assign it a new name. A common nam
 const { "*": splat } = params;
 ```
 
+## 404 Catch-All Route
+
+To create a route to catch non-matching routes, you can use the `route("*", "file-path")` route helper.
+
+If you use the `flatRoutes` convention, create a route file named `$.tsx`.
+
 ## Component Routes
 
 You can also use components that match the URL to elements anywhere in the component tree:


### PR DESCRIPTION
clarifies 404 route based on https://github.com/remix-run/react-router/discussions/13701#discussioncomment-13386093