### PR TITLE
chore: Fix error message on dedupe action

### DIFF
--- a/.github/workflows/deduplicate-lock-file.yml
+++ b/.github/workflows/deduplicate-lock-file.yml
@@ -42,6 +42,6 @@ jobs:
             echo "💿 no deduplication needed"
             exit 0
           fi
-          git commit -m "chore: deduplicate `pnpm-lock.yaml`"
+          git commit -m "chore: deduplicate \`pnpm-lock.yaml\`"
           git push
           echo "💿 https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"


### PR DESCRIPTION
This doesn't fix #13753 or #13756, but should get rid of some errant messaging that is misleading.