### PR TITLE
feat(cloudflare): allow `prefix` on `createWorkersKVSessionStorage`

### DIFF
--- a/.changeset/sharp-yaks-bathe.md
+++ b/.changeset/sharp-yaks-bathe.md
@@ -2,4 +2,4 @@
 "@react-router/cloudflare": minor
 ---
 
-Allow prefix on createWorkersKVSessionStorare
+Allow prefix on createWorkersKVSessionStorage

--- a/.changeset/sharp-yaks-bathe.md
+++ b/.changeset/sharp-yaks-bathe.md
@@ -2,4 +2,4 @@
 "@react-router/cloudflare": minor
 ---
 
-Allow prefix on createWorkersKVSessionStorage
+Allow `prefix` on `createWorkersKVSessionStorage`

--- a/.changeset/sharp-yaks-bathe.md
+++ b/.changeset/sharp-yaks-bathe.md
@@ -1,0 +1,5 @@
+---
+"@react-router/cloudflare": minor
+---
+
+Allow prefix on createWorkersKVSessionStorare


### PR DESCRIPTION
This is something I'm doing myself in a project and I think it would be useful to have directly in React Router for others as well.

Right now using `createWorkersKVSessionStorage` fills your Worker KV of keys like `64eb4897d922128d`, if you don't use a KV exclusively for your sessions you can make it really hard to use CF Worker KV Dashboard to inspect the keys.

There's also no way to list every session and delete them, e.g you can't do this:

```ts
let result = await env.KV.list({ prefix: "session:" });
for (let key of result.keys) await env.KV.delete(key.name);
```

This small change adds an optional `prefix` option that can be used to solve this, so you can now do:

```ts
const sessionStorage = createWorkersKVSessionStorage({ cookie, kv, prefix: "session:" }) 
```

And now this session storage will add `session:` to every key ending up with something like `session:64eb4897d922128d` which can be easily be listed and work with using KV bindings.
