### PR TITLE
Bug report: href() and escaped periods don't work together

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -255,6 +255,7 @@
 - namoscato
 - ned-park
 - nenene3
+- ngbrown
 - nichtsam
 - nikeee
 - nilubisan

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -26,4 +26,8 @@ describe("href", () => {
       `Path '/a/:b' requires param 'b' but it was not provided`
     );
   });
+
+  it("works with periods", () => {
+    expect(href("/a/:b.zip", { b: "hello" })).toBe("/a/hello.zip");
+  })
 });


### PR DESCRIPTION
This pull request updates the `bug-report-test.ts` to show a failure when using `href()` on paths that contain an escaped period.

I also updated `packages\react-router\__tests__\href-test.ts` with a failing test.

I'm using the file route conventions (`fs-routes`). A route that starts out like this: `app\routes\text.$id[.txt].ts` is turned into a page string of `"/text/:id.txt"` by `react-router typegen`.

This means that this is the only type correct way to use `href()` is:

```ts
href("/text/:id.txt", { id: "a123" })
```

But the output string is incorrect, as it is only: `/text/a123`, not `/text/a123.txt`.

A repository with essentially the same project as the test is available here: https://github.com/ngbrown/react-router-href-with-period

Using something like `route("text/:id.txt", "routes/text-file.ts")` also works for the routing portion, but doesn't change anything for the `href()` issue.

I'm not sure on the direction of the fix... whether the team want to change just `href()` or to also change the pages strings.