### PR TITLE
Fix(react-router): Generalize href to match possible routes

### DIFF
--- a/.changeset/slow-readers-thank.md
+++ b/.changeset/slow-readers-thank.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+`href()` now correctly processes routes that have an extension after the parameter or are a single optional parameter.

--- a/contributors.yml
+++ b/contributors.yml
@@ -255,6 +255,7 @@
 - namoscato
 - ned-park
 - nenene3
+- ngbrown
 - nichtsam
 - nikeee
 - nilubisan

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -26,4 +26,8 @@ describe("href", () => {
       `Path '/a/:b' requires param 'b' but it was not provided`
     );
   });
+
+  it("works with periods", () => {
+    expect(href("/a/:b.zip", { b: "hello" })).toBe("/a/hello.zip");
+  })
 });

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -9,16 +9,26 @@ describe("href", () => {
     expect(href("/a/:b", { b: "hello", z: "ignored" })).toBe("/a/hello");
     expect(href("/a/:b?", { b: "hello", z: "ignored" })).toBe("/a/hello");
     expect(href("/a/:b?")).toBe("/a");
+    expect(href("/:b?")).toBe("/");
+    expect(href("/a/:e-z", { "e-z": "hello" })).toBe("/a/hello");
   });
 
   it("works with repeated params", () => {
     expect(href("/a/:b?/:b/:b?/:b", { b: "hello" })).toBe(
       "/a/hello/hello/hello/hello"
     );
+    expect(href("/a/:c?/:b/:c?/:b", { b: "hello" })).toBe("/a/hello/hello");
   });
 
   it("works with splats", () => {
     expect(href("/a/*", { "*": "b/c" })).toBe("/a/b/c");
+    expect(href("/a/*", {})).toBe("/a");
+  });
+
+  it("works with malformed splats", () => {
+    // this is how packages\react-router\lib\router\utils.ts: compilePath() will handle these routes.
+    expect(href("/a/z*", { "*": "b/c" })).toBe("/a/z/b/c");
+    expect(href("/a/z*", {})).toBe("/a/z");
   });
 
   it("throws when required params are missing", () => {
@@ -29,5 +39,5 @@ describe("href", () => {
 
   it("works with periods", () => {
     expect(href("/a/:b.zip", { b: "hello" })).toBe("/a/hello.zip");
-  })
+  });
 });

--- a/packages/react-router/lib/href.ts
+++ b/packages/react-router/lib/href.ts
@@ -27,26 +27,27 @@ export function href<Path extends keyof Args>(
   ...args: Args[Path]
 ): string {
   let params = args[0];
-  return path
-    .split("/")
-    .map((segment) => {
-      if (segment === "*") {
-        return params ? params["*"] : undefined;
-      }
-
-      const match = segment.match(/^:([\w-]+)(\?)?/);
-      if (!match) return segment;
-      const param = match[1];
+  let result = path.replace(
+    /\/:([\w-]+)(\?)?/g, // same regex as in .\router\utils.ts: compilePath().
+    (_: string, param: string, isOptional) => {
       const value = params ? params[param] : undefined;
-
-      const isRequired = match[2] === undefined;
-      if (isRequired && value === undefined) {
-        throw Error(
+      if (isOptional == null && value == null) {
+        throw new Error(
           `Path '${path}' requires param '${param}' but it was not provided`
         );
       }
-      return value;
-    })
-    .filter((segment) => segment !== undefined)
-    .join("/");
+      return value == null ? "" : "/" + value;
+    }
+  );
+
+  if (result.endsWith("*")) {
+    // treat trailing splat the same way as compilePath, and force it to be as if it were `/*`.
+    // `react-router typegen` will not generate the params for a malformed splat, causing a type error, but we can still do the correct thing here.
+    result = result.slice(0, result.endsWith("/*") ? -2 : -1);
+    if (params && params["*"]) {
+      result += "/" + params["*"];
+    }
+  }
+
+  return result || "/";
 }


### PR DESCRIPTION
Fixes #13671 and supersedes #13613

It is possible to have routes with an extension (`/:id.txt`) or with a single optional parameter (`/:lang?`). `href()` did not handle those cases.

This fixes that with an implementation of `href()` that more closely resembles how [`complePath()`](https://github.com/ngbrown/react-router/blob/a89c1ccf751e34d9bca80055cd7dad50219ca6ba/packages/react-router/lib/router/utils.ts#L1231) handles the path.

For a demonstration of the issue, see the `bug-report-test.ts` in #13671 or [this example project](https://github.com/ngbrown/react-router-href-with-period).