### PR TITLE
Add `hasComponent` to RSC route manifest

### DIFF
--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -77,6 +77,7 @@ export type RenderedRoute = {
   errorElement?: React.ReactElement;
   handle?: any;
   hasAction: boolean;
+  hasComponent: boolean;
   hasErrorBoundary: boolean;
   hasLoader: boolean;
   hydrateFallbackElement?: React.ReactElement;
@@ -87,10 +88,6 @@ export type RenderedRoute = {
   parentId?: string;
   path?: string;
   shouldRevalidate?: ShouldRevalidateFunction;
-  // TODO: Add "hasComponent" or similar to help with the `shouldAllowOptOut`
-  // logic in the browser RSC single fetch implementation. The issue is that
-  // if there is no element, we have to go to the server. This helps with "route
-  // has no component therefore can opt out".
 };
 
 export type ServerRouteMatch = RenderedRoute & {
@@ -750,7 +747,8 @@ async function getServerRouteMatch(
     errorElement,
     handle: (match.route as any).handle,
     hasAction: !!match.route.action,
-    hasErrorBoundary: !!(match.route as any).ErrorBoundary,
+    hasComponent: !!Component,
+    hasErrorBoundary: !!ErrorBoundary,
     hasLoader: !!match.route.loader,
     hydrateFallbackElement,
     id: match.route.id,
@@ -787,6 +785,7 @@ async function getManifestRoute(
     clientLoader: route.clientLoader,
     handle: route.handle,
     hasAction: !!route.action,
+    hasComponent: !!route.Component,
     hasErrorBoundary: !!route.ErrorBoundary,
     errorElement,
     hasLoader: !!route.loader,


### PR DESCRIPTION
This is so we can detect whether routes without an element require an RSC render pass to get one. This is used for hydration and during client navigations to routes with client loaders.