### PR TITLE
docs(decisions): fix typos

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -401,3 +401,4 @@
 - zeromask1337
 - zheng-chuang
 - zxTomw
+- kilavvy

--- a/decisions/0003-data-strategy.md
+++ b/decisions/0003-data-strategy.md
@@ -141,7 +141,7 @@ We considered how to handle `shouldRevalidate` behavior. There's sort of 2 basic
 
 I _think_ (1) is preferred to keep the API at a minimum and avoid leaking into _other_ ways to opt-out of revalidation. We already have an API for that so let's lean into it.
 
-Additionally, another big con of (2) is that if we want to let them make revalidation decisions inside `dataStrategy` - we need to expose all of the informaiton required for that (`currentUrl`, `currentParams`, `nextUrl`, `nextParams`, `submission` info, `actionResult`, etc.) - the API becomes a mess.
+Additionally, another big con of (2) is that if we want to let them make revalidation decisions inside `dataStrategy` - we need to expose all of the information required for that (`currentUrl`, `currentParams`, `nextUrl`, `nextParams`, `submission` info, `actionResult`, etc.) - the API becomes a mess.
 
 Therefore we are aiming to stick with one and let `shouldRevalidate` be the only way to opt-out of revalidation.
 

--- a/decisions/0005-remixing-react-router.md
+++ b/decisions/0005-remixing-react-router.md
@@ -204,7 +204,7 @@ function NewErrorBoundary() {
   const error = useRouteError();
 
   if (error instanceof Response) {
-    return <MyOldCatchBoudnary error={error} />;
+    return <MyOldCatchBoundary error={error} />;
   } else {
     return <MyOldErrorBoundary error={error} />;
   }


### PR DESCRIPTION


**Description:**  
This pull request makes the following changes:
- Corrects a typo in the word "information" in the `0003-data-strategy.md` decision document.
- Updates the component name from `MyOldCatchBoundary` to `MyOldCatchBoundary` (removes the typo) in the `0005-remixing-react-router.md` decision document for consistency.

These changes improve documentation clarity and maintain consistency in component naming. No functional code changes are included.