### PR TITLE
feat(serve): support `systemd`'s socket activation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -195,6 +195,7 @@
 - knownasilya
 - koojaa
 - KostiantynPopovych
+- ktosiek
 - KubasuIvanSakwa
 - KutnerUri
 - kylegirard


### PR DESCRIPTION
This PR adds support for systemd's socket activation: it let's the init daemon manage listening sockets, and pass those sockets to the service when someone connects.

This is handy to reduce downtime on upgrades: the old version of the service can be stopped, and new version will pick up new connections. It still causes a noticeable delay, so it's not perfect. But it's very easy to setup :-)

I'm not using a library here, because the protocol between systemd and the service is very simple.

I'm not sure how to make an automated test, I would be happy to add one if anyone can point me in the right direction.

## Testing

systemd provides a tool for testing socket activation. Testing with 3 different ports looks like this:
```
cd playground/framework
npm build
systemd-socket-activate -l 1234 -l 127.0.0.1:3234 -l $PWD/test.sock \
  node_modules/.bin/react-router-serve \
  build/server/index.js
```

This will first output:
```
Listening on [::]:1234 as 3.
Listening on 127.0.0.1:3234 as 4.
Listening on /home/tomek/react-router/playground/framework/test.sock as 5.
```

And then, when you try to connect on any of those, it will run the app:
```
Communication attempt on fd 3.
Execing node_modules/.bin/react-router-serve (node_modules/.bin/react-router-serve build/server/index.js)
[react-router-serve] http://[::]:1234 (from fd 3)
[react-router-serve] http://127.0.0.1:3234 (from fd 4)
[react-router-serve] listening on unknown address (from fd 5)
GET / 200 - - 36.536 ms
```

(I don't know why server.address() can't get the UNIX socket path. I've tried running server.address() in a setTimeout, it did not help. Connections through that socket work, though)

### Systemd unit example
I've also tested this with an actual service:

`~/.config/systemd/user/rr.socket`:
```
[Unit]
Description=rr test

[Socket]
ListenStream=1500
```

`~/.config/systemd/user/rr.service`:
```
[Unit]
Description=rr test

[Service]
WorkingDirectory=/home/tomek/react-router/playground/framework
Environment=PATH=/home/tomek/.nvm/versions/node/v22.16.0/bin/:/usr/bin:/bin
ExecStart=/home/tomek/react-router/playground/framework/node_modules/.bin/react-router-serve \
  /home/tomek/react-router/playground/framework/build/server/index.js
```

Loading all that up: `systemctl --user daemon-reload && systemctl --user start rr.socket`
You can check it worked with `curl localhost:1500`, or in the browser.