### PR TITLE
fix: encode Unicode characters in redirect URLs

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -356,6 +356,7 @@
 - tkindy
 - tlinhart
 - tobias-edwards
+- tobigumo
 - tom-sherman
 - tomasr8
 - TomerAberbach

--- a/packages/react-router/__tests__/server-runtime/responses-test.ts
+++ b/packages/react-router/__tests__/server-runtime/responses-test.ts
@@ -87,4 +87,16 @@ describe("redirect", () => {
     let response = redirect("/profile", 301);
     expect(response.status).toEqual(301);
   });
+
+  it("handles Unicode characters in URLs", () => {
+    let response = redirect("/こんにちは");
+    expect(response.headers.get("Location")).toEqual("/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF");
+    expect(response.status).toEqual(302);
+  });
+
+  it("handles Unicode characters with emoji in URLs", () => {
+    let response = redirect("/hello/🌟");
+    expect(response.headers.get("Location")).toEqual("/hello/%F0%9F%8C%9F");
+    expect(response.status).toEqual(302);
+  });
 });

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1595,7 +1595,7 @@ export const redirect: RedirectFunction = (url, init = 302) => {
   }
 
   let headers = new Headers(responseInit.headers);
-  headers.set("Location", url);
+  headers.set("Location", encodeURI(url));
 
   return new Response(null, { ...responseInit, headers });
 };


### PR DESCRIPTION
Fixes #13857

Add `encodeURI()` to properly encode Unicode characters in the Location header.

**Before:**
```typescript
headers.set("Location", url);
```

**After:**
```typescript
headers.set("Location", encodeURI(url));
```

## Tests

Added test cases for Japanese text and emoji characters to ensure proper encoding.