### PR TITLE
Revert "Bump changesets/action from 1.4.10 to 1.5.3"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         # publish to npm.
       - name: 🚀 PR / Publish
         id: changesets
-        uses: changesets/action@v1.5.3
+        uses: changesets/action@v1.4.10
         with:
           version: pnpm run changeset:version
           commit: "chore: Update version for release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
         # publish to npm.
       - name: 🚀 PR / Publish
         id: changesets
+        # PLEASE KEEP THIS PINNED TO 1.4.10 to avoid a regression in 1.5.*
+        # See https://github.com/changesets/action/issues/465
         uses: changesets/action@v1.4.10
         with:
           version: pnpm run changeset:version


### PR DESCRIPTION
Reverts remix-run/react-router#13677

Changesets shipped a regression in 1.5 which caused tags not to push to github: https://github.com/changesets/action/issues/465#issuecomment-2895839548. We had pinned to 1.4 to avoid that (https://github.com/remix-run/react-router/commit/ddf8e164ec4690c7a83ff160012be2bb908d5833) but dependabot noticied and opened a PR to bump us back to 1.5 which re-introduced the tag issue (https://github.com/remix-run/react-router/pull/13677)
