### PR TITLE
docs: Add reference to meta function return types in route module documentation

### DIFF
--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -372,6 +372,7 @@ The meta of the last matching route is used, allowing you to override parent rou
 **See also**
 
 - [`meta` params][meta-params]
+- [`meta` function return types][meta-function]
 
 ## `shouldRevalidate`
 
@@ -409,4 +410,5 @@ Next: [Rendering Strategies](./rendering)
 [link-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 [meta-element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 [meta-params]: https://api.reactrouter.com/v7/interfaces/react_router.MetaArgs
+[meta-function]: https://api.reactrouter.com/v7/types/react_router.MetaDescriptor.html
 [use-revalidator]: https://api.reactrouter.com/v7/functions/react_router.useRevalidator.html


### PR DESCRIPTION
### Description
Adds a reference to the meta function return type `MetaDescriptor`, so that other sorts of meta types, apart from the regular meta tags, are more visible from the documentation.

### Context
For anyone working on improving SEO, there are multiple ways to introduce structured data with scripts, but being able to make it using the meta function doesn't seem to be particularly obvious in the documentation; thus, I thought about adding this callout to the auto-generated type alias. 

