### PR TITLE
fix(react-router): Remove Content-Length Header from Single Fetch Responses to Prevent Errors

### DIFF
--- a/integration/redirects-test.ts
+++ b/integration/redirects-test.ts
@@ -166,6 +166,21 @@ test.describe("redirects", () => {
         expect(await app.getHtml("#increment")).toMatch("Count:1");
       });
 
+      test("redirects to absolute URLs in the app with a SPA navigation and Content-Length header", async ({
+        page,
+      }) => {
+        let app = new PlaywrightFixture(appFixture, page);
+        await app.goto(`/absolute/content-length`, true);
+        await app.clickElement("#increment");
+        expect(await app.getHtml("#increment")).toMatch("Count:1");
+        await app.waitForNetworkAfter(() =>
+          app.clickSubmitButton("/absolute/content-length")
+        );
+        await page.waitForSelector(`h1:has-text("Landing")`);
+        // No hard reload
+        expect(await app.getHtml("#increment")).toMatch("Count:1");
+      });
+
       test("supports hard redirects within the app via reloadDocument", async ({
         page,
       }) => {

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -280,6 +280,12 @@ function generateSingleFetchResponse(
   //  - https://developers.cloudflare.com/speed/optimization/content/brotli/content-compression/
   resultHeaders.set("Content-Type", "text/x-script");
 
+  // Remove Content-Length because node:http will truncate the response body
+  // to match the Content-Length header, which can result in incomplete data
+  // if the actual encoded body is longer.
+  // https://nodejs.org/api/http.html#class-httpclientrequest
+  resultHeaders.delete("Content-Length");
+
   return new Response(
     encodeViaTurboStream(
       result,


### PR DESCRIPTION
fixes: #12850
minimal reproduction: https://stackblitz.com/edit/github-pejjugrp?file=app%2Froutes%2Fhome.tsx

While investigating the cause of this issue, I discovered an interesting behavior: removing the Content-Length header from the response results in the application functioning correctly.

Upon further examination, I found the following description in the documentation for Node.js's [http module](https://nodejs.org/api/http.html#class-httpclientrequest):
> Set Content-Length header to limit the response body size.

In fact, when setting a clearly insufficient value such as Content-Length: 6, the response body appears to be affected accordingly.

![スクリーンショット 2025-05-22 200127](https://github.com/user-attachments/assets/d1d53dc9-85e4-449a-bb8f-ed021251f9d5)

![スクリーンショット 2025-05-22 200153](https://github.com/user-attachments/assets/0044f4c6-f7d0-44bf-844b-e91b80f630ac)


As described in the issue, this becomes problematic when using response headers intended for redirect responses—such as those generated by authentication libraries—which often do not include a response body.
After considering how best to address this, I concluded that, regardless of whether the response is a redirect, the use of turbo-stream encoding can alter the expected body. Therefore, the most robust solution would be to remove the Content-Length header from all Single Fetch responses, which is what this PR implements.


Additional Notes:
There is a [comment on the issue](https://github.com/remix-run/react-router/issues/12850#issuecomment-2898045521) stating that the bug occurred in the development environment but not in production(node20, SSR enabled) . I have yet to determine the reason for this discrepancy.
Nevertheless, since I was able to reliably reproduce and fix the bug, I am submitting this pull request. 