### PR TITLE
docs: Added async keyword to the loader function in the Await documentation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -137,6 +137,7 @@
 - holynewbie
 - hongji00
 - hsbtr
+- hoosierhuy
 - hyesungoh
 - iamnishanth
 - ianflynnwork

--- a/docs/api/components/Await.md
+++ b/docs/api/components/Await.md
@@ -15,7 +15,7 @@ Used to render promise values with automatic error handling.
 ```tsx
 import { Await, useLoaderData } from "react-router";
 
-export function loader() {
+export async function loader() {
   // not awaited
   const reviews = getReviews();
   // awaited (blocks the transition)


### PR DESCRIPTION
Currently, in the documentation at the `docs/api/components/Await.md` section, the sample loader function uses an await in the fetch:  `const book = await fetch("/api/book").then((res) => res.json() );`, however, the function declaration does not have the `async` keyword.  This pull request aims to update the documentation for the loader function by adding the `async` keyword to the function in order to prevent a syntax error if someone inadvertently do a copy and paste. 