### PR TITLE
fix(react-router): strip search params from FOW path parameter

### DIFF
--- a/.changeset/honest-socks-fail.md
+++ b/.changeset/honest-socks-fail.md
@@ -1,5 +1,5 @@
 ---
-"@remix-run/router": patch
+"react-router": patch
 ---
 
 Strip search parameters from `patchRoutesOnNavigation` `path` param for fetcher calls

--- a/.changeset/honest-socks-fail.md
+++ b/.changeset/honest-socks-fail.md
@@ -1,0 +1,5 @@
+---
+"@remix-run/router": patch
+---
+
+Strip search parameters from `patchRoutesOnNavigation` `path` param for fetcher calls

--- a/packages/react-router/__tests__/router/lazy-discovery-test.ts
+++ b/packages/react-router/__tests__/router/lazy-discovery-test.ts
@@ -2361,10 +2361,18 @@ describe("Lazy Route Discovery (Fog of War)", () => {
       });
 
       let key = "key";
+
+      let data;
+      router.subscribe((state) => {
+        if (state.fetchers.has("key")) {
+          data = state.fetchers.get("key")!.data;
+        }
+      });
+
       router.fetch(key, "0", "/parent/child?a=b");
       await tick();
       expect(router.getFetcher(key).state).toBe("idle");
-      expect(router.getFetcher(key).data).toBe("CHILD");
+      expect(data).toBe("CHILD");
       expect(capturedPath).toBe("/parent/child");
     });
 
@@ -2395,13 +2403,21 @@ describe("Lazy Route Discovery (Fog of War)", () => {
       });
 
       let key = "key";
+
+      let data;
+      router.subscribe((state) => {
+        if (state.fetchers.has("key")) {
+          data = state.fetchers.get("key")!.data;
+        }
+      });
+
       router.fetch(key, "0", "/parent/child?a=b", {
         formMethod: "post",
         formData: createFormData({}),
       });
       await tick();
       expect(router.getFetcher(key).state).toBe("idle");
-      expect(router.getFetcher(key).data).toBe("CHILD");
+      expect(data).toBe("CHILD");
       expect(capturedPath).toBe("/parent/child");
     });
   });

--- a/packages/react-router/__tests__/router/lazy-discovery-test.ts
+++ b/packages/react-router/__tests__/router/lazy-discovery-test.ts
@@ -2333,5 +2333,76 @@ describe("Lazy Route Discovery (Fog of War)", () => {
       expect(router.getFetcher(key).state).toBe("idle");
       expect(fetcherData.get(key)).toBe("C ACTION");
     });
+
+    it("does not include search params in the `path` (fetcher.load)", async () => {
+      let capturedPath;
+
+      router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          {
+            path: "/",
+          },
+          {
+            id: "parent",
+            path: "parent",
+          },
+        ],
+        async patchRoutesOnNavigation({ path, patch }) {
+          capturedPath = path;
+          patch("parent", [
+            {
+              id: "child",
+              path: "child",
+              loader: () => "CHILD",
+            },
+          ]);
+        },
+      });
+
+      let key = "key";
+      router.fetch(key, "0", "/parent/child?a=b");
+      await tick();
+      expect(router.getFetcher(key).state).toBe("idle");
+      expect(router.getFetcher(key).data).toBe("CHILD");
+      expect(capturedPath).toBe("/parent/child");
+    });
+
+    it("does not include search params in the `path` (fetcher.submit)", async () => {
+      let capturedPath;
+
+      router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          {
+            path: "/",
+          },
+          {
+            id: "parent",
+            path: "parent",
+          },
+        ],
+        async patchRoutesOnNavigation({ path, patch }) {
+          capturedPath = path;
+          patch("parent", [
+            {
+              id: "child",
+              path: "child",
+              action: () => "CHILD",
+            },
+          ]);
+        },
+      });
+
+      let key = "key";
+      router.fetch(key, "0", "/parent/child?a=b", {
+        formMethod: "post",
+        formData: createFormData({}),
+      });
+      await tick();
+      expect(router.getFetcher(key).state).toBe("idle");
+      expect(router.getFetcher(key).data).toBe("CHILD");
+      expect(capturedPath).toBe("/parent/child");
+    });
   });
 });

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2330,7 +2330,7 @@ export function createRouter(init: RouterInit): Router {
     if (isFogOfWar) {
       let discoverResult = await discoverRoutes(
         requestMatches,
-        path,
+        new URL(fetchRequest.url).pathname,
         fetchRequest.signal,
         key
       );
@@ -2634,7 +2634,7 @@ export function createRouter(init: RouterInit): Router {
     if (isFogOfWar) {
       let discoverResult = await discoverRoutes(
         matches,
-        path,
+        new URL(fetchRequest.url).pathname,
         fetchRequest.signal,
         key
       );


### PR DESCRIPTION
Cherry-pick'd https://github.com/remix-run/react-router/pull/12899 into v7 since we forgot to do that we we landed it in v6 (fixes v7 regression of https://github.com/remix-run/react-router/issues/12896).