### PR TITLE
test(rsc): provide custom rsc-parcel-framework entries

### DIFF
--- a/integration/helpers/rsc-parcel-framework/app/entry.browser.tsx
+++ b/integration/helpers/rsc-parcel-framework/app/entry.browser.tsx
@@ -1,0 +1,41 @@
+"use client-entry";
+
+import * as React from "react";
+import { hydrateRoot } from "react-dom/client";
+import {
+  type unstable_RSCPayload as RSCPayload,
+  unstable_createCallServer as createCallServer,
+  unstable_getRSCStream as getRSCStream,
+  unstable_RSCHydratedRouter as RSCHydratedRouter,
+} from "react-router";
+import {
+  createFromReadableStream,
+  createTemporaryReferenceSet,
+  encodeReply,
+  setServerCallback,
+  // @ts-expect-error
+} from "react-server-dom-parcel/client";
+
+setServerCallback(
+  createCallServer({
+    createFromReadableStream,
+    createTemporaryReferenceSet,
+    encodeReply,
+  })
+);
+
+createFromReadableStream(getRSCStream()).then((payload: RSCPayload) => {
+  React.startTransition(() => {
+    hydrateRoot(
+      document,
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(RSCHydratedRouter, {
+          createFromReadableStream,
+          payload,
+        })
+      )
+    );
+  });
+});

--- a/integration/helpers/rsc-parcel-framework/app/entry.rsc.ts
+++ b/integration/helpers/rsc-parcel-framework/app/entry.rsc.ts
@@ -1,0 +1,32 @@
+"use server-entry";
+
+import {
+  createTemporaryReferenceSet,
+  decodeAction,
+  decodeReply,
+  loadServerAction,
+  renderToReadableStream,
+  // @ts-expect-error
+} from "react-server-dom-parcel/server.edge";
+import { unstable_matchRSCServerRequest as matchRSCServerRequest } from "react-router";
+
+import routes from "virtual:react-router/routes";
+
+import "./entry.browser.tsx";
+
+export function fetchServer(request: Request) {
+  return matchRSCServerRequest({
+    createTemporaryReferenceSet,
+    decodeAction,
+    decodeReply,
+    loadServerAction,
+    request,
+    routes,
+    generateResponse(match) {
+      return new Response(renderToReadableStream(match.payload), {
+        status: match.statusCode,
+        headers: match.headers,
+      });
+    },
+  });
+}

--- a/integration/helpers/rsc-parcel-framework/app/index.ts
+++ b/integration/helpers/rsc-parcel-framework/app/index.ts
@@ -1,3 +1,29 @@
-import requestHandler from "virtual:react-router/request-handler";
+import * as React from "react";
+// @ts-expect-error - no types
+import { renderToReadableStream } from "react-dom/server.edge" assert { env: "react-client" };
+import {
+  unstable_routeRSCServerRequest,
+  unstable_RSCStaticRouter,
+} from "react-router" assert { env: "react-client" };
+// @ts-expect-error
+import { createFromReadableStream } from "react-server-dom-parcel/client.edge" assert { env: "react-client" };
 
-export { requestHandler };
+import { fetchServer } from "./entry.rsc" assert { env: "react-server" };
+
+export const requestHandler = async (request: Request) => {
+  return unstable_routeRSCServerRequest({
+    request,
+    fetchServer,
+    createFromReadableStream,
+    async renderHTML(getPayload) {
+      return await renderToReadableStream(
+        React.createElement(unstable_RSCStaticRouter, { getPayload }),
+        {
+          bootstrapScriptContent: (
+            fetchServer as unknown as { bootstrapScript: string }
+          ).bootstrapScript,
+        }
+      );
+    },
+  });
+};


### PR DESCRIPTION
This decouples our test suite from the higher level conveniences of the Parcel plugin to ensure we're exposed to it as little as possible. Now, we're only testing against the `virtual:react-router/routes` virtual module.