### PR TITLE
docs: Add modes to all explanation/how to

### DIFF
--- a/docs/explanation/backend-for-frontend.md
+++ b/docs/explanation/backend-for-frontend.md
@@ -4,6 +4,11 @@ title: Backend For Frontend
 
 # Backend For Frontend
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 While React Router can serve as your fullstack application, it also fits perfectly into the "Backend for Frontend" architecture.
 
 The BFF strategy employs a web server with a job scoped to serving the frontend web app and connecting it to the services it needs: your database, mailer, job queues, existing backend APIs (REST, GraphQL), etc. Instead of your UI integrating directly from the browser to these services, it connects to the BFF, and the BFF connects to your services.

--- a/docs/explanation/code-splitting.md
+++ b/docs/explanation/code-splitting.md
@@ -6,7 +6,8 @@ title: Automatic Code Splitting
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 When using React Router's framework features, your application is automatically code split to improve the performance of initial load times when users visit your application.
 

--- a/docs/explanation/concurrency.md
+++ b/docs/explanation/concurrency.md
@@ -6,7 +6,8 @@ title: Network Concurrency Management
 
 [MODES: framework, data]
 
-## Overview
+<br/>
+<br/>
 
 When building web applications, managing network requests can be a daunting task. The challenges of ensuring up-to-date data and handling simultaneous requests often lead to complex logic in the application to deal with interruptions and race conditions. React Router simplifies this process by automating network management while mirroring and expanding upon the intuitive behavior of web browsers.
 

--- a/docs/explanation/hot-module-replacement.md
+++ b/docs/explanation/hot-module-replacement.md
@@ -6,7 +6,8 @@ title: Hot Module Replacement
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 Hot Module Replacement is a technique for updating modules in your app without needing to reload the page.
 It's a great developer experience, and React Router supports it when using Vite.

--- a/docs/explanation/lazy-route-discovery.md
+++ b/docs/explanation/lazy-route-discovery.md
@@ -6,7 +6,8 @@ title: Lazy Route Discovery
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 Lazy Route Discovery is a performance optimization that loads route information progressively as users navigate through your application, rather than loading the complete route manifest upfront.
 

--- a/docs/explanation/progressive-enhancement.md
+++ b/docs/explanation/progressive-enhancement.md
@@ -4,9 +4,14 @@ title: Progressive Enhancement
 
 # Progressive Enhancement
 
-> Progressive enhancement is a strategy in web design that puts emphasis on web content first, allowing everyone to access the basic content and functionality of a web page, whilst users with additional browser features or faster Internet access receive the enhanced version instead.
+[MODES: framework]
 
-<cite>- [Wikipedia][wikipedia]</cite>
+<br/>
+<br/>
+
+> Progressive enhancement is a strategy in web design that puts emphasis on web content first, allowing everyone to access the basic content and functionality of a web page, whilst users with additional browser features or faster Internet access receive the enhanced version instead.
+>
+> <cite>- [Wikipedia][wikipedia]</cite>
 
 When using React Router with Server-Side Rendering (the default in framework mode), you can automatically leverage the benefits of progressive enhancement.
 

--- a/docs/explanation/state-management.md
+++ b/docs/explanation/state-management.md
@@ -6,7 +6,8 @@ title: State Management
 
 [MODES: framework, data]
 
-## Overview
+<br/>
+<br/>
 
 State management in React typically involves maintaining a synchronized cache of server data on the client side. However, when using React Router as your framework, most of the traditional caching solutions become redundant because of how it inherently handles data synchronization.
 

--- a/docs/explanation/type-safety.md
+++ b/docs/explanation/type-safety.md
@@ -6,7 +6,8 @@ title: Type Safety
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 If you haven't done so already, check out our guide for [setting up type safety][route-module-type-safety] in a new project.
 

--- a/docs/how-to/accessibility.md
+++ b/docs/how-to/accessibility.md
@@ -10,11 +10,21 @@ React Router makes certain accessibility practices the default where possible an
 
 ## Links
 
+[MODES: framework,data,declarative]
+
+<br/>
+<br/>
+
 The [`<Link>` component][link] renders a standard anchor tag, meaning that you get its accessibility behaviors from the browser for free!
 
 React Router also provides the [`<NavLink/>`][navlink] which behaves the same as `<Link>`, but it also provides context for assistive technology when the link points to the current page. This is useful for building navigation menus or breadcrumbs.
 
 ## Routing
+
+[MODES: framework]
+
+<br/>
+<br/>
 
 If you are rendering [`<Scripts>`][scripts] in your app, there are some important things to consider to make client-side routing more accessible for your users.
 

--- a/docs/how-to/accessibility.md
+++ b/docs/how-to/accessibility.md
@@ -10,7 +10,7 @@ React Router makes certain accessibility practices the default where possible an
 
 ## Links
 
-[MODES: framework,data,declarative]
+[MODES: framework, data, declarative]
 
 <br/>
 <br/>

--- a/docs/how-to/client-data.md
+++ b/docs/how-to/client-data.md
@@ -4,6 +4,11 @@ title: Client Data
 
 # Client Data
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 You can fetch and mutate data directly in the browser using `clientLoader` and `clientAction` functions.
 
 These functions are the primary mechanism for data handling when using [SPA mode][spa]. This guide demonstrates common use cases for leveraging client data in Server-Side Rendering (SSR).

--- a/docs/how-to/error-boundary.md
+++ b/docs/how-to/error-boundary.md
@@ -4,6 +4,11 @@ title: Error Boundaries
 
 # Error Boundaries
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 To avoid rendering an empty page to users, route modules will automatically catch errors in your code and render the closest `ErrorBoundary`.
 
 Error boundaries are not intended for error reporting or rendering form validation errors. Please see [Form Validation](./form-validation) and [Error Reporting](./error-reporting) instead.

--- a/docs/how-to/error-boundary.md
+++ b/docs/how-to/error-boundary.md
@@ -4,7 +4,7 @@ title: Error Boundaries
 
 # Error Boundaries
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>

--- a/docs/how-to/error-reporting.md
+++ b/docs/how-to/error-reporting.md
@@ -4,6 +4,11 @@ title: Error Reporting
 
 # Error Reporting
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 React Router catches errors in your route modules and sends them to [error boundaries](./error-boundary) to prevent blank pages when errors occur. However, ErrorBoundary isn't sufficient for logging and reporting errors. To access these caught errors, use the handleError export of the server entry module.
 
 ## 1. Reveal the server entry

--- a/docs/how-to/fetchers.md
+++ b/docs/how-to/fetchers.md
@@ -4,6 +4,11 @@ title: Using Fetchers
 
 # Using Fetchers
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 Fetchers are useful for creating complex, dynamic user interfaces that require multiple, concurrent data interactions without causing a navigation.
 
 Fetchers track their own, independent state and can be used to load data, mutate data, submit forms, and generally interact with loaders and actions.

--- a/docs/how-to/fetchers.md
+++ b/docs/how-to/fetchers.md
@@ -4,7 +4,7 @@ title: Using Fetchers
 
 # Using Fetchers
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>

--- a/docs/how-to/file-route-conventions.md
+++ b/docs/how-to/file-route-conventions.md
@@ -4,6 +4,11 @@ title: File Route Conventions
 
 # File Route Conventions
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 The `@react-router/fs-routes` package enables file-convention based route config.
 
 ## Setting up

--- a/docs/how-to/file-uploads.md
+++ b/docs/how-to/file-uploads.md
@@ -4,6 +4,11 @@ title: File Uploads
 
 # File Uploads
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 Handle file uploads in your React Router applications. This guide uses some packages from the [Remix The Web][remix-the-web] project to make file uploads easier.
 
 _Thank you to David Adams for [writing an original guide](https://programmingarehard.com/2024/09/06/remix-file-uploads-updated.html/) on which this doc is based. You can refer to it for even more examples._

--- a/docs/how-to/form-validation.md
+++ b/docs/how-to/form-validation.md
@@ -4,6 +4,11 @@ title: Form Validation
 
 # Form Validation
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 This guide walks through a simple signup form implementation. You will likely want to pair these concepts with third-party validation libraries and error components, but this guide only focuses on the moving pieces for React Router.
 
 ## 1. Setting Up

--- a/docs/how-to/form-validation.md
+++ b/docs/how-to/form-validation.md
@@ -4,7 +4,7 @@ title: Form Validation
 
 # Form Validation
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>

--- a/docs/how-to/headers.md
+++ b/docs/how-to/headers.md
@@ -4,6 +4,11 @@ title: HTTP Headers
 
 # HTTP Headers
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 Headers are primarily defined with the route module `headers` export. You can also set headers in `entry.server.tsx`.
 
 ## From Route Modules

--- a/docs/how-to/navigation-blocking.md
+++ b/docs/how-to/navigation-blocking.md
@@ -6,7 +6,8 @@ title: Navigation Blocking
 
 [MODES: framework, data]
 
-## Overview
+<br/>
+<br/>
 
 When users are in the middle of a workflow, like filling out an important form, you may want to prevent them from navigating away from the page.
 

--- a/docs/how-to/pre-rendering.md
+++ b/docs/how-to/pre-rendering.md
@@ -4,6 +4,11 @@ title: Pre-Rendering
 
 # Pre-Rendering
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 Pre-Rendering allows you to speed up page loads for static content by rendering pages at build time instead of at runtime. Pre-rendering is enabled via the `prerender` config in `react-router.config.ts` and can be used in two ways based on the `ssr` config value:
 
 - Alongside a runtime SSR server with `ssr:true` (the default value)

--- a/docs/how-to/presets.md
+++ b/docs/how-to/presets.md
@@ -6,7 +6,8 @@ title: Presets
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 The [React Router config][react-router-config] supports a `presets` option to ease integration with other tools and hosting providers.
 

--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -4,7 +4,7 @@ title: Resource Routes
 
 # Resource Routes
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>

--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -4,6 +4,11 @@ title: Resource Routes
 
 # Resource Routes
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 When server rendering, routes can serve "resources" instead of rendering components, like images, PDFs, JSON payloads, webhooks, etc.
 
 ## Defining a Resource Route

--- a/docs/how-to/route-module-type-safety.md
+++ b/docs/how-to/route-module-type-safety.md
@@ -4,6 +4,11 @@ title: Route Module Type Safety
 
 # Route Module Type Safety
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 React Router generates route-specific types to power type inference for URL params, loader data, and more.
 This guide will help you set it up if you didn't start with a template.
 

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -4,6 +4,11 @@ title: Security
 
 # Security
 
+[MODES: framework]
+
+<br/>
+<br/>
+
 This is by no means a comprehensive guide, but React Router provides features to help address a few aspects under the _very large_ umbrella that is _Security_.
 
 ## `Content-Security-Policy`

--- a/docs/how-to/server-bundles.md
+++ b/docs/how-to/server-bundles.md
@@ -6,7 +6,8 @@ title: Server Bundles
 
 [MODES: framework]
 
-## Overview
+<br/>
+<br/>
 
 <docs-warning>This is an advanced feature designed for hosting provider integrations. When compiling your app into multiple server bundles, there will need to be a custom routing layer in front of your app directing requests to the correct bundle.</docs-warning>
 

--- a/docs/how-to/spa.md
+++ b/docs/how-to/spa.md
@@ -9,9 +9,7 @@ title: Single Page App (SPA)
 <br/>
 <br/>
 
-This guides focuses on how to build Single Page Apps with React Router Framework mode. If you're using React Router in declarative or data mode, you can design your own SPA architecture.
-
-## Overview
+<docs-info>This guide focuses on how to build Single Page Apps with React Router Framework mode. If you're using React Router in declarative or data mode, you can design your own SPA architecture.</docs-info>
 
 When using React Router as a framework, you can enable "SPA Mode" by setting `ssr:false` in your `react-router.config.ts` file. This will disable runtime server rendering and generate an `index.html` at build time that you can serve and hydrate as a SPA.
 

--- a/docs/how-to/status.md
+++ b/docs/how-to/status.md
@@ -4,7 +4,7 @@ title: Status Codes
 
 # Status Codes
 
-[MODES: framework,data]
+[MODES: framework ,data]
 
 <br/>
 <br/>

--- a/docs/how-to/status.md
+++ b/docs/how-to/status.md
@@ -4,6 +4,11 @@ title: Status Codes
 
 # Status Codes
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 Set status codes from loaders and actions with `data`.
 
 ```tsx filename=app/project.tsx lines=[3,12-15,20,23]

--- a/docs/how-to/suspense.md
+++ b/docs/how-to/suspense.md
@@ -4,6 +4,11 @@ title: Streaming with Suspense
 
 # Streaming with Suspense
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 Streaming with React Suspense allows apps to speed up initial renders by deferring non-critical data and unblocking UI rendering.
 
 React Router supports React Suspense by returning promises from loaders and actions.

--- a/docs/how-to/suspense.md
+++ b/docs/how-to/suspense.md
@@ -4,7 +4,7 @@ title: Streaming with Suspense
 
 # Streaming with Suspense
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>

--- a/docs/how-to/view-transitions.md
+++ b/docs/how-to/view-transitions.md
@@ -4,6 +4,11 @@ title: View Transitions
 
 # View Transitions
 
+[MODES: framework,data]
+
+<br/>
+<br/>
+
 Enable smooth animations between page transitions in your React Router applications using the [View Transitions API][view-transitions-api]. This feature allows you to create seamless visual transitions during client-side navigation.
 
 ## Basic View Transition

--- a/docs/how-to/view-transitions.md
+++ b/docs/how-to/view-transitions.md
@@ -4,7 +4,7 @@ title: View Transitions
 
 # View Transitions
 
-[MODES: framework,data]
+[MODES: framework, data]
 
 <br/>
 <br/>


### PR DESCRIPTION
Add's a MODES bar to all docs in the Explanation/How To sections that didn't already have one