### PR TITLE
test(rsc): fix RSC integration fixture start scripts

### DIFF
--- a/integration/helpers/rsc-parcel-framework/package.json
+++ b/integration/helpers/rsc-parcel-framework/package.json
@@ -16,7 +16,7 @@
     "clean": "rm -rf dist .parcel-cache .react-router .react-router-parcel",
     "dev": "parcel --no-cache --no-autoinstall",
     "build": "parcel build --no-cache --no-autoinstall",
-    "start": "node start.js",
+    "start": "cross-env NODE_ENV=production node start.js",
     "typecheck": "react-router typegen && pnpm build && tsc"
   },
   "devDependencies": {
@@ -34,6 +34,7 @@
   "dependencies": {
     "@mjackson/node-fetch-server": "0.6.1",
     "@parcel/runtime-rsc": "2.15.0",
+    "cross-env": "^7.0.3",
     "express": "^4.21.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/integration/helpers/rsc-parcel/package.json
+++ b/integration/helpers/rsc-parcel/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "parcel --no-cache",
     "build": "parcel build --no-cache",
-    "start": "node dist/server.js",
+    "start": "cross-env NODE_ENV=production node dist/server/server.js",
     "typecheck": "tsc"
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
   "dependencies": {
     "@mjackson/node-fetch-server": "0.6.1",
     "@parcel/runtime-rsc": "2.15.0",
+    "cross-env": "^7.0.3",
     "express": "^4.21.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@mjackson/node-fetch-server": "0.6.1",
     "compression": "^1.8.0",
+    "cross-env": "^7.0.3",
     "express": "^4.21.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@parcel/runtime-rsc':
         specifier: 2.15.0
         version: 2.15.0(@parcel/core@2.15.0)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -407,6 +410,9 @@ importers:
       '@parcel/runtime-rsc':
         specifier: 2.15.0
         version: 2.15.0(@parcel/core@2.15.0)
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -465,6 +471,9 @@ importers:
       compression:
         specifier: ^1.8.0
         version: 1.8.0
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       express:
         specifier: ^4.21.2
         version: 4.21.2


### PR DESCRIPTION
These are used when debugging integration tests in the `.tmp/integration` directory, but they're currently not working correctly.