### PR TITLE
chore(deps): replace `@hiogawa/vite-rsc` with `@vitejs/plugin-rsc`

### DIFF
--- a/docs/start/rsc/vite.md
+++ b/docs/start/rsc/vite.md
@@ -28,7 +28,7 @@ npm i react-router react react-dom react-server-dom-parcel @mjackson/node-fetch-
 Along with development dependencies
 
 ```shellscript nonumber
-npm i -D vite vite-plugin-devtools-json @hiogawa/vite-rsc typescript @types/react @types/react-dom @types/express @types/compression @types/node
+npm i -D vite vite-plugin-devtools-json @vitejs/plugin-rsc typescript @types/react @types/react-dom @types/express @types/compression @types/node
 ```
 
 ## Configure Parcel
@@ -58,7 +58,7 @@ import {
   decodeReply,
   loadServerAction,
   renderToReadableStream,
-} from "@hiogawa/vite-rsc/rsc";
+} from "@vitejs/plugin-rsc/rsc";
 import { unstable_matchRSCServerRequest as matchRSCServerRequest } from "react-router";
 
 import { routes } from "./routes/routes";
@@ -102,7 +102,7 @@ export default async function handler(request: Request) {
 Create a `src/prerender.tsx` file that will be responsible for rendering our application to HTML.
 
 ```tsx nonnumber
-import { createFromReadableStream } from "@hiogawa/vite-rsc/ssr";
+import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 import { renderToReadableStream as renderHTMLToReadableStream } from "react-dom/server.edge";
 import {
   unstable_routeRSCServerRequest as routeRSCServerRequest,
@@ -151,7 +151,7 @@ import {
   createFromReadableStream,
   encodeReply,
   setServerCallback,
-} from "@hiogawa/vite-rsc/browser";
+} from "@vitejs/plugin-rsc/browser";
 import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import {

--- a/docs/start/rsc/vite.md
+++ b/docs/start/rsc/vite.md
@@ -108,12 +108,12 @@ import {
   unstable_routeRSCServerRequest as routeRSCServerRequest,
   unstable_RSCStaticRouter as RSCStaticRouter,
 } from "react-router";
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 
 export async function prerender(
   request: Request,
   fetchServer: (request: Request) => Promise<Response>
 ): Promise<Response> {
+  const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index")
   return await routeRSCServerRequest({
     // The incoming request.
     request,

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@hiogawa/vite-rsc": "0.4.4",
+    "@vitejs/plugin-rsc": "0.4.10-alpha.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",

--- a/integration/helpers/rsc-vite/src/entry.browser.tsx
+++ b/integration/helpers/rsc-vite/src/entry.browser.tsx
@@ -5,7 +5,7 @@ import {
   createTemporaryReferenceSet,
   encodeReply,
   setServerCallback,
-} from "@hiogawa/vite-rsc/browser";
+} from "@vitejs/plugin-rsc/browser";
 import {
   unstable_createCallServer as createCallServer,
   unstable_getRSCStream as getRSCStream,

--- a/integration/helpers/rsc-vite/src/entry.rsc.tsx
+++ b/integration/helpers/rsc-vite/src/entry.rsc.tsx
@@ -4,7 +4,7 @@ import {
   decodeReply,
   loadServerAction,
   renderToReadableStream,
-} from "@hiogawa/vite-rsc/rsc";
+} from "@vitejs/plugin-rsc/rsc";
 import { unstable_matchRSCServerRequest as matchRSCServerRequest } from "react-router";
 
 import { routes } from "./routes";

--- a/integration/helpers/rsc-vite/src/entry.ssr.tsx
+++ b/integration/helpers/rsc-vite/src/entry.ssr.tsx
@@ -1,5 +1,5 @@
 import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
-import { createFromReadableStream } from "@hiogawa/vite-rsc/ssr";
+import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 // @ts-expect-error
 import * as ReactDomServer from "react-dom/server.edge";
 import {

--- a/integration/helpers/rsc-vite/src/entry.ssr.tsx
+++ b/integration/helpers/rsc-vite/src/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 // @ts-expect-error
 import * as ReactDomServer from "react-dom/server.edge";
@@ -11,6 +10,7 @@ export default async function handler(
   request: Request,
   fetchServer: (request: Request) => Promise<Response>
 ) {
+  const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
   return routeRSCServerRequest({
     request,
     fetchServer,

--- a/integration/helpers/rsc-vite/tsconfig.json
+++ b/integration/helpers/rsc-vite/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "@hiogawa/vite-rsc/types"],
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"],
     "jsx": "react-jsx"
   }
 }

--- a/integration/helpers/rsc-vite/vite.config.ts
+++ b/integration/helpers/rsc-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import rsc from "@hiogawa/vite-rsc/plugin";
+import rsc from "@vitejs/plugin-rsc/plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/integration/helpers/rsc-vite/vite.config.ts
+++ b/integration/helpers/rsc-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import rsc from "@vitejs/plugin-rsc/plugin";
+import rsc from "@vitejs/plugin-rsc";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/playground/rsc-vite/package.json
+++ b/playground/rsc-vite/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@hiogawa/vite-rsc": "0.4.4",
+    "@vitejs/plugin-rsc": "0.4.10-alpha.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",

--- a/playground/rsc-vite/src/entry.browser.tsx
+++ b/playground/rsc-vite/src/entry.browser.tsx
@@ -5,7 +5,7 @@ import {
   createTemporaryReferenceSet,
   encodeReply,
   setServerCallback,
-} from "@hiogawa/vite-rsc/browser";
+} from "@vitejs/plugin-rsc/browser";
 import {
   unstable_createCallServer as createCallServer,
   unstable_getRSCStream as getRSCStream,

--- a/playground/rsc-vite/src/entry.rsc.tsx
+++ b/playground/rsc-vite/src/entry.rsc.tsx
@@ -4,7 +4,7 @@ import {
   decodeReply,
   loadServerAction,
   renderToReadableStream,
-} from "@hiogawa/vite-rsc/rsc";
+} from "@vitejs/plugin-rsc/rsc";
 import { unstable_matchRSCServerRequest as matchRSCServerRequest } from "react-router";
 
 import { routes } from "./routes";

--- a/playground/rsc-vite/src/entry.ssr.tsx
+++ b/playground/rsc-vite/src/entry.ssr.tsx
@@ -1,5 +1,5 @@
 import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
-import { createFromReadableStream } from "@hiogawa/vite-rsc/ssr";
+import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 // @ts-expect-error
 import * as ReactDomServer from "react-dom/server.edge";
 import {

--- a/playground/rsc-vite/src/entry.ssr.tsx
+++ b/playground/rsc-vite/src/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/ssr";
 // @ts-expect-error
 import * as ReactDomServer from "react-dom/server.edge";
@@ -11,6 +10,7 @@ export default async function handler(
   request: Request,
   fetchServer: (request: Request) => Promise<Response>
 ) {
+  const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
   return routeRSCServerRequest({
     request,
     fetchServer,

--- a/playground/rsc-vite/tsconfig.json
+++ b/playground/rsc-vite/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "target": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "@hiogawa/vite-rsc/types"],
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"],
     "jsx": "react-jsx"
   }
 }

--- a/playground/rsc-vite/vite.config.ts
+++ b/playground/rsc-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import rsc from "@hiogawa/vite-rsc/plugin";
+import rsc from "@vitejs/plugin-rsc/plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/playground/rsc-vite/vite.config.ts
+++ b/playground/rsc-vite/vite.config.ts
@@ -1,4 +1,4 @@
-import rsc from "@vitejs/plugin-rsc/plugin";
+import rsc from "@vitejs/plugin-rsc";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,9 +478,6 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-router
     devDependencies:
-      '@hiogawa/vite-rsc':
-        specifier: 0.4.4
-        version: 0.4.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.1
@@ -496,6 +493,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
+      '@vitejs/plugin-rsc':
+        specifier: 0.4.10-alpha.1
+        version: 0.4.10-alpha.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
       typescript:
         specifier: ^5.1.6
         version: 5.4.5
@@ -1804,9 +1804,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-router
     devDependencies:
-      '@hiogawa/vite-rsc':
-        specifier: 0.4.4
-        version: 0.4.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.1
@@ -1822,6 +1819,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
+      '@vitejs/plugin-rsc':
+        specifier: 0.4.10-alpha.1
+        version: 0.4.10-alpha.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3369,16 +3369,6 @@ packages:
   '@hattip/walk@0.0.49':
     resolution: {integrity: sha512-AgJgKLooZyQnzMfoFg5Mo/aHM+HGBC9ExpXIjNqGimYTRgNbL/K7X5EM1kR2JY90BNKk9lo6Usq1T/nWFdT7TQ==}
     hasBin: true
-
-  '@hiogawa/transforms@0.1.3':
-    resolution: {integrity: sha512-vzDCWgXIk4D6Ea2aBSuNqTssN6sTAqm8xzeqXea68o9TvBm5IZhQ3u/8vmWEiJpAtrlTohcTc1Hfgi025iFpGA==}
-
-  '@hiogawa/vite-rsc@0.4.4':
-    resolution: {integrity: sha512-Yucbgb6g1bC3S6wofT+ZdtEhnwBZIt4YMZWxXzH9yHugcen0bUtasSATb1qGGraCxu03y8xtHOstXgS8sjdUOQ==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-      vite: '*'
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -5092,6 +5082,13 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+
+  '@vitejs/plugin-rsc@0.4.10-alpha.1':
+    resolution: {integrity: sha512-CsYFXD/8t07FqPDiYyqRcLb9Jm4WsMnrpnnEPzQUnHThr7zaBjSz76N3spsDsBEPDM1hDFFNneuQV1VtOWmTUg==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+      vite: '*'
 
   '@web3-storage/multipart-parser@1.0.0':
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
@@ -11444,24 +11441,6 @@ snapshots:
       cac: 6.7.14
       mime-types: 2.1.35
 
-  '@hiogawa/transforms@0.1.3':
-    dependencies:
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-      periscopic: 4.0.2
-
-  '@hiogawa/vite-rsc@0.4.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))':
-    dependencies:
-      '@hiogawa/transforms': 0.1.3
-      '@mjackson/node-fetch-server': 0.6.1
-      es-module-lexer: 1.7.0
-      magic-string: 0.30.17
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      turbo-stream: 3.1.0
-      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0)
-      vitefu: 1.0.6(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
-
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -13667,6 +13646,19 @@ snapshots:
       vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitejs/plugin-rsc@0.4.10-alpha.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.6.1
+      es-module-lexer: 1.7.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      periscopic: 4.0.2
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      turbo-stream: 3.1.0
+      vite: 6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0)
+      vitefu: 1.0.6(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.6.0))
 
   '@web3-storage/multipart-parser@1.0.0': {}
 


### PR DESCRIPTION
We've published a new package `@vitejs/plugin-rsc` with a same content as `@hiogawa/vite-rsc`, so this PR replaces it. There was a minor API change previously about `virtual:vite-rsc/bootstrap-script-content`, so I replaced that too.

It's currently published as alpha temporarily for testing, but soon after, we plan to publish v0.4.10. I'll keep this draft until then, but I just wanted to share our side plan on the package change. The package will be available on react plugin repo https://github.com/vitejs/vite-plugin-react/pull/521/.