### PR TITLE
feat(remix-routes-option-adapter): export `DefineRouteFunction` type

### DIFF
--- a/.changeset/brave-buttons-build.md
+++ b/.changeset/brave-buttons-build.md
@@ -1,0 +1,5 @@
+---
+"@react-router/remix-routes-option-adapter": minor
+---
+
+Export `DefineRouteFunction` type alongside `DefineRoutesFunction`

--- a/contributors.yml
+++ b/contributors.yml
@@ -51,6 +51,7 @@
 - BDomzalski
 - bhbs
 - bilalk711
+- bmsuseluda
 - bobziroll
 - bravo-kernel
 - Brendonovich

--- a/packages/react-router-remix-routes-option-adapter/defineRoutes.ts
+++ b/packages/react-router-remix-routes-option-adapter/defineRoutes.ts
@@ -28,7 +28,7 @@ interface DefineRouteChildren {
   (): void;
 }
 
-interface DefineRouteFunction {
+export interface DefineRouteFunction {
   (
     /**
      * The path this route uses to match the URL pathname.

--- a/packages/react-router-remix-routes-option-adapter/index.ts
+++ b/packages/react-router-remix-routes-option-adapter/index.ts
@@ -1,9 +1,9 @@
 import { type RouteConfigEntry } from "@react-router/dev/routes";
 
 import { routeManifestToRouteConfig } from "./manifest";
-import { defineRoutes, type DefineRoutesFunction } from "./defineRoutes";
+import { defineRoutes, type DefineRoutesFunction, type DefineRouteFunction } from "./defineRoutes";
 
-export type { DefineRoutesFunction };
+export type { DefineRoutesFunction, DefineRouteFunction };
 
 /**
  * Adapts routes defined using [Remix's `routes` config


### PR DESCRIPTION
Cherry pick of https://github.com/remix-run/react-router/pull/13614 to point to `dev`