### PR TITLE
Fix context parameter in createRoutesStub for non-middleware users

### DIFF
--- a/.changeset/strong-parrots-jog.md
+++ b/.changeset/strong-parrots-jog.md
@@ -1,0 +1,24 @@
+---
+"react-router": patch
+---
+
+Fix a regression in `createRoutesStub` introduced with the middleware feature.
+
+As part of that work we altered the signature to align with the new middleware APIs without making it backwards compatible with the prior `AppLoadContext` API. This permitted `createRoutesStub` to work if you were opting into middleware and the updated `context` typings, but broke `createRoutesStub` for users not yet opting into middleware.
+
+We've reverted this change and re-implemented it in such a way that both sets of users can leverage it.
+
+```tsx
+// If you have not opted into middleware, the old API should work again
+let context: AppLoadContext = {
+  /*...*/
+};
+let Stub = createRoutesStub(routes, context);
+
+// If you have opted into middleware, you should now pass an instantiated `unstable_routerContextProvider` instead of a `getContext` factory function.
+let context = new unstable_RouterContextProvider();
+context.set(SomeContext, someValue);
+let Stub = createRoutesStub(routes, context);
+```
+
+⚠️ This may be a breaking bug for if you have adopted the unstable Middleware feature and are using `createRoutesStub` with the updated API.

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import type {
   ActionFunction,
+  ActionFunctionArgs,
   LoaderFunction,
-  unstable_InitialContext,
+  LoaderFunctionArgs,
 } from "../../router/utils";
 import type {
   DataRouteObject,
@@ -12,7 +13,12 @@ import type {
 import type { LinksFunction, MetaFunction, RouteModules } from "./routeModules";
 import type { InitialEntry } from "../../router/history";
 import type { HydrationState } from "../../router/router";
-import { convertRoutesToDataRoutes } from "../../router/utils";
+import {
+  convertRoutesToDataRoutes,
+  unstable_RouterContextProvider,
+} from "../../router/utils";
+import type { MiddlewareEnabled } from "../../types/future";
+import type { AppLoadContext } from "../../server-runtime/data";
 import type {
   AssetsManifest,
   FutureConfig,
@@ -111,7 +117,9 @@ export interface RoutesTestStubProps {
  */
 export function createRoutesStub(
   routes: StubRouteObject[],
-  unstable_getContext?: () => unstable_InitialContext
+  _context: MiddlewareEnabled extends true
+    ? unstable_RouterContextProvider
+    : AppLoadContext
 ) {
   return function RoutesTestStub({
     initialEntries,
@@ -147,11 +155,15 @@ export function createRoutesStub(
         // @ts-expect-error `StubRouteObject` is stricter about `loader`/`action`
         // types compared to `AgnosticRouteObject`
         convertRoutesToDataRoutes(routes, (r) => r),
+        _context !== undefined
+          ? _context
+          : future?.unstable_middleware
+          ? new unstable_RouterContextProvider()
+          : {},
         remixContextRef.current.manifest,
         remixContextRef.current.routeModules
       );
       routerRef.current = createMemoryRouter(patched, {
-        unstable_getContext,
         initialEntries,
         initialIndex,
         hydrationData,
@@ -168,6 +180,7 @@ export function createRoutesStub(
 
 function processRoutes(
   routes: StubRouteObject[],
+  context: unknown,
   manifest: AssetsManifest,
   routeModules: RouteModules,
   parentId?: string
@@ -192,8 +205,12 @@ function processRoutes(
       ErrorBoundary: route.ErrorBoundary
         ? withErrorBoundaryProps(route.ErrorBoundary)
         : undefined,
-      action: route.action,
-      loader: route.loader,
+      action: route.action
+        ? (args: ActionFunctionArgs) => route.action!({ ...args, context })
+        : undefined,
+      loader: route.loader
+        ? (args: LoaderFunctionArgs) => route.loader!({ ...args, context })
+        : undefined,
       handle: route.handle,
       shouldRevalidate: route.shouldRevalidate,
     };
@@ -235,6 +252,7 @@ function processRoutes(
     if (route.children) {
       newRoute.children = processRoutes(
         route.children,
+        context,
         manifest,
         routeModules,
         newRoute.id


### PR DESCRIPTION
Fixes the callout from https://github.com/remix-run/react-router/pull/12941/files#r2190354882