### PR TITLE
propagate queryRoute errors that aren't Responses

### DIFF
--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -3940,10 +3940,7 @@ export function createStaticHandler(
           if (isResponse(error)) {
             return respond(error);
           }
-          return new Response(String(error), {
-            status: 500,
-            statusText: "Unexpected Server Error",
-          });
+          throw error;
         }
       );
       return response;


### PR DESCRIPTION
Attempt at fixing #13936

There are failing tests, not sure if that's indicative of an actual issue or if the tests need to be updated.