### PR TITLE
Always include additional route patches

### DIFF
--- a/.changeset/fuzzy-bottles-itch.md
+++ b/.changeset/fuzzy-bottles-itch.md
@@ -1,5 +1,0 @@
----
-"react-router": patch
----
-
-retain transition through form submission to allow useOptimistic to play correctly with pending states

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -894,14 +894,12 @@ async function getRenderPayload(
     })
   );
 
-  let patchesPromise = !isDataRequest
-    ? getAdditionalRoutePatches(
-        [staticContext.location.pathname],
-        routes,
-        basename,
-        staticContext.matches.map((m) => m.route.id)
-      )
-    : undefined;
+  let patchesPromise = getAdditionalRoutePatches(
+    [staticContext.location.pathname],
+    routes,
+    basename,
+    staticContext.matches.map((m) => m.route.id)
+  );
 
   let [matches, patches] = await Promise.all([matchesPromise, patchesPromise]);
 


### PR DESCRIPTION
Always include additional route patches in payload to aid in SPA / "lazy" discovery cases. Remove unnecessary changeset.