### PR TITLE
docs(how-to/middleware): remove "(unstable)"

### DIFF
--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -3,7 +3,7 @@ title: Middleware
 unstable: true
 ---
 
-# Middleware (unstable)
+# Middleware
 
 <docs-warning>The middleware feature is currently experimental and subject to breaking changes. Use the `future.unstable_middleware` flag to enable it.</docs-warning>
 


### PR DESCRIPTION
It's redundant since we have the callout at the top and the 🧪 in the sidebar