### PR TITLE
feat(express): add support for readable stream already closed

### DIFF
--- a/.changeset/honest-chicken-smash.md
+++ b/.changeset/honest-chicken-smash.md
@@ -1,0 +1,5 @@
+---
+"@react-router/express": patch
+---
+
+feat(express): add support for readable stream already closed

--- a/contributors.yml
+++ b/contributors.yml
@@ -122,6 +122,7 @@
 - haivuw
 - hampelm
 - harshmangalam
+- HenriqueLimas
 - hernanif1
 - HK-SHAO
 - holynewbie

--- a/integration/request-test.ts
+++ b/integration/request-test.ts
@@ -7,171 +7,248 @@ import {
   createFixture,
   js,
 } from "./helpers/create-fixture.js";
+import getPort from "get-port";
+import { createProject, customDev, viteConfig } from "./helpers/vite.js";
 
 let fixture: Fixture;
 let appFixture: AppFixture;
 
-test.beforeAll(async () => {
-  fixture = await createFixture({
-    files: {
-      "app/routes/_index.tsx": js`
-        import { Form, useLoaderData, useActionData } from "react-router";
+const sharedFiles = {
+  "app/routes/_index.tsx": js`
+      import { Form, useLoaderData, useActionData } from "react-router";
 
-        async function requestToJson(request) {
-          let body = null;
+      async function requestToJson(request) {
+        let body = null;
 
-          if (request.body) {
-            let fd = await request.formData();
-            body = Object.fromEntries(fd.entries());
-          }
+        if (request.body) {
+          let fd = await request.formData();
+          body = Object.fromEntries(fd.entries());
+        }
 
-          return {
-            method: request.method,
-            url: request.url,
-            headers: Object.fromEntries(request.headers.entries()),
-            body,
-          };
-        }
-        export async function loader({ request }) {
-          return requestToJson(request);
-        }
-        export function action({ request }) {
-          return requestToJson(request);
-        }
-        export default function Index() {
-          let loaderData = useLoaderData();
-          let actionData = useActionData();
-          return (
-            <div>
-              <button id="set-cookie" onClick={() => {
-                document.cookie = 'cookie=nomnom; path=/';
-              }}>
-                Set Cookie
+        return {
+          method: request.method,
+          url: request.url,
+          headers: Object.fromEntries(request.headers.entries()),
+          body,
+        };
+      }
+      export async function loader({ request }) {
+        return requestToJson(request);
+      }
+      export function action({ request }) {
+        return requestToJson(request);
+      }
+      export default function Index() {
+        let loaderData = useLoaderData();
+        let actionData = useActionData();
+        return (
+          <div>
+            <button id="set-cookie" onClick={() => {
+              document.cookie = 'cookie=nomnom; path=/';
+            }}>
+              Set Cookie
+            </button>
+            <Form method="get" reloadDocument>
+              <button type="submit" id="submit-get-ssr" name="type" value="ssr">
+                SSR GET
               </button>
-              <Form method="get" reloadDocument>
-                <button type="submit" id="submit-get-ssr" name="type" value="ssr">
-                  SSR GET
-                </button>
-              </Form>
-              <Form method="get">
-                <button type="submit" id="submit-get-csr" name="type" value="csr">
-                  CSR GET
-                </button>
-              </Form>
-              <Form method="post" reloadDocument>
-                <button type="submit" id="submit-post-ssr" name="type" value="ssr">
-                  SSR POST
-                </button>
-              </Form>
-              <Form method="post">
-                <button type="submit" id="submit-post-csr" name="type" value="csr">
-                  CSR POST
-                </button>
-              </Form>
-              <pre id="loader-data">{JSON.stringify(loaderData)}</pre>
-              {actionData ?
-                <pre id="action-data">{JSON.stringify(actionData)}</pre> :
-                null}
-            </div>
-          )
-        }
-      `,
-    },
+            </Form>
+            <Form method="get">
+              <button type="submit" id="submit-get-csr" name="type" value="csr">
+                CSR GET
+              </button>
+            </Form>
+            <Form method="post" reloadDocument>
+              <button type="submit" id="submit-post-ssr" name="type" value="ssr">
+                SSR POST
+              </button>
+            </Form>
+            <Form method="post">
+              <button type="submit" id="submit-post-csr" name="type" value="csr">
+                CSR POST
+              </button>
+            </Form>
+            <pre id="loader-data">{JSON.stringify(loaderData)}</pre>
+            {actionData ?
+              <pre id="action-data">{JSON.stringify(actionData)}</pre> :
+              null}
+          </div>
+        )
+      }
+    `,
+};
+
+test.describe("Request Tests", () => {
+  test.beforeAll(async () => {
+    fixture = await createFixture({
+      files: {
+        ...sharedFiles,
+      },
+    });
+
+    appFixture = await createAppFixture(fixture);
   });
 
-  appFixture = await createAppFixture(fixture);
+  test.afterAll(() => appFixture.close());
+
+  test("loader request on SSR GET requests", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("#set-cookie");
+
+    let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual(undefined);
+    expect(loaderData.body).toEqual(null);
+
+    await app.clickElement("#submit-get-ssr");
+
+    loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/\?type=ssr$/);
+    expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
+    expect(loaderData.body).toEqual(null);
+  });
+
+  test("loader request on CSR GET requests", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("#set-cookie");
+
+    let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual(undefined);
+    expect(loaderData.body).toEqual(null);
+
+    await app.clickElement("#submit-get-csr");
+
+    loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/\?type=csr$/);
+    expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
+    expect(loaderData.body).toEqual(null);
+  });
+
+  test("action + loader requests SSR POST requests", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("#set-cookie");
+
+    let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual(undefined);
+    expect(loaderData.body).toEqual(null);
+
+    await app.clickElement("#submit-post-ssr");
+
+    let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
+    expect(actionData.method).toEqual("POST");
+    expect(actionData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(actionData.headers.cookie).toEqual("cookie=nomnom");
+    expect(actionData.body).toEqual({ type: "ssr" });
+
+    loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
+    expect(loaderData.body).toEqual(null);
+  });
+
+  test("action + loader requests on CSR POST requests", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    await app.clickElement("#set-cookie");
+
+    let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual(undefined);
+    expect(loaderData.body).toEqual(null);
+
+    await app.clickElement("#submit-post-csr");
+
+    let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
+    expect(actionData.method).toEqual("POST");
+    expect(actionData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(actionData.headers.cookie).toEqual("cookie=nomnom");
+    expect(actionData.body).toEqual({ type: "csr" });
+
+    loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
+    expect(loaderData.method).toEqual("GET");
+    expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+    expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
+    expect(loaderData.body).toEqual(null);
+  });
 });
 
-test.afterAll(() => appFixture.close());
+test.describe("Request stream already closed", () => {
+  let port: number;
+  let cwd: string;
+  let stop: () => void;
 
-test("loader request on SSR GET requests", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  await app.goto("/");
-  await app.clickElement("#set-cookie");
+  test.beforeAll(async () => {
+    port = await getPort();
+    cwd = await createProject({
+      ...sharedFiles,
+      "vite.config.ts": await viteConfig.basic({ port }),
+      "server.mjs": String.raw`
+        import { createRequestHandler } from "@react-router/express";
+        import express from "express";
 
-  let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual(undefined);
-  expect(loaderData.body).toEqual(null);
+        let viteDevServer =
+          process.env.NODE_ENV === "production"
+            ? undefined
+            : await import("vite").then((vite) =>
+                vite.createServer({
+                  server: { middlewareMode: true },
+                })
+              );
 
-  await app.clickElement("#submit-get-ssr");
+        const app = express();
 
-  loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/\?type=ssr$/);
-  expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
-  expect(loaderData.body).toEqual(null);
-});
+        app.use(express.json());
+        app.use(express.urlencoded());
 
-test("loader request on CSR GET requests", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  await app.goto("/");
-  await app.clickElement("#set-cookie");
+        if (viteDevServer) {
+          app.use(viteDevServer.middlewares);
+        } else {
+          app.use(
+            "/assets",
+            express.static("build/client/assets", { immutable: true, maxAge: "1y" })
+          );
+        }
+        app.use(express.static("build/client", { maxAge: "1h" }));
 
-  let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual(undefined);
-  expect(loaderData.body).toEqual(null);
+        app.all(
+          "*",
+          createRequestHandler({
+            build: viteDevServer
+              ? () => viteDevServer.ssrLoadModule("virtual:react-router/server-build")
+              : await import("./build/index.js"),
+            getLoadContext: () => ({}),
+          })
+        );
 
-  await app.clickElement("#submit-get-csr");
+        const port = ${port};
+        app.listen(port, () => console.log('http://localhost:' + port));
+      `,
+    });
+    stop = await customDev({ cwd, port });
+  });
 
-  loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/\?type=csr$/);
-  expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
-  expect(loaderData.body).toEqual(null);
-});
+  test.afterAll(() => stop());
 
-test("action + loader requests SSR POST requests", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  await app.goto("/");
-  await app.clickElement("#set-cookie");
+  test("action with formData read", async ({ page }) => {
+    await page.goto(`http://localhost:${port}`, {
+      waitUntil: "networkidle",
+    });
 
-  let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual(undefined);
-  expect(loaderData.body).toEqual(null);
+    await page.locator("#submit-post-csr").click();
 
-  await app.clickElement("#submit-post-ssr");
-
-  let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
-  expect(actionData.method).toEqual("POST");
-  expect(actionData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(actionData.headers.cookie).toEqual("cookie=nomnom");
-  expect(actionData.body).toEqual({ type: "ssr" });
-
-  loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
-  expect(loaderData.body).toEqual(null);
-});
-
-test("action + loader requests on CSR POST requests", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  await app.goto("/");
-  await app.clickElement("#set-cookie");
-
-  let loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual(undefined);
-  expect(loaderData.body).toEqual(null);
-
-  await app.clickElement("#submit-post-csr");
-
-  let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
-  expect(actionData.method).toEqual("POST");
-  expect(actionData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(actionData.headers.cookie).toEqual("cookie=nomnom");
-  expect(actionData.body).toEqual({ type: "csr" });
-
-  loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
-  expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/$/);
-  expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
-  expect(loaderData.body).toEqual(null);
+    let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
+    expect(actionData.body).toEqual({ type: "csr" });
+  });
 });

--- a/packages/react-router-express/server.ts
+++ b/packages/react-router-express/server.ts
@@ -122,7 +122,18 @@ export function createRemixRequest(
   res.on("close", () => controller?.abort());
 
   if (req.method !== "GET" && req.method !== "HEAD") {
-    init.body = createReadableStreamFromReadable(req);
+    if (req.closed) {
+      if (
+        req.is("application/x-www-form-urlencoded") ||
+        req.is("multipart/form-data")
+      ) {
+        init.body = new URLSearchParams(req.body);
+      } else {
+        init.body = JSON.stringify(req.body || {});
+      }
+    } else {
+      init.body = createReadableStreamFromReadable(req);
+    }
     (init as { duplex: "half" }).duplex = "half";
   }
 


### PR DESCRIPTION
### Description

This change resolves an issue where the request body is inaccessible to `react-router` when a Node.js server, such as Express, uses middleware that consumes the request stream before it reaches the router's handler.

**Fixes:** [https://github.com/remix-run/remix/discussions/10132](https://github.com/remix-run/remix/discussions/10132)

### The Problem

In Node.js applications, it's common to use middleware like `express.json()` or `express.urlencoded()` to parse the request body. This process reads and consumes the request's `ReadableStream`.

Since Node.js streams cannot be consumed more than once (unlike the Web API's `ReadableStream` which can be cloned using the `.tee()` method), `react-router` is subsequently unable to read the request body. This is a frequent issue in applications that layer `react-router` with other Express middleware.

This PR introduces a new check to verify if the request stream has already been closed. If it has, the handler will now fallback to using the body that was already parsed and it transform it to string.