### PR TITLE
docs: fix grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
       - [Exposed Router Promises](#exposed-router-promises)
     - [Other Notable Changes](#other-notable-changes)
       - [`routes.ts`](#routests)
-      - [Typesafety improvements](#typesafety-improvements)
+      - [Type-safety improvements](#type-safety-improvements)
       - [Prerendering](#prerendering)
     - [Major Changes (`react-router`)](#major-changes-react-router)
     - [Major Changes (`@react-router/*`)](#major-changes-react-router-1)
@@ -1860,7 +1860,7 @@ Also note that, if you were using Remix's `routes` option to define config-based
 +];
 ```
 
-#### Typesafety improvements
+#### Type-safety improvements
 
 React Router now generates types for each of your route modules and passes typed props to route module component exports ([#11961](https://github.com/remix-run/react-router/pull/11961), [#12019](https://github.com/remix-run/react-router/pull/12019)). You can access those types by importing them from `./+types/<route filename without extension>`.
 

--- a/docs/start/modes.md
+++ b/docs/start/modes.md
@@ -56,8 +56,8 @@ ReactDOM.createRoot(root).render(
 
 Framework Mode wraps Data Mode with a Vite plugin to add the full React Router experience with:
 
-- typesafe `href`
-- typesafe Route Module API
+- type-safe `href`
+- type-safe Route Module API
 - intelligent code splitting
 - SPA, SSR, and static rendering strategies
 - and more
@@ -71,7 +71,7 @@ export default [
 ];
 ```
 
-You'll then have access to the Route Module API with typesafe params, loaderData, code splitting, SPA/SSR/SSG strategies, and more.
+You'll then have access to the Route Module API with type-safe params, loaderData, code splitting, SPA/SSR/SSG strategies, and more.
 
 ```ts filename=product.tsx
 import { Route } from "+./types/product.tsx";

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -16,7 +16,7 @@ The React Router Vite plugin adds framework features to React Router. This guide
 The Vite plugin adds:
 
 - Route loaders, actions, and automatic data revalidation
-- Typesafe Routes Modules
+- Type-safe Routes Modules
 - Automatic route code-splitting
 - Automatic scroll restoration across navigations
 - Optional Static pre-rendering

--- a/docs/upgrading/remix.md
+++ b/docs/upgrading/remix.md
@@ -394,7 +394,7 @@ Congratulations! You are now on React Router v7. Go ahead and run your applicati
 [v2-future-flags]: https://remix.run/docs/start/future-flags
 [routing]: ../start/framework/routing
 [fs-routing]: ../how-to/file-route-conventions
-[v7-changelog-types]: https://github.com/remix-run/react-router/blob/release-next/CHANGELOG.md#typesafety-improvements
+[v7-changelog-types]: https://github.com/remix-run/react-router/blob/release-next/CHANGELOG.md#type-safety-improvements
 [server-loaders]: ../start/framework/data-loading#server-data-loading
 [server-actions]: ../start/framework/actions#server-actions
 [ts-module-augmentation]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -14,7 +14,7 @@ The React Router Vite plugin adds framework features to React Router. This guide
 The Vite plugin adds:
 
 - Route loaders, actions, and automatic data revalidation
-- Typesafe Routes Modules
+- Type-safe Routes Modules
 - Automatic route code-splitting
 - Automatic scroll restoration across navigations
 - Optional Static pre-rendering


### PR DESCRIPTION
**Justification**:
In the context of computer science and programming, the word **"type-safe"** is used as a compound adjective modifying a noun.  This is the prevailing usage of the word, and is **already** used like this in other places in the documentation.  This pull request aims for consistency within the docs, and general English taxonomy.  