### PR TITLE
Inject client route component props during RSC render

### DIFF
--- a/.changeset/neat-jeans-sneeze.md
+++ b/.changeset/neat-jeans-sneeze.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+[REMOVE] Inject client route component props during RSC render

--- a/packages/react-router/index-react-server-client.ts
+++ b/packages/react-router/index-react-server-client.ts
@@ -9,6 +9,9 @@ export {
   Router,
   RouterProvider,
   Routes,
+  WithComponentProps as UNSAFE_WithComponentProps,
+  WithErrorBoundaryProps as UNSAFE_WithErrorBoundaryProps,
+  WithHydrateFallbackProps as UNSAFE_WithHydrateFallbackProps,
 } from "./lib/components";
 export {
   BrowserRouter,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -358,8 +358,11 @@ export {
 export {
   hydrationRouteProperties as UNSAFE_hydrationRouteProperties,
   mapRouteProperties as UNSAFE_mapRouteProperties,
+  WithComponentProps as UNSAFE_WithComponentProps,
   withComponentProps as UNSAFE_withComponentProps,
+  WithHydrateFallbackProps as UNSAFE_WithHydrateFallbackProps,
   withHydrateFallbackProps as UNSAFE_withHydrateFallbackProps,
+  WithErrorBoundaryProps as UNSAFE_WithErrorBoundaryProps,
   withErrorBoundaryProps as UNSAFE_withErrorBoundaryProps,
 } from "./lib/components";
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1235,57 +1235,85 @@ export function renderMatches(
   return _renderMatches(matches);
 }
 
-export type RouteComponentType = React.ComponentType<{
-  params: ReturnType<typeof useParams>;
-  loaderData: ReturnType<typeof useLoaderData>;
-  actionData: ReturnType<typeof useActionData>;
-  matches: ReturnType<typeof useMatches>;
-}>;
+function useRouteComponentProps() {
+  return {
+    params: useParams(),
+    loaderData: useLoaderData(),
+    actionData: useActionData(),
+    matches: useMatches(),
+  };
+}
+
+export type RouteComponentProps = ReturnType<typeof useRouteComponentProps>;
+export type RouteComponentType = React.ComponentType<RouteComponentProps>;
+
+export function WithComponentProps({
+  children,
+}: {
+  children: React.ReactElement;
+}) {
+  const props = useRouteComponentProps();
+  return React.cloneElement(children, props);
+}
 
 export function withComponentProps(Component: RouteComponentType) {
   return function WithComponentProps() {
-    const props = {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-      matches: useMatches(),
-    };
+    const props = useRouteComponentProps();
     return React.createElement(Component, props);
   };
 }
 
-export type HydrateFallbackType = React.ComponentType<{
-  params: ReturnType<typeof useParams>;
-  loaderData: ReturnType<typeof useLoaderData>;
-  actionData: ReturnType<typeof useActionData>;
-}>;
+function useHydrateFallbackProps() {
+  return {
+    params: useParams(),
+    loaderData: useLoaderData(),
+    actionData: useActionData(),
+  };
+}
+
+export type HydrateFallbackProps = ReturnType<typeof useHydrateFallbackProps>;
+export type HydrateFallbackType = React.ComponentType<HydrateFallbackProps>;
+
+export function WithHydrateFallbackProps({
+  children,
+}: {
+  children: React.ReactElement;
+}) {
+  const props = useHydrateFallbackProps();
+  return React.cloneElement(children, props);
+}
 
 export function withHydrateFallbackProps(HydrateFallback: HydrateFallbackType) {
   return function WithHydrateFallbackProps() {
-    const props = {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-    };
+    const props = useHydrateFallbackProps();
     return React.createElement(HydrateFallback, props);
   };
 }
 
-export type ErrorBoundaryType = React.ComponentType<{
-  params: ReturnType<typeof useParams>;
-  loaderData: ReturnType<typeof useLoaderData>;
-  actionData: ReturnType<typeof useActionData>;
-  error: ReturnType<typeof useRouteError>;
-}>;
+function useErrorBoundaryProps() {
+  return {
+    params: useParams(),
+    loaderData: useLoaderData(),
+    actionData: useActionData(),
+    error: useRouteError(),
+  };
+}
+
+export type ErrorBoundaryProps = ReturnType<typeof useErrorBoundaryProps>;
+export type ErrorBoundaryType = React.ComponentType<ErrorBoundaryProps>;
+
+export function WithErrorBoundaryProps({
+  children,
+}: {
+  children: React.ReactElement;
+}) {
+  const props = useErrorBoundaryProps();
+  return React.cloneElement(children, props);
+}
 
 export function withErrorBoundaryProps(ErrorBoundary: ErrorBoundaryType) {
   return function WithErrorBoundaryProps() {
-    const props = {
-      params: useParams(),
-      loaderData: useLoaderData(),
-      actionData: useActionData(),
-      error: useRouteError(),
-    };
+    const props = useErrorBoundaryProps();
     return React.createElement(ErrorBoundary, props);
   };
 }


### PR DESCRIPTION
We're now wrapping all client route components to ensure that all props match the equivalent values you'd get from the hooks, e.g. `loaderData` will include client loader data, whereas previously this prop would only ever be the server loader data.