### PR TITLE
docs(v6migration): absolute link should not be changed to relative

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -325,6 +325,7 @@
 - sbolel
 - scarf005
 - sealer3
+- seasick
 - senseibarni
 - sergiodxa
 - serranoarevalo

--- a/docs/upgrading/v6.md
+++ b/docs/upgrading/v6.md
@@ -92,10 +92,9 @@ function Dashboard() {
     <div>
       <h2>Dashboard</h2>
       <nav>
--        <Link to="/">Dashboard Home</Link>
+         <Link to="/">Dashboard Home</Link>
 -        <Link to="team">Team</Link>
 -        <Link to="projects">Projects</Link>
-+        <Link to="../">Dashboard Home</Link>
 +        <Link to="../team">Team</Link>
 +        <Link to="../projects">Projects</Link>
       </nav>


### PR DESCRIPTION
The **"V6 Migration"** contains a **"Update relative links"** section which shows that the `/` link should be updated to `../`, which I believe isn't correct.

This PR changes that.