### PR TITLE
docs(api): Fix doc examples that are missing async

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -268,6 +268,7 @@
 - namoscato
 - ned-park
 - nenene3
+- ngbrown
 - nichtsam
 - nikeee
 - nilubisan

--- a/docs/how-to/headers.md
+++ b/docs/how-to/headers.md
@@ -113,7 +113,7 @@ You can avoid the need to merge headers by only defining headers in "leaf routes
 The `handleRequest` export receives the headers from the route module as an argument. You can append global headers here.
 
 ```tsx
-export default function handleRequest(
+export default async function handleRequest(
   request,
   responseStatusCode,
   responseHeaders,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1269,7 +1269,7 @@ export interface AwaitProps<Resolve> {
  * @example
  * import { Await, useLoaderData } from "react-router";
  *
- * export function loader() {
+ * export async function loader() {
  *   // not awaited
  *   const reviews = getReviews();
  *   // awaited (blocks the transition)

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -373,7 +373,7 @@ export interface DOMRouterOpts {
    * ];
    *
    * let router = createBrowserRouter(routes, {
-   *   dataStrategy({ request, params, matches }) {
+   *   async dataStrategy({ request, params, matches }) {
    *     // Compose route fragments into a single GQL payload
    *     let gql = getFragmentsFromRouteHandles(matches);
    *     let data = await fetchGql(gql);


### PR DESCRIPTION
In the transition to the new generated docs, I noticed that the `async` keyword went missing on an example for the `Async` example. I fixed that and searched through the rest of the examples and found a few more `async` keywords missing.

No changeset because this is documentation. Targeting `dev` branch because the `docs.yml` workflow is only running on `dev`.