### PR TITLE
fix(jsdoc) Normalize generated path on Windows

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -268,6 +268,7 @@
 - namoscato
 - ned-park
 - nenene3
+- ngbrown
 - nichtsam
 - nikeee
 - nilubisan

--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -173,7 +173,8 @@ function buildRepoDocsLinks(outputDir: string): Map<string, string> {
   markdownFiles.forEach((filePath) => {
     const relativePath = path
       .relative(outputDir, filePath)
-      .replace(/\.md$/, "");
+      .replace(/\.md$/, "")
+      .replace(/\\/g, "/");
     const apiName = path.basename(relativePath);
 
     if (apiName !== "index") {


### PR DESCRIPTION
When fixing #14017, and test-generating the markdown files I noticed that all the relative references to local files generated with the slashes swapped. I'm on Windows. This change replaces the `"\"` with `"/"` at the source of generating the relative path on `path.relative()` in the `scripts/docs.ts` file.

No changeset because this is documentation mechanics.