### PR TITLE
docs(api/hooks/useFetcher): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -137,6 +137,7 @@
 - haivuw
 - hampelm
 - harshmangalam
+- Heher
 - HelpMe-Pls
 - HenriqueLimas
 - hernanif1

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1848,7 +1848,7 @@ export function useFetcher<T = any>({
   key,
 }: {
   /**
-    By default, `useFetcher` generate a unique fetcher scoped to that component. If you want to identify a fetcher with your own key such that you can access it from elsewhere in your app, you can do that with the `key` option:
+    By default, `useFetcher` generates a unique fetcher scoped to that component. If you want to identify a fetcher with your own key such that you can access it from elsewhere in your app, you can do that with the `key` option:
 
     ```tsx
     function SomeComp() {


### PR DESCRIPTION
While this typo fix is minor, I truly believe it's the last missing piece of the puzzle that will bring react-router the glory that it so deserves.