### PR TITLE
Add generic type parameter to `useLocation` for state typings

### DIFF
--- a/.changeset/beige-dragons-attack.md
+++ b/.changeset/beige-dragons-attack.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Add optional type parameter to useLocation that allows typing the state

--- a/contributors.yml
+++ b/contributors.yml
@@ -328,6 +328,7 @@
 - saul-atomrigs
 - sbolel
 - scarf005
+- sceee
 - sealer3
 - seasick
 - senseibarni

--- a/packages/react-router/__tests__/navigate-test.tsx
+++ b/packages/react-router/__tests__/navigate-test.tsx
@@ -588,7 +588,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
           {
             path: "b",
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -655,7 +655,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
           {
             path: "b",
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -728,7 +728,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
               return null;
             },
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>
@@ -803,7 +803,7 @@ describe("concurrent mode (using React.startTransition for updates)", () => {
               return null;
             },
             Component() {
-              let { state } = useLocation() as { state: { count: number } };
+              let { state } = useLocation<{ count: number }>();
               renders.push(state.count);
               return (
                 <>

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -139,7 +139,7 @@ export function useInRouterContext(): boolean {
  * @category Hooks
  * @returns The current {@link Location} object
  */
-export function useLocation(): Location {
+export function useLocation<State = any>(): Location<State> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the


### PR DESCRIPTION
* Add generic type parameter to useLocation for state typings that allows passing through the type to be used for the state as the Location interface already supports this