### PR TITLE
Enhance generatePath types to differentiate between required/optional params

### DIFF
--- a/.changeset/green-nails-call.md
+++ b/.changeset/green-nails-call.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Enhance generatePath types to better differentiate between optional and required params


### PR DESCRIPTION
Closes #14006 

We don't currently differentiate between required/optional params in `generatePath` which can produce some false positive/negative scenarios:

<img width="1420" height="794" alt="Screenshot 2025-07-22 at 12 54 26 PM" src="https://github.com/user-attachments/assets/843e0c92-2a24-4473-9f89-7144cfb34a04" />


This splits the existing `PathParam` logic out separate helpers that look specifically for required/optional params and then uses a union of them to restore it's current functionality.  That allows us to alter the accepted keys in the `generatePath` params object:

<img width="1268" height="836" alt="Screenshot 2025-07-22 at 12 47 08 PM" src="https://github.com/user-attachments/assets/ce16c222-c575-4e2b-96c6-faaa5cf30d75" />

It's not perfect but it's much better - since we can't (I don't think) do anything about the optionality of the second parameter without a breaking change, so no matter what if they leave the second param out entirely they may still get some false negatives.