### PR TITLE
fix: decode Windows paths to prevent ENOENT in dev mode

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3650,7 +3650,9 @@ export async function getEnvironmentOptionsResolvers(
                   let isRootRoute =
                     route.file === ctx.reactRouterConfig.routes.root.file;
 
-                  let code = readFileSync(routeFilePath, "utf-8");
+                  let cleanPath = path.normalize(decodeURIComponent(routeFilePath));
+                  let code = readFileSync(cleanPath, "utf-8");
+
 
                   return [
                     `${routeFilePath}${BUILD_CLIENT_ROUTE_QUERY_STRING}`,


### PR DESCRIPTION
## Fix: Decode Windows Paths in dev mode to prevent ENOENT

### Summary

This fixes an error on Windows when running Hydrogen/React Router projects from folders that include spaces (e.g. `D:\KOVI HAIR`). 

The Vite plugin currently passes encoded `%20` paths into `readFileSync`, causing:

```
ENOENT: no such file or directory, open 'D:\KOVI%20HAIR\...'
```

### Fix

We now decode `routeFilePath` before reading it:

```ts
const cleanPath = path.normalize(decodeURIComponent(routeFilePath));
const code = readFileSync(cleanPath, "utf-8");
```

### Notes

- Tested with Shopify Hydrogen dev setup and confirmed working
- No impact on macOS or Linux environments
- Fixes a long-standing issue for Windows users with space-containing directories
