### PR TITLE
fix(react-router/rsc): remove dependency on `@types/node` in TypeScript declaration files

### DIFF
--- a/.changeset/shiny-owls-glow.md
+++ b/.changeset/shiny-owls-glow.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+fix: remove dependency on @types/node in declaration files

--- a/.changeset/shiny-owls-glow.md
+++ b/.changeset/shiny-owls-glow.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-Remove dependency on `@types/node` in declaration files
+Remove dependency on `@types/node` in TypeScript declaration files

--- a/.changeset/shiny-owls-glow.md
+++ b/.changeset/shiny-owls-glow.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-fix: remove dependency on @types/node in declaration files
+Remove dependency on `@types/node` in declaration files

--- a/contributors.yml
+++ b/contributors.yml
@@ -247,6 +247,7 @@
 - mcansh
 - MeatSim
 - MenouerBetty
+- Methuselah96
 - mfijas
 - MichaelDeBoey
 - michal-antczak

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -69,13 +69,9 @@ type ServerContext = {
   redirect?: Response;
 };
 
-declare global {
-  var ___reactRouterServerStorage___:
-    | AsyncLocalStorage<ServerContext>
-    | undefined;
-}
-
-const globalVar = typeof globalThis !== "undefined" ? globalThis : global;
+const globalVar = (typeof globalThis !== "undefined" ? globalThis : global) as {
+  ___reactRouterServerStorage___?: AsyncLocalStorage<ServerContext>;
+};
 
 const ServerStorage = (globalVar.___reactRouterServerStorage___ ??=
   new AsyncLocalStorage<ServerContext>());


### PR DESCRIPTION
Fixes #14042 by removing the declaration of the `___reactRouterServerStorage___` variable from the global scope in the TypeScript declaration files. If it's desirable for this to exist in the declaration file, then I can explore other options, but it seems like somewhat of a private variable that doesn't need to be in the declaration files.