### PR TITLE
fix: empty dataResults causes "no corresponding fetcher result"

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -428,3 +428,4 @@
 - zeromask1337
 - zheng-chuang
 - zxTomw
+- ZxBing0066

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2902,14 +2902,14 @@ export function createRouter(init: RouterInit): Router {
 
     if (request.signal.aborted) {
       matches
-      .filter((m) => m.shouldLoad)
-      .forEach((m) => {
-        dataResults[m.route.id] = {
-          type: ResultType.error,
-          error: new Error("Data loading aborted"),
-        };
-      });
-      return dataResults
+        .filter((m) => m.shouldLoad)
+        .forEach((m) => {
+          dataResults[m.route.id] = {
+            type: ResultType.error,
+            error: new Error("Data loading aborted"),
+          };
+        });
+      return dataResults;
     }
 
     for (let [routeId, result] of Object.entries(results)) {

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -6295,7 +6295,7 @@ function processLoaderData(
   );
 
   // Process results from our revalidating fetchers
-  revalidatingFetchers
+  revalidatingFetcherscontributors.yml.
     // Keep those with no matches so we can bubble their 404's, otherwise only
     // process fetchers that needed to load
     .filter((f) => !f.matches || f.matches.some((m) => m.shouldLoad))

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -6295,7 +6295,7 @@ function processLoaderData(
   );
 
   // Process results from our revalidating fetchers
-  revalidatingFetcherscontributors.yml.
+  revalidatingFetchers
     // Keep those with no matches so we can bubble their 404's, otherwise only
     // process fetchers that needed to load
     .filter((f) => !f.matches || f.matches.some((m) => m.shouldLoad))

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2901,7 +2901,15 @@ export function createRouter(init: RouterInit): Router {
     }
 
     if (request.signal.aborted) {
-      return dataResults;
+      matches
+      .filter((m) => m.shouldLoad)
+      .forEach((m) => {
+        dataResults[m.route.id] = {
+          type: ResultType.error,
+          error: new Error("Data loading aborted"),
+        };
+      });
+      return dataResults
     }
 
     for (let [routeId, result] of Object.entries(results)) {


### PR DESCRIPTION
When requests are aborted, it should always return a valid dataResults; otherwise, `processLoaderData` throws the `"Did not find corresponding fetcher result"` error.

Introduced by [this PR](https://github.com/remix-run/react-router/pull/13521).

fixes #13712 