### PR TITLE
Fix RSC bug where outlets replace routes that skip revalidation

### DIFF
--- a/.changeset/young-beans-sneeze.md
+++ b/.changeset/young-beans-sneeze.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix RSC Data Mode issue where routes that return `false` from `shouldRevalidate` would be replaced by an `<Outlet />`

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -955,14 +955,9 @@ test.describe("Client Data", () => {
               console.error = _consoleError;
             });
 
-            test("hydrating clientLoader redirects trigger new .data requests to the server", async ({
+            test("hydrating clientLoader redirects trigger new data requests to the server", async ({
               page,
             }) => {
-              test.fixme(
-                templateName.includes("rsc"),
-                "Not working in the RSC implementation",
-              );
-
               appFixture = await createAppFixture(
                 await createFixture({
                   templateName,


### PR DESCRIPTION
This is a follow-up to https://github.com/remix-run/react-router/pull/14060, fixing the test that was skipped with `test.fixme`.