### PR TITLE
docs(explanation/code-splitting): fix typo

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -237,6 +237,7 @@
 - markdalgleish
 - markivancho
 - markmals
+- Marlon-Buckley
 - maruffahmed
 - marvinruder
 - mathpaquette

--- a/docs/explanation/code-splitting.md
+++ b/docs/explanation/code-splitting.md
@@ -31,7 +31,7 @@ Instead of bundling all routes into a single giant build, the modules referenced
 
 Because these entry points are coupled to URL segments, React Router knows just from a URL which bundles are needed in the browser, and more importantly, which are not.
 
-If the user visits `"/about"` then the bundles for `about.tsx` will be loaded but not `contact.tsx`. This ensures drastically reduces the JavaScript footprint for initial page loads and speeds up your application.
+If the user visits `"/about"` then the bundles for `about.tsx` will be loaded but not `contact.tsx`. This drastically reduces the JavaScript footprint for initial page loads and speeds up your application.
 
 ## Removal of Server Code
 


### PR DESCRIPTION
👋 Just spotted this misplaced word while reading your docs on code splitting.