### PR TITLE
perf: avoid slow searchParams mutation in manifest prefetching

### DIFF
--- a/.changeset/good-months-hope.md
+++ b/.changeset/good-months-hope.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Switch Lazy Route Discovery manifest URL generation to usea standalone `URLSearchParams` instance instead of `URL.searchParams` to avoid a major performance bottleneck in Chrome

--- a/contributors.yml
+++ b/contributors.yml
@@ -310,6 +310,7 @@
 - remorses
 - renyu-io
 - reyronald
+- richardscarrott
 - rifaidev
 - rimian
 - robbtraister


### PR DESCRIPTION
This PR improves the performance of `fetchAndApplyManifestPatches` by avoiding direct mutation of `url.searchParams`, which turns out to be _unbelievably_ slow (the `sort()` is absolutely fine in comparison).

https://issues.chromium.org/issues/331406951
https://github.com/nodejs/node/issues/51518

<img width="1404" height="1546" alt="Screenshot 2025-07-26 at 21 52 18" src="https://github.com/user-attachments/assets/2708dd1e-fd8a-4489-93d9-4c7bf35953f1" />

<img width="1440" height="1202" alt="Screenshot 2025-07-26 at 21 52 28" src="https://github.com/user-attachments/assets/71ac971b-8461-4ba6-896a-a983dc0ce4fb" />


This resolves [#14075](https://github.com/remix-run/react-router/issues/14075), where this performance bottleneck became noticeable when preloading thousands of paths during fog-of-war route discovery.

As @brophdawg11 notes in the issue, there's definitely room for algorithmic improvements on top of this — but figured it was worth sending this simple (but significant) optimisation initially as it's an easy win.

