### PR TITLE
Bug: path aliases don't get correctly resovlved in `routes.ts`

### DIFF
--- a/playground/framework-spa/app/modules/transactions/routes.ts
+++ b/playground/framework-spa/app/modules/transactions/routes.ts
@@ -1,0 +1,5 @@
+import { type RouteConfig, route } from "@react-router/dev/routes";
+
+export default [
+  route("transactions", "./routes/home.tsx"),
+] satisfies RouteConfig;

--- a/playground/framework-spa/app/modules/transactions/routes/home.tsx
+++ b/playground/framework-spa/app/modules/transactions/routes/home.tsx
@@ -1,0 +1,10 @@
+import { href, Link } from "react-router";
+
+export default function TransactionHomePage() {
+  return (
+    <div>
+      <h1>Transactions Home page</h1>
+      <Link to={href("/")}>Root Route</Link>
+    </div>
+  );
+}

--- a/playground/framework-spa/app/modules/user-management/routes.ts
+++ b/playground/framework-spa/app/modules/user-management/routes.ts
@@ -1,0 +1,5 @@
+import { type RouteConfig, route } from "@react-router/dev/routes";
+
+export default [
+  route("user-management", "./routes/home.tsx"),
+] satisfies RouteConfig;

--- a/playground/framework-spa/app/modules/user-management/routes/home.tsx
+++ b/playground/framework-spa/app/modules/user-management/routes/home.tsx
@@ -1,0 +1,10 @@
+import { href, Link } from "react-router";
+
+export default function UserManagementHomePage() {
+  return (
+    <div>
+      <h1>User Management Home page</h1>
+      <Link to={href("/")}>Root Route</Link>
+    </div>
+  );
+}

--- a/playground/framework-spa/app/routes.ts
+++ b/playground/framework-spa/app/routes.ts
@@ -1,3 +1,10 @@
 import { type RouteConfig, index } from "@react-router/dev/routes";
 
-export default [index("routes/_index.tsx")] satisfies RouteConfig;
+import transactionRoutes from "~/modules/transactions/routes";
+import userManagementRoutes from "~/modules/user-management/routes";
+
+export default [
+  index("routes/_index.tsx"),
+  ...transactionRoutes,
+  ...userManagementRoutes,
+] satisfies RouteConfig;

--- a/playground/framework-spa/app/routes/_index.tsx
+++ b/playground/framework-spa/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "react-router";
+import { href, Link, type MetaFunction } from "react-router";
 
 export const meta: MetaFunction = () => {
   return [
@@ -11,6 +11,7 @@ export default function Index() {
   return (
     <div style={{ fontFamily: "system-ui, sans-serif", lineHeight: "1.8" }}>
       <h1>Welcome to React Router</h1>
+<Link to={href("/transaction")}>Transactions Dashboard</Link>
     </div>
   );
 }


### PR DESCRIPTION
## TL;DR
All imports in `routes.ts` and all its direct or transitive imports have to be absolute or relative using `./` and `../` notation, path aliases like `~` and `@` aren't resolved correctly.

## The issue

Vite and TypeScript allows defining aliases to relatively access files without using `./` or `../` notation, this is pretty significant for complex apps at scale as imports point to different, sometimes deeply nested files.

One of the usecases that inspired React Router's config-based route pattern and `routes.ts` was this, for example if I want to make my apps modular or feature-based, I'd use high level folders to separate features, each of these feature might export their own routes, these routes need to be imported, and for the sake of readability and consistency, we use `~` or `@` symbols as relative path aliases.

Also, sometimes, we need to import variables into the `routes.ts` file, for example when you want to create a unique id for a route and you don't want to duplicate code and future-proof your app, this too, would be imported using an aliased path.

These use-cases aren't currently handled correctly when the `routes.ts` is evaluated and executed.

Please checkout the `playground/framework-spa/app/routes.ts` to better get the idea.

Try running `pnpm run dev` in `playground/framework-spa/` project.

### Expected Behavior
For the app to work seamlessly regardless of usage of import aliases.

### Actual Behavior

`Error: Route config in "routes.ts" is invalid.`
