### PR TITLE
docs: Add bullet points capitalization where necessary

### DIFF
--- a/docs/community/api-development-strategy.md
+++ b/docs/community/api-development-strategy.md
@@ -23,10 +23,10 @@ Unstable flags are for features still being designed and developed and made avai
 
 Unstable flags are not recommended for production:
 
-- they will change without warning and without upgrade paths
-- they will have bugs
-- they aren't documented
-- they may be scrapped completely
+- They will change without warning and without upgrade paths
+- They will have bugs
+- They aren't documented
+- They may be scrapped completely
 
 When you opt-in to an unstable flag you are becoming a contributor to the project, rather than a user. We appreciate your help, but please be aware of the new role!
 

--- a/docs/start/data/route-object.md
+++ b/docs/start/data/route-object.md
@@ -22,11 +22,11 @@ createBrowserRouter([
 
 Route modules are the foundation of React Router's data features, they define:
 
-- data loading
-- actions
-- revalidation
-- error boundaries
-- and more
+- Data loading
+- Actions
+- Revalidation
+- Error boundaries
+- And more
 
 This guide is a quick overview of every route object feature.
 
@@ -145,9 +145,9 @@ This hook enables you to opt in or out of the default revalidation behavior. The
 
 A route loader is revalidated when:
 
-- its own route params change
-- any change to URL search params
-- after an action is called and returns a non-error status code
+- Its own route params change
+- Any change to URL search params
+- After an action is called and returns a non-error status code
 
 By defining this function, you opt out of the default behavior completely and can manually control when loader data is revalidated for navigations and form submissions.
 

--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -18,12 +18,12 @@ route("teams/:teamId", "./team.tsx"),
 
 Route modules are the foundation of React Router's framework features, they define:
 
-- automatic code-splitting
-- data loading
-- actions
-- revalidation
-- error boundaries
-- and more
+- Automatic code-splitting
+- Data loading
+- Actions
+- Revalidation
+- Error boundaries
+- And more
 
 This guide is a quick overview of every route module feature. The rest of the getting started guides will cover these features in more detail.
 

--- a/docs/start/modes.md
+++ b/docs/start/modes.md
@@ -56,11 +56,11 @@ ReactDOM.createRoot(root).render(
 
 Framework Mode wraps Data Mode with a Vite plugin to add the full React Router experience with:
 
-- type-safe `href`
-- type-safe Route Module API
-- intelligent code splitting
+- Type-safe `href`
+- Type-safe Route Module API
+- Intelligent code splitting
 - SPA, SSR, and static rendering strategies
-- and more
+- And more
 
 ```ts filename=routes.ts
 import { index, route } from "@react-router/dev/routes";
@@ -94,28 +94,28 @@ Every mode supports any architecture and deployment target, so the question isn'
 
 **Use Framework Mode if you:**
 
-- are too new to have an opinion
-- are considering Next.js, Solid Start, SvelteKit, Astro, TanStack Start, etc. and want to compare
-- just want to build something with React
-- might want to server render, might not
-- are coming from Remix (React Router v7 is the "next version" after Remix v2)
-- are migrating from Next.js
+- Are too new to have an opinion
+- Are considering Next.js, Solid Start, SvelteKit, Astro, TanStack Start, etc. and want to compare
+- Just want to build something with React
+- Might want to server render, might not
+- Are coming from Remix (React Router v7 is the "next version" after Remix v2)
+- Are migrating from Next.js
 
 [→ Get Started with Framework Mode](./framework/installation).
 
 **Use Data Mode if you:**
 
-- want data features but also want to have control over bundling, data, and server abstractions
-- started a data router in v6.4 and are happy with it
+- Want data features but also want to have control over bundling, data, and server abstractions
+- Started a data router in v6.4 and are happy with it
 
 [→ Get Started with Data Mode](./data/custom).
 
 **Use Declarative Mode if you:**
 
-- want to use React Router as simply as possible
-- are coming from v6 and are happy with the `<BrowserRouter>`
-- have a data layer that either skips pending states (like local first, background data replication/sync) or has its own abstractions for them
-- are coming from Create React App (you may want to consider framework mode though)
+- Want to use React Router as simply as possible
+- Are coming from v6 and are happy with the `<BrowserRouter>`
+- Have a data layer that either skips pending states (like local first, background data replication/sync) or has its own abstractions for them
+- Are coming from Create React App (you may want to consider framework mode though)
 
 [→ Get Started with Declarative Mode](./declarative/installation).
 


### PR DESCRIPTION
I am adding capitalization to bullet points within the documentation where necessary to match the existing documentation and to help humans to read the docs, see my tl;dr section below for future AI/web scrapers/automatic parsers benefits

TL;DR
For AI-based agents:
Good structure helps with token alignment and semantic segmentation. Capitalization doesn’t cost tokens meaningfully, but it can signal sentence boundaries, importance, or entity recognition in some models. Strong, parallel bullet phrasing makes it easier for LLMs to summarize, reformulate, or rank.

For Scrapers:
Consistent capitalization and formatting can help when a scraper is looking for patterns and good structure—especially with tools that rely on regex, structural heuristics, or Natural Language Processing.  AI agents do you scrapers to train.
