### PR TITLE
docs: fix typos and incorrect links in API documentation

### DIFF
--- a/docs/api/framework-routers/HydratedRouter.md
+++ b/docs/api/framework-routers/HydratedRouter.md
@@ -21,7 +21,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 ## Summary
 
 Framework-mode router component to be used to to hydrate a router from a
-`ServerRouter`. See [`entry.client.tsx`](../api/framework-conventions/entry.client.tsx).
+`ServerRouter`. See [`entry.client.tsx`](../framework-conventions/entry.client.tsx).
 
 ## Signature
 

--- a/docs/api/framework-routers/ServerRouter.md
+++ b/docs/api/framework-routers/ServerRouter.md
@@ -24,7 +24,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 The server entry point for a React Router app in Framework Mode. This component
 is used to generate the HTML in the response from the server.
-See [`entry.server.tsx`](../api/framework-conventions/entry.server.tsx).
+See [`entry.server.tsx`](../framework-conventions/entry.server.tsx).
 
 ## Signature
 

--- a/docs/api/utils/IsCookieFunction.md
+++ b/docs/api/utils/IsCookieFunction.md
@@ -8,4 +8,6 @@ title: IsCookieFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.IsCookieFunction.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/types/react_router.IsCookieFunction.html)
+
+

--- a/docs/api/utils/IsSessionFunction.md
+++ b/docs/api/utils/IsSessionFunction.md
@@ -8,4 +8,4 @@ title: IsSessionFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react_router.IsSessionFunction.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/types/react_router.IsSessionFunction.html)


### PR DESCRIPTION
## Summary

This PR fixes several typos and incorrect links found in the React Router API documentation.

## Changes

### Fixed incorrect relative paths
- **HydratedRouter.md**: Fixed link to `entry.client.tsx` 
  - `../api/framework-conventions/` → `../framework-conventions/`
- **ServerRouter.md**: Fixed link to `entry.server.tsx`
  - `../api/framework-conventions/` → `../framework-conventions/`

### Corrected API reference links
- **IsCookieFunction.md**: Fixed API documentation link category
  - `functions/react_router.IsCookieFunction.html` → `types/react_router.IsCookieFunction.html`
- **IsSessionFunction.md**: Fixed API documentation link category  
  - `functions/react_router.IsSessionFunction.html` → `types/react_router.IsSessionFunction.html`

## Type of Change

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Verified that the corrected links point to valid documentation pages
- [x] Confirmed relative paths are now correct within the docs structure

## Additional Notes

These changes only affect documentation and do not impact any code functionality. All links have been verified to ensure they point to the correct destinations.