### PR TITLE
fix: rename without mkdir in Vite plugin

### DIFF
--- a/.changeset/polite-vans-travel.md
+++ b/.changeset/polite-vans-travel.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix rename without mkdir in Vite plugin

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1751,6 +1751,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
             if (!userSsrEmitAssets) {
               if (!existsSync(dest)) {
+                await mkdir(path.dirname(dest), { recursive: true });
                 await rename(src, dest);
                 movedAssetPaths.push(dest);
               } else {


### PR DESCRIPTION
Previously react-router was using fs-extra for rename which supported renaming a file into a folder that does not exist
https://github.com/jprichardson/node-fs-extra/blob/176ad6a6dbdec503c2d79fa70d17df32dff49972/lib/move/move-sync.js#L36

Now we need to manually create the folder, issue caused by https://github.com/remix-run/react-router/pull/13736



