### PR TITLE
React 18 "React.use" webpack fix

### DIFF
--- a/.changeset/rotten-foxes-deliver.md
+++ b/.changeset/rotten-foxes-deliver.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Prevent webpack error with React 18 when defining code that uses React.use

--- a/.changeset/rotten-foxes-deliver.md
+++ b/.changeset/rotten-foxes-deliver.md
@@ -2,4 +2,4 @@
 "react-router": patch
 ---
 
-Prevent webpack error with React 18 when defining code that uses React.use
+Adjust internal RSC usage of `React.use` to avoid Webpack compilation errors when using React 18

--- a/contributors.yml
+++ b/contributors.yml
@@ -125,6 +125,7 @@
 - gatzjames
 - gavriguy
 - Geist5000
+- GeoffKarnov
 - gesposito
 - gianlucca
 - gijo-varghese


### PR DESCRIPTION
This commit addresses webpack module resolution errors that occur when bundling React Router's RSC features in React 18 environments, where React.use does not exist.

**Problem:**
Webpack's static analysis phase occurs before any runtime code executes. When webpack encounters `React.use(getPayload())` in the source code, it attempts to validate that the `use` export exists in the React module during build time. In React 18, this export doesn't exist, causing the build error:

```
export 'use' (imported as 'React5') was not found in 'react' (possible exports: Children, Component, Fragment, Profiler, PureComponent, StrictMode, Suspense, __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, act, cloneElement, createContext, createElement, createFactory, createRef, forwardRef, isValidElement, lazy, memo, startTransition, unstable_act, useCallback, useContext, useDebugValue, useDeferredValue, useEffect, useId, useImperativeHandle, useInsertionEffect, useLayoutEffect, useMemo, useReducer, useRef, useState, useSyncExternalStore, useTransition, version)
```

**Solution:**
Implemented `react18compatibleUse` function that:

Moves the property resolution from build-time to runtime, bypassing webpack's static validation while maintaining the same functionality.

I tried many other alternate solutions but they all failed due to them being runtime solutions, but webpack's static analysis happens _before_ runtime.

This solution:
1. **Hides property access from static analysis** using dynamic property lookup with a string variable instead of direct `React.use` access
2. **Provides React 18/19 compatibility** by detecting if React.use exists at runtime and falling back to an informative error function
3. **Maintains identical API** to React.use, enabling seamless migration when React 18 support is eventually dropped
4. **Preserves type safety** with proper generic typing matching React 19's Usable<T> interface

Fixes #14020 