### PR TITLE
feat(react-router): add `scrollTo` prop to `ScrollRestoration`

### DIFF
--- a/.changeset/moody-hats-tickle.md
+++ b/.changeset/moody-hats-tickle.md
@@ -1,0 +1,5 @@
+---
+"react-router": minor
+---
+
+add scrollTo prop to <ScrollRestoration/> for custom scrolling behaviour

--- a/contributors.yml
+++ b/contributors.yml
@@ -141,6 +141,7 @@
 - HelpMe-Pls
 - HenriqueLimas
 - hernanif1
+- herrwitzi
 - hi-ogawa
 - HK-SHAO
 - holynewbie

--- a/docs/api/components/ScrollRestoration.md
+++ b/docs/api/components/ScrollRestoration.md
@@ -87,3 +87,25 @@ element
 The key to use for storing scroll positions in [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).
 Defaults to `"react-router-scroll-positions"`.
 
+### scrollTo
+
+A function that will be called to scroll to a specific position.
+This is useful for custom scroll restoration logic, such as explicitly seting the scroll behaviour to "auto"
+so that CSS (scroll-behavior: smooth on the html tag) does not affect the call (the current behaviour jumps around
+when switching pages in a non-intuitive way).
+Defaults to `window.scrollTo(0, y)`.
+
+```css
+html {
+  scroll-behavior: smooth;
+}
+```
+```tsx
+<ScrollRestoration
+  scrollTo={(y) => {
+    document.documentElement.style.scrollBehavior = "auto"
+    window.scrollTo(0, y)
+    document.documentElement.style.scrollBehavior = ""
+  }}
+/>
+```

--- a/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
+++ b/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
@@ -319,6 +319,69 @@ describe(`ScrollRestoration`, () => {
       // Ensure that scroll position is restored
       expect(scrollToMock).toHaveBeenCalledWith(0, 20);
     });
+
+    it("should restore scroll position with custom scrollTo", () => {
+      let scrollToMock = jest.spyOn(window, "scrollTo");
+      let router = createMemoryRouter([
+        {
+          id: "root",
+          path: "/",
+          element: (
+            <>
+              <Outlet />
+              <ScrollRestoration
+                scrollTo={(y) => window.scrollTo(0, y)}
+              />
+              <Scripts />
+            </>
+          ),
+        },
+      ]);
+      router.state.restoreScrollPosition = 20;
+      render(
+        <FrameworkContext.Provider value={context}>
+          <RouterProvider router={router} />
+        </FrameworkContext.Provider>,
+      );
+
+      expect(scrollToMock).toHaveBeenCalledWith(0, 20);
+    });
+
+    it("should restore scroll position on navigation with custom scrollTo", () => {
+      let scrollToMock = jest.spyOn(window, "scrollTo");
+      let router = createMemoryRouter([
+        {
+          id: "root",
+          path: "/",
+          element: (
+            <>
+              <Outlet />
+              <ScrollRestoration
+                scrollTo={(y) => window.scrollTo(0, y)}
+              />
+              <Scripts />
+            </>
+          ),
+        },
+      ]);
+      render(
+        <FrameworkContext.Provider value={context}>
+          <RouterProvider router={router} />
+        </FrameworkContext.Provider>,
+      );
+      // Always called when using <ScrollRestoration />
+      expect(scrollToMock).toHaveBeenCalledWith(0, 0);
+      // Mock user scroll
+      window.scrollTo(0, 20);
+      // Mock navigation
+      redirect("/otherplace");
+      // Mock return to original page where navigation had happened
+      expect(scrollToMock).toHaveBeenCalledWith(0, 0);
+      // Mock return to original page where navigation had happened
+      redirect("/");
+      // Ensure that scroll position is restored
+      expect(scrollToMock).toHaveBeenCalledWith(0, 20);
+    });
   });
 });
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -486,6 +486,13 @@ export interface GetScrollPositionFunction {
 }
 
 /**
+ * Function signature for scrolling to a specific position
+ */
+export interface ScrollToFunction {
+  (y: number): void;
+}
+
+/**
  * - "route": relative to the route hierarchy so `..` means remove all segments
  * of the current route even if it has many. For example, a `route("posts/:id")`
  * would have both `:id` and `posts` removed from the url.


### PR DESCRIPTION
Non-breaking continuation of #10318.

Adds an optional scrollTo prop to ScrollRestoration that is used instead of the default window.scrollTo calls. This allows the user to specify a custom function for scroll restoration.

The original PR was closed due to being breaking, and not going through a proposal for considering more generic behavior. A proposal was opened in #10328, but hasn't received any more activity for two years.

This allows the user to overwrite a global CSS scroll-behavior e.g. smooth on the html tag (the issue from the original PR):
```jsx
<ScrollRestoration
  scrollTo={(y) => {
    document.documentElement.style.scrollBehavior = "auto"
    window.scrollTo(0, y)
    document.documentElement.style.scrollBehavior = ""
  }}
/>
```