### PR TITLE
Add MDX route support to RSC Framework Mode

### DIFF
--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -10,6 +10,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "devDependencies": {
+    "@mdx-js/rollup": "^3.1.0",
     "@react-router/dev": "workspace:*",
     "@react-router/fs-routes": "workspace:*",
     "@types/express": "^5.0.0",

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -78,6 +78,7 @@ type ViteConfigBuildArgs = {
 type ViteConfigBaseArgs = {
   templateName?: TemplateName;
   envDir?: string;
+  mdx?: boolean;
 };
 
 type ViteConfigArgs = (
@@ -138,6 +139,7 @@ export const viteConfig = {
               "const { unstable_reactRouterRSC: reactRouter } = __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;",
             ].join("\n")
       }
+      ${args.mdx ? 'import mdx from "@mdx-js/rollup";' : ""}
       import { envOnlyMacros } from "vite-env-only";
       import tsconfigPaths from "vite-tsconfig-paths";
 
@@ -146,6 +148,7 @@ export const viteConfig = {
         ${viteConfig.build(args)}
         envDir: ${args.envDir ? `"${args.envDir}"` : "undefined"},
         plugins: [
+          ${args.mdx ? "mdx()," : ""}
           reactRouter(),
           envOnlyMacros(),
           tsconfigPaths()

--- a/integration/mdx-test.ts
+++ b/integration/mdx-test.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  createFixture,
+  createAppFixture,
+  js,
+} from "./helpers/create-fixture.js";
+import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
+import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
+import {
+  type TemplateName,
+  reactRouterConfig,
+  viteConfig,
+} from "./helpers/vite.js";
+
+const templateNames = [
+  "vite-5-template",
+  "rsc-vite-framework",
+] as const satisfies TemplateName[];
+
+test.describe("MDX", () => {
+  for (const templateName of templateNames) {
+    test.describe(`template: ${templateName}`, () => {
+      let fixture: Fixture;
+      let appFixture: AppFixture;
+
+      test.beforeAll(async () => {
+        fixture = await createFixture({
+          templateName,
+          files: {
+            "vite.config.js": await viteConfig.basic({
+              templateName,
+              mdx: true,
+            }),
+            "react-router.config.ts": reactRouterConfig({
+              viteEnvironmentApi: templateName.includes("rsc"),
+            }),
+            "app/root.tsx": js`
+              import { Outlet, Scripts } from "react-router"
+        
+              export default function Root() {
+                return (
+                  <html>
+                    <head></head>
+                    <body>
+                      <main>
+                        <Outlet />
+                      </main>
+                      <Scripts />
+                    </body>
+                  </html>
+                );
+              }
+            `,
+            "app/routes/_index.tsx": js`
+              import { Link } from "react-router"
+              export default function Component() {
+                return <Link to="/mdx">Go to MDX route</Link>
+              }
+            `,
+            "app/routes/mdx.mdx": js`
+              import { MdxComponent } from "../components/mdx-components";
+
+              export const loader = () => {
+                return {
+                  content: "MDX route content from loader",
+                }
+              }
+
+              ## MDX Route
+
+              <MdxComponent />
+            `,
+            // This needs to be a separate file to support RSC since
+            // `useLoaderData` is not available in RSC environments, and
+            // components defined within an MDX file must be exported. This
+            // means they're not removed in the RSC build.
+            "app/components/mdx-components.tsx": js`
+              import { useState, useEffect } from "react";
+              import { useLoaderData } from "react-router";
+
+              export function MdxComponent() {
+                const { content } = useLoaderData();
+                const [mounted, setMounted] = useState(false);
+                useEffect(() => {
+                  setMounted(true);
+                }, []);
+
+                return (
+                  <>
+                    <h3>Loader data</h3>
+                    <div data-loader-data>{content}</div>
+                    <h3>Mounted</h3>
+                    <div data-mounted>{mounted ? "true" : "false"}</div>
+                  </>
+                );
+              }
+            `,
+          },
+        });
+
+        appFixture = await createAppFixture(fixture);
+      });
+
+      test.afterAll(() => {
+        appFixture.close();
+      });
+
+      test("handles MDX routes", async ({ page }) => {
+        let app = new PlaywrightFixture(appFixture, page);
+        await app.goto("/mdx");
+
+        let loaderData = page.locator("[data-loader-data]");
+        await expect(loaderData).toHaveText("MDX route content from loader");
+
+        let mounted = page.locator("[data-mounted]");
+        await expect(mounted).toHaveText("true");
+      });
+    });
+  }
+});

--- a/integration/vite-plugin-order-validation-test.ts
+++ b/integration/vite-plugin-order-validation-test.ts
@@ -1,33 +1,60 @@
 import { test, expect } from "@playwright/test";
 import dedent from "dedent";
 
-import { createProject, build } from "./helpers/vite.js";
+import { createProject, build, reactRouterConfig } from "./helpers/vite.js";
 
-test.describe(() => {
-  let cwd: string;
-  let buildResult: ReturnType<typeof build>;
+test.describe("Vite plugin order validation", () => {
+  test.describe("MDX", () => {
+    test("Framework Mode", async () => {
+      let cwd = await createProject({
+        "vite.config.ts": dedent`
+          import { reactRouter } from "@react-router/dev/vite";
+          import mdx from "@mdx-js/rollup";
 
-  test.beforeAll(async () => {
-    cwd = await createProject({
-      "vite.config.ts": dedent`
-        import { reactRouter } from "@react-router/dev/vite";
-        import mdx from "@mdx-js/rollup";
+          export default {
+            plugins: [
+              reactRouter(),
+              mdx(),
+            ],
+          }
+        `,
+      });
 
-        export default {
-          plugins: [
-            reactRouter(),
-            mdx(),
-          ],
-        }
-      `,
+      let buildResult = build({ cwd });
+      expect(buildResult.stderr.toString()).toContain(
+        'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config file',
+      );
     });
 
-    buildResult = build({ cwd });
-  });
+    test("RSC Framework Mode", async () => {
+      let cwd = await createProject(
+        {
+          "vite.config.js": dedent`
+          import { defineConfig } from "vite";
+          import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
+          import mdx from "@mdx-js/rollup";
 
-  test("Vite / plugin order validation / MDX", () => {
-    expect(buildResult.stderr.toString()).toContain(
-      'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config file',
-    );
+          const { unstable_reactRouterRSC: reactRouterRSC } =
+            __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;
+
+          export default defineConfig({
+            plugins: [
+              reactRouterRSC(),
+              mdx(),
+            ],
+          });
+        `,
+          "react-router.config.ts": reactRouterConfig({
+            viteEnvironmentApi: true,
+          }),
+        },
+        "rsc-vite-framework",
+      );
+
+      let buildResult = build({ cwd });
+      expect(buildResult.stderr.toString()).toContain(
+        'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config file',
+      );
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@changesets/cli": "^2.26.2",
     "@manypkg/get-packages": "^1.1.3",
-    "@mdx-js/rollup": "^3.0.0",
+    "@mdx-js/rollup": "^3.1.0",
     "@playwright/test": "^1.49.1",
     "@remix-run/changelog-github": "^0.0.5",
     "@types/jest": "^29.5.4",
@@ -100,7 +100,8 @@
   "pnpm": {
     "patchedDependencies": {
       "@changesets/get-dependents-graph@1.3.6": "patches/@changesets__get-dependents-graph@1.3.6.patch",
-      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch"
+      "@changesets/assemble-release-plan": "patches/@changesets__assemble-release-plan.patch",
+      "@mdx-js/rollup": "patches/@mdx-js__rollup.patch"
     },
     "overrides": {
       "workerd": "1.20250705.0",

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -113,7 +113,7 @@ async function viteAppBuild(
           let hasReactRouterPlugin = config.plugins.find(
             (plugin) =>
               plugin.name === "react-router" ||
-              plugin.name === "react-router/rsc/config",
+              plugin.name === "react-router/rsc",
           );
           if (!hasReactRouterPlugin) {
             throw new Error(

--- a/packages/react-router-dev/vite/dev.ts
+++ b/packages/react-router-dev/vite/dev.ts
@@ -51,8 +51,7 @@ export async function dev(
   if (
     !server.config.plugins.find(
       (plugin) =>
-        plugin.name === "react-router" ||
-        plugin.name === "react-router/rsc/config",
+        plugin.name === "react-router" || plugin.name === "react-router/rsc",
     )
   ) {
     console.error(

--- a/packages/react-router-dev/vite/plugins/validate-plugin-order.ts
+++ b/packages/react-router-dev/vite/plugins/validate-plugin-order.ts
@@ -1,0 +1,34 @@
+import type * as Vite from "vite";
+
+export default function validatePluginOrder(): Vite.Plugin {
+  return {
+    name: "react-router:validate-plugin-order",
+    configResolved(viteConfig) {
+      let pluginIndex = (pluginName: string | string[]) => {
+        pluginName = Array.isArray(pluginName) ? pluginName : [pluginName];
+        return viteConfig.plugins.findIndex((plugin) =>
+          pluginName.includes(plugin.name),
+        );
+      };
+
+      let rollupPrePlugins = [
+        { pluginName: "@mdx-js/rollup", displayName: "@mdx-js/rollup" },
+      ];
+      for (let prePlugin of rollupPrePlugins) {
+        let prePluginIndex = pluginIndex(prePlugin.pluginName);
+        console.log(
+          prePluginIndex,
+          pluginIndex(["react-router", "react-router/rsc"]),
+        );
+        if (
+          prePluginIndex >= 0 &&
+          prePluginIndex > pluginIndex(["react-router", "react-router/rsc"])
+        ) {
+          throw new Error(
+            `The "${prePlugin.displayName}" plugin should be placed before the React Router plugin in your Vite config file`,
+          );
+        }
+      }
+    },
+  };
+}

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -19,6 +19,7 @@ import {
   parseRouteExports,
   CLIENT_NON_COMPONENT_EXPORTS,
 } from "./virtual-route-modules";
+import validatePluginOrder from "../plugins/validate-plugin-order";
 
 export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
   let configLoader: ConfigLoader;
@@ -29,7 +30,7 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
 
   return [
     {
-      name: "react-router/rsc/config",
+      name: "react-router/rsc",
       async config(viteUserConfig, { command, mode }) {
         await initEsModuleLexer;
         viteCommand = command;
@@ -300,6 +301,7 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
         return modules;
       },
     },
+    validatePluginOrder(),
     rsc({ entries: getRscEntries() }),
   ];
 }

--- a/patches/@mdx-js__rollup.patch
+++ b/patches/@mdx-js__rollup.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/index.js b/lib/index.js
+index ddbf4a0ebac3adb0c6277f4771ce413d8058a367..a412cc138011a53afa222ad7a4ae23d83ea18759 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -80,7 +80,7 @@ export function rollup(options) {
+         ...rest
+       })
+     },
+-    async transform(value, path) {
++    async transform(value, id) {
+       if (!formatAwareProcessors) {
+         formatAwareProcessors = createFormatAwareProcessors({
+           SourceMapGenerator,
+@@ -88,6 +88,7 @@ export function rollup(options) {
+         })
+       }
+ 
++      const [path] = id.split('?')
+       const file = new VFile({path, value})
+ 
+       if (

--- a/playground/rsc-vite-framework/app/root.tsx
+++ b/playground/rsc-vite-framework/app/root.tsx
@@ -1,5 +1,7 @@
-import { Link, Outlet } from "react-router";
+import { Meta, Link, Outlet } from "react-router";
 import "./root.css";
+
+export const meta = () => [{ title: "React Router Vite" }];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   console.log("Layout");
@@ -8,7 +10,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>React Router Vite</title>
+        <Meta />
       </head>
       <body>
         <header>
@@ -31,6 +33,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 <Link to="/client-loader-without-server-loader">
                   Client loader without server loader
                 </Link>
+              </li>
+              <li>
+                <Link to="/mdx">MDX</Link>
               </li>
             </ul>
           </nav>

--- a/playground/rsc-vite-framework/app/routes/mdx/route.mdx
+++ b/playground/rsc-vite-framework/app/routes/mdx/route.mdx
@@ -1,0 +1,16 @@
+import { useLoaderData } from "react-router";
+
+export const meta = () => [{ title: "MDX Route" }];
+
+export const loader = () => ({ message: "Loader data" });
+
+export function Message() {
+  const { message } = useLoaderData();
+  return <div>Loader data: {message}</div>;
+}
+
+# This is an MDX route
+
+Hello from an MDX route!
+
+<Message />

--- a/playground/rsc-vite-framework/mdx.d.ts
+++ b/playground/rsc-vite-framework/mdx.d.ts
@@ -1,0 +1,3 @@
+declare module "*.mdx" {
+  export default (...args: any[]) => unknown;
+}

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -10,6 +10,7 @@
     "typecheck": "react-router typegen && tsc"
   },
   "devDependencies": {
+    "@mdx-js/rollup": "^3.1.0",
     "@react-router/dev": "workspace:*",
     "@react-router/fs-routes": "workspace:*",
     "@types/express": "^5.0.0",

--- a/playground/rsc-vite-framework/vite.config.ts
+++ b/playground/rsc-vite-framework/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
 import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
+import mdx from "@mdx-js/rollup";
 
 const { unstable_reactRouterRSC: reactRouterRSC } =
   __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;
 
 export default defineConfig({
-  plugins: [reactRouterRSC()],
+  plugins: [mdx(), reactRouterRSC()],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ patchedDependencies:
   '@changesets/get-dependents-graph@1.3.6':
     hash: arforfmj6nw2w4znv7h66rwf5y
     path: patches/@changesets__get-dependents-graph@1.3.6.patch
+  '@mdx-js/rollup':
+    hash: wjxfd5pqp7spa3snsugst7roxm
+    path: patches/@mdx-js__rollup.patch
 
 importers:
 
@@ -43,8 +46,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       '@mdx-js/rollup':
-        specifier: ^3.0.0
-        version: 3.1.0(rollup@4.43.0)
+        specifier: ^3.1.0
+        version: 3.1.0(patch_hash=wjxfd5pqp7spa3snsugst7roxm)(rollup@4.43.0)
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.49.1
@@ -164,7 +167,7 @@ importers:
     dependencies:
       '@mdx-js/rollup':
         specifier: ^3.1.0
-        version: 3.1.0(rollup@4.43.0)
+        version: 3.1.0(patch_hash=wjxfd5pqp7spa3snsugst7roxm)(rollup@4.43.0)
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.49.1
@@ -539,6 +542,9 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-router
     devDependencies:
+      '@mdx-js/rollup':
+        specifier: ^3.1.0
+        version: 3.1.0(patch_hash=wjxfd5pqp7spa3snsugst7roxm)(rollup@4.43.0)
       '@react-router/dev':
         specifier: workspace:*
         version: link:../../../packages/react-router-dev
@@ -1935,6 +1941,9 @@ importers:
         specifier: ^8.7.0
         version: 8.7.0(react-router@packages+react-router)(react@19.1.0)(zod@3.24.2)
     devDependencies:
+      '@mdx-js/rollup':
+        specifier: ^3.1.0
+        version: 3.1.0(patch_hash=wjxfd5pqp7spa3snsugst7roxm)(rollup@4.43.0)
       '@react-router/dev':
         specifier: workspace:*
         version: link:../../packages/react-router-dev
@@ -11912,7 +11921,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/rollup@3.1.0(rollup@4.43.0)':
+  '@mdx-js/rollup@3.1.0(patch_hash=wjxfd5pqp7spa3snsugst7roxm)(rollup@4.43.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@rollup/pluginutils': 5.1.0(rollup@4.43.0)


### PR DESCRIPTION
Note that this feature depends on this PR to `@mdx-js/rollup` being published: https://github.com/mdx-js/mdx/pull/2629. For now, this fix is provided as a patch in this PR.