### PR TITLE
Update client middleware to propagate a the data strategy results up the chain

### DIFF
--- a/.changeset/violet-dots-collect.md
+++ b/.changeset/violet-dots-collect.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+[UNSTABLE] Update client middleware so it returns the data strategy results allowing for more advanced post-processing middleware


### PR DESCRIPTION
Currently, we return/bubble nothing in client middlewares because there's no `Response`, but this means you can't do post processing which eliminates one of our primary example use cases of middlewares which is [looking up CMS redirects on 404s](https://reactrouter.com/how-to/middleware#404-to-cms-redirect).

Middleware is implemented as part of `dataStrategy` and therefore the expected return value internally is the same thing returned by `dataStrategy` (`Record<string, DataStrategyResult>`) so it's already public API, so we can just stop purposefully hiding that from userland and bubble it back up (they don't need to use it though).  This also has the added benefit of removing another key difference (both in explanation and in implementation) between server and client middleware and makes them almost identical the the only difference being type of the `next` return value.

That example CMS use case in the client would now look like this:

```tsx
async function cmsFallbackMiddleware({ request }, next) {
  const results = await next();

  // Check if we got a 404 from any of our routes
  let is404 =
    isRouteErrorResponse(r.result) &&
    r.result.status === 404;
  if (Object.values(results).some((r) => is404(r))) {
    // Check CMS for a redirect
    const cmsRedirect = await checkCMSRedirects(
      request.url,
    );
    if (cmsRedirect) {
      throw redirect(cmsRedirect, 302);
    }
  }

  return results;

```