### PR TITLE
Support for buildDirectory on RSC framework output

### DIFF
--- a/.changeset/neat-beers-punch.md
+++ b/.changeset/neat-beers-punch.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Support for buildDirectory on RSC framework output

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -75,9 +75,21 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
             jsxDev: viteCommand !== "build",
           },
           environments: {
-            client: { build: { outDir: "build/client" } },
-            rsc: { build: { outDir: "build/server" } },
-            ssr: { build: { outDir: "build/server/__ssr_build" } },
+            client: {
+              build: {
+                outDir: join(config.buildDirectory, "client"),
+              },
+            },
+            rsc: {
+              build: {
+                outDir: join(config.buildDirectory, "server"),
+              },
+            },
+            ssr: {
+              build: {
+                outDir: join(config.buildDirectory, "server/__ssr_build"),
+              },
+            },
           },
           build: {
             rollupOptions: {


### PR DESCRIPTION
Currently the output folder always `build`. Here we update to support the `buildDirectory` from the react-router configuration