### PR TITLE
docs(api/hooks/useNavigate): add some extra reference links

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -324,12 +324,13 @@ function useIsomorphicLayoutEffect(
  * Declarative mode versus Data/Framework mode - the primary difference being
  * that the latter is able to return a stable reference that does not change
  * identity across navigations. The implementation in Data/Framework mode also
- * returns a `Promise` that resolves when the navigation is completed. This means
- * the return type of `useNavigate` is `void | Promise<void>`. This is accurate,
- * but can lead to some red squigglies based on the union in the return value:
+ * returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+ * that resolves when the navigation is completed. This means the return type of
+ * `useNavigate` is `void | Promise<void>`. This is accurate, but can lead to
+ * some red squigglies based on the union in the return value:
  *
  * - If you're using `typescript-eslint`, you may see errors from
- *   [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/)
+ *   [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises)
  * - In Framework/Data mode, `React.use(navigate())` will show a false-positive
  *   `Argument of type 'void | Promise<void>' is not assignable to parameter of
  *   type 'Usable<void>'` error


### PR DESCRIPTION
I would have created a PR agains `dev`, but these changes aren't available on `dev` (yet)