### PR TITLE
docs: update imports in installation.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -72,6 +72,7 @@
 - chasinhues
 - chensokheng
 - chr33s
+- chrille0313
 - chrisngobanh
 - christopherchudzicki
 - ChristophP

--- a/docs/start/data/installation.md
+++ b/docs/start/data/installation.md
@@ -27,7 +27,7 @@ npm i react-router
 
 Create a router and pass it to `RouterProvider`:
 
-```tsx lines=[1-4,9-14,19]
+```tsx lines=[3-4,9-14,19]
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter } from "react-router";

--- a/docs/start/data/installation.md
+++ b/docs/start/data/installation.md
@@ -28,13 +28,10 @@ npm i react-router
 Create a router and pass it to `RouterProvider`:
 
 ```tsx lines=[1-4,9-14,19]
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router";
-
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { createBrowserRouter } from "react-router";
+import { RouterProvider } from 'react-router/dom';
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
See the note on: https://reactrouter.com/api/data-routers/RouterProvider - The RouterProvider docs says to prefer the import from `react-router/dom` over `react-router`, but the [installation docs on data mode](https://reactrouter.com/start/data/installation#create-a-router-and-render) uses the one from `react-router`.