### PR TITLE
docs(start/data/installation): fix code highlighting

### DIFF
--- a/docs/start/data/installation.md
+++ b/docs/start/data/installation.md
@@ -27,7 +27,7 @@ npm i react-router
 
 Create a router and pass it to `RouterProvider`:
 
-```tsx lines=[3-4,9-14,19]
+```tsx lines=[3-4,6-11,16]
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter } from "react-router";


### PR DESCRIPTION
Highlight the correct lines (got broken in #14176).

Broken version:

<img width="779" height="515" alt="image" src="https://github.com/user-attachments/assets/9df30dc2-2629-4813-b7de-408d0c43295e" />

Before #14176:

<img width="785" height="585" alt="image" src="https://github.com/user-attachments/assets/01163da5-d828-4723-86fe-48508859e01d" />
