### PR TITLE
Inject CSS into server-first routes in RSC Framework Mode

### DIFF
--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -2,6 +2,7 @@
   "name": "integration-rsc-vite-framework",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": false,
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,6 +18,8 @@
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@vanilla-extract/css": "^1.17.4",
+    "@vanilla-extract/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^4.5.2",
     "@vitejs/plugin-rsc": "0.4.11",
     "cross-env": "^7.0.3",

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -96,10 +96,10 @@ async function createVirtualRouteModuleCode({
       } else if (staticExport === "ServerComponent") {
         code += `import React from "react";\n`;
         code += `import { ServerComponent } from "${serverModuleId}";\n`;
-        code += `export default function ServerComponentWithCss() {`;
+        code += `export default function ServerComponentWithCss(props) {`;
         code += `  return React.createElement(React.Fragment, null, [`;
         code += `    import.meta.viteRsc.loadCss(),`;
-        code += `    React.createElement(ServerComponent, null),`;
+        code += `    React.createElement(ServerComponent, props),`;
         code += `  ]);`;
         code += `}`;
       } else {

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -94,7 +94,14 @@ async function createVirtualRouteModuleCode({
       if (isClientNonComponentExport(staticExport)) {
         code += `export { ${staticExport} } from "${clientModuleId}";\n`;
       } else if (staticExport === "ServerComponent") {
-        code += `export { ServerComponent as default } from "${serverModuleId}";\n`;
+        code += `import React from "react";\n`;
+        code += `import { ServerComponent } from "${serverModuleId}";\n`;
+        code += `export default function ServerComponentWithCss() {`;
+        code += `  return React.createElement(React.Fragment, null, [`;
+        code += `    import.meta.viteRsc.loadCss(),`;
+        code += `    React.createElement(ServerComponent, null),`;
+        code += `  ]);`;
+        code += `}`;
       } else {
         code += `export { ${staticExport} } from "${serverModuleId}";\n`;
       }

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -121,7 +121,7 @@ async function createVirtualRouteModuleCode({
         code += `export { ${staticExport} } from "${clientModuleId}";\n`;
       } else if (
         isServerFirstComponentExport(staticExport) &&
-        // Layout wraps all other exports so doesn't need to have CSS injected
+        // Layout wraps all other component exports so doesn't need CSS injected
         staticExport !== "Layout"
       ) {
         code += `import { ${staticExport} as ${staticExport}WithoutCss } from "${serverModuleId}";\n`;

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -112,8 +112,6 @@ export async function routeRSCServerRequest({
     throw new Error("Missing body in server response");
   }
 
-  const detectRedirectResponse = serverResponse.clone();
-
   let serverResponseB: Response | null = null;
   if (hydrate) {
     serverResponseB = serverResponse.clone();
@@ -128,12 +126,7 @@ export async function routeRSCServerRequest({
   };
 
   try {
-    if (!detectRedirectResponse.body) {
-      throw new Error("Failed to clone server response");
-    }
-    const payload = (await createFromReadableStream(
-      detectRedirectResponse.body,
-    )) as RSCPayload;
+    const payload = await getPayload();
     if (
       serverResponse.status === SINGLE_FETCH_REDIRECT_STATUS &&
       payload.type === "redirect"

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -112,6 +112,8 @@ export async function routeRSCServerRequest({
     throw new Error("Missing body in server response");
   }
 
+  const detectRedirectResponse = serverResponse.clone();
+
   let serverResponseB: Response | null = null;
   if (hydrate) {
     serverResponseB = serverResponse.clone();
@@ -126,7 +128,12 @@ export async function routeRSCServerRequest({
   };
 
   try {
-    const payload = await getPayload();
+    if (!detectRedirectResponse.body) {
+      throw new Error("Failed to clone server response");
+    }
+    const payload = (await createFromReadableStream(
+      detectRedirectResponse.body,
+    )) as RSCPayload;
     if (
       serverResponse.status === SINGLE_FETCH_REDIRECT_STATUS &&
       payload.type === "redirect"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.7
         version: 18.2.7
+      '@vanilla-extract/css':
+        specifier: ^1.17.4
+        version: 1.17.4(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/vite-plugin':
+        specifier: ^5.1.1
+        version: 5.1.1(@types/node@22.14.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))(yaml@2.8.0)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))


### PR DESCRIPTION
The existing `vite-css` integration test wasn't being run against RSC Framework Mode. As part of this PR, I've ensured that these tests are now running against RSC Framework Mode and fail without the fix introduced in this PR.