### PR TITLE
fix(react-router/fs-routes): correctly apply ignoredFilePatterns to files and folders in flatRoutes

### DIFF
--- a/.changeset/nervous-timers-notice.md
+++ b/.changeset/nervous-timers-notice.md
@@ -1,0 +1,5 @@
+---
+"@react-router/fs-routes": patch
+---
+
+fix(react-router/fs-routes): correctly apply ignoredFilePatterns to files and folders in flatRoutes

--- a/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
+++ b/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
@@ -912,4 +912,54 @@ describe("flatRoutes", () => {
       );
     });
   });
+
+  describe("ignoredFilePatterns", () => {
+    let tempDir = path.join(
+      os.tmpdir(),
+      "react-router-fs-routes-test",
+      Math.random().toString(36).substring(2, 15),
+    );
+    let routesDir = path.join(tempDir, "routes");
+
+    beforeEach(() => {
+      mkdirSync(tempDir, { recursive: true });
+      mkdirSync(routesDir, { recursive: true });
+      writeFileSync(path.join(tempDir, "root.tsx"), "");
+    });
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test("should ignore a single file matching the pattern", () => {
+      let routeOne = path.join(routesDir, "one.tsx");
+      let routeTwo = path.join(routesDir, "two.tsx");
+      writeFileSync(routeOne, "");
+      writeFileSync(routeTwo, "");
+
+      let ignoredFilePatterns = ["two.tsx"];
+      let routeManifest = flatRoutes(tempDir, ignoredFilePatterns);
+
+      let routeIds = Object.keys(routeManifest);
+
+      expect(routeIds).not.toContain("routes/two");
+      expect(routeIds.length).toBe(1);
+    });
+
+    test("should ignore all files in a folder matching the pattern", () => {
+      let routeOne = path.join(routesDir, "one.tsx");
+      let routeTwoDir = path.join(routesDir, "two");
+      let routeTwo = path.join(routeTwoDir, "route.tsx");
+      writeFileSync(routeOne, "");
+      mkdirSync(routeTwoDir, { recursive: true });
+      writeFileSync(routeTwo, "");
+
+      let ignoredFilePatterns = ["two"];
+      let routeManifest = flatRoutes(tempDir, ignoredFilePatterns);
+
+      let routeIds = Object.keys(routeManifest);
+
+      expect(routeIds).not.toContain("routes/two");
+      expect(routeIds.length).toBe(1);
+    });
+  });
 });

--- a/packages/react-router-fs-routes/flatRoutes.ts
+++ b/packages/react-router-fs-routes/flatRoutes.ts
@@ -110,11 +110,12 @@ export function flatRoutes(
     if (entry.isDirectory()) {
       route = findRouteModuleForFolder(
         appDirectory,
+        routesDir,
         filepath,
         ignoredFileRegex,
       );
     } else if (entry.isFile()) {
-      route = findRouteModuleForFile(appDirectory, filepath, ignoredFileRegex);
+      route = findRouteModuleForFile(routesDir, filepath, ignoredFileRegex);
     }
 
     if (route) routes.push(route);
@@ -297,11 +298,11 @@ export function flatRoutesUniversal(
 }
 
 function findRouteModuleForFile(
-  appDirectory: string,
+  routesDir: string,
   filepath: string,
   ignoredFileRegex: RegExp[],
 ): string | null {
-  let relativePath = normalizeSlashes(path.relative(appDirectory, filepath));
+  let relativePath = normalizeSlashes(path.relative(routesDir, filepath));
   let isIgnored = ignoredFileRegex.some((regex) => regex.test(relativePath));
   if (isIgnored) return null;
   return filepath;
@@ -309,10 +310,11 @@ function findRouteModuleForFile(
 
 function findRouteModuleForFolder(
   appDirectory: string,
+  routesDir: string,
   filepath: string,
   ignoredFileRegex: RegExp[],
 ): string | null {
-  let relativePath = path.relative(appDirectory, filepath);
+  let relativePath = path.relative(routesDir, filepath);
   let isIgnored = ignoredFileRegex.some((regex) => regex.test(relativePath));
   if (isIgnored) return null;
 


### PR DESCRIPTION
fixes: #14157

The current implementation checks `ignoredFilePatterns` against file paths relative to the `app` directory (e.g. `"routes/mainPage.tsx"`) instead of the `routes` directory as [documented](https://reactrouter.com/how-to/file-route-conventions#setting-up) (e.g. `"mainPage.tsx"`). As a result, patterns like `"mainPage.tsx"` do not match and the behavior is surprising for users.
This PR fixes that by using paths relative to the routes directory when evaluating `ignoredFilePatterns`, restoring the documented behavior.