### PR TITLE
Delay turbo-stream serialization of .data redirects

### DIFF
--- a/.changeset/quiet-cows-build.md
+++ b/.changeset/quiet-cows-build.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+[UNSTABLE] Delay serialization of `.data` redirects to 202 responses until after middleware chain


### PR DESCRIPTION
This dedupes a good bit of code and keeps the middleware chain a bit more consistent between document/data requests since you can now inspect and "see" a redirect in both cases and you don't have to be aware of the implementation detail that is the turbo-stream encoding and the 202 response.  We just wait until right before we send the response before we serialize it via turbo-stream.

```tsx
function middleware() {
  let res = await next();

  // Currently, `res` would be a 202 response on `.data` requests and you can't easily 
  // see the location because it's encoded in the body.

  // Now, it's a standard 3xx redirect with a `Location` header on both document 
  // and data requests

  return res;
}

function loader() {
  return redirect('/');
}
```