### PR TITLE
Update missed type for clientMiddleware

### DIFF
--- a/.changeset/old-peas-fetch.md
+++ b/.changeset/old-peas-fetch.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+[REMOVE] Update type as a follow up to https://github.com/remix-run/react-router/pull/14151

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -8,6 +8,7 @@ import type {
   unstable_MiddlewareFunction,
   Params,
   ShouldRevalidateFunction,
+  DataStrategyResult,
 } from "../../router/utils";
 
 import type { EntryRoute } from "./routes";
@@ -25,7 +26,9 @@ export interface RouteModules {
 export interface RouteModule {
   clientAction?: ClientActionFunction;
   clientLoader?: ClientLoaderFunction;
-  unstable_clientMiddleware?: unstable_MiddlewareFunction<undefined>[];
+  unstable_clientMiddleware?: unstable_MiddlewareFunction<
+    Record<string, DataStrategyResult>
+  >[];
   ErrorBoundary?: ErrorBoundaryComponent;
   HydrateFallback?: HydrateFallbackComponent;
   Layout?: LayoutComponent;


### PR DESCRIPTION
Follow up to https://github.com/remix-run/react-router/pull/14151