### PR TITLE
Improve CSS HMR in RSC Framework Mode

### DIFF
--- a/integration/helpers/rsc-parcel/src/routes/root.tsx
+++ b/integration/helpers/rsc-parcel/src/routes/root.tsx
@@ -6,7 +6,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Vite (RSC)</title>
+        <title>Parcel (RSC)</title>
         <Links />
       </head>
       <body>

--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -21,7 +21,7 @@
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.11",
+    "@vitejs/plugin-rsc": "0.4.21",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0",

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@vitejs/plugin-rsc": "0.4.11",
+    "@vitejs/plugin-rsc": "0.4.21",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -536,8 +536,6 @@ async function hmrWorkflow({
 
     let input = page.locator("input");
     await expect(input).toBeVisible();
-    await input.type("stateful");
-    await expect(input).toHaveValue("stateful");
 
     let edit = createEditor(cwd);
     let modifyCss = (contents: string) =>
@@ -579,6 +577,7 @@ async function hmrWorkflow({
 
     for (const { file, selector } of testCases) {
       const routeFile = `app/routes/${routeBase}/${file}`;
+      await input.fill(routeFile);
       await edit(routeFile, modifyCss);
       await expect(
         page.locator(selector),
@@ -592,7 +591,7 @@ async function hmrWorkflow({
 
       // Ensure CSS updates were handled by HMR
       await expect(input, `State preservation for ${routeFile}`).toHaveValue(
-        "stateful",
+        routeFile,
       );
     }
 

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -118,7 +118,7 @@ const files = ({ templateName }: { templateName: TemplateName }) => ({
   ...Object.assign(
     {},
     ...getRouteBasePaths(templateName).map((routeBasePath) => {
-      const isServerFirstRoute = routeBasePath === "rsc-server-first-css";
+      const isServerFirstRoute = routeBasePath === "rsc-server-first-route";
       const exportName = isServerFirstRoute ? "ServerComponent" : "default";
 
       return {
@@ -579,7 +579,7 @@ async function hmrWorkflow({
       await expect(input).toHaveValue("stateful");
     }
 
-    // RSC Framework Mode doesn't support custom entries yet
+    // RSC Framework mode doesn't support custom entries yet
     if (!templateName.includes("rsc")) {
       // The following change triggers a full page reload, so we check it after all the checks for HMR state preservation
       await edit("app/entry.client.css", modifyCss);

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -78,7 +78,7 @@
     "@babel/types": "^7.27.7",
     "@npmcli/package-json": "^4.0.1",
     "@react-router/node": "workspace:*",
-    "@vitejs/plugin-rsc": "0.4.11",
+    "@vitejs/plugin-rsc": "0.4.21",
     "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.6",
     "chokidar": "^4.0.0",

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -112,6 +112,8 @@ export async function routeRSCServerRequest({
     throw new Error("Missing body in server response");
   }
 
+  const detectRedirectResponse = serverResponse.clone();
+
   let serverResponseB: Response | null = null;
   if (hydrate) {
     serverResponseB = serverResponse.clone();
@@ -126,7 +128,12 @@ export async function routeRSCServerRequest({
   };
 
   try {
-    const payload = await getPayload();
+    if (!detectRedirectResponse.body) {
+      throw new Error("Failed to clone server response");
+    }
+    const payload = (await createFromReadableStream(
+      detectRedirectResponse.body,
+    )) as RSCPayload;
     if (
       serverResponse.status === SINGLE_FETCH_REDIRECT_STATUS &&
       payload.type === "redirect"

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.11",
+    "@vitejs/plugin-rsc": "0.4.21",
     "cross-env": "^7.0.3",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx-frontmatter": "^5.2.0",

--- a/playground/rsc-vite/package.json
+++ b/playground/rsc-vite/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.11",
+    "@vitejs/plugin-rsc": "0.4.21",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,8 +512,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.11
-        version: 0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.21
+        version: 0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       typescript:
         specifier: ^5.1.6
         version: 5.4.5
@@ -573,8 +573,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.11
-        version: 0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.21
+        version: 0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1127,8 +1127,8 @@ importers:
         specifier: workspace:*
         version: link:../react-router-node
       '@vitejs/plugin-rsc':
-        specifier: 0.4.11
-        version: 0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.21
+        version: 0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       arg:
         specifier: ^5.0.1
         version: 5.0.2
@@ -1911,8 +1911,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.11
-        version: 0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.21
+        version: 0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1972,8 +1972,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.11
-        version: 0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.21
+        version: 0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3817,9 +3817,6 @@ packages:
   '@mjackson/node-fetch-server@0.6.1':
     resolution: {integrity: sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==}
 
-  '@mjackson/node-fetch-server@0.7.0':
-    resolution: {integrity: sha512-un8diyEBKU3BTVj3GzlTPA1kIjCkGdD+AMYQy31Gf9JCkfoZzwgJ79GUtHrF2BN3XPNMLpubbzPcxys+a3uZEw==}
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -4412,6 +4409,9 @@ packages:
 
   '@remix-run/changelog-github@0.0.5':
     resolution: {integrity: sha512-43tqwUqWqirbv6D9uzo55ASPsCJ61Ein1k/M8qn+Qpros0MmbmuzjLVPmtaxfxfe2ANX0LefLvCD0pAgr1tp4g==}
+
+  '@remix-run/node-fetch-server@0.8.0':
+    resolution: {integrity: sha512-8/sKegb4HrM6IdcQeU0KPhj9VOHm5SUqswJDHuMCS3mwbr/NRx078QDbySmn0xslahvvZoOENd7EnK40kWKxkg==}
 
   '@remix-run/web-blob@3.1.0':
     resolution: {integrity: sha512-owGzFLbqPH9PlKb8KvpNJ0NO74HWE2euAn61eEiyCXX/oteoVzTVSN8mpLgDjaxBf2btj5/nUllSUgpyd6IH6g==}
@@ -5232,8 +5232,8 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
 
-  '@vitejs/plugin-rsc@0.4.11':
-    resolution: {integrity: sha512-+4H4wLi+Y9yF58znBfKgGfX8zcqUGt8ngnmNgzrdGdF1SVz7EO0sg7WnhK5fFVHt6fUxsVEjmEabsCWHKPL1Tw==}
+  '@vitejs/plugin-rsc@0.4.21':
+    resolution: {integrity: sha512-bczK6FFl5R0Drob0VpfeQt5avMfdAchp6EMVBswBUdvxerEeYOEamAWB0zeDEf+5zYZvVISbE8M/dERllx2V9A==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -11984,8 +11984,6 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.6.1': {}
 
-  '@mjackson/node-fetch-server@0.7.0': {}
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -12827,6 +12825,8 @@ snapshots:
       dotenv: 8.6.0
     transitivePeerDependencies:
       - encoding
+
+  '@remix-run/node-fetch-server@0.8.0': {}
 
   '@remix-run/web-blob@3.1.0':
     dependencies:
@@ -13782,9 +13782,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-rsc@0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
-      '@mjackson/node-fetch-server': 0.7.0
+      '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0
       estree-walker: 3.0.3
       magic-string: 0.30.17
@@ -13795,9 +13795,9 @@ snapshots:
       vite: 6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0)
       vitefu: 1.1.1(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
 
-  '@vitejs/plugin-rsc@0.4.11(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@0.4.21(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
-      '@mjackson/node-fetch-server': 0.7.0
+      '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0
       estree-walker: 3.0.3
       magic-string: 0.30.17


### PR DESCRIPTION
This doesn't get us to 100% support, but this solves a number of issues and ensures the tests are passing against the fixes:

- Updated `@vitejs/plugin-rsc` to fix an issue where it was removing link tags that were rendered by our `Links` component.
- Cloned `serverResponse` to detect redirects to fix an issue where CSS was missing on page load in dev when using floated link tags.
- Updated `vite-css-test.ts` so that we're running all passing test cases with comments explaining what's left to fix.