### PR TITLE
docs: fix Data mode link to point to installation guide for consistency

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -426,6 +426,7 @@
 - willsmithte
 - Willvillegas
 - wkovacs64
+- wo-o29
 - woodywoodsta
 - xavier-lc
 - xcsnowcity

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ React Router is a multi-strategy router for React bridging the gap from React 18
 There are three primary ways, or "modes", to use it in your app, so there are three guides to get you started.
 
 - [Declarative](./start/declarative/installation)
-- [Data](.start/data/installation)
+- [Data](./start/data/installation)
 - [Framework](./start/framework/installation)
 
 Learn which mode is right for you in [Picking a Mode](./start/modes).

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ React Router is a multi-strategy router for React bridging the gap from React 18
 There are three primary ways, or "modes", to use it in your app, so there are three guides to get you started.
 
 - [Declarative](./start/declarative/installation)
-- [Data](./start/data/custom)
+- [Data](.start/data/installation)
 - [Framework](./start/framework/installation)
 
 Learn which mode is right for you in [Picking a Mode](./start/modes).


### PR DESCRIPTION
### Summary

Updated the Data mode link in the Getting Started section from `./start/data/custom` to `./start/data/installation`.

### Changes

- Changed the Data guide link to point to the installation page, matching the pattern used for the Declarative and Framework modes.
- This ensures all Getting Started links consistently point to installation instructions, making the documentation more predictable for users.

Previously, the Data guide link directed to a custom guide, whereas other mode links pointed to installation guides. By aligning all links to installation pages, users can reliably find setup information regardless of mode.
