### PR TITLE
docs: correct import path by removing invalid '+' prefix

### DIFF
--- a/docs/start/modes.md
+++ b/docs/start/modes.md
@@ -74,7 +74,7 @@ export default [
 You'll then have access to the Route Module API with type-safe params, loaderData, code splitting, SPA/SSR/SSG strategies, and more.
 
 ```ts filename=product.tsx
-import { Route } from "+./types/product.tsx";
+import { Route } from "./types/product.tsx";
 
 export async function loader({ params }: Route.LoaderArgs) {
   let product = await getProduct(params.pid);


### PR DESCRIPTION
### Summary

In the example code, the import statement was incorrectly written as:
```ts
import { Route } from "+./types/product.tsx";
```

This has been corrected to:
```ts
import { Route } from "./types/product.tsx";
```


### Reasoning

- The '+' character is invalid in JavaScript/TypeScript import syntax and causes syntax errors during compilation.
- An invalid import path prevents module resolution, leading to build or runtime failures.
- Correcting the path ensures the example aligns with standard ES module import syntax.
- This change improves documentation accuracy, developer experience, and prevents confusion for users referencing the code samples.
