### PR TITLE
fix(react-router): Ensure custom cookie transformers are used exclusively

### DIFF
--- a/.changeset/famous-donkeys-poke.md
+++ b/.changeset/famous-donkeys-poke.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+fix(react-router): Ensure custom cookie transformers are used exclusively

--- a/packages/react-router/__tests__/server-runtime/cookies-test.ts
+++ b/packages/react-router/__tests__/server-runtime/cookies-test.ts
@@ -196,6 +196,76 @@ describe("cookies", () => {
       );
     });
   });
+
+  describe("encode", () => {
+    it("encodes the cookie using default encoding when no encode function is provided", async () => {
+      let rawCookieValue = "cookie";
+      let cookie = createCookie("my-cookie");
+      let setCookie = await cookie.serialize(rawCookieValue);
+      expect(setCookie).not.toContain("my-cookie=cookie");
+    });
+
+    it("encodes the cookie using the provided encode function at initialization", async () => {
+      let rawCookieValue = "cookie";
+      let encodeFn = (str: string) => {
+        // Check that the value is not encoded before calling encodeFn
+        expect(str).toBe(rawCookieValue);
+        return str;
+      };
+      let cookie = createCookie("my-cookie", { encode: encodeFn });
+      let setCookie = await cookie.serialize(rawCookieValue);
+      expect(setCookie).toContain("my-cookie=cookie");
+    });
+
+    it("encodes the cookie using the provided encode function when specified during serialization", async () => {
+      let rawCookieValue = "cookie";
+      let encodeFn = (str: string) => {
+        // Check that the value is not encoded before calling encodeFn
+        expect(str).toBe(rawCookieValue);
+        return str;
+      };
+      let cookie = createCookie("my-cookie");
+      let setCookie = await cookie.serialize(rawCookieValue, {
+        encode: encodeFn,
+      });
+      expect(setCookie).toContain("my-cookie=cookie");
+    });
+  });
+
+  describe("decode", () => {
+    it("decodes cookie using default decode function", async () => {
+      let rawCookieValue = "cookie";
+      let cookie = createCookie("my-cookie");
+      let setCookie = await cookie.serialize(rawCookieValue);
+      let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+      expect(value).toBe(rawCookieValue);
+    });
+
+    it("decodes cookie using provided encode and decode functions during initialization", async () => {
+      let rawCookieValue = "cookie";
+      let encodeFn = (str: string) => str;
+      let decodeFn = (str: string) => str;
+      let cookie = createCookie("my-cookie", {
+        encode: encodeFn,
+        decode: decodeFn,
+      });
+      let setCookie = await cookie.serialize(rawCookieValue);
+      let value = await cookie.parse(getCookieFromSetCookie(setCookie));
+      expect(value).toBe(rawCookieValue);
+    });
+
+    it("decodes cookie using provided decode function during parsing", async () => {
+      let rawCookieValue = "cookie";
+      let encodeFn = (str: string) => str;
+      let decodeFn = (str: string) => str;
+      let cookie = createCookie("my-cookie", { encode: encodeFn });
+      let setCookie = await cookie.serialize(rawCookieValue);
+      let value = await cookie.parse(getCookieFromSetCookie(setCookie), {
+        decode: decodeFn,
+      });
+      expect(value).toBe(rawCookieValue);
+    });
+  });
 });
 
 function spyConsole() {


### PR DESCRIPTION
fixes: #13751

This commit fixes a bug where `createCookie` was applying its default transformations even when custom `encode` and `decode` functions were provided. 
This led to an unintended double-encoding of cookie values.

The fix ensures that if custom `encode` and `decode` functions exist in the cookie options, the default transformations are completely bypassed.
This aligns the `createCookie` API with its intended behavior: allowing developers to take full control of the serialization and deserialization process.