### PR TITLE
Update `@vitejs/plugin-rsc` to fix HMR issues

### DIFF
--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -21,7 +21,7 @@
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.24",
+    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0",

--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -21,7 +21,7 @@
     "@vanilla-extract/css": "^1.17.4",
     "@vanilla-extract/vite-plugin": "^5.1.1",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
+    "@vitejs/plugin-rsc": "0.4.25",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0",

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@vitejs/plugin-rsc": "0.4.24",
+    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
+    "@vitejs/plugin-rsc": "0.4.25",
     "@types/express": "^5.0.0",
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -551,15 +551,6 @@ async function hmrWorkflow({
         file: "styles-bundled.css",
         selector: "#css-bundled",
       },
-      // TODO: Fix HMR for CSS Modules in server-first routes in RSC Framework mode
-      ...(routeBase === "rsc-server-first-route"
-        ? []
-        : ([
-            {
-              file: "styles.module.css",
-              selector: "#css-modules",
-            },
-          ] as const)),
       {
         file: "styles-postcss-linked.css",
         selector: "#css-postcss-linked",
@@ -568,13 +559,15 @@ async function hmrWorkflow({
         file: "styles-vanilla-global.css.ts",
         selector: "#css-vanilla-global",
       },
-      // TODO: Fix HMR for locally scoped Vanilla Extract styles in RSC
-      // Framework mode. May require changes to the RSC plugin, or Vanilla
-      // Extract. Userland workaround for now:
-      // https://github.com/pawelblaszczyk5/vite-rsc-experiments/blob/643649f2e6562c859d9612126bfc3a183e03c7b5/apps/vanilla-extract/vite.config.ts
-      ...(templateName.includes("rsc")
+      // TODO: Fix HMR for CSS Modules and locally scoped Vanilla Extract in
+      // server-first routes in RSC Framework mode
+      ...(routeBase === "rsc-server-first-route"
         ? []
         : ([
+            {
+              file: "styles.module.css",
+              selector: "#css-modules",
+            },
             {
               file: "styles-vanilla-local.css.ts",
               selector: "#css-vanilla-local",
@@ -593,14 +586,6 @@ async function hmrWorkflow({
         page.locator(selector),
         `CSS update for ${routeFile}`,
       ).toHaveCSS("padding", NEW_PADDING);
-
-      // TODO: Fix state preservation for Vanilla Extract HMR
-      if (
-        templateName.includes("rsc") &&
-        file === "styles-vanilla-global.css.ts"
-      ) {
-        continue;
-      }
 
       // Ensure CSS updates were handled by HMR
       await expect(input, `State preservation for ${routeFile}`).toHaveValue(

--- a/integration/vite-css-test.ts
+++ b/integration/vite-css-test.ts
@@ -594,14 +594,10 @@ async function hmrWorkflow({
         `CSS update for ${routeFile}`,
       ).toHaveCSS("padding", NEW_PADDING);
 
-      // TODO: Fix state preservation when changing these styles in RSC
-      // Framework mode. This appears to be a deeper HMR issue with
-      // changing non-React modules imported by the route.
+      // TODO: Fix state preservation for Vanilla Extract HMR
       if (
         templateName.includes("rsc") &&
-        (file === "styles.module.css" ||
-          file === "styles-postcss-linked.css" ||
-          file === "styles-vanilla-global.css.ts")
+        file === "styles-vanilla-global.css.ts"
       ) {
         continue;
       }

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -352,6 +352,9 @@ async function workflow({
   await expect(hdrStatus).toHaveText(
     "HDR updated: route & direct 2 & indirect 2",
   );
-  await expect(input).toHaveValue("stateful");
+  // TODO: Investigate why this is flaky in CI for RSC Framework Mode
+  if (!templateName.includes("rsc")) {
+    await expect(input).toHaveValue("stateful");
+  }
   expect(page.errors).toEqual([]);
 }

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -352,9 +352,6 @@ async function workflow({
   await expect(hdrStatus).toHaveText(
     "HDR updated: route & direct 2 & indirect 2",
   );
-  // TODO: Investigate why this is flaky in CI for RSC Framework Mode
-  if (!templateName.includes("rsc")) {
-    await expect(input).toHaveValue("stateful");
-  }
+  await expect(input).toHaveValue("stateful");
   expect(page.errors).toEqual([]);
 }

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -78,7 +78,7 @@
     "@babel/types": "^7.27.7",
     "@npmcli/package-json": "^4.0.1",
     "@react-router/node": "workspace:*",
-    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
+    "@vitejs/plugin-rsc": "0.4.25",
     "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.6",
     "chokidar": "^4.0.0",

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -78,7 +78,7 @@
     "@babel/types": "^7.27.7",
     "@npmcli/package-json": "^4.0.1",
     "@react-router/node": "workspace:*",
-    "@vitejs/plugin-rsc": "0.4.24",
+    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
     "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.6",
     "chokidar": "^4.0.0",

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.24",
+    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
     "cross-env": "^7.0.3",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx-frontmatter": "^5.2.0",

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
+    "@vitejs/plugin-rsc": "0.4.25",
     "cross-env": "^7.0.3",
     "remark-frontmatter": "^5.0.0",
     "remark-mdx-frontmatter": "^5.2.0",

--- a/playground/rsc-vite/package.json
+++ b/playground/rsc-vite/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "0.4.24",
+    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0"

--- a/playground/rsc-vite/package.json
+++ b/playground/rsc-vite/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
-    "@vitejs/plugin-rsc": "https://pkg.pr.new/@vitejs/plugin-rsc@788",
+    "@vitejs/plugin-rsc": "0.4.25",
     "cross-env": "^7.0.3",
     "typescript": "^5.1.6",
     "vite": "^6.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.24
-        version: 0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
+        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       typescript:
         specifier: ^5.1.6
         version: 5.4.5
@@ -512,8 +512,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.24
-        version: 0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
+        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1066,8 +1066,8 @@ importers:
         specifier: workspace:*
         version: link:../react-router-node
       '@vitejs/plugin-rsc':
-        specifier: 0.4.24
-        version: 0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
+        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       arg:
         specifier: ^5.0.1
         version: 5.0.2
@@ -1795,8 +1795,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.24
-        version: 0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
+        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1856,8 +1856,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: 0.4.24
-        version: 0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
+        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5114,8 +5114,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
 
-  '@vitejs/plugin-rsc@0.4.24':
-    resolution: {integrity: sha512-luTrqS5qGup7r1IrzMkFPWxD2778j+jNOjfJ8ZPuk/m9HiDHkSs5oZbRizbdnc9d0HPMLRRmPWXyuAWHudeX4g==}
+  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788':
+    resolution: {tarball: https://pkg.pr.new/@vitejs/plugin-rsc@788}
+    version: 0.4.24
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -13641,7 +13642,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-rsc@0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0
@@ -13654,7 +13655,7 @@ snapshots:
       vite: 6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0)
       vitefu: 1.1.1(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
 
-  '@vitejs/plugin-rsc@0.4.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,8 +451,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
-        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.25
+        version: 0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       typescript:
         specifier: ^5.1.6
         version: 5.4.5
@@ -512,8 +512,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
-        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.25
+        version: 0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1066,8 +1066,8 @@ importers:
         specifier: workspace:*
         version: link:../react-router-node
       '@vitejs/plugin-rsc':
-        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
-        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.25
+        version: 0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       arg:
         specifier: ^5.0.1
         version: 5.0.2
@@ -1795,8 +1795,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
-        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.25
+        version: 0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1856,8 +1856,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
-        specifier: https://pkg.pr.new/@vitejs/plugin-rsc@788
-        version: https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
+        specifier: 0.4.25
+        version: 0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -5114,9 +5114,8 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
 
-  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788':
-    resolution: {tarball: https://pkg.pr.new/@vitejs/plugin-rsc@788}
-    version: 0.4.24
+  '@vitejs/plugin-rsc@0.4.25':
+    resolution: {integrity: sha512-ypXQ4aII1nvigRJOi3/fCVIoII5cbpNoCJvOzgJAoYGsvzsp/GyOcnY1PGUT90J2u5hiKne+PZEqOWUy3B2LQg==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -13642,7 +13641,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0
@@ -13655,7 +13654,7 @@ snapshots:
       vite: 6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0)
       vitefu: 1.1.1(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
 
-  '@vitejs/plugin-rsc@https://pkg.pr.new/@vitejs/plugin-rsc@788(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@0.4.25(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@remix-run/node-fetch-server': 0.8.0
       es-module-lexer: 1.7.0


### PR DESCRIPTION
This PR updates `@vitejs/plugin-rsc` to v0.4.25 to address HMR issues fixed in this PR: https://github.com/vitejs/vite-plugin-react/pull/788. This allows us to re-enable some of our CSS HMR tests in RSC Framework Mode.