### PR TITLE
fix(rsc): add `import.meta.hot.accept` to rsc entry

### DIFF
--- a/.changeset/stale-rice-learn.md
+++ b/.changeset/stale-rice-learn.md
@@ -1,5 +1,0 @@
----
-"@react-router/dev": patch
----
-
-Add `import.meta.hot.accept` to rsc entry to reduce the number of re-evaluated modules after server code change.

--- a/.changeset/stale-rice-learn.md
+++ b/.changeset/stale-rice-learn.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Add `import.meta.hot.accept` to rsc entry to reduce the number of re-evaluated modules after server code change.

--- a/packages/react-router-dev/config/default-rsc-entries/entry.rsc.tsx
+++ b/packages/react-router-dev/config/default-rsc-entries/entry.rsc.tsx
@@ -34,3 +34,7 @@ export default async function handler(request: Request) {
   >("ssr", "index");
   return ssr.default(request, fetchServer);
 }
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/playground/rsc-vite/src/entry.rsc.tsx
+++ b/playground/rsc-vite/src/entry.rsc.tsx
@@ -35,3 +35,7 @@ export default async function handler(request: Request) {
   >("ssr", "index");
   return ssr.default(request, fetchServer);
 }
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}


### PR DESCRIPTION
This PR adds same suggestion from https://github.com/remix-run/react-router-templates/pull/143. This should only affects how server module change causes re-evaluation of modules in rsc environment. Previously, any change would clear rsc environment module graph entirely (except externalized module which is in node's own module cache). With `import.meta.hot.accept`, this can be minimized to be only the modules from "entry" to "changed module" via import chain.