### PR TITLE
fix(dev): add `react` & `react-dom` to `peerDependencies`

### DIFF
--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -123,6 +123,8 @@
   },
   "peerDependencies": {
     "@react-router/serve": "workspace:^",
+    "react": "*",
+    "react-dom": "*",
     "react-router": "workspace:^",
     "typescript": "^5.1.0",
     "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1104,6 +1104,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react:
+        specifier: '*'
+        version: 19.1.0
+      react-dom:
+        specifier: '*'
+        version: 19.1.0(react@19.1.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.2


### PR DESCRIPTION
`Yarn@4` is reporting that `@react-router/dev` isn't properly fulfilling the `peerDependencies` declared by `@vitejs/plugin-rsc`:

```
pe2594 → ✘ @react-router/dev@npm:7.8.2 [87a77] doesn't provide react to @vitejs/plugin-rsc@npm:0.4.11 [63686]
pdd559 → ✘ @react-router/dev@npm:7.8.2 [87a77] doesn't provide react-dom to @vitejs/plugin-rsc@npm:0.4.11 [63686]
```

Looking at the `package.json` for `@vitejs/plugin-rsc`, that seems accurate:

https://github.com/vitejs/vite-plugin-react/blob/508bed6625d899fd5123b5495fe81166f2e9fa2f/packages/plugin-rsc/package.json#L66-L67

Since `@react-router/dev` doesn't need `react` or `react-dom` itself direct as `dependencies` or `devDependencies`, I believe the correct setup is to add them to `peerDependencies` so that dependency chain can be delegated up to the consuming React Router application.