### PR TITLE
Add `@vitejs/plugin-rsc` as optional peer dependency

### DIFF
--- a/integration/helpers/rsc-vite-framework/vite.config.ts
+++ b/integration/helpers/rsc-vite-framework/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vite";
+import rsc from "@vitejs/plugin-rsc";
 import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
 
 const { unstable_reactRouterRSC: reactRouterRSC } =
   __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;
 
 export default defineConfig({
-  plugins: [reactRouterRSC()],
+  plugins: [reactRouterRSC(), rsc()],
 });

--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -132,12 +132,14 @@ export const viteConfig = {
     `;
   },
   basic: async (args: ViteConfigArgs) => {
+    const isRsc = args.templateName?.includes("rsc");
     return dedent`
       ${
-        !args.templateName?.includes("rsc")
+        !isRsc
           ? "import { reactRouter } from '@react-router/dev/vite';"
           : [
               "import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from '@react-router/dev/internal';",
+              "import rsc from '@vitejs/plugin-rsc';",
               "const { unstable_reactRouterRSC: reactRouter } = __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;",
             ].join("\n")
       }
@@ -155,6 +157,7 @@ export const viteConfig = {
           ${args.mdx ? "mdx()," : ""}
           ${args.vanillaExtract ? "vanillaExtractPlugin({ emitCssInSsr: true })," : ""}
           reactRouter(),
+          ${isRsc ? "rsc()," : ""}
           envOnlyMacros(),
           tsconfigPaths()
         ],

--- a/integration/vite-plugin-order-validation-test.ts
+++ b/integration/vite-plugin-order-validation-test.ts
@@ -4,34 +4,34 @@ import dedent from "dedent";
 import { createProject, build, reactRouterConfig } from "./helpers/vite.js";
 
 test.describe("Vite plugin order validation", () => {
-  test.describe("MDX", () => {
-    test("Framework Mode", async () => {
-      let cwd = await createProject({
-        "vite.config.ts": dedent`
-          import { reactRouter } from "@react-router/dev/vite";
-          import mdx from "@mdx-js/rollup";
+  test("Framework Mode with MDX plugin after React Router plugin", async () => {
+    let cwd = await createProject({
+      "vite.config.ts": dedent`
+        import { reactRouter } from "@react-router/dev/vite";
+        import mdx from "@mdx-js/rollup";
 
-          export default {
-            plugins: [
-              reactRouter(),
-              mdx(),
-            ],
-          }
-        `,
-      });
-
-      let buildResult = build({ cwd });
-      expect(buildResult.stderr.toString()).toContain(
-        'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config file',
-      );
+        export default {
+          plugins: [
+            reactRouter(),
+            mdx(),
+          ],
+        }
+      `,
     });
 
-    test("RSC Framework Mode", async () => {
-      let cwd = await createProject(
-        {
-          "vite.config.js": dedent`
+    let buildResult = build({ cwd });
+    expect(buildResult.stderr.toString()).toContain(
+      'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config',
+    );
+  });
+
+  test("RSC Framework Mode with MDX plugin after React Router plugin", async () => {
+    let cwd = await createProject(
+      {
+        "vite.config.js": dedent`
           import { defineConfig } from "vite";
           import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
+          import rsc from "@vitejs/plugin-rsc";
           import mdx from "@mdx-js/rollup";
 
           const { unstable_reactRouterRSC: reactRouterRSC } =
@@ -40,21 +40,53 @@ test.describe("Vite plugin order validation", () => {
           export default defineConfig({
             plugins: [
               reactRouterRSC(),
+              rsc(),
               mdx(),
             ],
           });
         `,
-          "react-router.config.ts": reactRouterConfig({
-            viteEnvironmentApi: true,
-          }),
-        },
-        "rsc-vite-framework",
-      );
+        "react-router.config.ts": reactRouterConfig({
+          viteEnvironmentApi: true,
+        }),
+      },
+      "rsc-vite-framework",
+    );
 
-      let buildResult = build({ cwd });
-      expect(buildResult.stderr.toString()).toContain(
-        'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config file',
-      );
-    });
+    let buildResult = build({ cwd });
+    expect(buildResult.stderr.toString()).toContain(
+      'Error: The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config',
+    );
+  });
+
+  test("RSC Framework Mode with @vitejs/plugin-rsc before React Router plugin", async () => {
+    let cwd = await createProject(
+      {
+        "vite.config.js": dedent`
+          import { defineConfig } from "vite";
+          import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
+          import rsc from "@vitejs/plugin-rsc";
+          import mdx from "@mdx-js/rollup";
+
+          const { unstable_reactRouterRSC: reactRouterRSC } =
+            __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;
+
+          export default defineConfig({
+            plugins: [
+              rsc(),
+              reactRouterRSC(),
+            ],
+          });
+        `,
+        "react-router.config.ts": reactRouterConfig({
+          viteEnvironmentApi: true,
+        }),
+      },
+      "rsc-vite-framework",
+    );
+
+    let buildResult = build({ cwd });
+    expect(buildResult.stderr.toString()).toContain(
+      'Error: The "@vitejs/plugin-rsc" plugin should be placed after the React Router RSC plugin in your Vite config',
+    );
   });
 });

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -78,7 +78,6 @@
     "@babel/types": "^7.27.7",
     "@npmcli/package-json": "^4.0.1",
     "@react-router/node": "workspace:*",
-    "@vitejs/plugin-rsc": "0.4.26",
     "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.6",
     "chokidar": "^4.0.0",
@@ -110,6 +109,7 @@
     "@types/npmcli__package-json": "^4.0.0",
     "@types/set-cookie-parser": "^2.4.1",
     "@types/semver": "^7.7.0",
+    "@vitejs/plugin-rsc": "0.4.26",
     "esbuild-register": "^3.6.0",
     "execa": "5.1.1",
     "express": "^4.19.2",
@@ -123,12 +123,16 @@
   },
   "peerDependencies": {
     "@react-router/serve": "workspace:^",
+    "@vitejs/plugin-rsc": "*",
     "react-router": "workspace:^",
     "typescript": "^5.1.0",
     "vite": "^5.1.0 || ^6.0.0 || ^7.0.0",
     "wrangler": "^3.28.2 || ^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@vitejs/plugin-rsc": {
+      "optional": true
+    },
     "@react-router/serve": {
       "optional": true
     },

--- a/packages/react-router-dev/vite/plugins/validate-plugin-order.ts
+++ b/packages/react-router-dev/vite/plugins/validate-plugin-order.ts
@@ -11,19 +11,27 @@ export default function validatePluginOrder(): Vite.Plugin {
         );
       };
 
-      let rollupPrePlugins = [
-        { pluginName: "@mdx-js/rollup", displayName: "@mdx-js/rollup" },
-      ];
-      for (let prePlugin of rollupPrePlugins) {
-        let prePluginIndex = pluginIndex(prePlugin.pluginName);
-        if (
-          prePluginIndex >= 0 &&
-          prePluginIndex > pluginIndex(["react-router", "react-router/rsc"])
-        ) {
-          throw new Error(
-            `The "${prePlugin.displayName}" plugin should be placed before the React Router plugin in your Vite config file`,
-          );
-        }
+      let reactRouterRscPluginIndex = pluginIndex("react-router/rsc");
+      let viteRscPluginIndex = pluginIndex("rsc");
+      if (
+        reactRouterRscPluginIndex >= 0 &&
+        viteRscPluginIndex >= 0 &&
+        reactRouterRscPluginIndex > viteRscPluginIndex
+      ) {
+        throw new Error(
+          `The "@vitejs/plugin-rsc" plugin should be placed after the React Router RSC plugin in your Vite config`,
+        );
+      }
+
+      let reactRouterPluginIndex = pluginIndex([
+        "react-router",
+        "react-router/rsc",
+      ]);
+      let mdxPluginIndex = pluginIndex("@mdx-js/rollup");
+      if (mdxPluginIndex >= 0 && mdxPluginIndex > reactRouterPluginIndex) {
+        throw new Error(
+          `The "@mdx-js/rollup" plugin should be placed before the React Router plugin in your Vite config`,
+        );
       }
     },
   };

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -1,5 +1,4 @@
 import type * as Vite from "vite";
-import rsc, { type RscPluginOptions } from "@vitejs/plugin-rsc";
 import { init as initEsModuleLexer } from "es-module-lexer";
 import * as babel from "@babel/core";
 
@@ -58,6 +57,8 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           );
         }
 
+        const rscEntries = getRscEntries();
+
         return {
           resolve: {
             dedupe: [
@@ -93,16 +94,19 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           environments: {
             client: {
               build: {
+                rollupOptions: { input: { index: rscEntries.client } },
                 outDir: join(config.buildDirectory, "client"),
               },
             },
             rsc: {
               build: {
+                rollupOptions: { input: { index: rscEntries.rsc } },
                 outDir: join(config.buildDirectory, "server"),
               },
             },
             ssr: {
               build: {
+                rollupOptions: { input: { index: rscEntries.ssr } },
                 outDir: join(config.buildDirectory, "server/__ssr_build"),
               },
             },
@@ -359,7 +363,6 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
       },
     },
     validatePluginOrder(),
-    rsc({ entries: getRscEntries() }),
   ];
 }
 
@@ -374,7 +377,11 @@ function getRootDirectory(viteUserConfig: Vite.UserConfig) {
   return viteUserConfig.root ?? process.env.REACT_ROUTER_ROOT ?? process.cwd();
 }
 
-function getRscEntries(): NonNullable<RscPluginOptions["entries"]> {
+function getRscEntries(): {
+  client: string;
+  rsc: string;
+  ssr: string;
+} {
   const entriesDir = join(
     getDevPackageRoot(),
     "dist",

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -17,7 +17,6 @@
     "@types/node": "^22.13.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.5.2",
     "@vitejs/plugin-rsc": "0.4.26",
     "cross-env": "^7.0.3",
     "remark-frontmatter": "^5.0.0",

--- a/playground/rsc-vite-framework/vite.config.ts
+++ b/playground/rsc-vite-framework/vite.config.ts
@@ -1,17 +1,17 @@
 import { defineConfig } from "vite";
 import { __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__ } from "@react-router/dev/internal";
+import rsc from "@vitejs/plugin-rsc";
 import mdx from "@mdx-js/rollup";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 
-const { unstable_reactRouterRSC: reactRouterRSC } =
+const { unstable_reactRouterRSC: reactRouterRsc } =
   __INTERNAL_DO_NOT_USE_OR_YOU_WILL_GET_A_STRONGLY_WORDED_LETTER__;
 
 export default defineConfig({
   plugins: [
-    mdx({
-      remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter],
-    }),
-    reactRouterRSC(),
+    mdx({ remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter] }),
+    reactRouterRsc(),
+    rsc(),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1101,12 +1101,6 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
-      react:
-        specifier: '>=18'
-        version: 19.1.0
-      react-dom:
-        specifier: '>=18'
-        version: 19.1.0(react@19.1.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,9 +1065,6 @@ importers:
       '@react-router/node':
         specifier: workspace:*
         version: link:../react-router-node
-      '@vitejs/plugin-rsc':
-        specifier: 0.4.26
-        version: 0.4.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       arg:
         specifier: ^5.0.1
         version: 5.0.2
@@ -1104,6 +1101,12 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react:
+        specifier: '>=18'
+        version: 19.1.0
+      react-dom:
+        specifier: '>=18'
+        version: 19.1.0(react@19.1.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.2
@@ -1159,6 +1162,9 @@ importers:
       '@types/set-cookie-parser':
         specifier: ^2.4.1
         version: 2.4.7
+      '@vitejs/plugin-rsc':
+        specifier: 0.4.26
+        version: 0.4.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       esbuild-register:
         specifier: ^3.6.0
         version: 3.6.0(esbuild@0.25.4)
@@ -1852,9 +1858,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.7
         version: 18.2.7
-      '@vitejs/plugin-react':
-        specifier: ^4.5.2
-        version: 4.5.2(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       '@vitejs/plugin-rsc':
         specifier: 0.4.26
         version: 0.4.26(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))


### PR DESCRIPTION
This changes our strategy from wrapping `@vitejs/plugin-rsc` to expecting it to be a peer dependency when using RSC Framework Mode.