### PR TITLE
Improve `optimizeDeps` in RSC Framework Mode

### DIFF
--- a/packages/react-router-dev/vite/has-dependency.ts
+++ b/packages/react-router-dev/vite/has-dependency.ts
@@ -1,0 +1,13 @@
+export function hasDependency({
+  name,
+  rootDirectory,
+}: {
+  name: string;
+  rootDirectory: string;
+}) {
+  try {
+    return Boolean(require.resolve(name, { paths: [rootDirectory] }));
+  } catch (err) {
+    return false;
+  }
+}

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -58,6 +58,7 @@ import { resolveFileUrl } from "./resolve-file-url";
 import { combineURLs } from "./combine-urls";
 import { removeExports } from "./remove-exports";
 import { ssrExternals } from "./ssr-externals";
+import { hasDependency } from "./has-dependency";
 import {
   type RouteChunkName,
   type RouteChunkExportName,
@@ -819,14 +820,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     return JSON.parse(manifestContents) as Vite.Manifest;
   };
 
-  let hasDependency = (name: string) => {
-    try {
-      return Boolean(require.resolve(name, { paths: [ctx.rootDirectory] }));
-    } catch (err) {
-      return false;
-    }
-  };
-
   let getViteManifestAssetPaths = (
     viteManifest: Vite.Manifest,
   ): Set<string> => {
@@ -1293,7 +1286,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
               "react-router",
               "react-router/dom",
               // Check to avoid "Failed to resolve dependency: react-router-dom, present in 'optimizeDeps.include'"
-              ...(hasDependency("react-router-dom")
+              ...(hasDependency({
+                name: "react-router-dom",
+                rootDirectory: ctx.rootDirectory,
+              })
                 ? ["react-router-dom"]
                 : []),
             ],

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -13,6 +13,7 @@ import {
   type ResolvedReactRouterConfig,
   createConfigLoader,
 } from "../../config/config";
+import { hasDependency } from "../has-dependency";
 import { createVirtualRouteConfig } from "./virtual-route-config";
 import {
   transformVirtualRouteModules,
@@ -68,7 +69,9 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
               // You must render this element inside a <Remix> element`.
               "react-router",
               "react-router/dom",
-              "react-router-dom",
+              ...(hasDependency({ name: "react-router-dom", rootDirectory })
+                ? ["react-router-dom"]
+                : []),
             ],
           },
           optimizeDeps: {
@@ -84,6 +87,7 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
               "react/jsx-dev-runtime",
               "react-dom",
               "react-dom/client",
+              "react-router/internal/react-server-client",
             ],
           },
           esbuild: {


### PR DESCRIPTION
This makes the following improvements:
- Adds `react-router/internal/react-server-client` to the list of optimised deps. This ensures you don't get a flash when Vite first encounters this import.
- Checks whether `react-router-dom` is an app dependency before adding it to the `resolve.dedupe` list to avoid warnings that this package is missing.

The code has also been refactored to share the `hasDependency` util between both Vite plugins.