### PR TITLE
fix(react-router v6): handle parameters with static suffixes in generatePath

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -133,6 +133,7 @@
 - jmargeta
 - johnpangalos
 - jonkoops
+- joseph0926
 - jrakotoharisoa
 - juanpprieto
 - jungwoo3490

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -185,4 +185,25 @@ describe("generatePath", () => {
 
     consoleWarn.mockRestore();
   });
+
+  describe("with params followed by static text", () => {
+    it("interpolates params with file extensions", () => {
+      expect(generatePath("/books/:id.json", { id: "42" })).toBe(
+        "/books/42.json"
+      );
+      expect(generatePath("/api/:resource.xml", { resource: "users" })).toBe(
+        "/api/users.xml"
+      );
+      expect(generatePath("/:lang.html", { lang: "en" })).toBe("/en.html");
+    });
+
+    it("handles multiple extensions", () => {
+      expect(generatePath("/files/:name.tar.gz", { name: "archive" })).toBe(
+        "/files/archive.tar.gz"
+      );
+      expect(generatePath("/:file.min.js", { file: "app" })).toBe(
+        "/app.min.js"
+      );
+    });
+  });
 });

--- a/packages/router/utils.ts
+++ b/packages/router/utils.ts
@@ -903,12 +903,12 @@ export function generatePath<Path extends string>(
         return stringify(params[star]);
       }
 
-      const keyMatch = segment.match(/^:([\w-]+)(\??)$/);
+      const keyMatch = segment.match(/^:([\w-]+)(\??)(.*)/);
       if (keyMatch) {
-        const [, key, optional] = keyMatch;
+        const [, key, optional, suffix] = keyMatch;
         let param = params[key as PathParam<Path>];
         invariant(optional === "?" || param != null, `Missing ":${key}" param`);
-        return stringify(param);
+        return stringify(param) + suffix;
       }
 
       // Remove any optional markers from optional static segments


### PR DESCRIPTION
## This PR fixes the same issue as the [original PR](https://github.com/remix-run/react-router/pull/14269), but targets a fix for v6. 

Fixes #14040

## Problem

The current regex `/^:([\w-]+)(\??)$/` in `generatePath` requires an exact match of the entire segment to be a parameter. The `$` anchor means the segment must end immediately after the parameter name, causing patterns like `:id.json` to fail.

In v6.8.2 this worked correctly, but broke in v6.9.0

## Solution

Modified the regex to `/^:([\w-]+)(\??)(.*)/` which
- Removes the `$` anchor
- Captures any remaining text after the parameter as a suffix
- Appends the suffix to the interpolated result

## Changes

```diff
- const keyMatch = segment.match(/^:([\w-]+)(\??)$/);
+ const keyMatch = segment.match(/^:([\w-]+)(\??)(.*)/);
  if (keyMatch) {
-   const [, key, optional] = keyMatch;
+   const [, key, optional, suffix] = keyMatch;
    let param = params[key as PathParam<Path>];
    invariant(optional === "?" || param != null, `Missing ":${key}" param`);
-   return encodeURIComponent(stringify(param));
+   return encodeURIComponent(stringify(param)) + suffix;
  }
```

## Tests

Added comprehensive tests for parameters with static text

```typescript
describe("with params followed by static text", () => {
  it("interpolates params with file extensions", () => {
    expect(generatePath("/books/:id.json", { id: "42" })).toBe(
      "/books/42.json",
    );
    expect(generatePath("/api/:resource.xml", { resource: "users" })).toBe(
      "/api/users.xml",
    );
    expect(generatePath("/:lang.html", { lang: "en" })).toBe("/en.html");
  });

  it("handles multiple extensions", () => {
    expect(generatePath("/files/:name.tar.gz", { name: "archive" })).toBe(
      "/files/archive.tar.gz",
    );
    expect(generatePath("/:file.min.js", { file: "app" })).toBe(
      "/app.min.js",
    );
  });
});
```

All existing tests continue to pass, confirming no breaking changes.