### PR TITLE
chore: add generic state type to useLocation hook

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -140,7 +140,7 @@ export function useInRouterContext(): boolean {
  * @category Hooks
  * @returns The current {@link Location} object
  */
-export function useLocation(): Location {
+export function useLocation<StateType = unknown>(): Location<Partial<StateType>> {
   invariant(
     useInRouterContext(),
     // TODO: This error is probably because they somehow have 2 versions of the


### PR DESCRIPTION
### Context:

- The `useLocation` hook return type is `Location`  _(`Location<Type = any>`)_
- This hook is not expecting a generic type to deliver it for the `state` type to the `Location`
- The `state` in the `useLocation` hook return value becomes `any` => **REF1**

### Changes:
- Add Optional _(fallback to `unknown`)_ Generic `StateType` type to `useLocation` hook.
- Deliver it to the `Location` type generic as `Partial<StateType>` as `Location<Partial<StateType>>`.

### Why Partial:
- For extra type safety. 
  - In case of the `useLocation` hook is generically typed as `TypeThisAndThat`, 
  - but as an example, the `state` is not given by the `navigate('path/to/go', { state: null })`
  - The `useLocation` hook returned `state` data will not take this responsibility, and the consumer should do a type-check on their `state` data, since all data(object or primitive) will be potentially `undefined`.

---

##### REF1

```ts
/**
 * packages/react-router/lib/router/history.ts
 * /

// TODO: (v7) Change the Location generic default from `any` to `unknown` and
// remove Remix `useLocation` wrapper.

/**
 * An entry in a history stack. A location contains information about the
 * URL path, as well as possibly some arbitrary state and a key.
 */
export interface Location<State = any> extends Path { ... }
```