### PR TITLE
docs(useNavigate): fix broken markdown link to history api

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -82,6 +82,7 @@
 - clonemycode
 - Cmoen11
 - codeape2
+- coolport
 - coryhouse
 - ctnelson1997
 - cvbuelow

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -101,7 +101,7 @@ navigate(1);
 
 Be cautious with `navigate(number)`. If your application can load up to a
 route that has a button that tries to navigate forward/back, there may not be
-a `[`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
+a [`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
 entry to go back or forward to, or it can go somewhere you don't expect
 (like a different domain).
 


### PR DESCRIPTION
Description:
This PR fixes broken markdown link formatting in the useNavigate docs.