### PR TITLE
Mark `reveal` as unsupported in RSC Framework Mode

### DIFF
--- a/packages/react-router-dev/cli/commands.ts
+++ b/packages/react-router-dev/cli/commands.ts
@@ -16,6 +16,7 @@ import { transpile as convertFileToJS } from "./useJavascript";
 import * as profiler from "../vite/profiler";
 import * as Typegen from "../typegen";
 import { preloadVite, getVite } from "../vite/vite";
+import { hasReactRouterRscPlugin } from "../vite/has-rsc-plugin";
 
 export async function routes(
   rootDirectory?: string,
@@ -89,6 +90,25 @@ export async function generateEntry(
     mode?: string;
   } = {},
 ) {
+  rootDirectory = resolveRootDirectory(rootDirectory, flags);
+
+  if (
+    await hasReactRouterRscPlugin({
+      root: rootDirectory,
+      viteBuildOptions: {
+        config: flags.config,
+        mode: flags.mode,
+      },
+    })
+  ) {
+    console.error(
+      colors.red(
+        `The reveal command is currently not supported in RSC Framework Mode.`,
+      ),
+    );
+    process.exit(1);
+  }
+
   // if no entry passed, attempt to create both
   if (!entry) {
     await generateEntry("entry.client", rootDirectory, flags);
@@ -96,7 +116,6 @@ export async function generateEntry(
     return;
   }
 
-  rootDirectory = resolveRootDirectory(rootDirectory, flags);
   let configResult = await loadConfig({
     rootDirectory,
     mode: flags.mode ?? "production",

--- a/packages/react-router-dev/vite/build.ts
+++ b/packages/react-router-dev/vite/build.ts
@@ -15,6 +15,7 @@ import {
 } from "./plugin";
 import invariant from "../invariant";
 import { preloadVite, getVite } from "./vite";
+import { hasReactRouterRscPlugin } from "./has-rsc-plugin";
 export interface ViteBuildOptions {
   assetsInlineLimit?: number;
   clearScreen?: boolean;
@@ -233,28 +234,4 @@ async function viteBuild(
     reactRouterConfig,
     viteConfig,
   });
-}
-
-async function hasReactRouterRscPlugin({
-  root,
-  viteBuildOptions: { config, logLevel, mode },
-}: {
-  root: string;
-  viteBuildOptions: ViteBuildOptions;
-}): Promise<boolean> {
-  const vite = await import("vite");
-  const viteConfig = await vite.resolveConfig(
-    {
-      configFile: config,
-      logLevel,
-      mode: mode ?? "production",
-      root,
-    },
-    "build", // command
-    "production", // default mode
-    "production", // default NODE_ENV
-  );
-  return viteConfig.plugins.some(
-    (plugin) => plugin?.name === "react-router/rsc",
-  );
 }

--- a/packages/react-router-dev/vite/has-rsc-plugin.ts
+++ b/packages/react-router-dev/vite/has-rsc-plugin.ts
@@ -1,0 +1,29 @@
+import type * as Vite from "vite";
+
+export async function hasReactRouterRscPlugin({
+  root,
+  viteBuildOptions: { config, logLevel, mode },
+}: {
+  root: string;
+  viteBuildOptions: {
+    config?: string;
+    logLevel?: Vite.LogLevel;
+    mode?: string;
+  };
+}): Promise<boolean> {
+  const vite = await import("vite");
+  const viteConfig = await vite.resolveConfig(
+    {
+      configFile: config,
+      logLevel,
+      mode: mode ?? "production",
+      root,
+    },
+    "build", // command
+    "production", // default mode
+    "production", // default NODE_ENV
+  );
+  return viteConfig.plugins.some(
+    (plugin) => plugin?.name === "react-router/rsc",
+  );
+}


### PR DESCRIPTION
Until custom entries are supported, we need to ensure that we don't generate irrelevant unused entry files.