### PR TITLE
Typegen server-first routes in RSC Framework Mode

### DIFF
--- a/packages/react-router-dev/cli/commands.ts
+++ b/packages/react-router-dev/cli/commands.ts
@@ -247,6 +247,14 @@ export async function typegen(
 ) {
   root = resolveRootDirectory(root, flags);
 
+  const rsc = await hasReactRouterRscPlugin({
+    root,
+    viteBuildOptions: {
+      config: flags.config,
+      mode: flags.mode,
+    },
+  });
+
   if (flags.watch) {
     await preloadVite();
     const vite = getVite();
@@ -254,6 +262,7 @@ export async function typegen(
 
     await Typegen.watch(root, {
       mode: flags.mode ?? "development",
+      rsc,
       logger,
     });
     await new Promise(() => {}); // keep alive
@@ -262,5 +271,6 @@ export async function typegen(
 
   await Typegen.run(root, {
     mode: flags.mode ?? "production",
+    rsc,
   });
 }

--- a/packages/react-router-dev/typegen/context.ts
+++ b/packages/react-router-dev/typegen/context.ts
@@ -8,16 +8,19 @@ export type Context = {
   rootDirectory: string;
   configLoader: ConfigLoader;
   config: ResolvedReactRouterConfig;
+  rsc: boolean;
 };
 
 export async function createContext({
   rootDirectory,
   watch,
   mode,
+  rsc,
 }: {
   rootDirectory: string;
   watch: boolean;
   mode: string;
+  rsc: boolean;
 }): Promise<Context> {
   const configLoader = await createConfigLoader({ rootDirectory, mode, watch });
   const configResult = await configLoader.getConfig();
@@ -32,5 +35,6 @@ export async function createContext({
     configLoader,
     rootDirectory,
     config,
+    rsc,
   };
 }

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -274,7 +274,7 @@ function getRouteAnnotations({
     Babel.generate(matchesType).code +
     "\n\n" +
     ts`
-      type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }>;
+      type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }, ${ctx.rsc}>;
 
       export namespace Route {
         // links

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -29,8 +29,11 @@ async function write(...files: Array<VirtualFile>) {
   );
 }
 
-export async function run(rootDirectory: string, { mode }: { mode: string }) {
-  const ctx = await createContext({ rootDirectory, mode, watch: false });
+export async function run(
+  rootDirectory: string,
+  { mode, rsc }: { mode: string; rsc: boolean },
+) {
+  const ctx = await createContext({ rootDirectory, mode, rsc, watch: false });
   await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
   await write(
     generateFuture(ctx),
@@ -45,9 +48,9 @@ export type Watcher = {
 
 export async function watch(
   rootDirectory: string,
-  { mode, logger }: { mode: string; logger?: vite.Logger },
+  { mode, logger, rsc }: { mode: string; logger?: vite.Logger; rsc: boolean },
 ): Promise<Watcher> {
-  const ctx = await createContext({ rootDirectory, mode, watch: true });
+  const ctx = await createContext({ rootDirectory, mode, rsc, watch: true });
   await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
   await write(
     generateFuture(ctx),

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1197,6 +1197,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         if (viteCommand === "serve") {
           typegenWatcherPromise = Typegen.watch(rootDirectory, {
             mode,
+            rsc: false,
             // ignore `info` logs from typegen since they are redundant when Vite plugin logs are active
             logger: vite.createLogger("warn", { prefix: "[react-router]" }),
           });

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -266,6 +266,7 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
             getRootDirectory(viteUserConfig),
             {
               mode,
+              rsc: true,
               // ignore `info` logs from typegen since they are
               // redundant when Vite plugin logs are active
               logger: vite.createLogger("warn", {


### PR DESCRIPTION
This updates our typegen logic to handle server-first routes to ensure that `clientLoader`/`clientAction` are not factored into the types for the `loaderData`/`actionData` props when RSC Framework Mode is being used and a `ServerComponent` export is present.