### PR TITLE
docs: fix code example of buildEnd hook

### DIFF
--- a/docs/api/framework-conventions/react-router.config.ts.md
+++ b/docs/api/framework-conventions/react-router.config.ts.md
@@ -66,7 +66,7 @@ A function that is called after the full React Router build is complete.
 
 ```tsx filename=react-router.config.ts
 export default {
-  buildEnd: async ({ buildManifest, serverBuildPath }) => {
+  buildEnd: async ({ buildManifest, reactRouterConfig, viteConfig }) => {
     // Custom build logic here
     console.log("Build completed!");
   },


### PR DESCRIPTION
This PR fixes the code example of the `buildEnd` hook.
`serverBuildPath` doesn't currently exist.