### PR TITLE
docs(root.tsx): fix broken link on `root.tsx` page

### DIFF
--- a/docs/api/framework-conventions/root.tsx.md
+++ b/docs/api/framework-conventions/root.tsx.md
@@ -191,7 +191,7 @@ export function Layout({
 }
 ```
 
-[route-module]: ../start/framework/route-module
+[route-module]: ../../start/framework/route-module
 [react-link]: https://react.dev/reference/react-dom/components/link
 [react-meta]: https://react.dev/reference/react-dom/components/meta
 [react-title]: https://react.dev/reference/react-dom/components/title


### PR DESCRIPTION
This pull request includes a minor documentation fix to the [root.tsx page](https://reactrouter.com/api/framework-conventions/root.tsx#layout-export). The change updates a relative link to ensure it correctly points to the intended `route-module` documentation.