### PR TITLE
fix: support Vite plugins adding a server entry

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -60,6 +60,7 @@
 - briankb
 - BrianT1414
 - Bricklou
+- brillout
 - brockross
 - brookslybrand
 - brophdawg11

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3540,7 +3540,12 @@ export async function getEnvironmentOptionsResolvers(
               : viteUserConfig.build?.rollupOptions?.input) ??
             virtual.serverBuild.id,
           output: {
-            entryFileNames: serverBuildFile,
+            entryFileNames({ name }) {
+              return name === "virtual_react-router/server-build"
+                ? serverBuildFile
+                : // Rollup's default
+                  "[name].js";
+            },
             format: serverModuleFormat,
           },
         },


### PR DESCRIPTION
Add support for Vite plugins that add a server build entry. For example, this change is required for being able to use React Router with [Telefunc](https://telefunc.com).