### PR TITLE
fix(react-router-dev): Fix preset future flags merge

### DIFF
--- a/.changeset/fix-preset-future-flags.md
+++ b/.changeset/fix-preset-future-flags.md
@@ -1,0 +1,9 @@
+---
+"@react-router/dev": patch
+---
+
+Fix preset future flags being ignored during config resolution
+
+Fixes a bug where future flags defined by presets were completely ignored. The config resolution was incorrectly reading from `reactRouterUserConfig.future` instead of the merged `userAndPresetConfigs.future`, causing all preset-defined future flags to be lost.
+
+This fix ensures presets can properly enable experimental features as intended by the preset system design.

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -114,6 +114,17 @@ const files = {
           }),
         },
 
+        // Ensure presets can set future flags
+        {
+          name: "test-preset",
+          reactRouterConfig: async () => ({
+            future: {
+              v8_middleware: true,
+              unstable_optimizeDeps: true,
+            },
+          }),
+        },
+
         // Ensure presets can set buildEnd option (this is critical for Vercel support)
         {
           name: "test-preset",
@@ -128,6 +139,7 @@ const files = {
                   "export const buildManifest = " + serializeJs(buildManifest, { space: 2, unsafe: true }) + ";",
                   "export const reactRouterConfig = " + serializeJs(reactRouterConfig, { space: 2, unsafe: true }) + ";",
                   "export const assetsDir = " + JSON.stringify(viteConfig.build.assetsDir) + ";",
+                  "export const futureFlags = " + JSON.stringify(reactRouterConfig.future) + ";",
                 ].join("\\n"),
                 "utf-8"
               );
@@ -228,6 +240,15 @@ test.describe("Vite / presets", async () => {
         "ssr",
         "unstable_routeConfig",
       ]);
+
+      // Ensure future flags from presets are properly merged
+      expect(buildEndArgsMeta.futureFlags).toEqual({
+        v8_middleware: true,
+        unstable_optimizeDeps: true,
+        unstable_splitRouteModules: false,
+        unstable_subResourceIntegrity: false,
+        unstable_viteEnvironmentApi: false,
+      });
 
       // Ensure we get a valid build manifest
       expect(buildEndArgsMeta.buildManifest).toEqual({

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -587,15 +587,15 @@ async function resolveConfig({
   }
 
   let future: FutureConfig = {
-    v8_middleware: reactRouterUserConfig.future?.v8_middleware ?? false,
+    v8_middleware: userAndPresetConfigs.future?.v8_middleware ?? false,
     unstable_optimizeDeps:
-      reactRouterUserConfig.future?.unstable_optimizeDeps ?? false,
+      userAndPresetConfigs.future?.unstable_optimizeDeps ?? false,
     unstable_splitRouteModules:
-      reactRouterUserConfig.future?.unstable_splitRouteModules ?? false,
+      userAndPresetConfigs.future?.unstable_splitRouteModules ?? false,
     unstable_subResourceIntegrity:
-      reactRouterUserConfig.future?.unstable_subResourceIntegrity ?? false,
+      userAndPresetConfigs.future?.unstable_subResourceIntegrity ?? false,
     unstable_viteEnvironmentApi:
-      reactRouterUserConfig.future?.unstable_viteEnvironmentApi ?? false,
+      userAndPresetConfigs.future?.unstable_viteEnvironmentApi ?? false,
   };
 
   let reactRouterConfig: ResolvedReactRouterConfig = deepFreeze({


### PR DESCRIPTION
Fixes #14368

## Description

Preset-defined future flags were being completely ignored during configuration resolution. The bug prevented presets from enabling experimental features, which is critical functionality for third-party integrations and hosting providers.

## Problem

The config resolution was incorrectly reading from `reactRouterUserConfig.future` instead of the merged `userAndPresetConfigs.future` at `packages/react-router-dev/config/config.ts:589-599`.

The merged configuration was already computed earlier (line 440-443):
```typescript
let userAndPresetConfigs = mergeReactRouterConfig(
  ...presets,
  reactRouterUserConfig,
);
```

But the future flags resolution ignored this merged configuration entirely.

## Solution

Changed all references from `reactRouterUserConfig.future` to `userAndPresetConfigs.future` to properly read from the merged configuration.

## Testing

- Added integration test in `integration/vite-presets-test.ts` that verifies preset future flags are properly merged
- Test fails without the fix (all preset flags resolve to `false`)
- Test passes with the fix (preset flags are correctly applied)

```bash
pnpm test:integration --grep="presets"
# 16 passed (12.9s)
```
