### PR TITLE
better playwright fixtures: `cwd`, `edit`, `$`

### DIFF
--- a/integration/helpers/fixtures.ts
+++ b/integration/helpers/fixtures.ts
@@ -1,0 +1,138 @@
+import { ChildProcess } from "node:child_process";
+import * as fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { test as base } from "@playwright/test";
+import {
+  execa,
+  ExecaError,
+  type Options,
+  parseCommandString,
+  type ResultPromise,
+} from "execa";
+import * as Path from "pathe";
+
+import type { TemplateName } from "./vite.js";
+
+declare module "@playwright/test" {
+  interface Page {
+    errors: Error[];
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = Path.join(__filename, "../../..");
+const TMP = Path.join(ROOT, ".tmp/integration");
+const templatePath = (templateName: string) =>
+  Path.resolve(ROOT, "integration/helpers", templateName);
+
+type Edits = Record<string, string | ((contents: string) => string)>;
+
+async function applyEdits(cwd: string, edits: Edits) {
+  const promises = Object.entries(edits).map(async ([file, transform]) => {
+    const filepath = Path.join(cwd, file);
+    await fs.writeFile(
+      filepath,
+      typeof transform === "function"
+        ? transform(await fs.readFile(filepath, "utf8"))
+        : transform,
+      "utf8",
+    );
+    return;
+  });
+  await Promise.all(promises);
+}
+
+export const test = base.extend<{
+  template: TemplateName;
+  files: Edits;
+  cwd: string;
+  edit: (edits: Edits) => Promise<void>;
+  $: (
+    command: string,
+    options?: Pick<Options, "env" | "timeout">,
+  ) => ResultPromise<{ reject: false }> & {
+    buffer: { stdout: string; stderr: string };
+  };
+}>({
+  template: ["vite-6-template", { option: true }],
+  files: [{}, { option: true }],
+  page: async ({ page }, use) => {
+    page.errors = [];
+    page.on("pageerror", (error: Error) => page.errors.push(error));
+    await use(page);
+  },
+
+  cwd: async ({ template, files }, use, testInfo) => {
+    await fs.mkdir(TMP, { recursive: true });
+    const cwd = await fs.mkdtemp(Path.join(TMP, template + "-"));
+    testInfo.attach("cwd", { body: cwd });
+
+    await fs.cp(templatePath(template), cwd, {
+      errorOnExist: true,
+      recursive: true,
+    });
+
+    await applyEdits(cwd, files);
+
+    await use(cwd);
+  },
+
+  edit: async ({ cwd }, use) => {
+    await use(async (edits) => applyEdits(cwd, edits));
+  },
+
+  $: async ({ cwd }, use) => {
+    const spawn = execa({
+      cwd,
+      env: {
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+      },
+      reject: false,
+    });
+
+    let testHasEnded = false;
+    const processes: Array<ResultPromise> = [];
+    const unexpectedErrors: Array<Error> = [];
+
+    await use((command, options = {}) => {
+      const [file, ...args] = parseCommandString(command);
+
+      const p = spawn(file, args, options);
+      if (p instanceof ChildProcess) {
+        processes.push(p);
+      }
+
+      p.then((result) => {
+        if (!(result instanceof Error)) return result;
+
+        // Once the test has ended, this process will be killed as part of its teardown resulting in an ExecaError.
+        // We only care about surfacing errors that occurred during test execution, not during teardown.
+        const expectedError = testHasEnded && result instanceof ExecaError;
+        if (expectedError) return result;
+        unexpectedErrors.push(result);
+      });
+
+      const buffer = { stdout: "", stderr: "" };
+      p.stdout?.on("data", (data) => (buffer.stdout += data.toString()));
+      p.stderr?.on("data", (data) => (buffer.stderr += data.toString()));
+      return Object.assign(p, { buffer });
+    });
+
+    testHasEnded = true;
+    processes.forEach((p) => p.kill());
+
+    // Throw any unexpected errors that occurred during test execution
+    if (unexpectedErrors.length > 0) {
+      const errorMessage =
+        unexpectedErrors.length === 1
+          ? `Unexpected process error: ${unexpectedErrors[0].message}`
+          : `${unexpectedErrors.length} unexpected process errors:\n${unexpectedErrors.map((e, i) => `${i + 1}. ${e.message}`).join("\n")}`;
+
+      const error = new Error(errorMessage);
+      error.stack = unexpectedErrors[0].stack;
+      throw error;
+    }
+  },
+});

--- a/integration/package.json
+++ b/integration/package.json
@@ -25,7 +25,7 @@
     "cheerio": "^1.0.0-rc.12",
     "cross-spawn": "^7.0.3",
     "dedent": "^0.7.0",
-    "execa": "^5.1.1",
+    "execa": "^9.6.0",
     "express": "^4.19.2",
     "get-port": "^5.1.1",
     "glob": "8.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       execa:
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: ^9.6.0
+        version: 9.6.0
       express:
         specifier: ^4.19.2
         version: 4.21.2
@@ -598,7 +598,7 @@ importers:
         version: 3.0.1(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1))
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1))
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1)(terser@5.15.0))
 
   integration/helpers/vite-6-template:
     dependencies:
@@ -1161,7 +1161,7 @@ importers:
         version: 0.4.30(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vite@6.2.5(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.3)(yaml@2.8.0))
       esbuild-register:
         specifier: ^3.6.0
-        version: 3.6.0(esbuild@0.25.0)
+        version: 3.6.0(esbuild@0.25.4)
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -1573,7 +1573,7 @@ importers:
         version: 5.1.3(@types/node@22.14.0)(lightningcss@1.30.1)(terser@5.15.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1))
+        version: 4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1)(terser@5.15.0))
 
   playground/framework-vite-7-beta:
     dependencies:
@@ -4561,6 +4561,9 @@ packages:
   '@rushstack/eslint-patch@1.10.1':
     resolution: {integrity: sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/engine-oniguruma@3.8.1':
     resolution: {integrity: sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==}
 
@@ -4587,6 +4590,10 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@sinonjs/commons@2.0.0':
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
@@ -6376,6 +6383,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@9.6.0:
+    resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
@@ -6437,6 +6448,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -6583,6 +6598,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -6766,6 +6785,10 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -6988,6 +7011,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -7003,6 +7030,10 @@ packages:
   is-typed-array@1.1.13:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -8004,6 +8035,10 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -8149,6 +8184,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
@@ -8179,6 +8218,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -8317,6 +8360,10 @@ packages:
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
 
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
@@ -9064,6 +9111,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -9387,6 +9438,10 @@ packages:
   unicode-property-aliases-ecmascript@2.0.0:
     resolution: {integrity: sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==}
     engines: {node: '>=4'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unified@10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
@@ -9876,6 +9931,10 @@ packages:
 
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
   youch@3.3.4:
@@ -12878,6 +12937,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.1': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/engine-oniguruma@3.8.1':
     dependencies:
       '@shikijs/types': 3.8.1
@@ -12907,6 +12968,8 @@ snapshots:
   '@sideway/pinpoint@2.0.0': {}
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sinonjs/commons@2.0.0':
     dependencies:
@@ -14784,6 +14847,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esbuild-register@3.6.0(esbuild@0.25.4):
+    dependencies:
+      debug: 4.4.1
+      esbuild: 0.25.4
+    transitivePeerDependencies:
+      - supports-color
+
   esbuild@0.19.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.19.12
@@ -15256,6 +15326,21 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@9.6.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   exit-hook@2.2.1: {}
 
   exit@0.1.2: {}
@@ -15347,6 +15432,10 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -15501,6 +15590,11 @@ snapshots:
       source-map: 0.6.1
 
   get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.0.2:
     dependencies:
@@ -15748,6 +15842,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  human-signals@8.0.1: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -15929,6 +16025,8 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-stream@4.0.1: {}
+
   is-string@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
@@ -15944,6 +16042,8 @@ snapshots:
   is-typed-array@1.1.13:
     dependencies:
       which-typed-array: 1.1.15
+
+  is-unicode-supported@2.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -17543,6 +17643,11 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -17725,6 +17830,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-ms@4.0.0: {}
+
   parse-statements@1.0.11: {}
 
   parse5-htmlparser2-tree-adapter@7.0.0:
@@ -17749,6 +17856,8 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -17867,6 +17976,10 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 19.1.0
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
 
   printable-characters@1.0.42: {}
 
@@ -18710,6 +18823,8 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-final-newline@4.0.0: {}
+
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
@@ -19056,6 +19171,8 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.0.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   unified@10.1.2:
     dependencies:
       '@types/unist': 2.0.10
@@ -19362,7 +19479,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.1.3(@types/node@22.14.0)(lightningcss@1.30.1)(terser@5.15.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
@@ -19702,6 +19819,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  yoctocolors@2.1.2: {}
 
   youch@3.3.4:
     dependencies:


### PR DESCRIPTION
I'm bringing over the [testing utils I created for react-router-templates](https://github.com/remix-run/react-router-templates/blob/main/.tests/utils.ts) which are mostly [Playwright fixtures](https://playwright.dev/docs/test-fixtures).

The goal is for end-to-end tests to stick as close to real user setups and workflows as possible while making correct, thorough tests ergonomic.

```ts
import getPort from "get-port"

import { test } from "./helpers/fixtures"

test("hello world", async ({ edit, $, page }) => {
  await $("pnpm typecheck")
  
  const port = await getPort()
  const dev = $(`pnpm dev --port ${port}`)
  await serverIsReady(dev, port)
  
  await page.goto(`http://localhost:${port}`, { waitUntil: "networkidle" })

  await edit({
    "app/routes/_index.tsx": `
      export default function HelloWorld() {
        return <h1>Hello, world!</h1>
      }
    `,
    "vite.config.ts": (contents) => contents.replace(
      "import { reactRouter }",
      "import { unstable_reactRouterRSC as reactRouter }"
    ),
  })
  
  expect(page.locator("...")).toHaveText("...")
})
```

## What do Playwright fixtures do?

**1. Playwright statically analyzes which fixtures are used for each test**
In this test, we use the built-in `page` fixture as well as our own custom `edit` and `$` fixtures

**2. Playwright determines dependency graph for fixtures**
Our `edit` and `$` fixtures depend on another one of our custom fixtures called `cwd` which is in charge of setting up a temporary directory for out test. What's cool about this is that `edit` and `$` know about `cwd`, so I've set them up to automatically do everything relative to that path.

**3. Playwright runs pre-test code for fixtures in dependency order**
For us, this means that `cwd` pre-test actually runs now and creates the temporary directory. `edit` and `$` don't do much in the pre-test phase. Notably, the fixture get executed separately for each test, so we get file system isolation for each test by default!

`cwd` also registers the temporary directory path as an attachment. That means any time a test fails that used these new fixtures, it will include the `cwd` path neatly in the test output so you can immediately dive into that temporary dir and do some debugging.

**4. Playwright runs your test**
We start by running `pnpm typecheck` just like a user would in their own terminal. If the command fails, we'll get an error thrown here with the exit code and error message. Then we asynchronously spin up a Vite dev server via `pnpm dev` using the `--port` flag with a unique port so we can run any other tests with Vite dev servers in parallel and without port conflicts.

We _could_ create an abstraction for this like `const { process, port } = viteDev()` but I personally like how the `pnpm dev` command is right there in front of you.

Next, we wait until the `dev` process has a URL with our expected port in `stdout` via `serverIsReady` (this API is in flight, up for bikeshedding)

Then, we make edits to our app code _while_ the dev server is running. You can either provide a string or a `(contents: string) => string` function to manipulate the contents of each edited file.

At any point, you can use [Playwright's built-in `page` fixture](https://playwright.dev/docs/test-fixtures#built-in-fixtures) to test the page.

**5. Playwright runs post-test code for fixtures in reverse dependency order**
Now we give our fixtures a change to clean up. `edit` doesn't have any clean up, but `$` keep track of each process it spawned and gracefully terminates them via `.kill()` after the test is done to prevent any lingering, zombie processes from tests.

Currently, `cwd` does not clean up its own temporary directory because I am emulating how our tests worked previously, where we would only clean up `integration/.tmp` when all tests passed. Not sure if this was intentional or just a limitation of our previous flow, so I'm up to change that if we want.

## Fixtures-options

By default, tests use the `vite-6-template`, but I've also created two [fixtures-options](https://playwright.dev/docs/test-fixtures#fixtures-options) that let you configure tests before they run: `template` and `files`.

```ts
test.use({
  template: "vite-rolldown-template",
  files: {
    "app/start-with-this-file.ts": `export const hello = "world"`
    // same shape you would use for the `edit` fixture
  }
})
test("stuff", () => {/* ... */ })
```

`test.use` configures all tests in its scope, so you can use `test.describe` to do multiple different setups in the same file:

```ts
test.describe("Vite Rolldown", () => {
  test.use({ template: "vite-rolldown-template" })
  test("stuff", () => {/* ... */ })
})

test.describe("Vite 7 Beta", () => {
  test.use({ template: "vite-7-beta-template" })
  test("stuff", () => {/* ... */ })
})
```

You can even do this programmatically with a loop:

```ts
const templates: Array<string> = [/* ... */]
for (const template of templates) {
  test.describe(template, () => {
    test.use({ template })
    test("stuff", () => {/* ... */})
  })
}
```

