### PR TITLE
fix(docs): correct unclosed Route tag in JSX example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -337,6 +337,7 @@
 - ryanflorence
 - ryanhiebert
 - saengmotmi
+- SailorStat
 - samimsu
 - sanjai451
 - sanketshah19

--- a/docs/api/components/Routes.md
+++ b/docs/api/components/Routes.md
@@ -33,7 +33,7 @@ import { Route, Routes } from "react-router";
 <Routes>
   <Route index element={<StepOne />} />
   <Route path="step-2" element={<StepTwo />} />
-  <Route path="step-3" element={<StepThree />}>
+  <Route path="step-3" element={<StepThree />} />
 </Routes>
 ```
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1358,7 +1358,7 @@ export interface RoutesProps {
  * <Routes>
  *   <Route index element={<StepOne />} />
  *   <Route path="step-2" element={<StepTwo />} />
- *   <Route path="step-3" element={<StepThree />}>
+ *   <Route path="step-3" element={<StepThree />} />
  * </Routes>
  *
  * @public


### PR DESCRIPTION
Fix unclosed JSX tag in Route component example.

The Route component was missing the closing `/` which is required in JSX syntax.