### PR TITLE
unstable_useRoute

### DIFF
--- a/.changeset/six-lobsters-think.md
+++ b/.changeset/six-lobsters-think.md
@@ -1,0 +1,81 @@
+---
+"@react-router/dev": patch
+"react-router": patch
+---
+
+New (unstable) `useRoute` hook for accessing data from specific routes
+
+`useRouteLoaderData` has many shortcomings:
+
+1. Its `routeId` arg is typed as `string`, so TS won't complain if you pass in a non-existent route ID
+2. Type-safety was limited to a `typeof loader` generic that required you to manually import and pass in the type for the corresponding `loader`
+3. Even with `typeof loader`, the types were not aware of `clientLoader`, `HydrateFallback`, and `clientLoader.hydrate = true`, which all affect the type for `loaderData`
+4. It is limited solely to `loader` data, but does not provide `action` data
+5. It introduced confusion about when to use `useLoaderData` and when to use `useRouteLoaderData`
+
+```ts
+// app/routes/admin.tsx
+export const loader = () => ({ message: "Hello, loader!" });
+
+export const action = () => ({ message: "Hello, action!" });
+```
+
+```ts
+import { type loader } from "../routes/admin";
+
+export function Widget() {
+  const loaderData = useRouteLoaderData<typeof loader>("routes/admin");
+  // ...
+}
+```
+
+With `useRoute`, all of these concerns have been fixed:
+
+```ts
+import { unstable_useRoute as useRoute } from "react-router";
+
+export function Widget() {
+  const admin = useRoute("routes/admin");
+  console.log(admin?.loaderData?.message);
+  console.log(admin?.actionData?.message);
+  // ...
+}
+```
+
+Note: `useRoute` returns `undefined` if the route is not part of the current page.
+
+The `root` route is special because it is guaranteed to be part of the current page, so no need to use `?.` or any other `undefined` checks:
+
+```ts
+export function Widget() {
+  const root = useRoute("root");
+  console.log(root.loaderData?.message, root.actionData?.message);
+  // ...
+}
+```
+
+You may have noticed that `loaderData` and `actionData` are marked as optional.
+This is intentional as there's no guarantee that `loaderData` nor `actionData` exists when called in certain contexts like within an `ErrorBoundary`:
+
+```ts
+export function ErrorBoundary() {
+  const admin = useRoute("routes/admin");
+  console.log(admin?.loaderData?.message);
+  //                           ^^
+  // `loader` for itself could have thrown an error,
+  // so you need to check if `loaderData` exists!
+}
+```
+
+In an effort to consolidate on fewer, more intuitive hooks, `useRoute` can be called without arguments as a replacement for `useLoaderData` and `useActionData`:
+
+```ts
+export function Widget() {
+  const currentRoute = useRoute();
+  currentRoute.loaderData;
+  currentRoute.actionData;
+}
+```
+
+Since `Widget` is a reusable component that could be within any route, we have no guarantees about the types for `loaderData` nor `actionData`.
+As a result, they are both typed as `unknown` and it is up to you to narrow the type to what your reusable component needs (for example, via `zod`).

--- a/integration/use-route-test.ts
+++ b/integration/use-route-test.ts
@@ -1,0 +1,118 @@
+import tsx from "dedent";
+import { expect } from "@playwright/test";
+
+import { test } from "./helpers/fixtures";
+import * as Stream from "./helpers/stream";
+import getPort from "get-port";
+
+test.use({
+  files: {
+    "app/expect-type.ts": tsx`
+      export type Expect<T extends true> = T
+
+      export type Equal<X, Y> =
+        (<T>() => T extends X ? 1 : 2) extends
+        (<T>() => T extends Y ? 1 : 2) ? true : false
+    `,
+    "app/routes.ts": tsx`
+      import { type RouteConfig, route } from "@react-router/dev/routes"
+
+      export default [
+        route("parent", "routes/parent.tsx", [
+          route("current", "routes/current.tsx")
+        ]),
+        route("other", "routes/other.tsx"),
+      ] satisfies RouteConfig
+    `,
+    "app/root.tsx": tsx`
+      import { Outlet } from "react-router"
+
+      export const loader = () => ({ rootLoader: "root/loader" })
+      export const action = () => ({ rootAction: "root/action" })
+
+      export default function Component() {
+        return (
+          <>
+            <h1>Root</h1>
+            <Outlet />
+          </>
+        )
+      }
+    `,
+    "app/routes/parent.tsx": tsx`
+      import { Outlet } from "react-router"
+
+      export const loader = () => ({ parentLoader: "parent/loader" })
+      export const action = () => ({ parentAction: "parent/action" })
+
+      export default function Component() {
+        return (
+          <>
+            <h2>Parent</h2>
+            <Outlet />
+          </>
+        )
+      }
+    `,
+    "app/routes/current.tsx": tsx`
+      import { unstable_useRoute as useRoute } from "react-router"
+
+      import type { Expect, Equal } from "../expect-type"
+
+      export const loader = () => ({ currentLoader: "current/loader" })
+      export const action = () => ({ currentAction: "current/action" })
+
+      export default function Component() {
+        const current = useRoute()
+        type Test1 = Expect<Equal<typeof current, { loaderData: unknown, actionData: unknown }>>
+
+        const root = useRoute("root")
+        type Test2 = Expect<Equal<typeof root, { loaderData: { rootLoader: string } | undefined, actionData: { rootAction: string } | undefined }>>
+
+        const parent = useRoute("routes/parent")
+        type Test3 = Expect<Equal<typeof parent, { loaderData: { parentLoader: string } | undefined, actionData: { parentAction: string } | undefined } | undefined>>
+
+        const other = useRoute("routes/other")
+        type Test4 = Expect<Equal<typeof other, { loaderData: { otherLoader: string } | undefined, actionData: { otherAction: string } | undefined } | undefined>>
+
+        return (
+          <>
+            <pre data-root>{root.loaderData?.rootLoader}</pre>
+            <pre data-parent>{parent?.loaderData?.parentLoader}</pre>
+            {/* @ts-expect-error */}
+            <pre data-current>{current?.loaderData?.currentLoader}</pre>
+            <pre data-other>{other === undefined ? "undefined" : "something else"}</pre>
+          </>
+        )
+      }
+    `,
+    "app/routes/other.tsx": tsx`
+      export const loader = () => ({ otherLoader: "other/loader" })
+      export const action = () => ({ otherAction: "other/action" })
+
+      export default function Component() {
+        return <h2>Other</h2>
+      }
+    `,
+  },
+});
+
+test("useRoute", async ({ $, page }) => {
+  await $("pnpm typecheck");
+
+  const port = await getPort();
+  const url = `http://localhost:${port}`;
+
+  const dev = $(`pnpm dev --port ${port}`);
+  await Stream.match(dev.stdout, url);
+
+  await page.goto(url + "/parent/current", { waitUntil: "networkidle" });
+
+  await expect(page.locator("[data-root]")).toHaveText("root/loader");
+
+  await expect(page.locator("[data-parent]")).toHaveText("parent/loader");
+
+  await expect(page.locator("[data-current]")).toHaveText("current/loader");
+
+  await expect(page.locator("[data-other]")).toHaveText("undefined");
+});

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -105,13 +105,16 @@ export function generateRoutes(ctx: Context): Array<VirtualFile> {
           interface Register {
             pages: Pages
             routeFiles: RouteFiles
+            routeModules: RouteModules
           }
         }
       ` +
       "\n\n" +
       Babel.generate(pagesType(allPages)).code +
       "\n\n" +
-      Babel.generate(routeFilesType({ fileToRoutes, routeToPages })).code,
+      Babel.generate(routeFilesType({ fileToRoutes, routeToPages })).code +
+      "\n\n" +
+      Babel.generate(routeModulesType(ctx)).code,
   };
 
   // **/+types/*.ts
@@ -185,6 +188,29 @@ function routeFilesType({
                   ),
                 ]);
               }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+function routeModulesType(ctx: Context) {
+  return t.tsTypeAliasDeclaration(
+    t.identifier("RouteModules"),
+    null,
+    t.tsTypeLiteral(
+      Object.values(ctx.config.routes).map((route) =>
+        t.tsPropertySignature(
+          t.stringLiteral(route.id),
+          t.tsTypeAnnotation(
+            t.tsTypeQuery(
+              t.tsImportType(
+                t.stringLiteral(
+                  `./${Path.relative(ctx.rootDirectory, ctx.config.appDirectory)}/${route.file}`,
+                ),
+              ),
             ),
           ),
         ),

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -144,6 +144,7 @@ export {
   useRouteError,
   useRouteLoaderData,
   useRoutes,
+  useRoute,
 } from "./lib/hooks";
 
 // Expose old RR DOM API

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -144,7 +144,7 @@ export {
   useRouteError,
   useRouteLoaderData,
   useRoutes,
-  useRoute,
+  useRoute as unstable_useRoute,
 } from "./lib/hooks";
 
 // Expose old RR DOM API

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1856,7 +1856,7 @@ type UseRouteResult<Args extends UseRouteArgs> =
 
 type UseRoute<RouteId extends keyof RouteModules | unknown> = {
   loaderData: RouteId extends keyof RouteModules
-    ? GetLoaderData<RouteModules[RouteId]>
+    ? GetLoaderData<RouteModules[RouteId]> | undefined
     : unknown;
   actionData: RouteId extends keyof RouteModules
     ? GetActionData<RouteModules[RouteId]> | undefined

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1849,14 +1849,18 @@ type UseRouteArgs = [] | [routeId: keyof RouteModules];
 
 // prettier-ignore
 type UseRouteResult<Args extends UseRouteArgs> =
-  Args extends [] ? unknown :
+  Args extends [] ? UseRoute<unknown> :
   Args extends ["root"] ? UseRoute<"root"> :
   Args extends [infer RouteId extends keyof RouteModules] ? UseRoute<RouteId> | undefined :
   never;
 
-type UseRoute<RouteId extends keyof RouteModules> = {
-  loaderData: GetLoaderData<RouteModules[RouteId]>;
-  actionData: GetActionData<RouteModules[RouteId]>;
+type UseRoute<RouteId extends keyof RouteModules | unknown> = {
+  loaderData: RouteId extends keyof RouteModules
+    ? GetLoaderData<RouteModules[RouteId]>
+    : unknown;
+  actionData: RouteId extends keyof RouteModules
+    ? GetActionData<RouteModules[RouteId]> | undefined
+    : unknown;
 };
 
 export function useRoute<Args extends UseRouteArgs>(

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -50,8 +50,13 @@ import {
   resolveTo,
   stripBasename,
 } from "./router/utils";
-import type { SerializeFrom } from "./types/route-data";
+import type {
+  GetActionData,
+  GetLoaderData,
+  SerializeFrom,
+} from "./types/route-data";
 import type { unstable_ClientOnErrorFunction } from "./components";
+import type { RouteModules } from "./types/register";
 
 /**
  * Resolves a URL against the current {@link Location}.
@@ -1837,4 +1842,20 @@ function warningOnce(key: string, cond: boolean, message: string) {
     alreadyWarned[key] = true;
     warning(false, message);
   }
+}
+
+type UseRoute<T extends keyof RouteModules> = {
+  loaderData: GetLoaderData<RouteModules[T]>;
+  actionData: GetActionData<RouteModules[T]>;
+};
+export function useRoute<T extends keyof RouteModules>(
+  routeId: T,
+): UseRoute<T> | undefined {
+  const state = useDataRouterState(DataRouterStateHook.UseRouteLoaderData);
+  const route = state.matches.find(({ route }) => route.id === routeId);
+  if (route === undefined) return undefined;
+  return {
+    loaderData: state.loaderData[routeId],
+    actionData: state.actionData?.[routeId],
+  };
 }

--- a/packages/react-router/lib/types/register.ts
+++ b/packages/react-router/lib/types/register.ts
@@ -1,3 +1,5 @@
+import type { RouteModule } from "./route-module";
+
 /**
  * Apps can use this interface to "register" app-wide types for React Router via interface declaration merging and module augmentation.
  * React Router should handle this for you via type generation.
@@ -7,6 +9,7 @@
 export interface Register {
   // pages
   // routeFiles
+  // routeModules
 }
 
 // pages
@@ -25,3 +28,10 @@ export type RouteFiles = Register extends {
 }
   ? Registered
   : AnyRouteFiles;
+
+type AnyRouteModules = Record<string, RouteModule>;
+export type RouteModules = Register extends {
+  routeModules: infer Registered extends AnyRouteModules;
+}
+  ? Registered
+  : AnyRouteModules;


### PR DESCRIPTION
```tsx
export function AddToCart() {
  const productRoute = useRoute("routes/product")
  if (productRoute === undefined) throw new Error("Expected to be within product route")
  const { loaderData, actionData } = productRoute
  //          ^^^^^^^^^^^^^^^ these are now type-safe!
  return <div>{/* ... */}</div>
}
```

## TODO
- [x] Register `RouteModules` type as a lookup from route ID to route module
- [x] Create new type-safe hook: `useRoute<T>(routeId: T): UseRoute<T> | undefined`
- [x] tests
  - [x] Make sure to test eager declarations for route module exports (i.e. `const` not `function`)
- [x] changeset