### PR TITLE
Keep non-ServerComponent exports as client components

### DIFF
--- a/.changeset/gorgeous-panthers-hug.md
+++ b/.changeset/gorgeous-panthers-hug.md
@@ -1,0 +1,6 @@
+---
+"@react-router/dev": patch
+"react-router": patch
+---
+
+In (unstable) RSC Framework Mode, always keep the `ErrorBoundary`, `HydrateFallback` and `Layout` Route Module exports as client components, even when a `ServerComponent` export is present

--- a/docs/how-to/react-server-components.md
+++ b/docs/how-to/react-server-components.md
@@ -32,8 +32,8 @@ The quickest way to get started is with one of our templates.
 
 These templates come with React Router RSC APIs already configured, offering you out of the box features such as:
 
-- Server Component Routes
 - Server Side Rendering (SSR)
+- Server Components
 - Client Components (via [`"use client"`][use-client-docs] directive)
 - Server Functions (via [`"use server"`][use-server-docs] directive)
 
@@ -177,9 +177,9 @@ export default function Route({
 }
 ```
 
-### Server Component Routes
+### Route Server Components
 
-If a route exports a `ServerComponent` instead of the typical `default` component export, this component along with other route components (`ErrorBoundary`, `HydrateFallback`, `Layout`) will be server components rather than the usual client components.
+If a route exports a `ServerComponent` instead of the typical `default` component export, this will be a server component rather than the usual client component.
 
 ```tsx
 import type { Route } from "./+types/route";

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -658,7 +658,7 @@ test.describe("typegen", () => {
     });
   });
 
-  test.describe("server-first route component detection", () => {
+  test.describe("route server component detection", () => {
     test.describe("ServerComponent export", () => {
       test("when RSC Framework Mode plugin is present", async ({ edit, $ }) => {
         await edit({
@@ -702,38 +702,6 @@ test.describe("typegen", () => {
                 <>
                   <h1>ServerComponent</h1>
                   <p>Loader data: {loaderData.server}</p>
-                  <p>Action data: {actionData?.server}</p>
-                </>
-              )
-            }
-
-            export function ErrorBoundary({ 
-              loaderData, 
-              actionData 
-            }: Route.ErrorBoundaryProps) {
-              type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | undefined>>
-              type TestActionData = Expect<Equal<typeof actionData, { server: string } | undefined>>
-
-              return (
-                <>
-                  <h1>ErrorBoundary</h1>
-                  <p>Loader data: {loaderData?.server}</p>
-                  <p>Action data: {actionData?.server}</p>
-                </>
-              )
-            }
-
-            export function HydrateFallback({ 
-              loaderData, 
-              actionData 
-            }: Route.HydrateFallbackProps) {
-              type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | undefined>>
-              type TestActionData = Expect<Equal<typeof actionData, { server: string } | undefined>>
-
-              return (
-                <>
-                  <h1>HydrateFallback</h1>
-                  <p>Loader data: {loaderData?.server}</p>
                   <p>Action data: {actionData?.server}</p>
                 </>
               )
@@ -795,38 +763,6 @@ test.describe("typegen", () => {
                 </>
               )
             }
-
-            export function ErrorBoundary({ 
-              loaderData, 
-              actionData 
-            }: Route.ErrorBoundaryProps) {
-              type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | { client: string } | undefined>>
-              type TestActionData = Expect<Equal<typeof actionData, { server: string } | { client: string } | undefined>>
-
-              return (
-                <>
-                  <h1>ErrorBoundary</h1>
-                  {loaderData && <p>Loader data: {"server" in loaderData ? loaderData.server : loaderData.client}</p>}
-                  {actionData && <p>Action data: {"server" in actionData ? actionData.server : actionData.client}</p>}
-                </>
-              )
-            }
-
-            export function HydrateFallback({ 
-              loaderData, 
-              actionData 
-            }: Route.HydrateFallbackProps) {
-              type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | { client: string } | undefined>>
-              type TestActionData = Expect<Equal<typeof actionData, { server: string } | { client: string } | undefined>>
-
-              return (
-                <>
-                  <h1>HydrateFallback</h1>
-                  {loaderData && <p>Loader data: {"server" in loaderData ? loaderData.server : loaderData.client}</p>}
-                  {actionData && <p>Action data: {"server" in actionData ? actionData.server : actionData.client}</p>}
-                </>
-              )
-            }
           `,
         });
         await $("pnpm typecheck");
@@ -874,38 +810,6 @@ test.describe("typegen", () => {
               <>
                 <h1>default (Component)</h1>
                 <p>Loader data: {"server" in loaderData ? loaderData.server : loaderData.client}</p>
-                {actionData && <p>Action data: {"server" in actionData ? actionData.server : actionData.client}</p>}
-              </>
-            )
-          }
-
-          export function ErrorBoundary({ 
-            loaderData, 
-            actionData 
-          }: Route.ErrorBoundaryProps) {
-            type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | { client: string } | undefined>>
-            type TestActionData = Expect<Equal<typeof actionData, { server: string } | { client: string } | undefined>>
-
-            return (
-              <>
-                <h1>ErrorBoundary</h1>
-                {loaderData && <p>Loader data: {"server" in loaderData ? loaderData.server : loaderData.client}</p>}
-                {actionData && <p>Action data: {"server" in actionData ? actionData.server : actionData.client}</p>}
-              </>
-            )
-          }
-
-          export function HydrateFallback({ 
-            loaderData, 
-            actionData 
-          }: Route.HydrateFallbackProps) {
-            type TestLoaderData = Expect<Equal<typeof loaderData, { server: string } | { client: string } | undefined>>
-            type TestActionData = Expect<Equal<typeof actionData, { server: string } | { client: string } | undefined>>
-
-            return (
-              <>
-                <h1>HydrateFallback</h1>
-                {loaderData && <p>Loader data: {"server" in loaderData ? loaderData.server : loaderData.client}</p>}
                 {actionData && <p>Action data: {"server" in actionData ? actionData.server : actionData.client}</p>}
               </>
             )

--- a/packages/react-router/lib/types/route-module-annotations.ts
+++ b/packages/react-router/lib/types/route-module-annotations.ts
@@ -120,7 +120,7 @@ type CreateClientActionArgs<T extends RouteInfo> = ClientDataFunctionArgs<
   serverAction: () => Promise<ServerDataFrom<T["module"]["action"]>>;
 };
 
-type IsServerFirstRoute<
+type HasServerComponent<
   T extends RouteInfo,
   RSCEnabled extends boolean,
 > = RSCEnabled extends true
@@ -129,24 +129,14 @@ type IsServerFirstRoute<
     : false
   : false;
 
-type CreateHydrateFallbackProps<
-  T extends RouteInfo,
-  RSCEnabled extends boolean,
-> = {
+type CreateHydrateFallbackProps<T extends RouteInfo> = {
   params: T["params"];
-} & (IsServerFirstRoute<T, RSCEnabled> extends true
-  ? {
-      /** The data returned from the `loader` */
-      loaderData?: ServerDataFrom<T["module"]["loader"]>;
-      /** The data returned from the `action` following an action submission. */
-      actionData?: ServerDataFrom<T["module"]["action"]>;
-    }
-  : {
-      /** The data returned from the `loader` or `clientLoader` */
-      loaderData?: T["loaderData"];
-      /** The data returned from the `action` or `clientAction` following an action submission. */
-      actionData?: T["actionData"];
-    });
+} & {
+  /** The data returned from the `loader` or `clientLoader` */
+  loaderData?: T["loaderData"];
+  /** The data returned from the `action` or `clientAction` following an action submission. */
+  actionData?: T["actionData"];
+};
 
 type Match<T extends MatchInfo> = Pretty<{
   id: T["id"];
@@ -182,7 +172,7 @@ type CreateComponentProps<T extends RouteInfo, RSCEnabled extends boolean> = {
   params: T["params"];
   /** An array of the current {@link https://api.reactrouter.com/v7/interfaces/react_router.UIMatch.html route matches}, including parent route matches. */
   matches: Matches<T["matches"]>;
-} & (IsServerFirstRoute<T, RSCEnabled> extends true
+} & (HasServerComponent<T, RSCEnabled> extends true
   ? {
       /** The data returned from the `loader` */
       loaderData: ServerDataFrom<T["module"]["loader"]>;
@@ -196,10 +186,7 @@ type CreateComponentProps<T extends RouteInfo, RSCEnabled extends boolean> = {
       actionData?: T["actionData"];
     });
 
-type CreateErrorBoundaryProps<
-  T extends RouteInfo,
-  RSCEnabled extends boolean,
-> = {
+type CreateErrorBoundaryProps<T extends RouteInfo> = {
   /**
    * {@link https://reactrouter.com/start/framework/routing#dynamic-segments Dynamic route params} for the current route.
    * @example
@@ -216,19 +203,12 @@ type CreateErrorBoundaryProps<
    **/
   params: T["params"];
   error: unknown;
-} & (IsServerFirstRoute<T, RSCEnabled> extends true
-  ? {
-      /** The data returned from the `loader` */
-      loaderData?: ServerDataFrom<T["module"]["loader"]>;
-      /** The data returned from the `action` following an action submission. */
-      actionData?: ServerDataFrom<T["module"]["action"]>;
-    }
-  : {
-      /** The data returned from the `loader` or `clientLoader` */
-      loaderData?: T["loaderData"];
-      /** The data returned from the `action` or `clientAction` following an action submission. */
-      actionData?: T["actionData"];
-    });
+} & {
+  /** The data returned from the `loader` or `clientLoader` */
+  loaderData?: T["loaderData"];
+  /** The data returned from the `action` or `clientAction` following an action submission. */
+  actionData?: T["actionData"];
+};
 
 export type GetAnnotations<
   Info extends RouteInfo,
@@ -266,13 +246,13 @@ export type GetAnnotations<
   ClientActionArgs: CreateClientActionArgs<Info>;
 
   // HydrateFallback
-  HydrateFallbackProps: CreateHydrateFallbackProps<Info, RSCEnabled>;
+  HydrateFallbackProps: CreateHydrateFallbackProps<Info>;
 
-  // default (Component)
+  // default (Component) / ServerComponent
   ComponentProps: CreateComponentProps<Info, RSCEnabled>;
 
   // ErrorBoundary
-  ErrorBoundaryProps: CreateErrorBoundaryProps<Info, RSCEnabled>;
+  ErrorBoundaryProps: CreateErrorBoundaryProps<Info>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
This changes our approach to Route Module component exports in RSC Framework Mode. Instead of converting _every_ component export to a server component when a `ServerComponent` export is present, we now keep all other component exports as client components. In the future, if we want these other exports to support server component usage, these should individually be extended to support `Server`-prefixed variants, but that's not part of this PR.

Fixes https://github.com/remix-run/react-router/issues/14398