### PR TITLE
Fix typegen support for routes outside appDirectory

### DIFF
--- a/.changeset/yellow-carpets-own.md
+++ b/.changeset/yellow-carpets-own.md
@@ -2,4 +2,4 @@
 "@react-router/dev": patch
 ---
 
-Fix typegen support for routes outside appDirectory
+Include all routes within the React Router root directory when performing typegen, not just routes within the app directory.

--- a/.changeset/yellow-carpets-own.md
+++ b/.changeset/yellow-carpets-own.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix typegen support for routes outside appDirectory

--- a/contributors.yml
+++ b/contributors.yml
@@ -20,6 +20,7 @@
 - alberto
 - AlemTuzlak
 - Aleuck
+- alex-pex
 - alexandernanberg
 - alexanderson1993
 - alexlbr

--- a/integration/helpers/fixtures.ts
+++ b/integration/helpers/fixtures.ts
@@ -31,6 +31,7 @@ type Edits = Record<string, string | ((contents: string) => string)>;
 async function applyEdits(cwd: string, edits: Edits) {
   const promises = Object.entries(edits).map(async ([file, transform]) => {
     const filepath = Path.join(cwd, file);
+    await fs.mkdir(Path.dirname(filepath), { recursive: true });
     await fs.writeFile(
       filepath,
       typeof transform === "function"

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 
-import { expect } from "@playwright/test";
 import tsx from "dedent";
 import * as Path from "pathe";
 
@@ -337,7 +336,7 @@ test.describe("typegen", () => {
     await $("pnpm typecheck");
   });
 
-  test("routes outside app dir", async ({ cwd, edit, $ }) => {
+  test("routes outside app dir", async ({ edit, $ }) => {
     await edit({
       "react-router.config.ts": tsx`
         export default {
@@ -374,14 +373,6 @@ test.describe("typegen", () => {
       `,
     });
     await $("pnpm typecheck");
-
-    // Verify that the types file was generated in the correct location
-    const annotationPath = Path.join(
-      cwd,
-      ".react-router/types/app/pages/+types/product.ts",
-    );
-    const annotation = await fs.readFile(annotationPath, "utf8");
-    expect(annotation).toContain("export namespace Route");
   });
 
   test("matches", async ({ edit, $ }) => {

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -338,10 +338,6 @@ test.describe("typegen", () => {
   });
 
   test("routes outside app dir", async ({ cwd, edit, $ }) => {
-    // Create the subdirectories
-    await fs.mkdir(Path.join(cwd, "app/router"), { recursive: true });
-    await fs.mkdir(Path.join(cwd, "app/pages"), { recursive: true });
-    
     await edit({
       "react-router.config.ts": tsx`
         export default {

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -336,7 +336,7 @@ test.describe("typegen", () => {
     await $("pnpm typecheck");
   });
 
-  test("routes outside app dir", async ({ edit, $ }) => {
+  test("routes within root dir, but outside app dir", async ({ edit, $ }) => {
     await edit({
       "react-router.config.ts": tsx`
         export default {

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -119,7 +119,7 @@ export function generateRoutes(ctx: Context): Array<VirtualFile> {
 
   // **/+types/*.ts
   const allAnnotations: Array<VirtualFile> = Array.from(fileToRoutes.entries())
-    .filter(([file]) => isInAppDirectory(ctx, file))
+    .filter(([file]) => isInRootDirectory(ctx, file))
     .map(([file, routeIds]) =>
       getRouteAnnotations({ ctx, file, routeIds, lineages }),
     );
@@ -221,9 +221,9 @@ function routeModulesType(ctx: Context) {
   );
 }
 
-function isInAppDirectory(ctx: Context, routeFile: string): boolean {
+function isInRootDirectory(ctx: Context, routeFile: string): boolean {
   const path = Path.resolve(ctx.config.appDirectory, routeFile);
-  return path.startsWith(ctx.config.appDirectory);
+  return path.startsWith(ctx.rootDirectory);
 }
 
 function getRouteAnnotations({


### PR DESCRIPTION
## Description :

Adds support for generating types for route files that are referenced outside of `appDirectory`, as long as they remain within the project root.

## Problem

Previously, type generation was strictly limited to files within `appDirectory`. The `isInAppDirectory` check in `generate.ts` would filter out any route files that were not direct children of `appDirectory`, even if they were within the project root.

This limitation was unnecessarily restrictive for projects that organize their code with route configuration in one directory and route modules in sibling directories. For example:

```
app/
  ├── router/          (appDirectory)
  │   ├── routes.ts
  │   └── root.tsx
  └── pages/           (route modules here)
      └── product.tsx
```
```js
// app/router/routes.ts
export default [
    route("products/:id", "../pages/product.tsx")
] satisfies RouteConfig;
```

Typegen would skip generating types for route modules outside of `app/router/` path, breaking type safety. The generated types will be:

```
.react-router/types/
  └── app/
      ├── router/
          └── +types/
              └── root.ts
```

## Solution

I modified `generate.ts` to check if route files are within the project root instead of just within appDirectory:

```diff
- function isInAppDirectory(ctx: Context, routeFile: string): boolean {
+ function isInRootDirectory(ctx: Context, routeFile: string): boolean {
    const path = Path.resolve(ctx.config.appDirectory, routeFile);
-   return path.startsWith(ctx.config.appDirectory);
+   return path.startsWith(ctx.rootDirectory);
  }
```

The generated types will be:

```
.react-router/types/
  └── app/
      ├── router/
          └── +types/
              └── root.ts  
      └── pages/           (previously missing)
          └── +types/
              └── product.ts
```

## Tests

Test setup:

- Config: appDirectory: "app/router"
- Routes defined in: app/router/routes.ts
- Route module located in: app/pages/product.tsx (outside appDirectory)

** A new test has been added ** in `typegen-test.ts`, named "routes outside app dir". All existing tests continue to pass, confirming no breaking changes.
