### PR TITLE
Escape `optimizeDeps.entries` paths in `ssr` environment

### DIFF
--- a/packages/react-router-dev/vite/optimize-deps-entries.ts
+++ b/packages/react-router-dev/vite/optimize-deps-entries.ts
@@ -4,13 +4,15 @@ import { resolveRelativeRouteFilePath } from "./resolve-relative-route-file-path
 import { getVite } from "./vite";
 
 export function getOptimizeDepsEntries({
-  entryClientFilePath,
+  entryFilePath,
   reactRouterConfig,
+  isClientEnvironment,
 }: {
-  entryClientFilePath: string;
+  entryFilePath: string;
   reactRouterConfig: ResolvedReactRouterConfig;
+  isClientEnvironment: boolean;
 }) {
-  if (!reactRouterConfig.future.unstable_optimizeDeps) {
+  if (isClientEnvironment && !reactRouterConfig.future.unstable_optimizeDeps) {
     return [];
   }
 
@@ -18,7 +20,7 @@ export function getOptimizeDepsEntries({
   const viteMajorVersion = parseInt(vite.version.split(".")[0], 10);
 
   return [
-    vite.normalizePath(entryClientFilePath),
+    vite.normalizePath(entryFilePath),
     ...Object.values(reactRouterConfig.routes).map((route) =>
       resolveRelativeRouteFilePath(route, reactRouterConfig),
     ),

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1247,8 +1247,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           },
           optimizeDeps: {
             entries: getOptimizeDepsEntries({
-              entryClientFilePath: ctx.entryClientFilePath,
+              entryFilePath: ctx.entryClientFilePath,
               reactRouterConfig: ctx.reactRouterConfig,
+              isClientEnvironment: true,
             }),
             include: [
               // Pre-bundle React dependencies to avoid React duplicates,
@@ -1363,8 +1364,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             ? isSsrBundleEnvironmentName(name)
             : name === "ssr")
         ) {
-          const vite = getVite();
-
           return {
             resolve: {
               external:
@@ -1379,16 +1378,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             optimizeDeps:
               options.optimizeDeps?.noDiscovery === false
                 ? {
-                    entries: [
-                      vite.normalizePath(ctx.entryServerFilePath),
-                      ...Object.values(ctx.reactRouterConfig.routes).map(
-                        (route) =>
-                          resolveRelativeRouteFilePath(
-                            route,
-                            ctx.reactRouterConfig,
-                          ),
-                      ),
-                    ],
+                    entries: getOptimizeDepsEntries({
+                      entryFilePath: ctx.entryServerFilePath,
+                      reactRouterConfig: ctx.reactRouterConfig,
+                      isClientEnvironment: false,
+                    }),
                     include: [
                       "react",
                       "react/jsx-dev-runtime",

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -132,8 +132,9 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           },
           optimizeDeps: {
             entries: getOptimizeDepsEntries({
-              entryClientFilePath: defaultEntries.client,
+              entryFilePath: defaultEntries.client,
               reactRouterConfig: config,
+              isClientEnvironment: true,
             }),
             esbuildOptions: {
               jsx: "automatic",


### PR DESCRIPTION
@markdalgleish and I discussed https://github.com/remix-run/react-router/pull/13570. That was then closed in favour of https://github.com/remix-run/react-router/pull/13748, which didn't apply the path escaping to `optimizeDeps.entries` for the `ssr` environment. This PR fixes that.

Note that there needs to be some follow-up work to ensure that `ssr` and `rsc` environments support optimising server dependencies with the new RSC support.