### PR TITLE
Fix invalid markdown link for createHashRouter

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -308,6 +308,7 @@
 - pawelblaszczyk5
 - pcattori
 - penx
+- peterneave
 - petersendidit
 - phildl
 - phryneas

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -766,7 +766,7 @@ export function createBrowserRouter(
 
 /**
  * Create a new {@link DataRouter| data router} that manages the application
- * path via the URL [`hash`]https://developer.mozilla.org/en-US/docs/Web/API/URL/hash).
+ * path via the URL [`hash`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash).
  *
  * @public
  * @category Data Routers


### PR DESCRIPTION
This fixes a link in the documentation.

Current issue visible at https://reactrouter.com/api/data-routers/createHashRouter#summary