### PR TITLE
docs: fix references

### DIFF
--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -146,7 +146,7 @@ test.describe("Vite / route / server-only module referenced by client", () => {
 
         `  But other route exports in 'app/routes/_index.tsx' depend on '${specifier}'.`,
 
-        "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
+        "  See https://reactrouter.com/explanation/code-splitting#removal-of-server-code",
       ].forEach(expect(stderr).toMatch);
     });
   }
@@ -206,7 +206,7 @@ test.describe("Vite / non-route / server-only module referenced by client", () =
 
         `    '${specifier}' imported by 'app/reexport-server-only.ts'`,
 
-        "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
+        "  See https://reactrouter.com/explanation/code-splitting#removal-of-server-code",
       ].forEach(expect(stderr).toMatch);
     });
   }

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2084,7 +2084,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
               "",
               `  But other route exports in '${importerShort}' depend on '${id}'.`,
               "",
-              "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
+              "  See https://reactrouter.com/explanation/code-splitting#removal-of-server-code",
               "",
             ].join("\n"),
           );
@@ -2096,7 +2096,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             "",
             `    '${id}' imported by '${importerShort}'`,
             "",
-            "  See https://remix.run/docs/en/main/guides/vite#splitting-up-client-and-server-code",
+            "  See https://reactrouter.com/explanation/code-splitting#removal-of-server-code",
             "",
           ].join("\n"),
         );

--- a/packages/react-router-fs-routes/index.ts
+++ b/packages/react-router-fs-routes/index.ts
@@ -12,7 +12,7 @@ import { normalizeSlashes } from "./normalizeSlashes";
 /**
  * Creates route config from the file system using a convention that matches
  * [Remix v2's route file
- * naming](https://remix.run/docs/en/v2/file-conventions/routes-files), for use
+ * naming](https://v2.remix.run/docs/file-conventions/routes), for use
  * within `routes.ts`.
  */
 export async function flatRoutes(

--- a/packages/react-router-node/sessions/fileStorage.ts
+++ b/packages/react-router-node/sessions/fileStorage.ts
@@ -26,7 +26,7 @@ interface FileSessionStorageOptions {
  * The advantage of using this instead of cookie session storage is that
  * files may contain much more data than cookies.
  *
- * @see https://remix.run/utils/sessions#createfilesessionstorage-node
+ * @see https://api.reactrouter.com/v7/functions/_react_router_node.createFileSessionStorage
  */
 export function createFileSessionStorage<Data = SessionData, FlashData = Data>({
   cookie,

--- a/packages/react-router-remix-routes-option-adapter/index.ts
+++ b/packages/react-router-remix-routes-option-adapter/index.ts
@@ -11,7 +11,7 @@ export type { DefineRoutesFunction, DefineRouteFunction };
 
 /**
  * Adapts routes defined using [Remix's `routes` config
- * option](https://remix.run/docs/en/v2/file-conventions/vite-config#routes) to
+ * option](https://v2.remix.run/docs/file-conventions/vite-config#routes) to
  * React Router's config format, for use within `routes.ts`.
  */
 export async function remixRoutesOptionAdapter(

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -119,7 +119,7 @@ export type LayoutComponent = ComponentType<{
  * A function that defines `<link>` tags to be inserted into the `<head>` of
  * the document on route transitions.
  *
- * @see https://remix.run/route/meta
+ * @see https://reactrouter.com/start/framework/route-module#meta
  */
 export interface LinksFunction {
   (): LinkDescriptor[];
@@ -267,7 +267,7 @@ export type RouteComponent = ComponentType<{}>;
 /**
  * An arbitrary object that is associated with a route.
  *
- * @see https://remix.run/route/handle
+ * @see https://reactrouter.com/how-to/using-handle
  */
 export type RouteHandle = unknown;
 


### PR DESCRIPTION
Fix a handful of references to the Remix docs that either don't point to a real page anymore, or should point to the React Router docs instead.