### PR TITLE
fix(dev/vite/plugin): fix `p-map` import

### DIFF
--- a/.changeset/curly-balloons-fry.md
+++ b/.changeset/curly-balloons-fry.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Use a dynamic `import()` to load ESM-only `p-map` dependency to avoid issues on Node 20.18 and below

--- a/contributors.yml
+++ b/contributors.yml
@@ -452,3 +452,4 @@
 - zeromask1337
 - zheng-chuang
 - zxTomw
+- HeyyyNeo

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -36,7 +36,6 @@ import pick from "lodash/pick";
 import jsesc from "jsesc";
 import colors from "picocolors";
 import kebabCase from "lodash/kebabCase";
-import pMap from "p-map";
 
 import * as Typegen from "../typegen";
 import type { RouteManifestEntry, RouteManifest } from "../config/routes";
@@ -2815,7 +2814,8 @@ async function handlePrerender(
     concurrency = prerender.unstable_concurrency ?? 1;
   }
 
-  await pMap(build.prerender, prerenderSinglePath, { concurrency });
+  const pMap = await import("p-map");
+  await pMap.default(build.prerender, prerenderSinglePath, { concurrency });
 }
 
 function getStaticPrerenderPaths(routes: DataRouteObject[]) {


### PR DESCRIPTION
I am able to run the project after changing esm import to dynamic import
Fixes : #14489 
This piece of granular code fixes the issue: (Did changes directly in minified js code)

```
const import_p_map = await import('p-map');
await (0, import_p_map.default)(build.prerender, prerenderSinglePath, { concurrency });
```

Steps taken to validate the fix

Build is same as previous
<img width="1498" height="662" alt="Screenshot 2025-11-01 at 7 56 58 PM" src="https://github.com/user-attachments/assets/1246a770-0e78-4cbe-a6b8-8d5b571869cb" />

How is it verified
In this current project i ran the build and copied the vite.js content and pasted in my own project
Both node v20, v25 runs the project seamlessly



