### PR TITLE
Improve AgnosticBaseRouteObject type for projects using exactOptionalPropertyTypes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -39,6 +39,7 @@
 - arnassavickas
 - aroyan
 - Artur-
+- AsamK
 - ashusnapx
 - avipatel97
 - awreese

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -628,14 +628,14 @@ export type LazyRouteDefinition<R extends AgnosticRouteObject> =
  * Base RouteObject with common props shared by all types of routes
  */
 type AgnosticBaseRouteObject = {
-  caseSensitive?: boolean;
-  path?: string;
-  id?: string;
-  middleware?: MiddlewareFunction[];
-  loader?: LoaderFunction | boolean;
-  action?: ActionFunction | boolean;
-  hasErrorBoundary?: boolean;
-  shouldRevalidate?: ShouldRevalidateFunction;
+  caseSensitive?: boolean | undefined;
+  path?: string | undefined;
+  id?: string | undefined;
+  middleware?: MiddlewareFunction[] | undefined;
+  loader?: LoaderFunction | boolean | undefined;
+  action?: ActionFunction | boolean | undefined;
+  hasErrorBoundary?: boolean | undefined;
+  shouldRevalidate?: ShouldRevalidateFunction | undefined;
   handle?: any;
   lazy?: LazyRouteDefinition<AgnosticBaseRouteObject>;
 };


### PR DESCRIPTION
Projects that use typescript with the exactOptionalPropertyTypes=true setting see a type error when using react-router.
The workaround of using skipLibCheck=false is not desirable as it weakens type-system accuracy for the whole project. https://www.typescriptlang.org/tsconfig/#skipLibCheck

This PR makes the minimal changes to work for projects using exactOptionalPropertyTypes=true and would be immensely helpful

Fixes #10392
Fixes #11991
Fixes #14504