### PR TITLE
docs: improve Form component's discovery description

### DIFF
--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1038,16 +1038,16 @@ HistoryRouter.displayName = "unstable_HistoryRouter";
 export interface LinkProps
   extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
   /**
-   * Defines the link discovery behavior.
+   * Defines the link [lazy route discovery](../../explanation/lazy-route-discovery) behavior.
+   *
+   * - **render** — default, discover the route when the link renders
+   * - **none** — don't eagerly discover, only discover if the link is clicked
    *
    * ```tsx
    * <Link /> // default ("render")
    * <Link discover="render" />
    * <Link discover="none" />
    * ```
-   *
-   * - **render** — default, discover the route when the link renders
-   * - **none** — don't eagerly discover, only discover if the link is clicked
    */
   discover?: DiscoverBehavior;
 
@@ -1717,16 +1717,16 @@ export interface FetcherFormProps extends SharedFormProps {}
  */
 export interface FormProps extends SharedFormProps {
   /**
-   * Defines the form discovery behavior.
+   * Defines the form [lazy route discovery](../../explanation/lazy-route-discovery) behavior.
+   *
+   * - **render** — default, discover the route when the form renders
+   * - **none** — don't eagerly discover, only discover if the form is submitted
    *
    * ```tsx
    * <Form /> // default ("render")
    * <Form discover="render" />
    * <Form discover="none" />
    * ```
-   *
-   * - **render** — default, discover the route when the form renders
-   * - **none** — don't eagerly discover, only discover if the form is submitted
    */
   discover?: DiscoverBehavior;
 

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -76,7 +76,8 @@ export function useFrameworkContext(): FrameworkContextObject {
 // Public API
 
 /**
- * Defines the discovery behavior of the link:
+ * Defines the [lazy route discovery](../../explanation/lazy-route-discovery)
+ * behavior of the link/form:
  *
  * - "render" - default, discover the route when the link renders
  * - "none" - don't eagerly discover, only discover if the link is clicked


### PR DESCRIPTION
The confusing example and broken link on this doc were brought to my attention: https://reactrouter.com/7.10.0/api/components/Form#discover