### PR TITLE
Update vite module load in RSC plugin to avoid Node 20 CJS issues

### DIFF
--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -1,4 +1,4 @@
-import * as Vite from "vite";
+import type * as Vite from "vite";
 import { init as initEsModuleLexer } from "es-module-lexer";
 import * as Path from "pathe";
 import * as babel from "@babel/core";
@@ -118,6 +118,9 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           reactRouterConfig: config,
         });
 
+        // Async import here to avoid CJS warnings on the console
+        let viteNormalizePath = (await import("vite")).normalizePath;
+
         return {
           resolve: {
             dedupe: [
@@ -172,7 +175,7 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
                   },
                   output: {
                     manualChunks(id) {
-                      const normalized = Vite.normalizePath(id);
+                      const normalized = viteNormalizePath(id);
                       if (
                         normalized.includes("node_modules/react/") ||
                         normalized.includes("node_modules/react-dom/") ||


### PR DESCRIPTION
Fixes a CJS warning in CI because we began importing the vite library using `import`

<img width="757" height="349" alt="Screenshot 2025-12-11 at 10 41 12 AM" src="https://github.com/user-attachments/assets/d59898f6-7c27-44e5-8fd5-1e74a5bf9054" />
