### PR TITLE
Align UNSAFE history exports

### DIFF
--- a/.changeset/friendly-moose-argue.md
+++ b/.changeset/friendly-moose-argue.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Export `UNSAFE_createMemoryHistory` and `UNSAFE_createHashHistory` alongside `UNSAFE_createBrowserHistory` for consistency. These are not intended to be used for new apps but intended to help apps usiong `unstable_HistoryRouter` migrate from v6->v7 so they can adopt the newer APIs.

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -349,7 +349,9 @@ export type {
 
 /** @internal */
 export {
+  createMemoryHistory as UNSAFE_createMemoryHistory,
   createBrowserHistory as UNSAFE_createBrowserHistory,
+  createHashHistory as UNSAFE_createHashHistory,
   invariant as UNSAFE_invariant,
 } from "./lib/router/history";
 


### PR DESCRIPTION
If we're going to export one of these as `UNSAFE_`, we should export all 3 to be consistent (see https://github.com/remix-run/react-router/discussions/12466)