### PR TITLE
Fix double slash normalization for `useNavigate` paths with colons

### DIFF
--- a/.changeset/blue-parrots-grin.md
+++ b/.changeset/blue-parrots-grin.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix double slash normalization for useNavigate colon urls

--- a/packages/react-router/__tests__/resolvePath-test.tsx
+++ b/packages/react-router/__tests__/resolvePath-test.tsx
@@ -63,6 +63,32 @@ describe("resolvePath", () => {
     spy.mockRestore();
   });
 
+  it("handles relative paths with an embedded colon", () => {
+    expect(resolvePath("foo:bar", "/")).toMatchObject({
+      pathname: "/foo:bar",
+    });
+
+    expect(resolvePath("./foo:bar", "/")).toMatchObject({
+      pathname: "/foo:bar",
+    });
+
+    expect(resolvePath("../foo:bar", "/")).toMatchObject({
+      pathname: "/foo:bar",
+    });
+
+    expect(resolvePath("foo:bar", "/path")).toMatchObject({
+      pathname: "/path/foo:bar",
+    });
+
+    expect(resolvePath("./foo:bar", "/path")).toMatchObject({
+      pathname: "/path/foo:bar",
+    });
+
+    expect(resolvePath("../foo:bar", "/path")).toMatchObject({
+      pathname: "/foo:bar",
+    });
+  });
+
   it('ignores trailing slashes on the "from" pathname when resolving relative paths', () => {
     expect(resolvePath("../search", "/inbox/")).toMatchObject({
       pathname: "/search",

--- a/packages/react-router/__tests__/resolvePath-test.tsx
+++ b/packages/react-router/__tests__/resolvePath-test.tsx
@@ -1,22 +1,6 @@
 import { resolvePath } from "react-router";
 
 describe("resolvePath", () => {
-  it("does not touch with protocol-less absolute paths", () => {
-    expect(resolvePath("//google.com")).toMatchObject({
-      pathname: "//google.com",
-    });
-
-    expect(resolvePath("//google.com/../../path")).toMatchObject({
-      pathname: "//google.com/../../path",
-    });
-
-    expect(resolvePath("//google.com?q=query#hash")).toMatchObject({
-      pathname: "//google.com",
-      search: "?q=query",
-      hash: "#hash",
-    });
-  });
-
   it('resolves absolute paths irrespective of the "from" pathname', () => {
     expect(resolvePath("/search", "/inbox")).toMatchObject({
       pathname: "/search",

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1603,23 +1603,11 @@ export function resolvePath(to: To, fromPathname = "/"): Path {
 
   let pathname: string;
   if (toPathname) {
-    if (isAbsoluteUrl(toPathname)) {
-      pathname = toPathname;
+    toPathname = toPathname.replace(/\/\/+/g, "/");
+    if (toPathname.startsWith("/")) {
+      pathname = resolvePathname(toPathname.substring(1), "/");
     } else {
-      if (toPathname.includes("//")) {
-        let oldPathname = toPathname;
-        toPathname = toPathname.replace(/\/\/+/g, "/");
-        warning(
-          false,
-          `Pathnames cannot have embedded double slashes - normalizing ` +
-            `${oldPathname} -> ${toPathname}`,
-        );
-      }
-      if (toPathname.startsWith("/")) {
-        pathname = resolvePathname(toPathname.substring(1), "/");
-      } else {
-        pathname = resolvePathname(toPathname, fromPathname);
-      }
+      pathname = resolvePathname(toPathname, fromPathname);
     }
   } else {
     pathname = fromPathname;


### PR DESCRIPTION
Closes https://github.com/remix-run/react-router/issues/14711

This is a rework of the solution from https://github.com/remix-run/react-router/pull/14529 that removes the absolute path check because `resolvePath` doesn't need to handle absolute URLs.