### PR TITLE
Fix hyperlink of History keyword in useNavigate.md

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -212,6 +212,7 @@
 - kachun333
 - Kakamotobi
 - kantuni
+- kaoths
 - kapil-patel
 - kapilepatel
 - KaranRandhir

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -103,7 +103,7 @@ navigate(1);
 
 Be cautious with `navigate(number)`. If your application can load up to a
 route that has a button that tries to navigate forward/back, there may not be
-a `[`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
+a [`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
 entry to go back or forward to, or it can go somewhere you don't expect
 (like a different domain).
 


### PR DESCRIPTION
### Summary 
Fix the corrupted hyperlink of `History` keyword in [Navigate back and forward in the history stack](https://reactrouter.com/api/hooks/useNavigate#navigate-back-or-forward-in-the-history-stack).

### Screenshits
| before (from website) | after (from vscode) |
|-|-|
| <img width="817" height="418" alt="image" src="https://github.com/user-attachments/assets/e13c4e3a-cdb2-4fbb-a634-7e8df66ca55a" /> | <img width="1069" height="327" alt="image" src="https://github.com/user-attachments/assets/323a76eb-9794-451f-aa39-5f0e62d8d7db" /> |

