### PR TITLE
fix(react-router): make setSearchParams reference stable across renders

### DIFF
--- a/.changeset/stable-setsearchparams-9991.md
+++ b/.changeset/stable-setsearchparams-9991.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Make `setSearchParams` return a stable reference across renders so it can be safely used in `useEffect` dependency arrays

--- a/contributors.yml
+++ b/contributors.yml
@@ -473,3 +473,4 @@
 - zeromask1337
 - zheng-chuang
 - zxTomw
+- DukeDeSouth

--- a/packages/react-router/.changes/patch.stable-setsearchparams.md
+++ b/packages/react-router/.changes/patch.stable-setsearchparams.md
@@ -1,5 +1,1 @@
----
-"react-router": patch
----
-
 Make `setSearchParams` return a stable reference across renders so it can be safely used in `useEffect` dependency arrays


### PR DESCRIPTION
## Human View

### Summary

`setSearchParams` returned by `useSearchParams()` is recreated every time search params change because `searchParams` is in the `useCallback` dependency array. This causes:

- `useEffect(() => { ... }, [setSearchParams])` to re-run on every search params change
- Memoized child components receiving `setSearchParams` as a prop to re-render unnecessarily
- Infinite re-render loops when effects update search params

This is a 3-year-old issue reported by @kentcdodds with 77 reactions and 33+ comments.

### Solution

Store `searchParams` in a ref and update it via `React.useEffect`. The callback reads from `searchParamsRef.current` instead of the closure-captured `searchParams`, allowing `searchParams` to be removed from the `useCallback` dependency array.

#### Why `useEffect` and not render-time ref assignment?

A previous PR (#10740) was [reviewed](https://github.com/remix-run/react-router/pull/10740#discussion_r1417875662) by @Brendonovich who correctly pointed out that writing to `ref.current` during render violates React's concurrent mode rules. This PR addresses that concern by updating the ref in an effect, which runs after React commits the render — making it safe under concurrent rendering.

#### Why not `useLayoutEffect`?

`useSearchParams` can run during SSR, where `useLayoutEffect` produces warnings. `useEffect` is sufficient because `setSearchParams` is never called between render and effect execution (it's only called from event handlers or other effects, both of which run after effects).

### Changes

- **`packages/react-router/lib/dom/lib.tsx`** (+13/-3): Add `searchParamsRef` + `useEffect`, update callback to read from ref, remove `searchParams` from deps
- **`packages/react-router/__tests__/dom/search-params-test.tsx`** (+142/-0): Three new tests:
  1. Reference stability: `setSearchParams` identity is preserved across renders
  2. Effect stability: `useEffect([setSearchParams])` doesn't re-run on params change
  3. Functional updates: `setSearchParams(prev => ...)` reads current params via ref

### Test plan

- [x] All 8 search-params tests pass (5 existing + 3 new)
- [x] Full test suite: 114/118 suites pass (4 pre-existing failures unrelated to this change)
- [x] Verified `setSearchParams` reference equality across renders
- [x] Verified `useEffect([setSearchParams])` fires once on mount only
- [x] Verified functional updates receive current search params after navigation

Fixes #9991

---

## AI View (DCCE Protocol v1.0)

### Metadata
- **Generator**: Claude (Anthropic) via Cursor IDE
- **Methodology**: AI-assisted development with human oversight and review

### AI Contribution Summary
- Solution design and implementation

### Verification Steps Performed
1. Reproduced the reported issue
2. Analyzed source code to identify root cause
3. Implemented and tested the fix

### Human Review Guidance
- Core changes are in: `searchParamsRef.current`, `ref.current`, `packages/react-router/lib/dom/lib.tsx`

Made with M7 [Cursor](https://cursor.com)
