### PR TITLE
fix: preserve query params and hash on manifest version mismatch reload

### DIFF
--- a/.changeset/fix-manifest-mismatch-query-params.md
+++ b/.changeset/fix-manifest-mismatch-query-params.md
@@ -1,0 +1,7 @@
+---
+"react-router": patch
+---
+
+Fixed manifest version mismatch reload losing query parameters and hash
+
+When React Router detects a manifest version mismatch during navigation (e.g., after a new deployment), it performs a hard reload. Previously, this reload would lose query parameters and hash from the target URL. Now the full URL including search params and hash is preserved.

--- a/contributors.yml
+++ b/contributors.yml
@@ -66,6 +66,7 @@
 - BrianT1414
 - Bricklou
 - brockross
+- brettburley
 - brookslybrand
 - brophdawg11
 - btav

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -189,6 +189,7 @@ function createHydratedRouter({
       ssrInfo.context.future.unstable_trailingSlashAwareDataRequests,
     ),
     patchRoutesOnNavigation: getPatchRoutesOnNavigationFunction(
+      () => router,
       ssrInfo.manifest,
       ssrInfo.routeModules,
       ssrInfo.context.ssr,

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -3,6 +3,7 @@ import type { PatchRoutesOnNavigationFunction } from "../../context";
 import type { Router as DataRouter } from "../../router/router";
 import type { RouteManifest } from "../../router/utils";
 import { matchRoutes } from "../../router/utils";
+import { createPath } from "../../router/history";
 import type { AssetsManifest } from "./entry";
 import type { RouteModules } from "./routeModules";
 import type { EntryRoute } from "./routes";
@@ -67,6 +68,7 @@ export function getPartialManifest(
 }
 
 export function getPatchRoutesOnNavigationFunction(
+  getRouter: () => DataRouter,
   manifest: AssetsManifest,
   routeModules: RouteModules,
   ssr: boolean,
@@ -78,13 +80,15 @@ export function getPatchRoutesOnNavigationFunction(
     return undefined;
   }
 
-  return async ({ path, patch, signal, fetcherKey }) => {
+  return async ({ path, patch, signal }) => {
     if (discoveredPaths.has(path)) {
       return;
     }
+    // Use navigation location for navigations, fallback to current location for fetchers
+    let errorReloadPath = createPath(getRouter().state.navigation.location || window.location);
     await fetchAndApplyManifestPatches(
       [path],
-      fetcherKey ? window.location.href : path,
+      errorReloadPath,
       manifest,
       routeModules,
       ssr,


### PR DESCRIPTION
## Summary

Fixes #14774

When React Router detects a manifest version mismatch during navigation (e.g., after a new deployment), it performs a hard reload. Previously, this would only reload to the pathname, losing query parameters and hash from the target URL.

## Problem

In `fog-of-war.ts` line 87, the navigation was passing just `path` instead of the full URL:
```ts
fetcherKey ? window.location.href : path,
```

This caused query parameters like `?token=abc123` and hashes like `#section` to be stripped during the reload.

## Solution

- Pass a `getRouter` callback to `getPatchRoutesOnNavigationFunction` to access the router state
- For navigations (non-fetcher), use `navigation.location` from the router state to build the full reload URL including `pathname`, `search`, and `hash`
- For fetchers, continue using `window.location.href` as before

## Testing

Added an integration test that:
1. Navigates to a route with query params and hash (`/target?foo=bar#section`)
2. Simulates a manifest version mismatch (204 response with `X-Remix-Reload-Document` header)
3. Verifies the reload preserves the full URL including query params and hash

```bash
pnpm test:integration:run --project chromium -g "preserves query params and hash on manifest version mismatch reload"
```