### PR TITLE
fix(react-router-dev): avoid duplicate stylesheet links for nested suspended routes

### DIFF
--- a/.changeset/serious-berries-pretend.md
+++ b/.changeset/serious-berries-pretend.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+avoid duplicate stylesheet links in framework mode when parent/layout routes and suspended child routes reference the same dynamic CSS asset, while preserving leaf-route dynamic CSS retention behavior

--- a/.changeset/serious-berries-pretend.md
+++ b/.changeset/serious-berries-pretend.md
@@ -1,5 +1,0 @@
----
-"@react-router/dev": patch
----
-
-avoid duplicate stylesheet links in framework mode when parent/layout routes and suspended child routes reference the same dynamic CSS asset, while preserving leaf-route dynamic CSS retention behavior

--- a/integration/vite-css-suspended-duplicate-test.ts
+++ b/integration/vite-css-suspended-duplicate-test.ts
@@ -1,0 +1,177 @@
+import { test, expect } from "@playwright/test";
+import getPort from "get-port";
+
+import {
+  build,
+  createEditor,
+  createProject,
+  reactRouterServe,
+  viteConfig,
+} from "./helpers/vite.js";
+
+const js = String.raw;
+
+test.describe("Vite CSS suspended duplicate styles", () => {
+  let port: number;
+  let cwd: string;
+  let stop: () => void;
+
+  test.beforeAll(async () => {
+    port = await getPort();
+    cwd = await createProject(
+      {
+        "vite.config.ts": await viteConfig.basic({
+          port,
+          templateName: "vite-6-template",
+          vanillaExtract: true,
+        }),
+        "app/routes.ts": js`
+          import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+          export default [
+            route(":slug", "routes/$slug/layout.tsx", [
+              index("routes/$slug/route.tsx"),
+            ]),
+          ] satisfies RouteConfig;
+        `,
+        "app/components/WithStyles.css.ts": js`
+          import { style } from "@vanilla-extract/css";
+
+          export const withStyles = style({
+            color: "rgb(255, 0, 0)",
+          });
+        `,
+        "app/components/WithStyles.tsx": js`
+          import * as styles from "./WithStyles.css";
+
+          export function WithStyles() {
+            return <div data-with-styles className={styles.withStyles}>with styles</div>;
+          }
+        `,
+        "app/components/Suspended.tsx": js`
+          import { WithStyles } from "./WithStyles";
+
+          export function Suspended() {
+            return <WithStyles />;
+          }
+        `,
+        "app/routes/$slug/layout.tsx": js`
+          import { lazy, Suspense } from "react";
+          import { Outlet } from "react-router";
+
+          const SuspendedLazy = lazy(() =>
+            import("../../components/Suspended").then(({ Suspended }) => ({
+              default: Suspended,
+            })),
+          );
+
+          import { WithStyles } from "../../components/WithStyles";
+
+          export default function LayoutRoute() {
+            return (
+              <>
+                <h1 data-layout>layout</h1>
+                <Suspense fallback={"loading-layout"}>
+                  <SuspendedLazy />
+                </Suspense>
+                <Outlet />
+              </>
+            );
+          }
+        `,
+        "app/routes/$slug/route.tsx": js`
+          import { lazy, Suspense } from "react";
+
+          const SuspendedLazy = lazy(() =>
+            import("../../components/Suspended").then(({ Suspended }) => ({
+              default: Suspended,
+            })),
+          );
+
+          export default function SlugIndexRoute() {
+            return (
+              <>
+                <h2 data-route>route</h2>
+                <Suspense fallback={"loading-route"}>
+                  <SuspendedLazy />
+                </Suspense>
+              </>
+            );
+          }
+        `,
+      },
+      "vite-6-template",
+    );
+
+    let edit = createEditor(cwd);
+    await edit("package.json", (contents) =>
+      contents.replace('"sideEffects": false', '"sideEffects": true'),
+    );
+
+    let { status } = build({ cwd });
+    expect(status).toBe(0);
+    stop = await reactRouterServe({ cwd, port });
+  });
+
+  test.afterAll(() => stop());
+
+  test("does not duplicate stylesheet links for suspended components in nested routes", async ({
+    page,
+  }) => {
+    let stylesheetRequests: string[] = [];
+    page.on("requestfinished", (request) => {
+      if (request.resourceType() === "stylesheet") {
+        stylesheetRequests.push(request.url());
+      }
+    });
+
+    await page.goto(`http://localhost:${port}/some`, {
+      waitUntil: "networkidle",
+    });
+
+    await expect(page.locator("[data-layout]")).toHaveText("layout");
+    await expect(page.locator("[data-route]")).toHaveText("route");
+    await expect(page.locator("[data-with-styles]").first()).toHaveCSS(
+      "color",
+      "rgb(255, 0, 0)",
+    );
+
+    let stylesheetHrefs = await page.evaluate(() =>
+      Array.from(
+        document.querySelectorAll<HTMLLinkElement>("link[rel='stylesheet']"),
+      )
+        .map((link) => link.getAttribute("href"))
+        .filter((href): href is string => href != null),
+    );
+
+    let normalizeHref = (href: string) => href.replace(/#$/, "");
+    let normalizedLinkHrefs = stylesheetHrefs
+      .map(normalizeHref)
+      .filter((href) => href.includes("WithStyles.css.ts-"));
+    let normalizedRequestHrefs = stylesheetRequests.map((requestUrl) => {
+      let url = new URL(requestUrl);
+      return normalizeHref(url.pathname + url.search + url.hash);
+    })
+      .filter((href) => href.includes("WithStyles.css.ts-"));
+
+    let duplicateLinkHrefs = normalizedLinkHrefs.filter(
+      (href, index, hrefs) => hrefs.indexOf(href) !== index,
+    );
+    let duplicateRequestHrefs = normalizedRequestHrefs.filter(
+      (href, index, hrefs) => hrefs.indexOf(href) !== index,
+    );
+
+    expect(normalizedLinkHrefs.length).toBeGreaterThan(0);
+    expect(
+      duplicateLinkHrefs,
+      `Duplicate stylesheet links found.\nraw=${JSON.stringify(stylesheetHrefs)}\nnormalized=${JSON.stringify(normalizedLinkHrefs)}`,
+    ).toEqual([]);
+
+    if (normalizedRequestHrefs.length > 0) {
+      expect(
+        duplicateRequestHrefs,
+        `Duplicate stylesheet requests found.\nraw=${JSON.stringify(stylesheetRequests)}\nnormalized=${JSON.stringify(normalizedRequestHrefs)}`,
+      ).toEqual([]);
+    }
+  });
+});

--- a/integration/vite-css-suspended-duplicate-test.ts
+++ b/integration/vite-css-suspended-duplicate-test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import getPort from "get-port";
 
 import {
@@ -7,79 +7,207 @@ import {
   createProject,
   reactRouterServe,
   viteConfig,
+  viteMajorTemplates,
 } from "./helpers/vite.js";
 
 const js = String.raw;
 
-test.describe("Vite CSS suspended duplicate styles", () => {
-  let port: number;
-  let cwd: string;
-  let stop: () => void;
+function collectStylesheetRequests(page: Page): string[] {
+  let stylesheetRequests: string[] = [];
+  page.on("requestfinished", (request) => {
+    if (request.resourceType() === "stylesheet") {
+      stylesheetRequests.push(request.url());
+    }
+  });
+  return stylesheetRequests;
+}
 
-  test.beforeAll(async () => {
-    port = await getPort();
-    cwd = await createProject(
-      {
-        "vite.config.ts": await viteConfig.basic({
-          port,
-          templateName: "vite-6-template",
-          vanillaExtract: true,
-        }),
-        "app/routes.ts": js`
+async function assertNoDuplicateStylesheets({
+  page,
+  stylesheetRequests,
+  assetName,
+}: {
+  page: Page;
+  stylesheetRequests: string[];
+  assetName: string;
+}) {
+  let stylesheetHrefs = await page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll<HTMLLinkElement>("link[rel='stylesheet']"),
+    )
+      .map((link) => link.getAttribute("href"))
+      .filter((href): href is string => href != null),
+  );
+
+  let normalizeHref = (href: string) => href.replace(/#$/, "");
+  let normalizedLinkHrefs = stylesheetHrefs
+    .map(normalizeHref)
+    .filter((href) => href.includes(assetName));
+  let normalizedRequestHrefs = stylesheetRequests
+    .map((requestUrl) => {
+      let url = new URL(requestUrl);
+      return normalizeHref(url.pathname + url.search + url.hash);
+    })
+    .filter((href) => href.includes(assetName));
+
+  let duplicateLinkHrefs = normalizedLinkHrefs.filter(
+    (href, index, hrefs) => hrefs.indexOf(href) !== index,
+  );
+  let duplicateRequestHrefs = normalizedRequestHrefs.filter(
+    (href, index, hrefs) => hrefs.indexOf(href) !== index,
+  );
+
+  expect(normalizedLinkHrefs.length).toBeGreaterThan(0);
+  expect(
+    duplicateLinkHrefs,
+    `Duplicate stylesheet links found.\nraw=${JSON.stringify(stylesheetHrefs)}\nnormalized=${JSON.stringify(normalizedLinkHrefs)}`,
+  ).toEqual([]);
+
+  if (normalizedRequestHrefs.length > 0) {
+    expect(
+      duplicateRequestHrefs,
+      `Duplicate stylesheet requests found.\nraw=${JSON.stringify(stylesheetRequests)}\nnormalized=${JSON.stringify(normalizedRequestHrefs)}`,
+    ).toEqual([]);
+  }
+}
+
+test.describe("Vite CSS suspended duplicate styles", () => {
+  viteMajorTemplates.forEach(({ templateName, templateDisplayName }) => {
+    test.describe(templateDisplayName, () => {
+      let port: number;
+      let cwd: string;
+      let stop: () => void;
+
+      test.beforeAll(async () => {
+        port = await getPort();
+        cwd = await createProject(
+          {
+            "vite.config.ts": await viteConfig.basic({
+              port,
+              templateName,
+              vanillaExtract: true,
+            }),
+            "app/routes.ts": js`
           import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
           export default [
+            route("layout-shared", "routes/layout-shared/layout.tsx", [
+              index("routes/layout-shared/route.tsx"),
+            ]),
             route(":slug", "routes/$slug/layout.tsx", [
               index("routes/$slug/route.tsx"),
             ]),
           ] satisfies RouteConfig;
         `,
-        "app/components/WithStyles.css.ts": js`
+            "app/root.tsx": js`
+          import { Links, Meta, Outlet, Scripts } from "react-router";
+          import { WithStyles } from "./components/WithStyles";
+
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <WithStyles />
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+            "app/components/WithStyles.css.ts": js`
           import { style } from "@vanilla-extract/css";
 
           export const withStyles = style({
             color: "rgb(255, 0, 0)",
           });
         `,
-        "app/components/WithStyles.tsx": js`
+            "app/components/WithStyles.tsx": js`
           import * as styles from "./WithStyles.css";
 
           export function WithStyles() {
             return <div data-with-styles className={styles.withStyles}>with styles</div>;
           }
         `,
-        "app/components/Suspended.tsx": js`
+            "app/components/Suspended.tsx": js`
           import { WithStyles } from "./WithStyles";
 
           export function Suspended() {
             return <WithStyles />;
           }
         `,
-        "app/routes/$slug/layout.tsx": js`
-          import { lazy, Suspense } from "react";
+            "app/components/LayoutWithStyles.css.ts": js`
+          import { style } from "@vanilla-extract/css";
+
+          export const layoutWithStyles = style({
+            color: "rgb(0, 128, 0)",
+          });
+        `,
+            "app/components/LayoutWithStyles.tsx": js`
+          import * as styles from "./LayoutWithStyles.css";
+
+          export function LayoutWithStyles() {
+            return <div data-layout-with-styles className={styles.layoutWithStyles}>layout with styles</div>;
+          }
+        `,
+            "app/components/LayoutSuspended.tsx": js`
+          import { LayoutWithStyles } from "./LayoutWithStyles";
+
+          export function LayoutSuspended() {
+            return <LayoutWithStyles />;
+          }
+        `,
+            "app/routes/layout-shared/layout.tsx": js`
           import { Outlet } from "react-router";
+          import { LayoutWithStyles } from "../../components/LayoutWithStyles";
 
-          const SuspendedLazy = lazy(() =>
-            import("../../components/Suspended").then(({ Suspended }) => ({
-              default: Suspended,
-            })),
-          );
-
-          import { WithStyles } from "../../components/WithStyles";
-
-          export default function LayoutRoute() {
+          export default function LayoutSharedRoute() {
             return (
               <>
-                <h1 data-layout>layout</h1>
-                <Suspense fallback={"loading-layout"}>
-                  <SuspendedLazy />
-                </Suspense>
+                <h1 data-layout-shared>layout shared</h1>
+                <LayoutWithStyles />
                 <Outlet />
               </>
             );
           }
         `,
-        "app/routes/$slug/route.tsx": js`
+            "app/routes/layout-shared/route.tsx": js`
+          import { lazy, Suspense } from "react";
+
+          const LayoutSuspendedLazy = lazy(() =>
+            import("../../components/LayoutSuspended").then(({ LayoutSuspended }) => ({
+              default: LayoutSuspended,
+            })),
+          );
+
+          export default function LayoutSharedIndexRoute() {
+            return (
+              <>
+                <h2 data-layout-shared-route>layout shared route</h2>
+                <Suspense fallback={"loading-layout-shared-route"}>
+                  <LayoutSuspendedLazy />
+                </Suspense>
+              </>
+            );
+          }
+        `,
+            "app/routes/$slug/layout.tsx": js`
+          import { Outlet } from "react-router";
+
+          export default function LayoutRoute() {
+            return (
+              <>
+                <h1 data-layout>layout</h1>
+                <Outlet />
+              </>
+            );
+          }
+        `,
+            "app/routes/$slug/route.tsx": js`
           import { lazy, Suspense } from "react";
 
           const SuspendedLazy = lazy(() =>
@@ -99,79 +227,79 @@ test.describe("Vite CSS suspended duplicate styles", () => {
             );
           }
         `,
-      },
-      "vite-6-template",
-    );
+          },
+          templateName,
+        );
 
-    let edit = createEditor(cwd);
-    await edit("package.json", (contents) =>
-      contents.replace('"sideEffects": false', '"sideEffects": true'),
-    );
+        let edit = createEditor(cwd);
+        await edit("package.json", (contents) =>
+          contents.replace('"sideEffects": false', '"sideEffects": true'),
+        );
 
-    let { status } = build({ cwd });
-    expect(status).toBe(0);
-    stop = await reactRouterServe({ cwd, port });
-  });
+        let { status } = build({ cwd });
+        expect(status).toBe(0);
+        stop = await reactRouterServe({ cwd, port });
+      });
 
-  test.afterAll(() => stop());
+      test.afterAll(() => stop());
 
-  test("does not duplicate stylesheet links for suspended components in nested routes", async ({
-    page,
-  }) => {
-    let stylesheetRequests: string[] = [];
-    page.on("requestfinished", (request) => {
-      if (request.resourceType() === "stylesheet") {
-        stylesheetRequests.push(request.url());
-      }
+      test("does not duplicate stylesheet links when root and leaf routes share suspended component CSS", async ({
+        page,
+      }) => {
+        let stylesheetRequests = collectStylesheetRequests(page);
+
+        await page.goto(`http://localhost:${port}/some`, {
+          waitUntil: "networkidle",
+        });
+
+        await expect(page.locator("[data-layout]")).toHaveText("layout");
+        await expect(page.locator("[data-route]")).toHaveText("route");
+        await expect(page.locator("[data-with-styles]")).toHaveCount(2);
+        await expect(page.locator("[data-with-styles]").first()).toHaveCSS(
+          "color",
+          "rgb(255, 0, 0)",
+        );
+        await expect(page.locator("[data-with-styles]").last()).toHaveCSS(
+          "color",
+          "rgb(255, 0, 0)",
+        );
+
+        await assertNoDuplicateStylesheets({
+          page,
+          stylesheetRequests,
+          assetName: "WithStyles-",
+        });
+      });
+
+      test("does not duplicate stylesheet links when layout and leaf routes share suspended component CSS", async ({
+        page,
+      }) => {
+        let stylesheetRequests = collectStylesheetRequests(page);
+
+        await page.goto(`http://localhost:${port}/layout-shared`, {
+          waitUntil: "networkidle",
+        });
+
+        await expect(page.locator("[data-layout-shared]")).toHaveText(
+          "layout shared",
+        );
+        await expect(page.locator("[data-layout-shared-route]")).toHaveText(
+          "layout shared route",
+        );
+        await expect(page.locator("[data-layout-with-styles]")).toHaveCount(2);
+        await expect(
+          page.locator("[data-layout-with-styles]").first(),
+        ).toHaveCSS("color", "rgb(0, 128, 0)");
+        await expect(
+          page.locator("[data-layout-with-styles]").last(),
+        ).toHaveCSS("color", "rgb(0, 128, 0)");
+
+        await assertNoDuplicateStylesheets({
+          page,
+          stylesheetRequests,
+          assetName: "LayoutWithStyles-",
+        });
+      });
     });
-
-    await page.goto(`http://localhost:${port}/some`, {
-      waitUntil: "networkidle",
-    });
-
-    await expect(page.locator("[data-layout]")).toHaveText("layout");
-    await expect(page.locator("[data-route]")).toHaveText("route");
-    await expect(page.locator("[data-with-styles]").first()).toHaveCSS(
-      "color",
-      "rgb(255, 0, 0)",
-    );
-
-    let stylesheetHrefs = await page.evaluate(() =>
-      Array.from(
-        document.querySelectorAll<HTMLLinkElement>("link[rel='stylesheet']"),
-      )
-        .map((link) => link.getAttribute("href"))
-        .filter((href): href is string => href != null),
-    );
-
-    let normalizeHref = (href: string) => href.replace(/#$/, "");
-    let normalizedLinkHrefs = stylesheetHrefs
-      .map(normalizeHref)
-      .filter((href) => href.includes("WithStyles.css.ts-"));
-    let normalizedRequestHrefs = stylesheetRequests.map((requestUrl) => {
-      let url = new URL(requestUrl);
-      return normalizeHref(url.pathname + url.search + url.hash);
-    })
-      .filter((href) => href.includes("WithStyles.css.ts-"));
-
-    let duplicateLinkHrefs = normalizedLinkHrefs.filter(
-      (href, index, hrefs) => hrefs.indexOf(href) !== index,
-    );
-    let duplicateRequestHrefs = normalizedRequestHrefs.filter(
-      (href, index, hrefs) => hrefs.indexOf(href) !== index,
-    );
-
-    expect(normalizedLinkHrefs.length).toBeGreaterThan(0);
-    expect(
-      duplicateLinkHrefs,
-      `Duplicate stylesheet links found.\nraw=${JSON.stringify(stylesheetHrefs)}\nnormalized=${JSON.stringify(normalizedLinkHrefs)}`,
-    ).toEqual([]);
-
-    if (normalizedRequestHrefs.length > 0) {
-      expect(
-        duplicateRequestHrefs,
-        `Duplicate stylesheet requests found.\nraw=${JSON.stringify(stylesheetRequests)}\nnormalized=${JSON.stringify(normalizedRequestHrefs)}`,
-      ).toEqual([]);
-    }
   });
 });

--- a/integration/vite-css-suspended-duplicate-test.ts
+++ b/integration/vite-css-suspended-duplicate-test.ts
@@ -94,13 +94,18 @@ test.describe("Vite CSS suspended duplicate styles", () => {
             route("layout-shared", "routes/layout-shared/layout.tsx", [
               index("routes/layout-shared/route.tsx"),
             ]),
+            route("persistent-owner", "routes/persistent-owner/layout.tsx", [
+              index("routes/persistent-owner/route.tsx"),
+            ]),
+            route("persistent-without-owner", "routes/persistent-without-owner.tsx"),
             route(":slug", "routes/$slug/layout.tsx", [
               index("routes/$slug/route.tsx"),
             ]),
           ] satisfies RouteConfig;
         `,
             "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router";
+          import { Link, Links, Meta, Outlet, Scripts } from "react-router";
+          import { LoadPersistentWithStyles } from "./components/LoadPersistentWithStyles";
           import { WithStyles } from "./components/WithStyles";
 
           export default function Root() {
@@ -111,6 +116,9 @@ test.describe("Vite CSS suspended duplicate styles", () => {
                   <Links />
                 </head>
                 <body>
+                  <Link to="/persistent-owner">persistent owner</Link>
+                  <Link to="/persistent-without-owner">persistent without owner</Link>
+                  <LoadPersistentWithStyles />
                   <WithStyles />
                   <Outlet />
                   <Scripts />
@@ -161,6 +169,46 @@ test.describe("Vite CSS suspended duplicate styles", () => {
             return <LayoutWithStyles />;
           }
         `,
+            "app/components/PersistentWithStyles.css.ts": js`
+          import { style } from "@vanilla-extract/css";
+
+          export const persistentWithStyles = style({
+            color: "rgb(0, 0, 255)",
+          });
+        `,
+            "app/components/PersistentWithStyles.tsx": js`
+          import * as styles from "./PersistentWithStyles.css";
+
+          export function PersistentWithStyles() {
+            return <div data-persistent-with-styles className={styles.persistentWithStyles}>persistent with styles</div>;
+          }
+        `,
+            "app/components/LoadPersistentWithStyles.tsx": js`
+          import { lazy, Suspense, useState } from "react";
+
+          const PersistentWithStylesLazy = lazy(() =>
+            import("./PersistentWithStyles").then(({ PersistentWithStyles }) => ({
+              default: PersistentWithStyles,
+            })),
+          );
+
+          export function LoadPersistentWithStyles() {
+            const [show, setShow] = useState(false);
+
+            return (
+              <>
+                <button data-load-persistent-with-styles onClick={() => setShow(true)}>
+                  load persistent with styles
+                </button>
+                {show ? (
+                  <Suspense fallback={"loading-persistent-with-styles"}>
+                    <PersistentWithStylesLazy />
+                  </Suspense>
+                ) : null}
+              </>
+            );
+          }
+        `,
             "app/routes/layout-shared/layout.tsx": js`
           import { Outlet } from "react-router";
           import { LayoutWithStyles } from "../../components/LayoutWithStyles";
@@ -193,6 +241,30 @@ test.describe("Vite CSS suspended duplicate styles", () => {
                 </Suspense>
               </>
             );
+          }
+        `,
+            "app/routes/persistent-owner/layout.tsx": js`
+          import { Outlet } from "react-router";
+          import { PersistentWithStyles } from "../../components/PersistentWithStyles";
+
+          export default function PersistentOwnerLayoutRoute() {
+            return (
+              <>
+                <h1 data-persistent-owner>persistent owner</h1>
+                <PersistentWithStyles />
+                <Outlet />
+              </>
+            );
+          }
+        `,
+            "app/routes/persistent-owner/route.tsx": js`
+          export default function PersistentOwnerIndexRoute() {
+            return <h2 data-persistent-owner-route>persistent owner route</h2>;
+          }
+        `,
+            "app/routes/persistent-without-owner.tsx": js`
+          export default function PersistentWithoutOwnerRoute() {
+            return <h1 data-persistent-without-owner>persistent without owner</h1>;
           }
         `,
             "app/routes/$slug/layout.tsx": js`
@@ -299,6 +371,49 @@ test.describe("Vite CSS suspended duplicate styles", () => {
           stylesheetRequests,
           assetName: "LayoutWithStyles-",
         });
+      });
+
+      test("retains dynamically imported CSS after leaving a non-leaf route that statically owns the same asset", async ({
+        page,
+      }) => {
+        let persistentStylesheetSelector =
+          "link[rel='stylesheet'][href*='PersistentWithStyles-']";
+
+        await page.goto(`http://localhost:${port}/persistent-owner`, {
+          waitUntil: "networkidle",
+        });
+
+        await page.locator("[data-load-persistent-with-styles]").click();
+        await expect(page.locator("[data-persistent-with-styles]")).toHaveCount(
+          2,
+        );
+        await expect(
+          page.locator("[data-persistent-with-styles]").first(),
+        ).toHaveCSS("color", "rgb(0, 0, 255)");
+        await expect(page.locator(persistentStylesheetSelector)).toHaveCount(2);
+        await expect(
+          page.locator(`${persistentStylesheetSelector}[href$='#']`),
+        ).toHaveCount(1);
+
+        await page
+          .getByRole("link", {
+            name: "persistent without owner",
+          })
+          .click();
+        await expect(
+          page.locator("[data-persistent-without-owner]"),
+        ).toHaveText("persistent without owner");
+        await expect(page.locator("[data-persistent-with-styles]")).toHaveCount(
+          1,
+        );
+        await expect(page.locator("[data-persistent-with-styles]")).toHaveCSS(
+          "color",
+          "rgb(0, 0, 255)",
+        );
+        await expect(page.locator(persistentStylesheetSelector)).toHaveCount(1);
+        await expect(
+          page.locator(`${persistentStylesheetSelector}[href$='#']`),
+        ).toHaveCount(0);
       });
     });
   });

--- a/packages/react-router-dev/.changes/patch.vite-css-duplicate-links.md
+++ b/packages/react-router-dev/.changes/patch.vite-css-duplicate-links.md
@@ -1,0 +1,1 @@
+Avoid duplicate stylesheet links in Framework mode when ancestor routes and suspended leaf routes reference the same dynamic CSS asset.

--- a/packages/react-router-dev/.changes/patch.vite-css-duplicate-links.md
+++ b/packages/react-router-dev/.changes/patch.vite-css-duplicate-links.md
@@ -1,1 +1,1 @@
-Avoid duplicate stylesheet links in Framework mode when ancestor routes and suspended leaf routes reference the same dynamic CSS asset.
+Avoid duplicate stylesheet links in Framework mode when routes share dynamic CSS assets while retaining dynamically imported styles across route navigations.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -336,13 +336,12 @@ const getReactRouterManifestBuildAssets = (
   allDynamicCssFiles: Set<string>,
   entryFilePath: string,
   route: RouteManifestEntry | null,
+  ancestorRouteCssHrefs = new Set<string>(),
 ): ReactRouterManifest["entry"] & { css: string[] } => {
   let entryChunk = resolveChunk(ctx, viteManifest, entryFilePath);
   invariant(entryChunk, `Chunk not found: ${entryFilePath}`);
 
   let isRootRoute = Boolean(route && route.parentId === undefined);
-  // Keep `#` only for leaf routes to preserve dynamic-import CSS retention
-  // without duplicating parent/layout route styles.
   let shouldUseForciblyUniqueCssHrefs =
     route !== null &&
     !Object.values(ctx.reactRouterConfig.routes).some(
@@ -391,6 +390,9 @@ const getReactRouterManifestBuildAssets = (
           .flatMap((e) => e.css ?? [])
           .map((href) => {
             let publicHref = `${ctx.publicPath}${href}`;
+            if (ancestorRouteCssHrefs.has(publicHref)) {
+              return null;
+            }
             // If this CSS file is also dynamically imported anywhere in the
             // application, we append a hash to the href so Vite ignores it when
             // managing dynamic CSS injection. If we don't do this, Vite's
@@ -497,6 +499,10 @@ function getAllDynamicCssFiles(
 
 function dedupe<T>(array: T[]): T[] {
   return [...new Set(array)];
+}
+
+function normalizeManifestCssHref(href: string): string {
+  return href.endsWith("#") ? href.slice(0, -1) : href;
 }
 
 const writeFileSafe = async (file: string, contents: string): Promise<void> => {
@@ -945,6 +951,48 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
     let enforceSplitRouteModules =
       ctx.reactRouterConfig.splitRouteModules === "enforce";
+    let routeBuildAssetsCache = new Map<
+      string,
+      ReactRouterManifest["entry"] & { css: string[] }
+    >();
+    let getRouteBuildAssets = (
+      route: RouteManifestEntry,
+    ): ReactRouterManifest["entry"] & { css: string[] } => {
+      let cachedAssets = routeBuildAssetsCache.get(route.id);
+      if (cachedAssets) {
+        return cachedAssets;
+      }
+
+      let ancestorRouteCssHrefs = new Set<string>();
+      let ancestorRoute =
+        route.parentId === undefined
+          ? undefined
+          : ctx.reactRouterConfig.routes[route.parentId];
+      while (ancestorRoute) {
+        let ancestorAssets = getRouteBuildAssets(ancestorRoute);
+        for (let cssHref of ancestorAssets.css) {
+          ancestorRouteCssHrefs.add(normalizeManifestCssHref(cssHref));
+        }
+        ancestorRoute =
+          ancestorRoute.parentId === undefined
+            ? undefined
+            : ctx.reactRouterConfig.routes[ancestorRoute.parentId];
+      }
+
+      let routeFile = path.join(ctx.reactRouterConfig.appDirectory, route.file);
+      let assets = getReactRouterManifestBuildAssets(
+        ctx,
+        viteConfig,
+        viteManifest,
+        allDynamicCssFiles,
+        `${routeFile}${BUILD_CLIENT_ROUTE_QUERY_STRING}`,
+        route,
+        ancestorRouteCssHrefs,
+      );
+      routeBuildAssetsCache.set(route.id, assets);
+      return assets;
+    };
+
     for (let route of Object.values(ctx.reactRouterConfig.routes)) {
       let routeFile = path.join(ctx.reactRouterConfig.appDirectory, route.file);
       let sourceExports = routeManifestExports[route.id];
@@ -991,14 +1039,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         hasClientMiddleware,
         hasDefaultExport: sourceExports.includes("default"),
         hasErrorBoundary: sourceExports.includes("ErrorBoundary"),
-        ...getReactRouterManifestBuildAssets(
-          ctx,
-          viteConfig,
-          viteManifest,
-          allDynamicCssFiles,
-          `${routeFile}${BUILD_CLIENT_ROUTE_QUERY_STRING}`,
-          route,
-        ),
+        ...getRouteBuildAssets(route),
         clientActionModule: hasRouteChunkByExportName.clientAction
           ? getPublicModulePathForEntry(
               ctx,

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -333,7 +333,8 @@ const getReactRouterManifestBuildAssets = (
   ctx: ReactRouterPluginContext,
   viteConfig: Vite.ResolvedConfig,
   viteManifest: Vite.Manifest,
-  allDynamicCssFiles: Set<string>,
+  dynamicCssRouteIdsByFile: Map<string, Set<string>>,
+  routeAndAncestorIdsByRouteId: Map<string, Set<string>>,
   entryFilePath: string,
   route: RouteManifestEntry | null,
   ancestorRouteCssHrefs = new Set<string>(),
@@ -342,11 +343,6 @@ const getReactRouterManifestBuildAssets = (
   invariant(entryChunk, `Chunk not found: ${entryFilePath}`);
 
   let isRootRoute = Boolean(route && route.parentId === undefined);
-  let shouldUseForciblyUniqueCssHrefs =
-    route !== null &&
-    !Object.values(ctx.reactRouterConfig.routes).some(
-      (candidateRoute) => candidateRoute.parentId === route.id,
-    );
 
   let routeModuleChunks = routeChunkNames
     .map((routeChunkName) =>
@@ -393,20 +389,23 @@ const getReactRouterManifestBuildAssets = (
             if (ancestorRouteCssHrefs.has(publicHref)) {
               return null;
             }
-            // If this CSS file is also dynamically imported anywhere in the
-            // application, we append a hash to the href so Vite ignores it when
-            // managing dynamic CSS injection. If we don't do this, Vite's
-            // dynamic import logic might hold off on inserting a new `link`
-            // element because it's already in the page, only for React Router
-            // to remove it when navigating to a new route, resulting in missing
-            // styles. By appending a hash, Vite doesn't detect that the CSS is
-            // already in the page and always manages its own `link` element.
-            // This means that Vite's CSS stays in the page even if the
-            // route-level CSS is removed from the document. We use a hash here
-            // because it's a unique `href` value but isn't a unique network
-            // request and only adds a single character.
-            return allDynamicCssFiles.has(href) &&
-              shouldUseForciblyUniqueCssHrefs
+            // If a route outside this route's subtree dynamically imports this
+            // CSS file, we append a hash so Vite manages its own `link` element.
+            // Otherwise, Vite might reuse this route-level link only for React
+            // Router to remove it while the dynamic importer is still mounted.
+            // We use a hash because it's a unique `href` value but isn't a unique
+            // network request and only adds a single character.
+            let dynamicCssRouteIds = dynamicCssRouteIdsByFile.get(href);
+            let shouldUseForciblyUniqueCssHref =
+              route !== null &&
+              dynamicCssRouteIds !== undefined &&
+              Array.from(dynamicCssRouteIds).some(
+                (dynamicCssRouteId) =>
+                  !routeAndAncestorIdsByRouteId
+                    .get(dynamicCssRouteId)
+                    ?.has(route.id),
+              );
+            return shouldUseForciblyUniqueCssHref
               ? `${publicHref}#`
               : publicHref;
           }),
@@ -444,11 +443,11 @@ function resolveDependantChunks(
   return Array.from(chunks);
 }
 
-function getAllDynamicCssFiles(
+function getDynamicCssRouteIdsByFile(
   ctx: ReactRouterPluginContext,
   viteManifest: Vite.Manifest,
-): Set<string> {
-  let allDynamicCssFiles = new Set<string>();
+): Map<string, Set<string>> {
+  let dynamicCssRouteIdsByFile = new Map<string, Set<string>>();
 
   for (let route of Object.values(ctx.reactRouterConfig.routes)) {
     let routeFile = path.join(ctx.reactRouterConfig.appDirectory, route.file);
@@ -459,12 +458,16 @@ function getAllDynamicCssFiles(
     );
 
     if (entryChunk) {
-      let visitedChunks = new Set<Vite.ManifestChunk>();
+      let visitedStaticChunks = new Set<Vite.ManifestChunk>();
+      let visitedDynamicChunks = new Set<Vite.ManifestChunk>();
 
       function walk(
         chunk: Vite.ManifestChunk,
         isDynamicImportContext: boolean,
       ) {
+        let visitedChunks = isDynamicImportContext
+          ? visitedDynamicChunks
+          : visitedStaticChunks;
         if (visitedChunks.has(chunk)) {
           return;
         }
@@ -473,7 +476,12 @@ function getAllDynamicCssFiles(
 
         if (isDynamicImportContext && chunk.css) {
           for (let cssFile of chunk.css) {
-            allDynamicCssFiles.add(cssFile);
+            let dynamicCssRouteIds = dynamicCssRouteIdsByFile.get(cssFile);
+            if (!dynamicCssRouteIds) {
+              dynamicCssRouteIds = new Set();
+              dynamicCssRouteIdsByFile.set(cssFile, dynamicCssRouteIds);
+            }
+            dynamicCssRouteIds.add(route.id);
           }
         }
 
@@ -494,7 +502,28 @@ function getAllDynamicCssFiles(
     }
   }
 
-  return allDynamicCssFiles;
+  return dynamicCssRouteIdsByFile;
+}
+
+function getRouteAndAncestorIdsByRouteId(
+  routes: RouteManifest,
+): Map<string, Set<string>> {
+  let routeAndAncestorIdsByRouteId = new Map<string, Set<string>>();
+
+  for (let route of Object.values(routes)) {
+    let ancestorIds = new Set<string>();
+    let ancestorRoute: RouteManifestEntry | undefined = route;
+    while (ancestorRoute && !ancestorIds.has(ancestorRoute.id)) {
+      ancestorIds.add(ancestorRoute.id);
+      ancestorRoute =
+        ancestorRoute.parentId === undefined
+          ? undefined
+          : routes[ancestorRoute.parentId];
+    }
+    routeAndAncestorIdsByRouteId.set(route.id, ancestorIds);
+  }
+
+  return routeAndAncestorIdsByRouteId;
 }
 
 function dedupe<T>(array: T[]): T[] {
@@ -930,13 +959,20 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       getClientBuildDirectory(ctx.reactRouterConfig),
     );
 
-    let allDynamicCssFiles = getAllDynamicCssFiles(ctx, viteManifest);
+    let dynamicCssRouteIdsByFile = getDynamicCssRouteIdsByFile(
+      ctx,
+      viteManifest,
+    );
+    let routeAndAncestorIdsByRouteId = getRouteAndAncestorIdsByRouteId(
+      ctx.reactRouterConfig.routes,
+    );
 
     let entry = getReactRouterManifestBuildAssets(
       ctx,
       viteConfig,
       viteManifest,
-      allDynamicCssFiles,
+      dynamicCssRouteIdsByFile,
+      routeAndAncestorIdsByRouteId,
       ctx.entryClientFilePath,
       null,
     );
@@ -984,7 +1020,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         ctx,
         viteConfig,
         viteManifest,
-        allDynamicCssFiles,
+        dynamicCssRouteIdsByFile,
+        routeAndAncestorIdsByRouteId,
         `${routeFile}${BUILD_CLIENT_ROUTE_QUERY_STRING}`,
         route,
         ancestorRouteCssHrefs,

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -341,6 +341,13 @@ const getReactRouterManifestBuildAssets = (
   invariant(entryChunk, `Chunk not found: ${entryFilePath}`);
 
   let isRootRoute = Boolean(route && route.parentId === undefined);
+  // Keep `#` only for leaf routes to preserve dynamic-import CSS retention
+  // without duplicating parent/layout route styles.
+  let shouldUseForciblyUniqueCssHrefs =
+    route !== null &&
+    !Object.values(ctx.reactRouterConfig.routes).some(
+      (candidateRoute) => candidateRoute.parentId === route.id,
+    );
 
   let routeModuleChunks = routeChunkNames
     .map((routeChunkName) =>
@@ -396,7 +403,10 @@ const getReactRouterManifestBuildAssets = (
             // route-level CSS is removed from the document. We use a hash here
             // because it's a unique `href` value but isn't a unique network
             // request and only adds a single character.
-            return allDynamicCssFiles.has(href) ? `${publicHref}#` : publicHref;
+            return allDynamicCssFiles.has(href) &&
+              shouldUseForciblyUniqueCssHrefs
+              ? `${publicHref}#`
+              : publicHref;
           }),
       ]
         .flat(1)


### PR DESCRIPTION
This seems to be a problem caused by adding `#`, similar to the previously submitted PR (#14687), so I attempted to fix it.

Fixes duplicated stylesheet links in Framework mode for suspended components in nested routes

When reproducing the issue, I confirmed it does not occur in dev mode, but does occur when running the built app.  
The behavior appears related to the forced-unique `#` stylesheet href logic introduced to preserve dynamic-import CSS behavior.

## Changes

- Added e2e test
  - `integration/vite-css-suspended-duplicate-test.ts`
- Updated Vite plugin stylesheet href handling
  - `packages/react-router-dev/vite/plugin.ts`

Fixes #14754