### PR TITLE
fix(react-router): prevent JSON-LD duplication and hydration mismatch in React 19

### DIFF
--- a/.changeset/tame-bananas-work.md
+++ b/.changeset/tame-bananas-work.md
@@ -1,0 +1,5 @@
+---
+"react-router": minor
+---
+
+fix: prevent JSON-LD duplication and hydration mismatch in React 19 by using stable index-based keys and adding suppressHydrationWarning.

--- a/contributors.yml
+++ b/contributors.yml
@@ -474,3 +474,4 @@
 - zeromask1337
 - zheng-chuang
 - zxTomw
+- Ammar123890

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -585,13 +585,13 @@ export function Meta(): React.JSX.Element {
       routeMeta =
         typeof routeModule.meta === "function"
           ? (routeModule.meta as MetaFunction)({
-            data,
-            loaderData: data,
-            params,
-            location,
-            matches,
-            error,
-          })
+              data,
+              loaderData: data,
+              params,
+              location,
+              matches,
+              error,
+            })
           : Array.isArray(routeModule.meta)
             ? [...routeModule.meta]
             : routeModule.meta;
@@ -606,10 +606,10 @@ export function Meta(): React.JSX.Element {
     if (!Array.isArray(routeMeta)) {
       throw new Error(
         "The route at " +
-        _match.route.path +
-        " returns an invalid value. All route meta functions must " +
-        "return an array of meta objects." +
-        "\n\nTo reference the meta function API, see https://remix.run/route/meta",
+          _match.route.path +
+          " returns an invalid value. All route meta functions must " +
+          "return an array of meta objects." +
+          "\n\nTo reference the meta function API, see https://remix.run/route/meta",
       );
     }
 
@@ -804,86 +804,88 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
 
     let routeModulesScript = !isStatic
       ? " "
-      : `${manifest.hmr?.runtime
-        ? `import ${JSON.stringify(manifest.hmr.runtime)};`
-        : ""
-      }${!enableFogOfWar ? `import ${JSON.stringify(manifest.url)}` : ""};
+      : `${
+          manifest.hmr?.runtime
+            ? `import ${JSON.stringify(manifest.hmr.runtime)};`
+            : ""
+        }${!enableFogOfWar ? `import ${JSON.stringify(manifest.url)}` : ""};
 ${matches
-        .map((match, routeIndex) => {
-          let routeVarName = `route${routeIndex}`;
-          let manifestEntry = manifest.routes[match.route.id];
-          invariant(manifestEntry, `Route ${match.route.id} not found in manifest`);
-          let {
-            clientActionModule,
-            clientLoaderModule,
-            clientMiddlewareModule,
-            hydrateFallbackModule,
-            module,
-          } = manifestEntry;
+  .map((match, routeIndex) => {
+    let routeVarName = `route${routeIndex}`;
+    let manifestEntry = manifest.routes[match.route.id];
+    invariant(manifestEntry, `Route ${match.route.id} not found in manifest`);
+    let {
+      clientActionModule,
+      clientLoaderModule,
+      clientMiddlewareModule,
+      hydrateFallbackModule,
+      module,
+    } = manifestEntry;
 
-          let chunks: Array<{ module: string; varName: string }> = [
-            ...(clientActionModule
-              ? [
-                {
-                  module: clientActionModule,
-                  varName: `${routeVarName}_clientAction`,
-                },
-              ]
-              : []),
-            ...(clientLoaderModule
-              ? [
-                {
-                  module: clientLoaderModule,
-                  varName: `${routeVarName}_clientLoader`,
-                },
-              ]
-              : []),
-            ...(clientMiddlewareModule
-              ? [
-                {
-                  module: clientMiddlewareModule,
-                  varName: `${routeVarName}_clientMiddleware`,
-                },
-              ]
-              : []),
-            ...(hydrateFallbackModule
-              ? [
-                {
-                  module: hydrateFallbackModule,
-                  varName: `${routeVarName}_HydrateFallback`,
-                },
-              ]
-              : []),
-            { module, varName: `${routeVarName}_main` },
-          ];
+    let chunks: Array<{ module: string; varName: string }> = [
+      ...(clientActionModule
+        ? [
+            {
+              module: clientActionModule,
+              varName: `${routeVarName}_clientAction`,
+            },
+          ]
+        : []),
+      ...(clientLoaderModule
+        ? [
+            {
+              module: clientLoaderModule,
+              varName: `${routeVarName}_clientLoader`,
+            },
+          ]
+        : []),
+      ...(clientMiddlewareModule
+        ? [
+            {
+              module: clientMiddlewareModule,
+              varName: `${routeVarName}_clientMiddleware`,
+            },
+          ]
+        : []),
+      ...(hydrateFallbackModule
+        ? [
+            {
+              module: hydrateFallbackModule,
+              varName: `${routeVarName}_HydrateFallback`,
+            },
+          ]
+        : []),
+      { module, varName: `${routeVarName}_main` },
+    ];
 
-          if (chunks.length === 1) {
-            return `import * as ${routeVarName} from ${JSON.stringify(module)};`;
-          }
+    if (chunks.length === 1) {
+      return `import * as ${routeVarName} from ${JSON.stringify(module)};`;
+    }
 
-          let chunkImportsSnippet = chunks
-            .map((chunk) => `import * as ${chunk.varName} from "${chunk.module}";`)
-            .join("\n");
+    let chunkImportsSnippet = chunks
+      .map((chunk) => `import * as ${chunk.varName} from "${chunk.module}";`)
+      .join("\n");
 
-          let mergedChunksSnippet = `const ${routeVarName} = {${chunks
-            .map((chunk) => `...${chunk.varName}`)
-            .join(",")}};`;
+    let mergedChunksSnippet = `const ${routeVarName} = {${chunks
+      .map((chunk) => `...${chunk.varName}`)
+      .join(",")}};`;
 
-          return [chunkImportsSnippet, mergedChunksSnippet].join("\n");
-        })
-        .join("\n")}
-  ${enableFogOfWar
-        ? // Inline a minimal manifest with the SSR matches
+    return [chunkImportsSnippet, mergedChunksSnippet].join("\n");
+  })
+  .join("\n")}
+  ${
+    enableFogOfWar
+      ? // Inline a minimal manifest with the SSR matches
         `window.__reactRouterManifest = ${JSON.stringify(
           getPartialManifest(manifest, router),
           null,
           2,
         )};`
-        : ""
-      }
+      : ""
+  }
   window.__reactRouterRouteModules = {${matches
-        .map((match, index) => `${JSON.stringify(match.route.id)}:route${index}`)
-        .join(",")}};
+    .map((match, index) => `${JSON.stringify(match.route.id)}:route${index}`)
+    .join(",")}};
 
 import(${JSON.stringify(manifest.entry.module)});`;
 
@@ -914,12 +916,12 @@ import(${JSON.stringify(manifest.entry.module)});`;
     isHydrated || isRSCRouterContext
       ? []
       : dedupe(
-        manifest.entry.imports.concat(
-          getModuleLinkHrefs(matches, manifest, {
-            includeHydrateFallback: true,
-          }),
-        ),
-      );
+          manifest.entry.imports.concat(
+            getModuleLinkHrefs(matches, manifest, {
+              includeHydrateFallback: true,
+            }),
+          ),
+        );
 
   let sri = typeof manifest.sri === "object" ? manifest.sri : {};
 

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -585,13 +585,13 @@ export function Meta(): React.JSX.Element {
       routeMeta =
         typeof routeModule.meta === "function"
           ? (routeModule.meta as MetaFunction)({
-              data,
-              loaderData: data,
-              params,
-              location,
-              matches,
-              error,
-            })
+            data,
+            loaderData: data,
+            params,
+            location,
+            matches,
+            error,
+          })
           : Array.isArray(routeModule.meta)
             ? [...routeModule.meta]
             : routeModule.meta;
@@ -606,10 +606,10 @@ export function Meta(): React.JSX.Element {
     if (!Array.isArray(routeMeta)) {
       throw new Error(
         "The route at " +
-          _match.route.path +
-          " returns an invalid value. All route meta functions must " +
-          "return an array of meta objects." +
-          "\n\nTo reference the meta function API, see https://remix.run/route/meta",
+        _match.route.path +
+        " returns an invalid value. All route meta functions must " +
+        "return an array of meta objects." +
+        "\n\nTo reference the meta function API, see https://remix.run/route/meta",
       );
     }
 
@@ -621,7 +621,7 @@ export function Meta(): React.JSX.Element {
 
   return (
     <>
-      {meta.flat().map((metaProps) => {
+      {meta.flat().map((metaProps, index) => {
         if (!metaProps) {
           return null;
         }
@@ -656,10 +656,13 @@ export function Meta(): React.JSX.Element {
         if ("script:ld+json" in metaProps) {
           try {
             let json = JSON.stringify(metaProps["script:ld+json"]);
+            let ldJsonKey = `script:ld+json:${index}`;
+
             return (
               <script
-                key={`script:ld+json:${json}`}
+                key={ldJsonKey}
                 type="application/ld+json"
+                suppressHydrationWarning
                 dangerouslySetInnerHTML={{ __html: escapeHtml(json) }}
               />
             );
@@ -667,7 +670,7 @@ export function Meta(): React.JSX.Element {
             return null;
           }
         }
-        return <meta key={JSON.stringify(metaProps)} {...metaProps} />;
+        return <meta key={index} {...metaProps} />;
       })}
     </>
   );
@@ -801,88 +804,86 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
 
     let routeModulesScript = !isStatic
       ? " "
-      : `${
-          manifest.hmr?.runtime
-            ? `import ${JSON.stringify(manifest.hmr.runtime)};`
-            : ""
-        }${!enableFogOfWar ? `import ${JSON.stringify(manifest.url)}` : ""};
+      : `${manifest.hmr?.runtime
+        ? `import ${JSON.stringify(manifest.hmr.runtime)};`
+        : ""
+      }${!enableFogOfWar ? `import ${JSON.stringify(manifest.url)}` : ""};
 ${matches
-  .map((match, routeIndex) => {
-    let routeVarName = `route${routeIndex}`;
-    let manifestEntry = manifest.routes[match.route.id];
-    invariant(manifestEntry, `Route ${match.route.id} not found in manifest`);
-    let {
-      clientActionModule,
-      clientLoaderModule,
-      clientMiddlewareModule,
-      hydrateFallbackModule,
-      module,
-    } = manifestEntry;
+        .map((match, routeIndex) => {
+          let routeVarName = `route${routeIndex}`;
+          let manifestEntry = manifest.routes[match.route.id];
+          invariant(manifestEntry, `Route ${match.route.id} not found in manifest`);
+          let {
+            clientActionModule,
+            clientLoaderModule,
+            clientMiddlewareModule,
+            hydrateFallbackModule,
+            module,
+          } = manifestEntry;
 
-    let chunks: Array<{ module: string; varName: string }> = [
-      ...(clientActionModule
-        ? [
-            {
-              module: clientActionModule,
-              varName: `${routeVarName}_clientAction`,
-            },
-          ]
-        : []),
-      ...(clientLoaderModule
-        ? [
-            {
-              module: clientLoaderModule,
-              varName: `${routeVarName}_clientLoader`,
-            },
-          ]
-        : []),
-      ...(clientMiddlewareModule
-        ? [
-            {
-              module: clientMiddlewareModule,
-              varName: `${routeVarName}_clientMiddleware`,
-            },
-          ]
-        : []),
-      ...(hydrateFallbackModule
-        ? [
-            {
-              module: hydrateFallbackModule,
-              varName: `${routeVarName}_HydrateFallback`,
-            },
-          ]
-        : []),
-      { module, varName: `${routeVarName}_main` },
-    ];
+          let chunks: Array<{ module: string; varName: string }> = [
+            ...(clientActionModule
+              ? [
+                {
+                  module: clientActionModule,
+                  varName: `${routeVarName}_clientAction`,
+                },
+              ]
+              : []),
+            ...(clientLoaderModule
+              ? [
+                {
+                  module: clientLoaderModule,
+                  varName: `${routeVarName}_clientLoader`,
+                },
+              ]
+              : []),
+            ...(clientMiddlewareModule
+              ? [
+                {
+                  module: clientMiddlewareModule,
+                  varName: `${routeVarName}_clientMiddleware`,
+                },
+              ]
+              : []),
+            ...(hydrateFallbackModule
+              ? [
+                {
+                  module: hydrateFallbackModule,
+                  varName: `${routeVarName}_HydrateFallback`,
+                },
+              ]
+              : []),
+            { module, varName: `${routeVarName}_main` },
+          ];
 
-    if (chunks.length === 1) {
-      return `import * as ${routeVarName} from ${JSON.stringify(module)};`;
-    }
+          if (chunks.length === 1) {
+            return `import * as ${routeVarName} from ${JSON.stringify(module)};`;
+          }
 
-    let chunkImportsSnippet = chunks
-      .map((chunk) => `import * as ${chunk.varName} from "${chunk.module}";`)
-      .join("\n");
+          let chunkImportsSnippet = chunks
+            .map((chunk) => `import * as ${chunk.varName} from "${chunk.module}";`)
+            .join("\n");
 
-    let mergedChunksSnippet = `const ${routeVarName} = {${chunks
-      .map((chunk) => `...${chunk.varName}`)
-      .join(",")}};`;
+          let mergedChunksSnippet = `const ${routeVarName} = {${chunks
+            .map((chunk) => `...${chunk.varName}`)
+            .join(",")}};`;
 
-    return [chunkImportsSnippet, mergedChunksSnippet].join("\n");
-  })
-  .join("\n")}
-  ${
-    enableFogOfWar
-      ? // Inline a minimal manifest with the SSR matches
+          return [chunkImportsSnippet, mergedChunksSnippet].join("\n");
+        })
+        .join("\n")}
+  ${enableFogOfWar
+        ? // Inline a minimal manifest with the SSR matches
         `window.__reactRouterManifest = ${JSON.stringify(
           getPartialManifest(manifest, router),
           null,
           2,
         )};`
-      : ""
-  }
+        : ""
+      }
   window.__reactRouterRouteModules = {${matches
-    .map((match, index) => `${JSON.stringify(match.route.id)}:route${index}`)
-    .join(",")}};
+        .map((match, index) => `${JSON.stringify(match.route.id)}:route${index}`)
+        .join(",")}};
 
 import(${JSON.stringify(manifest.entry.module)});`;
 
@@ -913,12 +914,12 @@ import(${JSON.stringify(manifest.entry.module)});`;
     isHydrated || isRSCRouterContext
       ? []
       : dedupe(
-          manifest.entry.imports.concat(
-            getModuleLinkHrefs(matches, manifest, {
-              includeHydrateFallback: true,
-            }),
-          ),
-        );
+        manifest.entry.imports.concat(
+          getModuleLinkHrefs(matches, manifest, {
+            includeHydrateFallback: true,
+          }),
+        ),
+      );
 
   let sri = typeof manifest.sri === "object" ? manifest.sri : {};
 


### PR DESCRIPTION
### **The Problem**

Currently, the `<Meta />` component renders `script:ld+json` tags using the stringified JSON content as the React `key`. In **React 19**, this creates a critical failure point when combined with CDNs (like Cloudflare) or streaming SSR:

1. **Hydration Mismatch (Error #418):** CDNs often minify HTML by stripping whitespace. Because the `key` is derived from the stringified JSON, the server-rendered key (with spaces) does not match the client-hydrated key (minified).
2. **Tag Duplication:** React 19 treats the `<head>` and `<body>` as **HostSingletons**. When a hydration mismatch occurs on a script within these singletons, React 19 orphans the server node and appends a new client-side node. This results in **duplicate LD+JSON blocks**, which invalidates SEO structured data.

### **The Solution**

This PR stabilizes meta-tag identity by shifting from content-based keys to position-based keys:

* **Stable Index Keys:** Changed the `key` for `script:ld+json` to use the descriptor `index`. This ensures the identity of the tag is tied to its position in the array, which is guaranteed to be consistent between server and client rendering passes.
* **Hydration Shield:** Added `suppressHydrationWarning={true}` to the script tag. This allows React to ignore minor whitespace or character encoding discrepancies introduced by external infrastructure.
* **Unified Stability:** Updated the fallback key for standard meta tags to use the `index` instead of `JSON.stringify(metaProps)`, making the entire `<Meta />` component resilient to CDN-induced hydration failures.


### **Related Issues**

This fix aligns with recent architectural changes in other major routing frameworks to support React 19's stricter hydration rules:

* **TanStack Router:** [[Issue #6653 - [Hydration mismatch with scripts in Head](fix: preserve data script content during client hydration](https://github.com/TanStack/router/pull/6653)
 
* **Nuxt-jsonld:** [[Issue #423 - Duplicate structured data items](https://github.com/ymmooot/nuxt-jsonld/issues/423)](https://github.com/ymmooot/nuxt-jsonld/issues/423)

* **Remix Router:** [[Issue #14797 - [Duplicate JSON-LD scripts]](https://github.com/remix-run/react-router/discussions/14797#discussioncomment-15760310)

---


