### PR TITLE
Revert "fix: clear timeout when turbo-stream encoding completes"

### DIFF
--- a/.changeset/clear-stream-timeout.md
+++ b/.changeset/clear-stream-timeout.md
@@ -1,5 +1,0 @@
----
-"react-router": patch
----
-
-fix: clear timeout when turbo-stream encoding completes

--- a/contributors.yml
+++ b/contributors.yml
@@ -277,7 +277,6 @@
 - maximevtush
 - maxpou
 - mcansh
-- mcollina
 - MeatSim
 - MenouerBetty
 - Methuselah96

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -385,14 +385,10 @@ export function encodeViaTurboStream(
     () => controller.abort(new Error("Server Timeout")),
     typeof streamTimeout === "number" ? streamTimeout : 4950,
   );
-
-  let clearStreamTimeout = () => clearTimeout(timeoutId);
-
-  requestSignal.addEventListener("abort", clearStreamTimeout);
+  requestSignal.addEventListener("abort", () => clearTimeout(timeoutId));
 
   return encode(data, {
     signal: controller.signal,
-    onComplete: clearStreamTimeout,
     plugins: [
       (value) => {
         // Even though we sanitized errors on context.errors prior to responding,

--- a/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
+++ b/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
@@ -138,10 +138,9 @@ export function encode(
     plugins?: EncodePlugin[];
     postPlugins?: EncodePlugin[];
     signal?: AbortSignal;
-    onComplete?: () => void;
   },
 ) {
-  const { plugins, postPlugins, signal, onComplete } = options ?? {};
+  const { plugins, postPlugins, signal } = options ?? {};
 
   const encoder: ThisEncode = {
     deferred: {},
@@ -275,7 +274,6 @@ export function encode(
       }
       await Promise.all(Object.values(encoder.deferred));
 
-      onComplete?.();
       controller.close();
     },
   });


### PR DESCRIPTION
Reverts remix-run/react-router#14735 - should have merged to `dev` instead of `main`

