### PR TITLE
fix: clear timeout when turbo-stream encoding completes (#14735)

### DIFF
--- a/.changeset/clear-stream-timeout.md
+++ b/.changeset/clear-stream-timeout.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+fix: clear timeout when turbo-stream encoding completes

--- a/contributors.yml
+++ b/contributors.yml
@@ -276,6 +276,7 @@
 - maximevtush
 - maxpou
 - mcansh
+- mcollina
 - MeatSim
 - MenouerBetty
 - Methuselah96

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -385,10 +385,14 @@ export function encodeViaTurboStream(
     () => controller.abort(new Error("Server Timeout")),
     typeof streamTimeout === "number" ? streamTimeout : 4950,
   );
-  requestSignal.addEventListener("abort", () => clearTimeout(timeoutId));
+
+  let clearStreamTimeout = () => clearTimeout(timeoutId);
+
+  requestSignal.addEventListener("abort", clearStreamTimeout);
 
   return encode(data, {
     signal: controller.signal,
+    onComplete: clearStreamTimeout,
     plugins: [
       (value) => {
         // Even though we sanitized errors on context.errors prior to responding,

--- a/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
+++ b/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
@@ -138,9 +138,10 @@ export function encode(
     plugins?: EncodePlugin[];
     postPlugins?: EncodePlugin[];
     signal?: AbortSignal;
+    onComplete?: () => void;
   },
 ) {
-  const { plugins, postPlugins, signal } = options ?? {};
+  const { plugins, postPlugins, signal, onComplete } = options ?? {};
 
   const encoder: ThisEncode = {
     deferred: {},
@@ -274,6 +275,7 @@ export function encode(
       }
       await Promise.all(Object.values(encoder.deferred));
 
+      onComplete?.();
       controller.close();
     },
   });


### PR DESCRIPTION
Cherry pick of https://github.com/remix-run/react-router/pull/14735 against the `dev` branch