### PR TITLE
Preserve query params on manifest mismatch reload

### DIFF
--- a/.changeset/warm-clouds-shine.md
+++ b/.changeset/warm-clouds-shine.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Preserve query parameters and hash on manifest version mismatch reload

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -189,6 +189,7 @@ function createHydratedRouter({
       ssrInfo.context.future.unstable_trailingSlashAwareDataRequests,
     ),
     patchRoutesOnNavigation: getPatchRoutesOnNavigationFunction(
+      () => router,
       ssrInfo.manifest,
       ssrInfo.routeModules,
       ssrInfo.context.ssr,

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -8,6 +8,7 @@ import type { RouteModules } from "./routeModules";
 import type { EntryRoute } from "./routes";
 import { createClientRoutes } from "./routes";
 import type { ServerBuild } from "../../server-runtime/build";
+import { createPath } from "../../router/history";
 
 // Currently rendered links that may need prefetching
 const nextPaths = new Set<string>();
@@ -67,6 +68,7 @@ export function getPartialManifest(
 }
 
 export function getPatchRoutesOnNavigationFunction(
+  getRouter: () => DataRouter,
   manifest: AssetsManifest,
   routeModules: RouteModules,
   ssr: boolean,
@@ -82,9 +84,14 @@ export function getPatchRoutesOnNavigationFunction(
     if (discoveredPaths.has(path)) {
       return;
     }
+    let { state } = getRouter();
     await fetchAndApplyManifestPatches(
       [path],
-      fetcherKey ? window.location.href : path,
+      // If we're patching for a fetcher call, reload the current location
+      // Otherwise prefer any ongoing navigation location
+      fetcherKey
+        ? window.location.href
+        : createPath(state.navigation.location || state.location),
       manifest,
       routeModules,
       ssr,


### PR DESCRIPTION
Replaces https://github.com/remix-run/react-router/pull/14771, https://github.com/remix-run/react-router/pull/14787
Fixes https://github.com/remix-run/react-router/issues/14774