### PR TITLE
ci: declare explicit token permissions across test/integration workflows

### DIFF
--- a/.github/workflows/close-no-repro-issue.yml
+++ b/.github/workflows/close-no-repro-issue.yml
@@ -7,6 +7,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   close-no-repro-issue:
     name: 🚪 Close issue

--- a/.github/workflows/close-no-repro-issues.yml
+++ b/.github/workflows/close-no-repro-issues.yml
@@ -13,6 +13,10 @@ on:
         description: "Dry Run? (no issues will be closed)"
         default: false
 
+permissions:
+  contents: read
+  issues: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:

--- a/.github/workflows/integration-full.yml
+++ b/.github/workflows/integration-full.yml
@@ -19,6 +19,9 @@ on:
       - "contributors.yml"
       - "**/*.md"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "⚙️ Build"

--- a/.github/workflows/integration-pr-ubuntu.yml
+++ b/.github/workflows/integration-pr-ubuntu.yml
@@ -15,6 +15,9 @@ on:
       - "contributors.yml"
       - "**/*.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration-pr-windows-macos.yml
+++ b/.github/workflows/integration-pr-windows-macos.yml
@@ -11,6 +11,9 @@ on:
       - "packages/react-router-dev/**"
       - "!**/*.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -3,6 +3,9 @@ name: 🛠️ Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   CI: true
 

--- a/.github/workflows/shared-integration.yml
+++ b/.github/workflows/shared-integration.yml
@@ -23,6 +23,9 @@ on:
         type: number
         default: 45
 
+permissions:
+  contents: read
+
 env:
   CI: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ on:
       - "docs/**"
       - "**/*.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary\nAdd explicit least-privilege workflow permissions in places currently relying on implicit defaults:\n\n- `.github/workflows/test.yml`\n- `.github/workflows/integration-full.yml`\n- `.github/workflows/integration-pr-ubuntu.yml`\n- `.github/workflows/integration-pr-windows-macos.yml`\n- `.github/workflows/shared-build.yml`\n- `.github/workflows/shared-integration.yml`\n- `.github/workflows/close-no-repro-issue.yml`\n- `.github/workflows/close-no-repro-issues.yml`\n\n## Permission choices\n- Read-only CI/reusable workflows: `contents: read`\n- Issue-closing workflows: `contents: read` + `issues: write`\n\n## Why\nThis narrows default token scope and documents intent for each workflow while preserving existing behavior.\n\n## Notes\n- configuration-only changes\n- no build/test logic changes\n