### PR TITLE
docs: fix duplicated wording in navigate options comment

### DIFF
--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1222,7 +1222,7 @@ export interface LinkProps
   unstable_defaultShouldRevalidate?: boolean;
 
   /**
-   * Masked path for for this navigation, when you want to navigate the router to
+   * Masked path for this navigation, when you want to navigate the router to
    * one location but display a separate location in the URL bar.
    *
    * This is useful for contextual navigations such as opening an image in a modal


### PR DESCRIPTION
## Summary
- fix duplicated wording in `packages/react-router/lib/dom/lib.tsx`
- changed `Masked path for for this navigation` -> `Masked path for this navigation`

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- guideline reference: https://github.com/remix-run/react-router/blob/main/CONTRIBUTING.md
- trivial docs/comment wording fix only
- no behavior or API changes

## Validation
- single-file text/comment/docs change