### PR TITLE
fix(Link): memoize merged ref to prevent unnecessary ref callback invocations

### DIFF
--- a/.changeset/stable-link-ref-callback.md
+++ b/.changeset/stable-link-ref-callback.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Memoize the merged `Link` ref callback to avoid unnecessary ref callback invocations on re-renders.

--- a/packages/react-router/__tests__/dom/link-click-test.tsx
+++ b/packages/react-router/__tests__/dom/link-click-test.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 import { act } from "@testing-library/react";
-import { MemoryRouter, Routes, Route, Link } from "../../index";
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  Link,
+  UNSAFE_FrameworkContext as FrameworkContext,
+} from "../../index";
 
 function click(anchor: HTMLAnchorElement, eventInit?: MouseEventInit) {
   let event = new MouseEvent("click", {
@@ -357,6 +363,121 @@ describe("A <Link> click", () => {
       let h1 = node.querySelector("h1");
       expect(h1).not.toBeNull();
       expect(h1?.textContent).toEqual("Home");
+    });
+  });
+
+  describe("when rerendering with a stable ref callback", () => {
+    it("does not re-invoke the ref callback", () => {
+      let ref = jest.fn();
+
+      function Home() {
+        let [count, setCount] = React.useState(0);
+
+        return (
+          <div>
+            <button onClick={() => setCount((value) => value + 1)}>Update</button>
+            <Link to="/home" ref={ref}>
+              Home {count}
+            </Link>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOM.createRoot(node).render(
+          <MemoryRouter initialEntries={["/home"]}>
+            <Routes>
+              <Route path="home" element={<Home />} />
+            </Routes>
+          </MemoryRouter>,
+        );
+      });
+
+      let anchor = node.querySelector("a");
+      let button = node.querySelector("button");
+      expect(anchor).not.toBeNull();
+      expect(button).not.toBeNull();
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenLastCalledWith(anchor);
+
+      act(() => {
+        button?.dispatchEvent(
+          new MouseEvent("click", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+
+      expect(ref).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-invoke the ref callback with prefetch='intent'", () => {
+      let ref = jest.fn();
+
+      function Home() {
+        return (
+          <div>
+            <Link to="/home" ref={ref} prefetch="intent">
+              Home
+            </Link>
+          </div>
+        );
+      }
+
+      act(() => {
+        ReactDOM.createRoot(node).render(
+          <FrameworkContext.Provider
+            value={
+              {
+                future: {},
+                manifest: { routes: {}, entry: { imports: [], module: "" } },
+                routeModules: {},
+                ssr: false,
+                isSpaMode: true,
+                routeDiscovery: { mode: "lazy", manifestPath: "" },
+              } as any
+            }
+          >
+            <MemoryRouter initialEntries={["/home"]}>
+              <Routes>
+                <Route path="home" element={<Home />} />
+              </Routes>
+            </MemoryRouter>
+          </FrameworkContext.Provider>,
+        );
+      });
+
+      let anchor = node.querySelector("a");
+      expect(anchor).not.toBeNull();
+      expect(ref).toHaveBeenCalledTimes(1);
+      expect(ref).toHaveBeenLastCalledWith(anchor);
+
+      // mouseenter triggers setMaybePrefetch(true) → re-render
+      act(() => {
+        anchor?.dispatchEvent(
+          new MouseEvent("mouseenter", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+
+      // mouseleave triggers cancelIntent() → re-render
+      act(() => {
+        anchor?.dispatchEvent(
+          new MouseEvent("mouseleave", {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+
+      // ref should still have been called only once (on mount)
+      expect(ref).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-router/__tests__/dom/link-click-test.tsx
+++ b/packages/react-router/__tests__/dom/link-click-test.tsx
@@ -375,7 +375,9 @@ describe("A <Link> click", () => {
 
         return (
           <div>
-            <button onClick={() => setCount((value) => value + 1)}>Update</button>
+            <button onClick={() => setCount((value) => value + 1)}>
+              Update
+            </button>
             <Link to="/home" ref={ref}>
               Home {count}
             </Link>

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1394,6 +1394,11 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       }
     }
 
+    let mergedRef = React.useMemo(
+      () => mergeRefs(forwardedRef, prefetchRef),
+      [forwardedRef, prefetchRef],
+    );
+
     let isSpaLink = !(parsed.isExternal || reloadDocument);
     let link = (
       // eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -1404,7 +1409,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
           (isSpaLink ? maskedHref : undefined) || parsed.absoluteURL || href
         }
         onClick={isSpaLink ? handleClick : onClick}
-        ref={mergeRefs(forwardedRef, prefetchRef)}
+        ref={mergedRef}
         target={target}
         data-discover={
           !isAbsolute && discover === "render" ? "true" : undefined


### PR DESCRIPTION
`Link` calls `mergeRefs(forwardedRef, prefetchRef)` inline in JSX, so a new `RefCallback` is created on every render. React sees the ref identity change and calls the old ref with `null` then the new ref with the DOM node — even if the consumer passes a stable ref callback. This causes the ref to be invoked twice on every re-render (#12705).

Fixed by wrapping in `useMemo`:

```tsx
let mergedRef = React.useMemo(
  () => mergeRefs(forwardedRef, prefetchRef),
  [forwardedRef, prefetchRef],
);
```

`useMemo` fits here since we're memoizing the return value of `mergeRefs`, not a user callback. `prefetchRef` comes from `useRef` so it's stable, and `forwardedRef` only changes when the parent passes a different ref — so `mergedRef` stays the same across normal re-renders.

Added two tests: one for a plain state-driven re-render, and one for `prefetch="intent"` with mouseenter/mouseleave triggering re-renders via `FrameworkContext`.

Fixes #12705