### PR TITLE
`isHydrationRequest` not cleared when hydration navigation is aborted

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -79,23 +79,35 @@ test.beforeAll(async () => {
           return { query: q };
         }
 
-        // Track first call so only the hydration invocation blocks.
-        let isFirstCall = true;
+        // Track call count so only the hydration invocation blocks.
+        let callCount = 0;
 
-        export async function clientLoader({ serverLoader }) {
-          if (isFirstCall) {
-            isFirstCall = false;
+        export async function clientLoader({ serverLoader, request }) {
+          callCount++;
+          let currentCall = callCount;
+          let url = new URL(request.url);
+          let q = url.searchParams.get("q") || "empty";
+
+          if (currentCall === 1) {
             // Block hydration loader. Without this, serverLoader() returns
             // initialData synchronously during hydration, the loader completes
             // instantly, and isHydrationRequest is cleared in the finally block
             // before we can trigger a navigation to expose the bug.
             await new Promise((resolve) => setTimeout(resolve, 30000));
           }
-          // On second call (PUSH navigation): isFirstCall is false, no delay.
+          // On second call (PUSH navigation): no delay.
           // But isHydrationRequest is still true because the first call
           // (hydration) is stuck in its 30s delay and hasn't reached finally.
           // So serverLoader() returns stale initialData instead of fetching.
-          return await serverLoader();
+          let serverData = await serverLoader();
+          return {
+            ...serverData,
+            // clientLoader-specific fields prove the clientLoader ran and
+            // show what it saw — even when serverLoader() returns stale data.
+            clientLoaderRan: true,
+            clientLoaderCallCount: currentCall,
+            clientLoaderQuery: q,
+          };
         }
         clientLoader.hydrate = true;
 
@@ -105,6 +117,9 @@ test.beforeAll(async () => {
             <div>
               <h1 data-testid="page">Search</h1>
               <p data-testid="query">{data.query}</p>
+              <p data-testid="client-loader-ran">{String(data.clientLoaderRan ?? false)}</p>
+              <p data-testid="client-loader-call-count">{String(data.clientLoaderCallCount ?? 0)}</p>
+              <p data-testid="client-loader-query">{String(data.clientLoaderQuery ?? "none")}</p>
               <Link to="/search?q=updated">Update query</Link>
             </div>
           );
@@ -131,6 +146,12 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
 }) => {
   let app = new PlaywrightFixture(appFixture, page);
 
+  // Centralized locators for reuse and readability
+  let serverQuery = page.locator('[data-testid="query"]');
+  let clientLoaderRan = page.locator('[data-testid="client-loader-ran"]');
+  let clientLoaderCallCount = page.locator('[data-testid="client-loader-call-count"]');
+  let clientLoaderQuery = page.locator('[data-testid="client-loader-query"]');
+
   // SSR the search page with ?q=initial.
   // After "load", scripts have executed and React has hydrated the DOM.
   // useLayoutEffect has fired → router.initialize() → hydration POP started.
@@ -138,6 +159,26 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
   // The SSR HTML is visible and links are clickable (React hydrated the DOM),
   // but router.state.initialized is false (hydration POP hasn't completed).
   await app.goto("/search?q=initial");
+
+  // Verify SSR state: the server-rendered HTML shows the server loader data,
+  // but clientLoader hasn't completed yet (it's blocked in its 30s delay),
+  // so the clientLoader-specific fields show their fallback defaults.
+  await expect(
+    serverQuery,
+    "SSR should render the server loader's query param"
+  ).toHaveText("initial");
+  await expect(
+    clientLoaderRan,
+    "clientLoader has not completed yet during SSR — should show fallback"
+  ).toHaveText("false");
+  await expect(
+    clientLoaderCallCount,
+    "clientLoader has not completed yet during SSR — call count should be 0"
+  ).toHaveText("0");
+  await expect(
+    clientLoaderQuery,
+    "clientLoader has not completed yet during SSR — query should show fallback"
+  ).toHaveText("none");
 
   // Click the link to change search params while hydration is pending.
   // This triggers router.navigate("/search?q=updated") → startNavigation(PUSH)
@@ -157,17 +198,40 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
 
   // Wait for the URL to update and React to re-render
   await page.waitForURL(/q=updated/);
-  await page.waitForTimeout(1000);
 
-  // The critical assertion: should show "updated" from the new URL,
-  // NOT "initial" from the stale SSR data.
+  // Verify clientLoader ran successfully — these fields are added by clientLoader
+  // and prove it executed, regardless of what serverLoader() returned.
+  await expect(
+    clientLoaderRan,
+    "clientLoader should have executed for the PUSH navigation"
+  ).toHaveText("true");
+
+  // 1st call = hydration (aborted), 2nd call = PUSH navigation
+  await expect(
+    clientLoaderCallCount,
+    "clientLoader should be on its 2nd invocation (1st was the aborted hydration)"
+  ).toHaveText("2");
+
+  // clientLoader reads the request URL directly — it always sees "updated"
+  // because this IS the PUSH navigation to ?q=updated.
+  await expect(
+    clientLoaderQuery,
+    "clientLoader should see q=updated from the PUSH navigation request URL"
+  ).toHaveText("updated");
+
+  // The critical assertion: serverLoader() data should show "updated" from
+  // the new URL, NOT "initial" from stale SSR data.
   //
   // BUG: isHydrationRequest=true + hasInitialData=true
   //   → serverLoader() returns initialData ({ query: "initial" })
-  //   → page shows "initial" despite URL being ?q=updated
+  //   → clientLoader returns { query: "initial", clientLoaderQuery: "updated" }
+  //   → The clientLoader ran correctly, but serverLoader() returned stale data!
   //
   // FIXED: isHydrationRequest=false (cleared when hydration aborted)
   //   → serverLoader() calls fetchServerLoader() → returns { query: "updated" }
-  let query = await page.textContent('[data-testid="query"]');
-  expect(query).toBe("updated");
+  //   → clientLoader returns { query: "updated", clientLoaderQuery: "updated" }
+  await expect(
+    serverQuery,
+    "serverLoader() should return fresh data (q=updated), not stale SSR hydration data (q=initial)"
+  ).toHaveText("updated");
 });

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -12,85 +12,107 @@ let fixture: Fixture;
 let appFixture: AppFixture;
 
 ////////////////////////////////////////////////////////////////////////////////
-// 👋 Hola! I'm here to help you write a great bug report pull request.
+// Bug: isHydrationRequest closure not cleared when hydration navigation is
+// aborted, causing serverLoader() to return stale SSR data.
 //
-// You don't need to fix the bug, this is just to report one.
+// When routes use clientLoader.hydrate = true, React Router sets
+// isHydrationRequest = true per route. During hydration, serverLoader()
+// returns initialData (SSR data) when isHydrationRequest is true AND the
+// route has initial data. The flag is cleared in a finally block after the
+// loader executes.
 //
-// The pull request you are submitting is supposed to fail when created, to let
-// the team see the erroneous behavior, and understand what's going wrong.
+// The bug: when the hydration POP is aborted by a new navigation, loaders
+// that haven't completed yet never reach their finally block, so
+// isHydrationRequest stays true. If the new navigation matches the SAME
+// route (e.g., same path with different search params), isHydrationRequest
+// is still true AND hasInitialData is true, so serverLoader() returns
+// stale SSR data instead of fetching.
 //
-// If you happen to have a fix as well, it will have to be applied in a subsequent
-// commit to this pull request, and your now-succeeding test will have to be moved
-// to the appropriate file.
+// IMPORTANT: React Router runs all matched route loaders in PARALLEL.
+// During hydration, serverLoader() returns initialData synchronously,
+// so a loader that just does `await serverLoader()` completes almost
+// instantly — clearing isHydrationRequest before we can abort. To
+// reproduce, the clientLoader must do async work BEFORE calling
+// serverLoader(), keeping the loader pending long enough for the abort
+// to happen while isHydrationRequest is still true.
 //
-// First, make sure to install dependencies and build React Router. From the root of
-// the project, run this:
+// We use a "firstCall" flag so only the hydration invocation is slow.
+// The subsequent PUSH invocation runs fast but still sees
+// isHydrationRequest=true (the hydration call hasn't reached finally).
 //
-//    ```
-//    pnpm install && pnpm build
-//    ```
-//
-// If you have never installed playwright on your system before, you may also need
-// to install a browser engine:
-//
-//    ```
-//    pnpm exec playwright install chromium
-//    ```
-//
-// Now try running this test:
-//
-//    ```
+// To run:
 //    pnpm test:integration bug-report --project chromium
-//    ```
-//
-// You can add `--watch` to the end to have it re-run on file changes:
-//
-//    ```
-//    pnpm test:integration bug-report --project chromium --watch
-//    ```
 ////////////////////////////////////////////////////////////////////////////////
-
-test.beforeEach(async ({ context }) => {
-  await context.route(/\.data$/, async (route) => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    route.continue();
-  });
-});
 
 test.beforeAll(async () => {
   fixture = await createFixture({
-    ////////////////////////////////////////////////////////////////////////////
-    // 💿 Next, add files to this object, just like files in a real app,
-    // `createFixture` will make an app and run your tests against it.
-    ////////////////////////////////////////////////////////////////////////////
     files: {
-      "app/routes/_index.tsx": js`
-        import { useLoaderData, Link } from "react-router";
+      "app/root.tsx": js`
+        import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 
-        export function loader() {
-          return "pizza";
-        }
-
-        export default function Index() {
-          let data = useLoaderData();
+        export default function Root() {
           return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
+            <html lang="en">
+              <head>
+                <Meta />
+                <Links />
+              </head>
+              <body>
+                <Outlet />
+                <ScrollRestoration />
+                <Scripts />
+              </body>
+            </html>
+          );
         }
       `,
 
-      "app/routes/burgers.tsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
+      // Search route that reads ?q= from the URL.
+      // SSR'd at /search?q=initial, then navigated to /search?q=updated.
+      // Since it's the SAME route, it has initialData AND isHydrationRequest=true.
+      "app/routes/search.tsx": js`
+        import { useLoaderData, Link } from "react-router";
+
+        export function loader({ request }) {
+          let url = new URL(request.url);
+          let q = url.searchParams.get("q") || "empty";
+          return { query: q };
+        }
+
+        // Track first call so only the hydration invocation blocks.
+        let isFirstCall = true;
+
+        export async function clientLoader({ serverLoader }) {
+          if (isFirstCall) {
+            isFirstCall = false;
+            // Block hydration loader. Without this, serverLoader() returns
+            // initialData synchronously during hydration, the loader completes
+            // instantly, and isHydrationRequest is cleared in the finally block
+            // before we can trigger a navigation to expose the bug.
+            await new Promise((resolve) => setTimeout(resolve, 30000));
+          }
+          // On second call (PUSH navigation): isFirstCall is false, no delay.
+          // But isHydrationRequest is still true because the first call
+          // (hydration) is stuck in its 30s delay and hasn't reached finally.
+          // So serverLoader() returns stale initialData instead of fetching.
+          return await serverLoader();
+        }
+        clientLoader.hydrate = true;
+
+        export default function Search() {
+          let data = useLoaderData();
+          return (
+            <div>
+              <h1 data-testid="page">Search</h1>
+              <p data-testid="query">{data.query}</p>
+              <Link to="/search?q=updated">Update query</Link>
+            </div>
+          );
         }
       `,
     },
   });
 
-  // This creates an interactive app using playwright.
   appFixture = await createAppFixture(fixture);
 });
 
@@ -99,29 +121,53 @@ test.afterAll(() => {
 });
 
 ////////////////////////////////////////////////////////////////////////////////
-// 💿 Almost done, now write your failing test case(s) down here Make sure to
-// add a good description for what you expect React Router to do 👇🏽
+// When a navigation to the same route (different search params) aborts
+// pending hydration, serverLoader() should fetch fresh data — not return
+// the stale SSR initialData.
 ////////////////////////////////////////////////////////////////////////////////
 
-test("[description of what you expect it to do]", async ({ page }) => {
+test("serverLoader() fetches fresh data when same-route navigation aborts hydration", async ({
+  page,
+}) => {
   let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
 
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
+  // SSR the search page with ?q=initial.
+  // After "load", scripts have executed and React has hydrated the DOM.
+  // useLayoutEffect has fired → router.initialize() → hydration POP started.
+  // Both clientLoaders are now blocked in their 30s delays (first call).
+  // The SSR HTML is visible and links are clickable (React hydrated the DOM),
+  // but router.state.initialized is false (hydration POP hasn't completed).
+  await app.goto("/search?q=initial");
 
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
+  // Click the link to change search params while hydration is pending.
+  // This triggers router.navigate("/search?q=updated") → startNavigation(PUSH)
+  // which aborts the pending hydration POP.
+  //
+  // The PUSH calls both loaders again (second invocation):
+  //   - Root loader: isFirstCall=false → no delay → serverLoader()
+  //   - Search loader: isFirstCall=false → no delay → serverLoader()
+  //
+  // The search route's isHydrationRequest is STILL TRUE because the first
+  // invocation (hydration) is stuck in its 30s setTimeout and hasn't reached
+  // the finally block that clears it.
+  //
+  // Use { wait: false } — the PUSH may complete with no network request
+  // (bug: serverLoader returns initialData from memory).
+  await app.clickLink("/search?q=updated", { wait: false });
 
-  // Go check out the other tests to see what else you can do.
+  // Wait for the URL to update and React to re-render
+  await page.waitForURL(/q=updated/);
+  await page.waitForTimeout(1000);
+
+  // The critical assertion: should show "updated" from the new URL,
+  // NOT "initial" from the stale SSR data.
+  //
+  // BUG: isHydrationRequest=true + hasInitialData=true
+  //   → serverLoader() returns initialData ({ query: "initial" })
+  //   → page shows "initial" despite URL being ?q=updated
+  //
+  // FIXED: isHydrationRequest=false (cleared when hydration aborted)
+  //   → serverLoader() calls fetchServerLoader() → returns { query: "updated" }
+  let query = await page.textContent('[data-testid="query"]');
+  expect(query).toBe("updated");
 });
-
-////////////////////////////////////////////////////////////////////////////////
-// 💿 Finally, push your changes to your fork of React Router
-// and open a pull request!
-////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -82,6 +82,17 @@ test.beforeAll(async () => {
         // Track call count so only the hydration invocation blocks.
         let callCount = 0;
 
+        // Externally-resolvable promise so the test can release the
+        // hydration loader on demand — no fixed timeout needed.
+        let resolveHydrationBlock: () => void;
+        let hydrationBlock = new Promise<void>((r) => {
+          resolveHydrationBlock = r;
+        });
+        // Expose on window so Playwright can call it (guard for SSR).
+        if (typeof window !== "undefined") {
+          (window as any).__resolveHydrationBlock = () => resolveHydrationBlock();
+        }
+
         export async function clientLoader({ serverLoader, request }) {
           callCount++;
           let currentCall = callCount;
@@ -89,11 +100,12 @@ test.beforeAll(async () => {
           let q = url.searchParams.get("q") || "empty";
 
           if (currentCall === 1) {
-            // Block hydration loader. Without this, serverLoader() returns
-            // initialData synchronously during hydration, the loader completes
-            // instantly, and isHydrationRequest is cleared in the finally block
-            // before we can trigger a navigation to expose the bug.
-            await new Promise((resolve) => setTimeout(resolve, 30000));
+            // Block hydration loader until the test releases it.
+            // Without this, serverLoader() returns initialData synchronously
+            // during hydration, the loader completes instantly, and
+            // isHydrationRequest is cleared before we can trigger a
+            // navigation to expose the bug.
+            await hydrationBlock;
           }
           // On second call (PUSH navigation): no delay.
           // But isHydrationRequest is still true because the first call
@@ -155,7 +167,7 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
   // SSR the search page with ?q=initial.
   // After "load", scripts have executed and React has hydrated the DOM.
   // useLayoutEffect has fired → router.initialize() → hydration POP started.
-  // Both clientLoaders are now blocked in their 30s delays (first call).
+  // The hydration clientLoader is now blocked on the hydrationBlock promise.
   // The SSR HTML is visible and links are clickable (React hydrated the DOM),
   // but router.state.initialized is false (hydration POP hasn't completed).
   await app.goto("/search?q=initial");
@@ -189,8 +201,8 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
   //   - Search loader: isFirstCall=false → no delay → serverLoader()
   //
   // The search route's isHydrationRequest is STILL TRUE because the first
-  // invocation (hydration) is stuck in its 30s setTimeout and hasn't reached
-  // the finally block that clears it.
+  // invocation (hydration) is blocked on the hydrationBlock promise and
+  // hasn't reached the finally block that clears it.
   //
   // Use { wait: false } — the PUSH may complete with no network request
   // (bug: serverLoader returns initialData from memory).
@@ -234,4 +246,7 @@ test("serverLoader() fetches fresh data when same-route navigation aborts hydrat
     serverQuery,
     "serverLoader() should return fresh data (q=updated), not stale SSR hydration data (q=initial)"
   ).toHaveText("updated");
+
+  // Release the blocked hydration loader so it doesn't hang during teardown.
+  await page.evaluate(() => (window as any).__resolveHydrationBlock());
 });

--- a/integration/playwright.config.ts
+++ b/integration/playwright.config.ts
@@ -31,7 +31,10 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 3 : 0,
   reporter: process.env.CI ? "dot" : [["html", { open: "never" }]],
-  use: { actionTimeout: 0 },
+  use: {
+    actionTimeout: 0,
+    trace: "retain-on-failure",
+  },
 
   projects: [
     {


### PR DESCRIPTION
# `isHydrationRequest` not cleared when hydration navigation is aborted, causing `serverLoader()` to return stale SSR data

### What version of React Router are you using?

7.9.3

### Steps to Reproduce

**Failing integration test**: See `integration/bug-report-test.ts` in this PR's branch.

The test:

1. Creates a `/search` route with `clientLoader.hydrate = true` that reads `?q=` from the URL
2. The `clientLoader` does async work before calling `serverLoader()` (simulating real-world patterns like cache seeding). A `firstCall` flag ensures only the hydration invocation is slow — the subsequent PUSH invocation runs immediately.
3. SSRs the page at `/search?q=initial`, then clicks a link to `/search?q=updated` before hydration completes
4. Asserts the page shows `"updated"` — but it shows `"initial"` (stale SSR data)

To run: `pnpm test:integration bug-report --project chromium`

### Expected Behavior

When the hydration POP navigation is aborted by a new PUSH navigation, `serverLoader()` in the PUSH navigation's loaders should fetch fresh data from the server.

### Actual Behavior

`serverLoader()` returns the original SSR `initialData` (for the wrong URL) because the `isHydrationRequest` closure variable was never cleared.

### Root Cause Analysis

In `createClientRoutes` (`lib/dom/ssr/routes.tsx`), each route with `hydrate = true` that matched the initial SSR URL gets a closure variable `isHydrationRequest = true`. The route's `dataRoute.loader` uses this flag to decide whether `serverLoader()` returns `initialData` (cached SSR data) or calls `fetchServerLoader()` (network request). The flag is cleared in a `finally` block after the loader executes.

The problem: when the hydration POP navigation is aborted (via `pendingNavigationController.abort()` in `startNavigation`), loaders that haven't completed yet never reach their `finally` block, so `isHydrationRequest` stays `true`. When the new PUSH navigation calls these loaders (second invocation, same closure), `serverLoader()` sees `isHydrationRequest === true` and returns `initialData` — the SSR data for the **original** URL params, not the navigation target.

**Key detail**: React Router runs matched route loaders in parallel. During hydration, a `clientLoader` that just does `await serverLoader()` completes almost instantly (since `serverLoader()` returns `initialData` synchronously), clearing `isHydrationRequest` before any abort can happen. The bug only manifests when the `clientLoader` does async work *before* calling `serverLoader()` (e.g., cache operations, analytics, initialization) — keeping the loader pending long enough for the hydration POP to be aborted while `isHydrationRequest` is still `true`.

**Timeline:**

```
React renders         → DOM ready, but router.state.initialized = false
useLayoutEffect       → router.initialize() → startNavigation(POP, {initialHydration: true})
                        ... hydration loaders start (parallel) ...
                        ... clientLoader does async work before serverLoader() ...
User clicks link      → startNavigation(PUSH, /search?q=updated)
                        → pendingNavigationController.abort()  // aborts hydration POP
                        → isHydrationRequest still true (finally block never reached)
PUSH loader runs      → serverLoader() checks isHydrationRequest === true
(2nd invocation)        → hasInitialData === true (same route matched SSR URL)
                        → returns initialData ({ query: "initial" }), not fresh data
```

**Evidence from instrumented build (in our production app):**

```
[startNavigation] action=POP  initialHydration=true  abortingPending=false initialized=false
[startNavigation] action=PUSH initialHydration=false abortingPending=true  initialized=false
[loader] route=file-browser url=?expanded=data isHydrationRequest=true  // WRONG — should be false
[serverLoader] HYDRATION-PATH — returning initialData instead of fetching
```

### Suggested Fix

When the hydration navigation is aborted, clear `isHydrationRequest` for all routes — not just the ones whose loaders completed. Options:

1. **On abort, iterate routes and clear the flag:**
   When `pendingNavigationController.abort()` fires for an `initialHydration` navigation, set `isHydrationRequest = false` for all hydrating routes.

2. **Check URL in the loader:**
   In `dataRoute.loader`, compare the request URL to `initialState.location` — if they differ, clear `isHydrationRequest` before calling `serverLoader()`.

3. **Use router state instead of closure:**
   Replace the `isHydrationRequest` closure with a check against `router.state.initialized` or similar, which is always up-to-date.

Option 1 is the most direct fix. Option 3 is the cleanest long-term.

```diff
diff --git a/packages/react-router/lib/dom/ssr/routes.tsx b/packages/react-router/lib/dom/ssr/routes.tsx
index 0c1682c25..426a5778f 100644
--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -343,7 +343,11 @@ export function createClientRoutes(
         { request, params, context, unstable_pattern }: LoaderFunctionArgs,
         singleFetch?: unknown,
       ) => {
-        try {
+        // Capture and clear immediately so that if this call is aborted
+        // mid-flight, subsequent calls won't see a stale `true` value
+        let _isHydrationRequest = isHydrationRequest;
+        isHydrationRequest = false;
+
         let result = await prefetchStylesAndCallHandler(async () => {
           invariant(
             routeModule,
@@ -363,7 +367,7 @@ export function createClientRoutes(
               preventInvalidServerHandlerCall("loader", route);
 
               // On the first call, resolve with the server result
-                if (isHydrationRequest) {
+              if (_isHydrationRequest) {
                 if (hasInitialData) {
                   return initialData;
                 }
@@ -378,11 +382,6 @@ export function createClientRoutes(
           });
         });
         return result;
-        } finally {
-          // Whether or not the user calls `serverLoader`, we only let this
-          // stick around as true for one loader call
-          isHydrationRequest = false;
-        }
       };
 
       // Let React Router know whether to run this on hydration
diff --git a/packages/react-router/lib/rsc/browser.tsx b/packages/react-router/lib/rsc/browser.tsx
index 865ef8832..ec2c2ad16 100644
--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -893,7 +893,11 @@ function createRouteFromServerManifest(
     index: match.index,
     loader: match.clientLoader
       ? async (args, singleFetch) => {
-          try {
+          // Capture and clear immediately so that if this call is aborted
+          // mid-flight, subsequent calls won't see a stale `true` value
+          let _isHydrationRequest = isHydrationRequest;
+          isHydrationRequest = false;
+
           let result = await match.clientLoader!({
             ...args,
             serverLoader: () => {
@@ -903,7 +907,7 @@ function createRouteFromServerManifest(
                 match.hasLoader,
               );
               // On the first call, resolve with the server result
-                if (isHydrationRequest) {
+              if (_isHydrationRequest) {
                 if (hasInitialData) {
                   return initialData;
                 }
@@ -915,9 +919,6 @@ function createRouteFromServerManifest(
             },
           });
           return result;
-          } finally {
-            isHydrationRequest = false;
-          }
         }
       : // We always make the call in this RSC world since even if we don't
         // have a `loader` we may need to get the `element` implementation
```

The above diff allows this failing test to pass, and I believe addresses the intent and fixes the bug