### PR TITLE
Fix typegen for pathless layouts with only nested layout children

### DIFF
--- a/.changeset/fix-typegen-empty-page.md
+++ b/.changeset/fix-typegen-empty-page.md
@@ -1,0 +1,7 @@
+---
+"@react-router/dev": patch
+---
+
+Fix typegen for pathless layouts with only nested layout children
+
+Previously, typegen would generate invalid TypeScript when a pathless layout route had only other pathless layout routes as children (no pages). This fix handles the case where `pages.size` is 0 by generating valid TypeScript.

--- a/.changeset/fix-typegen-empty-page.md
+++ b/.changeset/fix-typegen-empty-page.md
@@ -1,7 +1,0 @@
----
-"@react-router/dev": patch
----
-
-Fix typegen for pathless layouts with only nested layout children
-
-Previously, typegen would generate invalid TypeScript when a pathless layout route had only other pathless layout routes as children (no pages). This fix handles the case where `pages.size` is 0 by generating valid TypeScript.

--- a/contributors.yml
+++ b/contributors.yml
@@ -321,6 +321,7 @@
 - nowells
 - Nurai1
 - nwleedev
+- nyxsky404
 - Obi-Dann
 - okalil
 - OlegDev1

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -869,40 +869,19 @@ test.describe("typegen", () => {
     });
   });
 
-  test("pathless layout with only nested layout children generates valid TypeScript", async ({ edit, $ }) => {
+  test("layout without pages", async ({ edit, $ }) => {
     await edit({
       "app/routes.ts": tsx`
-        import { type RouteConfig, layout, route } from "@react-router/dev/routes";
+        import { type RouteConfig, layout } from "@react-router/dev/routes";
 
         export default [
-          layout("routes/_parent-layout.tsx", [
-            layout("routes/_child-layout.tsx", [
-              route("page-a", "routes/page-a.tsx"),
-              route("page-b", "routes/page-b.tsx"),
-            ]),
-          ]),
+          layout("routes/layout.tsx", []),
         ] satisfies RouteConfig;
       `,
-      "app/routes/_parent-layout.tsx": tsx`
+      "app/routes/layout.tsx": tsx`
         import { Outlet } from "react-router"
         export default function Component() {
           return <div><Outlet /></div>
-        }
-      `,
-      "app/routes/_child-layout.tsx": tsx`
-        import { Outlet } from "react-router"
-        export default function Component() {
-          return <div><Outlet /></div>
-        }
-      `,
-      "app/routes/page-a.tsx": tsx`
-        export default function Component() {
-          return <h1>Page A</h1>
-        }
-      `,
-      "app/routes/page-b.tsx": tsx`
-        export default function Component() {
-          return <h1>Page B</h1>
         }
       `,
     });

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -868,4 +868,44 @@ test.describe("typegen", () => {
       });
     });
   });
+
+  test("pathless layout with only nested layout children generates valid TypeScript", async ({ edit, $ }) => {
+    await edit({
+      "app/routes.ts": tsx`
+        import { type RouteConfig, layout, route } from "@react-router/dev/routes";
+
+        export default [
+          layout("routes/_parent-layout.tsx", [
+            layout("routes/_child-layout.tsx", [
+              route("page-a", "routes/page-a.tsx"),
+              route("page-b", "routes/page-b.tsx"),
+            ]),
+          ]),
+        ] satisfies RouteConfig;
+      `,
+      "app/routes/_parent-layout.tsx": tsx`
+        import { Outlet } from "react-router"
+        export default function Component() {
+          return <div><Outlet /></div>
+        }
+      `,
+      "app/routes/_child-layout.tsx": tsx`
+        import { Outlet } from "react-router"
+        export default function Component() {
+          return <div><Outlet /></div>
+        }
+      `,
+      "app/routes/page-a.tsx": tsx`
+        export default function Component() {
+          return <h1>Page A</h1>
+        }
+      `,
+      "app/routes/page-b.tsx": tsx`
+        export default function Component() {
+          return <h1>Page B</h1>
+        }
+      `,
+    });
+    await $("pnpm typecheck");
+  });
 });

--- a/packages/react-router-dev/.changes/patch.fix-typegen-layouts-without-pages.md
+++ b/packages/react-router-dev/.changes/patch.fix-typegen-layouts-without-pages.md
@@ -1,0 +1,4 @@
+Fix typegen for layouts without pages
+
+Previously, typegen could produce `pages: ;` in `.react-router/types/+routes.ts` when a route corresponded to 0 pages.
+Now, `pages: never;` is correctly generated for those cases.

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -178,7 +178,7 @@ function routeFilesType({
                   t.tsPropertySignature(
                     t.identifier("page"),
                     t.tsTypeAnnotation(
-                      pages
+                      pages.size > 0
                         ? t.tsUnionType(
                             Array.from(pages).map((page) =>
                               t.tsLiteralType(t.stringLiteral(page)),


### PR DESCRIPTION
## Description

Fixes #14783

This PR fixes a bug where the typegen command would generate invalid TypeScript for pathless layout routes that have only nested layout children (no direct leaf routes).

## Root Cause

The `routeFilesType` function in `packages/react-router-dev/typegen/generate.ts` was checking `pages ? ... : t.tsNeverKeyword()` to determine whether to generate a union type or `never`. However, since `pages` is a `Set` object, it's always truthy—even when empty. This caused the code to generate an empty union type (`page: ;`), which is invalid TypeScript and causes `TS1110: Type expected` errors.

## The Fix

Changed the condition from `pages` to `pages.size > 0` to correctly check if the Set contains any elements before generating a union type.

## Testing

- Added an integration test case: "pathless layout with only nested layout children generates valid TypeScript"
- The test verifies that typegen produces valid TypeScript for the exact scenario described in #14783

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/remix-run/react-router/blob/main/docs/community/contributing.md)
- [x] I have followed the [Code of Conduct](https://github.com/remix-run/react-router/blob/main/CODE_OF_CONDUCT.md)
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings