### PR TITLE
POC: clientLoader.unstable_batch - batch clientLoader with single fetch server call

### DIFF
--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -68,6 +68,7 @@ export type ClientLoaderFunction = ((
   args: ClientLoaderFunctionArgs,
 ) => ReturnType<LoaderFunction>) & {
   hydrate?: boolean;
+  unstable_batch?: boolean;
 };
 
 /**

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -4,6 +4,7 @@ import type { HydrationState } from "../../router/router";
 import type {
   ActionFunctionArgs,
   DataRouteObject,
+  LoaderFunction,
   LoaderFunctionArgs,
   RouteManifest,
   ShouldRevalidateFunction,
@@ -360,6 +361,11 @@ export function createClientRoutes(
               return fetchServerLoader(singleFetch);
             }
 
+            let batchLoaderPromise: unknown;
+            if (routeModule.clientLoader.unstable_batch) {
+              batchLoaderPromise = fetchServerLoader(singleFetch);
+            }
+
             return routeModule.clientLoader({
               request,
               params,
@@ -380,7 +386,7 @@ export function createClientRoutes(
                 }
 
                 // Call the server loader for client-side navigations
-                return fetchServerLoader(singleFetch);
+                return batchLoaderPromise || fetchServerLoader(singleFetch);
               },
             });
           });
@@ -399,6 +405,8 @@ export function createClientRoutes(
         route.hasLoader,
         isSpaMode,
       );
+      dataRoute.loader.unstable_batch =
+        routeModule.clientLoader?.unstable_batch;
 
       dataRoute.action = (
         {
@@ -494,14 +502,28 @@ export function createClientRoutes(
                   )
                 : await getLazyRoute();
               invariant(clientLoader, "No `clientLoader` export found");
-              return (args: LoaderFunctionArgs, singleFetch?: unknown) =>
-                clientLoader({
+              let loader: LoaderFunction = (
+                args: LoaderFunctionArgs,
+                singleFetch?: unknown,
+              ) => {
+                let batchLoaderPromise: unknown;
+                if (clientLoader.unstable_batch) {
+                  batchLoaderPromise = fetchServerLoader(singleFetch);
+                }
+
+                return clientLoader({
                   ...args,
                   async serverLoader() {
                     preventInvalidServerHandlerCall("loader", route);
-                    return fetchServerLoader(singleFetch);
+                    return batchLoaderPromise || fetchServerLoader(singleFetch);
                   },
                 });
+              };
+
+              loader.unstable_batch =
+                clientLoader.unstable_batch;
+
+              return loader;
             }
           : undefined,
         action: route.hasClientAction

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -199,6 +199,13 @@ export function getTurboStreamSingleFetchDataStrategy(
     ssr,
     basename,
     trailingSlashAware,
+    (match) => {
+      // Don't allow opt out if the clientLoader asked to batch the serverLoader call
+      let batched =
+        typeof match.route.loader === "function" &&
+        match.route.loader.unstable_batch === true;
+      return !batched;
+    },
   );
   return async (args) => args.runClientMiddleware(dataStrategy);
 }

--- a/packages/react-router/lib/router/instrumentation.ts
+++ b/packages/react-router/lib/router/instrumentation.ts
@@ -219,8 +219,13 @@ export function getRouteInstrumentationUpdates(
         getHandlerInfo(args[0] as LoaderFunctionArgs | ActionFunctionArgs),
       );
       if (instrumented) {
-        if (key === "loader" && original.hydrate === true) {
-          (instrumented as LoaderFunction).hydrate = true;
+        if (key === "loader") {
+          if (original.hydrate === true) {
+            (instrumented as LoaderFunction).hydrate = true;
+          }
+          if (original.unstable_batch === true) {
+            (instrumented as LoaderFunction).unstable_batch = true;
+          }
         }
         // @ts-expect-error
         instrumented[UninstrumentedSymbol] = original;

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -329,14 +329,16 @@ export type MiddlewareFunction<Result = unknown> = (
 /**
  * Arguments passed to loader functions
  */
-export interface LoaderFunctionArgs<Context = DefaultContext>
-  extends DataFunctionArgs<Context> {}
+export interface LoaderFunctionArgs<
+  Context = DefaultContext,
+> extends DataFunctionArgs<Context> {}
 
 /**
  * Arguments passed to action functions
  */
-export interface ActionFunctionArgs<Context = DefaultContext>
-  extends DataFunctionArgs<Context> {}
+export interface ActionFunctionArgs<
+  Context = DefaultContext,
+> extends DataFunctionArgs<Context> {}
 
 /**
  * Loaders and actions can return anything
@@ -353,7 +355,7 @@ export type LoaderFunction<Context = DefaultContext> = {
     args: LoaderFunctionArgs<Context>,
     handlerCtx?: unknown,
   ): DataFunctionReturnValue;
-} & { hydrate?: boolean };
+} & { hydrate?: boolean; unstable_batch?: boolean };
 
 /**
  * Route action function signature
@@ -506,8 +508,9 @@ export interface DataStrategyMatch extends RouteMatch<string, DataRouteObject> {
   ) => Promise<DataStrategyResult>;
 }
 
-export interface DataStrategyFunctionArgs<Context = DefaultContext>
-  extends DataFunctionArgs<Context> {
+export interface DataStrategyFunctionArgs<
+  Context = DefaultContext,
+> extends DataFunctionArgs<Context> {
   /**
    * Matches for this route extended with Data strategy APIs
    */

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -966,6 +966,7 @@ function createRouteFromServerManifest(
       match.hasLoader,
       false,
     );
+    dataRoute.loader.unstable_batch = match.clientLoader?.unstable_batch;
   }
 
   return dataRoute;

--- a/playground/framework/app/root.tsx
+++ b/playground/framework/app/root.tsx
@@ -6,6 +6,11 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router";
+import type { Route } from "./+types/root";
+
+export function loader({ params }: Route.LoaderArgs) {
+  return { name: `Super cool product #${params.id}` };
+}
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/playground/framework/app/routes/product.tsx
+++ b/playground/framework/app/routes/product.tsx
@@ -4,6 +4,14 @@ export function loader({ params }: Route.LoaderArgs) {
   return { name: `Super cool product #${params.id}` };
 }
 
+export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
+  let data = await serverLoader();
+  await new Promise((r) => setTimeout(r, 1000));
+  return { name: data.name + " (mutated)" };
+}
+
+clientLoader.unstable_batch = true;
+
 export default function Component({ loaderData }: Route.ComponentProps) {
   return <h1>{loaderData.name}</h1>;
 }


### PR DESCRIPTION
POC for a new `unstable_batch` flag on `clientLoader` that allows a route's client loader to participate in the normal single fetch server request, rather than forcing a separate out-of-band server call.

```ts
export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
  const data = await serverLoader({ batch: true });
  // ... client-side augmentation ...
  return { ...data, extra: "client-only stuff" };
}

clientLoader.unstable_batch = true
```

With `unstable_batch = true`:
- The server loader call is **initiated eagerly** before `clientLoader` runs, as part of the normal single fetch request alongside all other loaders
- When the `clientLoader` calls `serverLoader()`, it awaits the already-in-flight batched response rather than issuing a new request

**Known limitation: `<Link prefetch>`**

`<Link prefetch>` still excludes routes with `hasClientLoader` from the prefetch `.data` URL on the first prefetch, even when `unstable_batch = true` because we don't have the route module to know if `unstable_batch` is set.

plan:
 - we already do an AST parse at route module extraction for splitting loader/action/etc.
 - move that up to manifest creation time and cache
 - short circuit on quick regex for unstable_batch 
 - add `clientLoaderBatch` boolean to manifest
