### PR TITLE
fix: `encodeViaTurboStream` leaks memory via unremoved `AbortSignal` listener

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -254,6 +254,7 @@
 - lounsbrough
 - lpaube
 - lqze
+- luchsamapparat
 - lukerSpringTree
 - m-dad
 - m-kawafuji

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -386,7 +386,10 @@ export function encodeViaTurboStream(
     typeof streamTimeout === "number" ? streamTimeout : 4950,
   );
 
-  let clearStreamTimeout = () => clearTimeout(timeoutId);
+  let clearStreamTimeout = () => {
+    clearTimeout(timeoutId);
+    requestSignal.removeEventListener("abort", clearStreamTimeout);
+  };
 
   requestSignal.addEventListener("abort", clearStreamTimeout);
 


### PR DESCRIPTION
`encodeViaTurboStream` registers a `clearStreamTimeout` listener on `requestSignal` but never removes it. Even though #14735 correctly added `onComplete: clearStreamTimeout` to clear the timer when encoding finishes, the listener itself remains attached to the `AbortSignal` for the lifetime of the `Request` object.

Because the `clearStreamTimeout` closure captures `timeoutId`, the `Timeout` object (and everything it transitively retains) cannot be GC'd until the `Request` is eventually collected. Under sustained request load this causes unbounded accumulation of live `Timeout` objects, like in this heap snapshot:

<img width="1229" height="674" alt="image" src="https://github.com/user-attachments/assets/901fab2a-0e7e-42c6-8ba6-fc477d4b85e9" />

In our case, we use `AsyncLocalStorage` to scope per-request state. Because of this leak, each `Timeout` retains its full `AsyncContextFrame` and with it the entire ALS store associated with the request.

The above screenshot is from running 100 E2E tests against our application.

This is a heap snapshot after the same 100 E2E tests after applying the fix:

<img width="130" height="52" alt="image" src="https://github.com/user-attachments/assets/1f2e109a-31d8-4c32-8a37-83b8a51ee810" />
