### PR TITLE
fix: allow Framework Mode route components to be passed to createRoutesStub

### DIFF
--- a/.changeset/fix-createRoutesStub-component-type.md
+++ b/.changeset/fix-createRoutesStub-component-type.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix type error when passing Framework Mode route components using `Route.ComponentProps` to `createRoutesStub`

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1936,7 +1936,7 @@ function useRouteComponentProps() {
 }
 
 export type RouteComponentProps = ReturnType<typeof useRouteComponentProps>;
-export type RouteComponentType = React.ComponentType<RouteComponentProps>;
+type RouteComponentType = React.ComponentType<RouteComponentProps>;
 
 export function WithComponentProps({
   children,
@@ -1963,7 +1963,7 @@ function useHydrateFallbackProps() {
 }
 
 export type HydrateFallbackProps = ReturnType<typeof useHydrateFallbackProps>;
-export type HydrateFallbackType = React.ComponentType<HydrateFallbackProps>;
+type HydrateFallbackType = React.ComponentType<HydrateFallbackProps>;
 
 export function WithHydrateFallbackProps({
   children,
@@ -1991,7 +1991,7 @@ function useErrorBoundaryProps() {
 }
 
 export type ErrorBoundaryProps = ReturnType<typeof useErrorBoundaryProps>;
-export type ErrorBoundaryType = React.ComponentType<ErrorBoundaryProps>;
+type ErrorBoundaryType = React.ComponentType<ErrorBoundaryProps>;
 
 export function WithErrorBoundaryProps({
   children,

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -23,9 +23,6 @@ import type {
   FrameworkContextObject,
 } from "./entry";
 import {
-  type RouteComponentType,
-  type HydrateFallbackType,
-  type ErrorBoundaryType,
   Outlet,
   RouterProvider,
   createMemoryRouter,
@@ -37,9 +34,9 @@ import type { EntryRoute } from "./routes";
 import { FrameworkContext } from "./components";
 
 interface StubRouteExtensions {
-  Component?: RouteComponentType;
-  HydrateFallback?: HydrateFallbackType;
-  ErrorBoundary?: ErrorBoundaryType;
+  Component?: React.ComponentType<any>;
+  HydrateFallback?: React.ComponentType<any>;
+  ErrorBoundary?: React.ComponentType<any>;
   loader?: LoaderFunction;
   action?: ActionFunction;
   children?: StubRouteObject[];


### PR DESCRIPTION
`Component`, `HydrateFallback`, and `ErrorBoundary` in `StubRouteExtensions` were typed as `React.ComponentType<RouteComponentProps>` (and equivalents), which was too narrow

Framework Mode components annotated with `Route.ComponentProps` have more specific `params` and `matches` types — TypeScript's contravariance on function parameters means they aren't assignable to the broader type

Widening these to `React.ComponentType<any>` fixes the type error while remaining safe at runtime, since `withComponentProps` always injects the correct props from router hooks regardless of the component's declared type.

Fixes #14886