### PR TITLE
fix(types): remove deprecated FormEventHandler override from SharedFormProps

### DIFF
--- a/.changeset/fix-form-onsubmit-type.md
+++ b/.changeset/fix-form-onsubmit-type.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Remove explicit `onSubmit` type override from `SharedFormProps` to fix deprecation warning with `@types/react@19.x`

--- a/contributors.yml
+++ b/contributors.yml
@@ -351,6 +351,7 @@
 - refusado
 - remorses
 - renyu-io
+- restareaByWeezy
 - reyronald
 - RFCreate
 - richardkall

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1771,13 +1771,6 @@ interface SharedFormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   preventScrollReset?: boolean;
 
   /**
-   * A function to call when the form is submitted. If you call
-   * [`event.preventDefault()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
-   * then this form will not do anything.
-   */
-  onSubmit?: React.FormEventHandler<HTMLFormElement>;
-
-  /**
    * Specify the default revalidation behavior after this submission
    *
    * If no `shouldRevalidate` functions are present on the active routes, then this


### PR DESCRIPTION
Closes #14795

`SharedFormProps` was explicitly declaring `onSubmit` as `React.FormEventHandler<HTMLFormElement>`, which is now deprecated in `@types/react@19.2.13`. The thing is, `SharedFormProps` already extends `React.FormHTMLAttributes<HTMLFormElement>` — which inherits `onSubmit` from `DOMAttributes`. So the explicit declaration was just overriding whatever `@types/react` provides with a hardcoded (now-deprecated) type.

Removing it lets the type flow naturally from the parent interface:
- `@types/react@18.x` users get `FormEventHandler<T>` (same as before)
- `@types/react@19.x` users get `SubmitEventHandler<T>` (no more deprecation warning)

This addresses @timdorr's concern about not breaking users on older React types — since we're not picking a side, we're just letting `@types/react` decide.