### PR TITLE
fix(vite): do not force node condition in non-Node environments

### DIFF
--- a/.changeset/fix-vite-node-condition.md
+++ b/.changeset/fix-vite-node-condition.md
@@ -1,0 +1,7 @@
+---
+"@react-router/dev": patch
+---
+
+fix(vite): do not force `node` condition in non-Node environments
+
+When `v8_viteEnvironmentApi` is enabled, the `"node"` condition is no longer unconditionally added to `externalConditions` for all SSR environments. Instead, it is set per-environment in the `configEnvironment` hook, using `noExternal: true` as the signal that the target runtime is not Node.js (e.g. Cloudflare Workers). This fixes builds for non-Node runtimes that cannot import Node builtins like `http` and `https`.

--- a/contributors.yml
+++ b/contributors.yml
@@ -215,6 +215,7 @@
 - justjavac
 - kachun333
 - Kakamotobi
+- Kanevry
 - kantuni
 - kaoths
 - kapil-patel

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1474,6 +1474,18 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 // impact consumers because for them `ssrExternals` is undefined and
                 // Cloudflare's "noExternal: true" config remains intact.
                 options.resolve?.noExternal === true ? undefined : ssrExternals,
+              // Only add "node" to externalConditions for Node.js environments.
+              // Non-Node runtimes like Cloudflare Workers signal via
+              // `noExternal: true` and their adapter plugins set their own
+              // conditions (e.g. "workerd", "worker").
+              ...(options.resolve?.noExternal !== true
+                ? {
+                    externalConditions: [
+                      ...(options.resolve?.externalConditions ?? []),
+                      "node",
+                    ],
+                  }
+                : {}),
             },
             optimizeDeps:
               options.optimizeDeps?.noDiscovery === false
@@ -4059,7 +4071,10 @@ export async function getEnvironmentOptionsResolvers(
 
     // There is no helpful export with the default external conditions (see
     // https://github.com/vitejs/vite/pull/20279 for more details). So, for now,
-    // we are hardcording the default here.
+    // we are hardcoding the default here. When `v8_viteEnvironmentApi` is
+    // enabled, external conditions are set per-environment in the
+    // `configEnvironment` hook so that non-Node runtimes (e.g. Cloudflare
+    // Workers) are not forced to use the "node" condition.
     let defaultExternalConditions = ["node"];
 
     let baseConditions = [
@@ -4075,7 +4090,9 @@ export async function getEnvironmentOptionsResolvers(
             ? undefined
             : ssrExternals,
         conditions: [...baseConditions, ...maybeDefaultServerConditions],
-        externalConditions: [...baseConditions, ...defaultExternalConditions],
+        externalConditions: ctx.reactRouterConfig.future.v8_viteEnvironmentApi
+          ? [...baseConditions]
+          : [...baseConditions, ...defaultExternalConditions],
       },
       build: {
         // We move SSR-only assets to client assets. Note that the


### PR DESCRIPTION
## What

Stop unconditionally adding the `"node"` condition to `externalConditions` for all SSR environments when `v8_viteEnvironmentApi` is enabled. Instead, set it per-environment in the `configEnvironment` hook so that non-Node runtimes are not forced to resolve Node.js-specific package exports.

Fixes #14730

## Why

The Vite plugin hardcodes `let defaultExternalConditions = ["node"]` in `getBaseServerOptions()` and applies it to all SSR environments. When deploying to Cloudflare Workers (or other edge runtimes), this forces Vite to resolve Node.js-specific exports from packages, causing builds to fail because these runtimes cannot import builtins like `http` and `https`.

The `"node"` condition was deliberately introduced in #13871 because Vite does not export `defaultExternalConditions`. However, it should not be applied to non-Node environments.

## How

Two changes in `packages/react-router-dev/vite/plugin.ts`:

1. **`getBaseServerOptions()`**: When `v8_viteEnvironmentApi` is enabled, `externalConditions` no longer includes `"node"`. This mirrors how `resolve.external` is already conditional on `v8_viteEnvironmentApi`.

2. **`configEnvironment` hook**: `"node"` is added to `externalConditions` only when `options.resolve?.noExternal !== true`. This uses the same `noExternal` signal already checked in this hook for `resolve.external`, set by `@cloudflare/vite-plugin` for non-Node runtimes.

**Behavior by scenario:**
- Node.js (`v8_viteEnvironmentApi=true`): `"node"` added via `configEnvironment` — same as before
- Cloudflare Workers (`v8_viteEnvironmentApi=true`, `noExternal: true`): `"node"` NOT added — fix
- Legacy (`v8_viteEnvironmentApi=false`): unchanged

## Test Plan

- [x] Full test suite: 120/120 suites, 2509/2509 tests pass
- [x] `pnpm build` — all packages build successfully
- [x] `pnpm typecheck` — zero type errors
- [x] `pnpm lint` — zero new errors
- [x] Code path analysis confirms correct behavior for Node.js, Cloudflare Workers, and legacy modes