### PR TITLE
Add Vite plugin registry metadata

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -350,6 +350,7 @@
 - QzCurious
 - redabacha
 - refusado
+- remcohaszing
 - remorses
 - renyu-io
 - reyronald

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -2,6 +2,16 @@
   "name": "@react-router/dev",
   "version": "7.14.0",
   "description": "Dev tools and CLI for React Router",
+  "keywords": [
+    "react",
+    "router",
+    "route",
+    "routing",
+    "history",
+    "link",
+    "vite",
+    "vite-plugin"
+  ],
   "homepage": "https://reactrouter.com",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"
@@ -43,6 +53,17 @@
   },
   "bin": {
     "react-router": "bin.js"
+  },
+  "compatiblePackages": {
+    "schemaVersion": 1,
+    "rolldown": {
+      "type": "incompatible",
+      "reason": "Uses Vite-specific APIs"
+    },
+    "rollup": {
+      "type": "incompatible",
+      "reason": "Uses Vite-specific APIs"
+    }
   },
   "scripts": {
     "build": "wireit",

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -5,10 +5,7 @@
   "keywords": [
     "react",
     "router",
-    "route",
-    "routing",
-    "history",
-    "link",
+    "react-router",
     "vite",
     "vite-plugin"
   ],


### PR DESCRIPTION
This adds the `vite-plugin` keyword to `@react-router/dev`, so it shows up in the [Vite plugin registry](https://registry.vite.dev). This also documents it’s incompatible with Rollup and Rolldown.

I also copied the keywords from the `react-router` package.