### PR TITLE
fix: prevent basename doubling in normalizeTo when `to` already includes basename

### DIFF
--- a/.changeset/fix-fetcher-basename-double.md
+++ b/.changeset/fix-fetcher-basename-double.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fixed `normalizeTo` doubling the basename when `to` already includes it (e.g., from `useFormAction()`), which caused `useFetcher().submit()` to produce a 404 when a basename was configured.

--- a/contributors.yml
+++ b/contributors.yml
@@ -353,6 +353,7 @@
 - refusado
 - remorses
 - renyu-io
+- restareaByWeezy
 - reyronald
 - RFCreate
 - richardkall

--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -30,6 +30,7 @@ import {
   useAsyncError,
   useFetcher,
   useFetchers,
+  useFormAction,
   useLoaderData,
   useLocation,
   useNavigate,
@@ -7714,6 +7715,71 @@ function testDomRouter(
             </div>"
           `);
         });
+        it("fetcher.submit with useFormAction() should not double basename", async () => {
+          function Comp() {
+            let fetcher = useFetcher();
+            let action = useFormAction();
+            return (
+              <>
+                <p>{`data:${fetcher.data}`}</p>
+                <p>{`action:${action}`}</p>
+                <button
+                  onClick={() =>
+                    fetcher.submit({}, { method: "post", action })
+                  }
+                >
+                  submit
+                </button>
+              </>
+            );
+          }
+
+          function ErrorComp() {
+            let error = useRouteError() as any;
+            return <p>{`error:${error.status || error.message}`}</p>;
+          }
+
+          let router = createTestRouter(
+            [
+              {
+                path: "/",
+                children: [
+                  {
+                    path: "article",
+                    Component: Comp,
+                    ErrorBoundary: ErrorComp,
+                    action: () => "ARTICLE_ACTION",
+                  },
+                ],
+              },
+            ],
+            {
+              basename: "/base",
+              window: getWindow("/base/article"),
+            },
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          // Verify initial render shows correct action URL
+          expect(screen.getByText("action:/base/article")).toBeDefined();
+
+          fireEvent.click(screen.getByText("submit"));
+          await waitFor(() => screen.getByText(/ARTICLE_ACTION/));
+          expect(getHtml(container)).toMatchInlineSnapshot(`
+            "<div>
+              <p>
+                data:ARTICLE_ACTION
+              </p>
+              <p>
+                action:/base/article
+              </p>
+              <button>
+                submit
+              </button>
+            </div>"
+          `);
+        });
+
         it("prepends the basename to fetcher.Form paths", async () => {
           let router = createTestRouter(
             [

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -4816,7 +4816,11 @@ function normalizeTo(
   }
 
   // If we're operating within a basename, prepend it to the pathname.
+  // First strip the basename if it's already present (e.g., when `to` came
+  // from useFormAction() which includes the basename) to avoid doubling.
   if (basename !== "/") {
+    path.pathname =
+      stripBasename(path.pathname, basename) || path.pathname;
     path.pathname = prependBasename({ basename, pathname: path.pathname });
   }
 


### PR DESCRIPTION
## Problem

Fixes #14458

When `useFetcher().submit()` is called with an action URL that already includes the basename (e.g., from `useFormAction()`), the `normalizeTo` function prepends the basename a second time, resulting in a path like `/base/base/article` instead of `/base/article`. This causes route matching to fail with a 404 error.

## Root Cause

`useFormAction()` returns a basename-prefixed URL (e.g., `/base/article`) since it's designed for use in DOM `<form action="...">` attributes. When this value is passed to `fetcher.submit({ action })`, the router's `normalizeTo` function calls `prependBasename` without first checking if the pathname already contains the basename.

For form element submissions, `getFormSubmissionInfo` strips the basename from the form's action attribute before passing it to the router. However, for programmatic submissions via `options.action`, no such stripping occurs.

## Solution

In `normalizeTo`, call `stripBasename` on `path.pathname` before `prependBasename`. If the pathname already includes the basename, it gets stripped first, then prepended once. If it doesn't include the basename, `stripBasename` returns null and the original pathname is used unchanged.

## Changeset

Included a patch changeset for `react-router`.

## Test Plan

- Added regression test: `fetcher.submit` with `useFormAction()` should not double basename
- Verified all 26 existing basename-related tests still pass
- Verified all 97 fetcher unit tests still pass
- Verified full react-router test suite (2134 tests) passes