### PR TITLE
fix: normalize file path before creating route ID in configRoutesToRouteManifest

### DIFF
--- a/.changeset/fix-relative-route-id.md
+++ b/.changeset/fix-relative-route-id.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fixed route IDs becoming absolute paths when routes are defined using the `relative()` helper in `routes.ts`.

--- a/contributors.yml
+++ b/contributors.yml
@@ -353,6 +353,7 @@
 - refusado
 - remorses
 - renyu-io
+- restareaByWeezy
 - reyronald
 - RFCreate
 - richardkall

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -360,13 +360,14 @@ export function configRoutesToRouteManifest(
   let routeManifest: RouteManifest = {};
 
   function walk(route: RouteConfigEntry, parentId?: string) {
-    let id = route.id || createRouteId(route.file);
+    let normalizedFile = Path.isAbsolute(route.file)
+      ? Path.relative(appDirectory, route.file)
+      : route.file;
+    let id = route.id || createRouteId(normalizedFile);
     let manifestItem: RouteManifestEntry = {
       id,
       parentId,
-      file: Path.isAbsolute(route.file)
-        ? Path.relative(appDirectory, route.file)
-        : route.file,
+      file: normalizedFile,
       path: route.path,
       index: route.index,
       caseSensitive: route.caseSensitive,


### PR DESCRIPTION
## Problem

Fixes #14125

When routes are defined using the `relative()` helper in `routes.ts`, route IDs become absolute file paths (e.g., `/home/projects/app/routes/home`) instead of the expected relative paths (e.g., `routes/home`).

This happens because `relative()` calls `Path.resolve(directory, file)` to produce absolute paths, and `configRoutesToRouteManifest` passes this absolute path directly to `createRouteId()` without normalizing it first.

## Root Cause

In `configRoutesToRouteManifest`'s `walk()` function, the `file` property was already normalized from absolute to relative:

```ts
file: Path.isAbsolute(route.file)
  ? Path.relative(appDirectory, route.file)
  : route.file,
```

But `createRouteId(route.file)` on the line above used the raw `route.file`, which is still absolute when coming from `relative()`.

## Solution

Extract the file normalization into a shared `normalizedFile` variable so both the route ID and the `file` property use the relative path.

```ts
let normalizedFile = Path.isAbsolute(route.file)
  ? Path.relative(appDirectory, route.file)
  : route.file;
let id = route.id || createRouteId(normalizedFile);
```

This is a minimal change that applies the existing normalization logic to the ID computation.

## Changeset

Included a patch changeset for `@react-router/dev`.

## Test Plan

- Verified the logic: `relative()` produces absolute paths via `Path.resolve()`, and the fix ensures `createRouteId` receives a relative path, matching the behavior of non-`relative()` routes
- No existing unit tests for `configRoutesToRouteManifest` in the repo; the fix is a straightforward refactor of existing normalization logic