### PR TITLE
fix(dev): prevent HMR updates from being dropped during concurrent/slow network conditions

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -321,6 +321,7 @@
 - nowells
 - Nurai1
 - nwleedev
+- NYCU-Chung
 - Obi-Dann
 - okalil
 - OlegDev1

--- a/packages/react-router-dev/.changes/patch.fix-hmr-race-condition.md
+++ b/packages/react-router-dev/.changes/patch.fix-hmr-race-condition.md
@@ -1,0 +1,1 @@
+Prevent HMR updates from being dropped during concurrent or slow network conditions in dev

--- a/packages/react-router-dev/vite/static/refresh-utils.mjs
+++ b/packages/react-router-dev/vite/static/refresh-utils.mjs
@@ -3,9 +3,29 @@
 
 function debounce(fn, delay) {
   let handle;
+  let running = false;
+  let queued = false;
+
+  async function execute() {
+    if (running) {
+      queued = true;
+      return;
+    }
+    running = true;
+    try {
+      await fn();
+    } finally {
+      running = false;
+      if (queued) {
+        queued = false;
+        handle = setTimeout(execute, delay);
+      }
+    }
+  }
+
   return () => {
     clearTimeout(handle);
-    handle = setTimeout(fn, delay);
+    handle = setTimeout(execute, delay);
   };
 }
 
@@ -15,14 +35,15 @@ const enqueueUpdate = debounce(async () => {
   if (routeUpdates.size > 0) {
     manifest = JSON.parse(JSON.stringify(__reactRouterManifest));
 
+    let processedIds = [];
     for (let route of routeUpdates.values()) {
-      manifest.routes[route.id] = route;
       let imported = window.__reactRouterRouteModuleUpdates.get(route.id);
       if (!imported) {
-        throw Error(
-          `[react-router:hmr] No module update found for route ${route.id}`,
-        );
+        // Module not loaded yet — skip this route for now. It will be
+        // processed on the next enqueueUpdate call once the module arrives.
+        continue;
       }
+      manifest.routes[route.id] = route;
       let routeModule = {
         ...imported,
         // react-refresh takes care of updating these in-place,
@@ -41,29 +62,38 @@ const enqueueUpdate = debounce(async () => {
           : imported.HydrateFallback,
       };
       window.__reactRouterRouteModules[route.id] = routeModule;
+      processedIds.push(route.id);
     }
 
-    let needsRevalidation = new Set(
-      Array.from(routeUpdates.values())
-        .filter(
-          (route) =>
-            route.hasLoader ||
-            route.hasClientLoader ||
-            route.hasClientMiddleware,
-        )
-        .map((route) => route.id),
-    );
+    if (processedIds.length > 0) {
+      let needsRevalidation = new Set(
+        processedIds
+          .map((id) => routeUpdates.get(id))
+          .filter(
+            (route) =>
+              route.hasLoader ||
+              route.hasClientLoader ||
+              route.hasClientMiddleware,
+          )
+          .map((route) => route.id),
+      );
 
-    let routes = __reactRouterDataRouter.createRoutesForHMR(
-      needsRevalidation,
-      manifest.routes,
-      window.__reactRouterRouteModules,
-      window.__reactRouterContext.ssr,
-      window.__reactRouterContext.isSpaMode,
-    );
-    __reactRouterDataRouter._internalSetRoutes(routes);
-    routeUpdates.clear();
-    window.__reactRouterRouteModuleUpdates.clear();
+      let routes = __reactRouterDataRouter.createRoutesForHMR(
+        needsRevalidation,
+        manifest.routes,
+        window.__reactRouterRouteModules,
+        window.__reactRouterContext.ssr,
+        window.__reactRouterContext.isSpaMode,
+      );
+      __reactRouterDataRouter._internalSetRoutes(routes);
+
+      for (let id of processedIds) {
+        routeUpdates.delete(id);
+        window.__reactRouterRouteModuleUpdates.delete(id);
+      }
+    } else {
+      manifest = null;
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

Fixes #14906

When the network is slow or edits arrive in rapid succession, HMR updates can be silently dropped or crash the dev server runtime. This PR fixes three race conditions in `refresh-utils.mjs`:

### Race 1: Module not yet imported when `enqueueUpdate` fires

Vite sends the route manifest update (`react-router:hmr` event) and the module chunk as separate payloads. On slow networks, the manifest arrives and triggers `enqueueUpdate`, but `window.__reactRouterRouteModuleUpdates.get(route.id)` returns `undefined` because the module chunk hasn't finished downloading.

**Before:** Throws `Error('[react-router:hmr] No module update found for route ...')`, permanently breaking HMR for the session.
**After:** Skips unready routes with `continue` and retries them on the next cycle.

### Race 2: `routeUpdates.clear()` wipes pending updates

The old code called `routeUpdates.clear()` and `window.__reactRouterRouteModuleUpdates.clear()` after processing, which also removed entries added by new edits that arrived *during* async processing.

**Before:** New updates silently lost.
**After:** Only deletes successfully processed route IDs, preserving pending entries.

### Race 3: Async-unaware debounce

The debounce wrapper uses `setTimeout` but `enqueueUpdate` is `async`. If a new edit triggers the debounce while the previous `enqueueUpdate` is still awaiting (e.g., `revalidate()`), the new timeout can fire concurrently or the first execution's cleanup can race with the second's setup.

**Before:** Fire-and-forget — no awareness of in-flight execution.
**After:** Tracks `running` state; queues a re-execution after the current one completes.

## Reproduction

See the reproduction repo linked in #14906: https://github.com/AviVahl/react-router-hmr-issue

The issue reproduces consistently when simulating a slower network in the browser dev tools. With this fix applied, all consecutive HMR updates are correctly applied regardless of network speed.

## Changes

- `packages/react-router-dev/vite/static/refresh-utils.mjs`: 56 insertions, 26 deletions
  - Async-aware debounce with `running`/`queued` flags
  - Graceful skip of routes whose modules haven't loaded yet
  - Partial cleanup (only delete processed route IDs)

## Test plan

- [x] Existing `vite-hmr-hdr-test.ts` "everything everywhere all at once" test validates concurrent edits still work
- [x] Manual testing with Chrome DevTools network throttling (Slow 3G) confirms all edits apply
- [x] Changes are backward-compatible — when timing is normal, behavior is identical to before