### PR TITLE
fix(dev): normalize assetsBuildDirectory path for cross-OS builds

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -843,10 +843,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         virtual.serverManifest.id,
       )};
       export const assetsBuildDirectory = ${JSON.stringify(
-        path.relative(
+        getVite().normalizePath(path.relative(
           ctx.rootDirectory,
           getClientBuildDirectory(ctx.reactRouterConfig),
-        ),
+        )),
       )};
       export const basename = ${JSON.stringify(ctx.reactRouterConfig.basename)};
       export const future = ${JSON.stringify(ctx.reactRouterConfig.future)};


### PR DESCRIPTION
Fixes #14950.

`path.relative()` returns backslashes on Windows. The resulting `assetsBuildDirectory` string gets serialized into the server build module via `JSON.stringify`. When the build output is deployed to Linux, `express.static()` receives a path like `build\\client` and can't resolve it — all `/assets/*` requests 404.

The same file already wraps `path.relative()` with `getVite().normalizePath()` at three other call sites (lines 271, 300, 946) for exactly this reason. This patch applies the same treatment to the `assetsBuildDirectory` generation that was missed.

On Linux/macOS builds, `normalizePath` is a no-op since `path.relative` already returns forward slashes.