### PR TITLE
Fix generatePath typing for optional params

### DIFF
--- a/.changeset/fresh-bears-drive.md
+++ b/.changeset/fresh-bears-drive.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Enhance `generatePath` types to better differentiate between optional and required params

--- a/contributors.yml
+++ b/contributors.yml
@@ -158,6 +158,7 @@
 - haivuw
 - hampelm
 - harshmangalam
+- harshit-d3v
 - harucn
 - HelpMe-Pls
 - HenriqueLimas

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -788,28 +788,55 @@ type RegexMatchPlus<
     : never
   : never;
 
-// Recursive helper for finding path parameters in the absence of wildcards
-type _PathParam<Path extends string> =
+// Union of all path parameters - required and optional
+export type PathParam<Path extends string> =
+  | RequiredPathParam<Path>
+  | OptionalPathParam<Path>;
+
+// Recursive helper for finding required path parameters in the absence of wildcards
+type _RequiredPathParam<Path extends string> =
   // split path into individual path segments
   Path extends `${infer L}/${infer R}`
-    ? _PathParam<L> | _PathParam<R>
-    : // find params after `:`
-      Path extends `:${infer Param}`
-      ? Param extends `${infer Optional}?${string}`
-        ? RegexMatchPlus<ParamChar, Optional>
-        : RegexMatchPlus<ParamChar, Param>
-      : // otherwise, there aren't any params present
-        never;
+    ? _RequiredPathParam<L> | _RequiredPathParam<R>
+    : // ignore optional params
+      Path extends `:${string}?${string}`
+      ? never
+      : // find required params after `:`
+        Path extends `:${infer Param}`
+        ? RegexMatchPlus<ParamChar, Param>
+        : // otherwise, there aren't any params present
+          never;
 
-export type PathParam<Path extends string> =
+type RequiredPathParam<Path extends string> =
   // check if path is just a wildcard
   Path extends "*" | "/*"
     ? "*"
     : // look for wildcard at the end of the path
       Path extends `${infer Rest}/*`
-      ? "*" | _PathParam<Rest>
+      ? "*" | _RequiredPathParam<Rest>
       : // look for params in the absence of wildcards
-        _PathParam<Path>;
+        _RequiredPathParam<Path>;
+
+// Recursive helper for finding optional path parameters in the absence of wildcards
+type _OptionalPathParam<Path extends string> =
+  // split path into individual path segments
+  Path extends `${infer L}/${infer R}`
+    ? _OptionalPathParam<L> | _OptionalPathParam<R>
+    : // find optional params after `:`
+      Path extends `:${infer Optional}?${infer Rest}`
+      ? RegexMatchPlus<ParamChar, Optional> | _OptionalPathParam<Rest>
+      : // otherwise, there aren't any optional params present
+        never;
+
+type OptionalPathParam<Path extends string> =
+  // check if path is just a wildcard
+  Path extends "*" | "/*"
+    ? "*"
+    : // look for wildcard at the end of the path
+      Path extends `${infer Rest}/*`
+      ? "*" | _OptionalPathParam<Rest>
+      : // look for params in the absence of wildcards
+        _OptionalPathParam<Path>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _tests = [
@@ -821,6 +848,32 @@ type _tests = [
   Expect<Equal<PathParam<"/:a/b/:c/*">, "a" | "c" | "*">>,
   Expect<Equal<PathParam<"/:lang.xml">, "lang">>,
   Expect<Equal<PathParam<"/:lang?.xml">, "lang">>,
+  Expect<Equal<RequiredPathParam<"/a/b/*">, "*">>,
+  Expect<Equal<RequiredPathParam<":a">, "a">>,
+  Expect<Equal<RequiredPathParam<"/a/:b">, "b">>,
+  Expect<Equal<RequiredPathParam<"/a/blahblahblah:b">, never>>,
+  Expect<Equal<RequiredPathParam<"/:a/:b">, "a" | "b">>,
+  Expect<Equal<RequiredPathParam<"/:a/b/:c/*">, "a" | "c" | "*">>,
+  Expect<Equal<RequiredPathParam<"/:lang.xml">, "lang">>,
+  Expect<Equal<OptionalPathParam<"/a/b/*">, "*">>,
+  Expect<Equal<OptionalPathParam<":a?">, "a">>,
+  Expect<Equal<OptionalPathParam<"/a/:b?">, "b">>,
+  Expect<Equal<OptionalPathParam<"/a/blahblahblah:b?">, never>>,
+  Expect<Equal<OptionalPathParam<"/:a?/:b?">, "a" | "b">>,
+  Expect<Equal<OptionalPathParam<"/:a?/b/:c?/*">, "a" | "c" | "*">>,
+  Expect<Equal<OptionalPathParam<"/:lang?.xml">, "lang">>,
+  Expect<Equal<PathParam<"/:a?/:b">, "a" | "b">>,
+  Expect<Equal<RequiredPathParam<"/:a?/:b">, "b">>,
+  Expect<Equal<OptionalPathParam<"/:a?/:b">, "a">>,
+  Expect<Equal<PathParam<"/:a?/b/:c">, "a" | "c">>,
+  Expect<Equal<RequiredPathParam<"/:a?/b/:c">, "c">>,
+  Expect<Equal<OptionalPathParam<"/:a?/b/:c">, "a">>,
+  Expect<Equal<PathParam<"/:a/:b">, "a" | "b">>,
+  Expect<Equal<RequiredPathParam<"/:a/:b">, "a" | "b">>,
+  Expect<Equal<OptionalPathParam<"/:a/:b">, never>>,
+  Expect<Equal<PathParam<"/:a?/:b?">, "a" | "b">>,
+  Expect<Equal<RequiredPathParam<"/:a?/:b?">, never>>,
+  Expect<Equal<OptionalPathParam<"/:a?/:b?">, "a" | "b">>,
 ];
 
 // Attempt to parse the given string segment. If it fails, then just return the
@@ -1366,7 +1419,9 @@ function matchRouteBranch<
 export function generatePath<Path extends string>(
   originalPath: Path,
   params: {
-    [key in PathParam<Path>]: string | null;
+    [key in RequiredPathParam<Path>]: string;
+  } & {
+    [key in OptionalPathParam<Path>]?: string | null | undefined;
   } = {} as any,
 ): string {
   let path: string = originalPath;

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -807,15 +807,7 @@ type _RequiredPathParam<Path extends string> =
         : // otherwise, there aren't any params present
           never;
 
-type RequiredPathParam<Path extends string> =
-  // check if path is just a wildcard
-  Path extends "*" | "/*"
-    ? "*"
-    : // look for wildcard at the end of the path
-      Path extends `${infer Rest}/*`
-      ? "*" | _RequiredPathParam<Rest>
-      : // look for params in the absence of wildcards
-        _RequiredPathParam<Path>;
+type RequiredPathParam<Path extends string> = _RequiredPathParam<Path>;
 
 // Recursive helper for finding optional path parameters in the absence of wildcards
 type _OptionalPathParam<Path extends string> =
@@ -838,6 +830,12 @@ type OptionalPathParam<Path extends string> =
       : // look for params in the absence of wildcards
         _OptionalPathParam<Path>;
 
+type GeneratePathParams<Path extends string> = {
+  [key in RequiredPathParam<Path>]: string | null;
+} & {
+  [key in OptionalPathParam<Path>]?: string | null | undefined;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _tests = [
   Expect<Equal<PathParam<"/a/b/*">, "*">>,
@@ -848,12 +846,12 @@ type _tests = [
   Expect<Equal<PathParam<"/:a/b/:c/*">, "a" | "c" | "*">>,
   Expect<Equal<PathParam<"/:lang.xml">, "lang">>,
   Expect<Equal<PathParam<"/:lang?.xml">, "lang">>,
-  Expect<Equal<RequiredPathParam<"/a/b/*">, "*">>,
+  Expect<Equal<RequiredPathParam<"/a/b/*">, never>>,
   Expect<Equal<RequiredPathParam<":a">, "a">>,
   Expect<Equal<RequiredPathParam<"/a/:b">, "b">>,
   Expect<Equal<RequiredPathParam<"/a/blahblahblah:b">, never>>,
   Expect<Equal<RequiredPathParam<"/:a/:b">, "a" | "b">>,
-  Expect<Equal<RequiredPathParam<"/:a/b/:c/*">, "a" | "c" | "*">>,
+  Expect<Equal<RequiredPathParam<"/:a/b/:c/*">, "a" | "c">>,
   Expect<Equal<RequiredPathParam<"/:lang.xml">, "lang">>,
   Expect<Equal<OptionalPathParam<"/a/b/*">, "*">>,
   Expect<Equal<OptionalPathParam<":a?">, "a">>,
@@ -874,6 +872,16 @@ type _tests = [
   Expect<Equal<PathParam<"/:a?/:b?">, "a" | "b">>,
   Expect<Equal<RequiredPathParam<"/:a?/:b?">, never>>,
   Expect<Equal<OptionalPathParam<"/:a?/:b?">, "a" | "b">>,
+  Expect<Equal<PathParam<"/:id?/:id">, "id">>,
+  Expect<Equal<RequiredPathParam<"/:id?/:id">, "id">>,
+  Expect<Equal<OptionalPathParam<"/:id?/:id">, "id">>,
+  Expect<Equal<GeneratePathParams<"/:lang/login">["lang"], string | null>>,
+  Expect<
+    Equal<GeneratePathParams<"/:lang?/login">["lang"], string | null | undefined>
+  >,
+  Expect<Equal<GeneratePathParams<"/:id/*">["id"], string | null>>,
+  Expect<Equal<GeneratePathParams<"/:id/*">["*"], string | null | undefined>>,
+  Expect<Equal<GeneratePathParams<"/:id?/:id">["id"], string | null>>,
 ];
 
 // Attempt to parse the given string segment. If it fails, then just return the
@@ -1418,11 +1426,7 @@ function matchRouteBranch<
  */
 export function generatePath<Path extends string>(
   originalPath: Path,
-  params: {
-    [key in RequiredPathParam<Path>]: string;
-  } & {
-    [key in OptionalPathParam<Path>]?: string | null | undefined;
-  } = {} as any,
+  params: GeneratePathParams<Path> = {} as GeneratePathParams<Path>,
 ): string {
   let path: string = originalPath;
   if (path.endsWith("*") && path !== "*" && !path.endsWith("/*")) {


### PR DESCRIPTION
## Summary
- differentiate required and optional path params in `generatePath` typings
- allow optional params to be omitted without weakening required param checks
- add internal type coverage and a patch changeset for the typing fix

## Testing
- pnpm test packages/react-router/__tests__/generatePath-test.tsx
- pnpm --filter react-router build
- pnpm --filter react-router typecheck