### PR TITLE
Client-side route matching optimizations

### DIFF
--- a/.changeset/tough-needles-doubt.md
+++ b/.changeset/tough-needles-doubt.md
@@ -1,0 +1,27 @@
+---
+"react-router": patch
+---
+
+Improve route matching performance in Framework/Data Mode
+
+- Avoiding unnecessary calls to `matchRoutes` in data router scenarios
+  - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
+  - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
+- Leverage pre-computed pre-computing flattened/cached route branches during client side route matching
+- This builds on top of prior server optimizations and provides an additional set of gains (~30%):
+  - Original server optimizations branch
+    - Throughput: 952.7 req/s
+    - Latency mean: 8.716ms
+    - Latency p50: 9.452ms
+    - Latency p95: 11.610ms
+    - Latency p99: 12.544ms
+    - Latency min: 1.656ms
+    - Latency max: 15.936ms
+  - This branch
+    - Throughput: 1235.3 req/s
+    - Latency mean: 6.095ms
+    - Latency p50: 6.655ms
+    - Latency p95: 8.327ms
+    - Latency p99: 12.133ms
+    - Latency min: 1.066ms
+    - Latency max: 19.056ms

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -31,6 +31,7 @@ import type {
   NonIndexRouteObject,
   Params,
   PatchRoutesOnNavigationFunction,
+  RouteManifest,
   RouteMatch,
   RouteObject,
   TrackedPromise,
@@ -756,6 +757,7 @@ export function RouterProvider({
               >
                 <MemoizedDataRoutes
                   routes={router.routes}
+                  manifest={router.manifest}
                   future={router.future}
                   state={state}
                   isStatic={false}
@@ -803,18 +805,26 @@ const MemoizedDataRoutes = React.memo(DataRoutes);
 
 export function DataRoutes({
   routes,
+  manifest,
   future,
   state,
   isStatic,
   onError,
 }: {
   routes: DataRouteObject[];
+  manifest: RouteManifest;
   future: DataRouter["future"];
   state: RouterState;
   isStatic: boolean;
   onError?: ClientOnErrorFunction;
 }): React.ReactElement | null {
-  return useRoutesImpl(routes, undefined, { state, isStatic, onError, future });
+  return useRoutesImpl(routes, undefined, {
+    manifest,
+    state,
+    isStatic,
+    onError,
+    future,
+  });
 }
 
 /**

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -20,7 +20,12 @@ import {
   IDLE_NAVIGATION,
   createStaticHandler as routerCreateStaticHandler,
 } from "../router/router";
-import type { RouteManifest, RouteObject } from "../router/utils";
+import type {
+  DataRouteObject,
+  RouteBranch,
+  RouteManifest,
+  RouteObject,
+} from "../router/utils";
 import {
   convertRoutesToDataRoutes,
   isRouteErrorResponse,
@@ -207,6 +212,7 @@ export function StaticRouterProvider({
                 unstable_useTransitions={false}
               >
                 <DataRoutes
+                  manifest={router.manifest}
                   routes={router.routes}
                   future={router.future}
                   state={state}
@@ -372,12 +378,14 @@ export function createStaticHandler(
  * `query`
  * @param opts Options
  * @param opts.future Future flags for the static {@link DataRouter}
+ * @param opts.branches Optional pre-computed route branches
  * @returns A static {@link DataRouter} that can be used to render the provided routes
  */
 export function createStaticRouter(
   routes: RouteObject[],
   context: StaticHandlerContext,
   opts: {
+    branches?: RouteBranch<DataRouteObject>[];
     future?: Partial<FutureConfig>;
   } = {},
 ): DataRouter {
@@ -434,6 +442,12 @@ export function createStaticRouter(
     },
     get routes() {
       return dataRoutes;
+    },
+    get branches() {
+      return opts.branches;
+    },
+    get manifest() {
+      return manifest;
     },
     get window() {
       return undefined;

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -2,7 +2,11 @@ import type { StaticHandlerContext } from "../../router/router";
 
 import type { EntryRoute } from "./routes";
 import type { RouteModules } from "./routeModules";
-import type { RouteManifest } from "../../router/utils";
+import type {
+  DataRouteObject,
+  RouteBranch,
+  RouteManifest,
+} from "../../router/utils";
 import type { ServerBuild } from "../../server-runtime/build";
 
 type SerializedError = {
@@ -39,6 +43,7 @@ export interface FrameworkContextObject {
 // Additional React-Router information needed at runtime, but not hydrated
 // through RemixContext
 export interface EntryContext extends FrameworkContextObject {
+  branches: RouteBranch<DataRouteObject>[];
   staticHandlerContext: StaticHandlerContext;
   serverHandoffStream?: ReadableStream<Uint8Array>;
 }

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -1,14 +1,11 @@
 import * as React from "react";
 import type { Router as DataRouter } from "../../router/router";
 import type {
+  DataRouteObject,
   PatchRoutesOnNavigationFunction,
   RouteManifest,
 } from "../../router/utils";
-import {
-  joinPaths,
-  matchRoutes,
-  removeDoubleSlashes,
-} from "../../router/utils";
+import { joinPaths, matchRoutesImpl } from "../../router/utils";
 import type { AssetsManifest } from "./entry";
 import type { RouteModules } from "./routeModules";
 import type { EntryRoute } from "./routes";
@@ -56,7 +53,13 @@ export function getPartialManifest(
   }
 
   paths.forEach((path) => {
-    let matches = matchRoutes(router.routes, path, router.basename);
+    let matches = matchRoutesImpl<DataRouteObject>(
+      router.routes,
+      path,
+      router.basename || "/",
+      false,
+      router.branches,
+    );
     if (matches) {
       matches.forEach((m) => routeIds.add(m.route.id));
     }

--- a/packages/react-router/lib/dom/ssr/server.tsx
+++ b/packages/react-router/lib/dom/ssr/server.tsx
@@ -90,7 +90,9 @@ export function ServerRouter({
     }
   }
 
-  let router = createStaticRouter(routes, context.staticHandlerContext);
+  let router = createStaticRouter(routes, context.staticHandlerContext, {
+    branches: context.branches,
+  });
 
   return (
     <>

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -33,6 +33,7 @@ import type {
   Params,
   PathMatch,
   PathPattern,
+  RouteManifest,
   RouteMatch,
   RouteObject,
   UIMatch,
@@ -760,6 +761,7 @@ export function useRoutesImpl(
   routes: RouteObject[],
   locationArg?: Partial<Location> | string,
   dataRouterOpts?: {
+    manifest: RouteManifest;
     state: DataRouter["state"];
     isStatic: boolean;
     onError: ClientOnErrorFunction | undefined;
@@ -860,7 +862,16 @@ export function useRoutesImpl(
     remainingPathname = "/" + segments.slice(parentSegments.length).join("/");
   }
 
-  let matches = matchRoutes(routes, { pathname: remainingPathname });
+  let matches =
+    dataRouterOpts && dataRouterOpts.state.matches.length
+      ? // If we're in a data router, use the matches we've already identified but ensure
+        // we have the latest route instances from the manifest in case elements have changed
+        dataRouterOpts.state.matches.map((m) =>
+          Object.assign(m, {
+            route: dataRouterOpts.manifest[m.route.id] || m.route,
+          }),
+        )
+      : matchRoutes(routes, { pathname: remainingPathname });
 
   if (ENABLE_DEV_WARNINGS) {
     warning(

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -33,6 +33,7 @@ import type {
   Params,
   PathMatch,
   PathPattern,
+  RouteManifest,
   RouteMatch,
   RouteObject,
   UIMatch,
@@ -761,6 +762,7 @@ export function useRoutesImpl(
   routes: RouteObject[],
   locationArg?: Partial<Location> | string,
   dataRouterOpts?: {
+    manifest: RouteManifest;
     state: DataRouter["state"];
     isStatic: boolean;
     onError: ClientOnErrorFunction | undefined;
@@ -861,7 +863,16 @@ export function useRoutesImpl(
     remainingPathname = "/" + segments.slice(parentSegments.length).join("/");
   }
 
-  let matches = matchRoutes(routes, { pathname: remainingPathname });
+  let matches =
+    dataRouterOpts && dataRouterOpts.state.matches.length
+      ? // If we're in a data router, use the matches we've already identified but ensure
+        // we have the latest route instances from the manifest in case elements have changed
+        dataRouterOpts.state.matches.map((m) =>
+          Object.assign(m, {
+            route: dataRouterOpts.manifest[m.route.id] || m.route,
+          }),
+        )
+      : matchRoutes(routes, { pathname: remainingPathname });
 
   if (ENABLE_DEV_WARNINGS) {
     warning(

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -62,7 +62,6 @@ import {
   isUnsupportedLazyRouteObjectKey,
   isUnsupportedLazyRouteFunctionKey,
   isRouteErrorResponse,
-  matchRoutes,
   matchRoutesImpl,
   prependBasename,
   resolveTo,
@@ -112,6 +111,22 @@ export interface Router {
    * Return the routes for this router instance
    */
   get routes(): DataRouteObject[];
+
+  /**
+   * @private
+   * PRIVATE - DO NOT USE
+   *
+   * Return the route branches for this router instance
+   */
+  get branches(): RouteBranch<DataRouteObject>[] | undefined;
+
+  /**
+   * @private
+   * PRIVATE - DO NOT USE
+   *
+   * Return the manifest for this router instance
+   */
+  get manifest(): RouteManifest;
 
   /**
    * @private
@@ -909,6 +924,63 @@ const ResetLoaderDataSymbol = Symbol("ResetLoaderData");
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
+ * Encapsulates the stable and in-flight route trees together with their
+ * pre-computed branch caches so the structures always stay in sync.
+ */
+class DataRoutes {
+  #routes: DataRouteObject[];
+  #branches: RouteBranch<DataRouteObject>[];
+  #hmrRoutes: DataRouteObject[] | undefined;
+  #hmrBranches: RouteBranch<DataRouteObject>[] | undefined;
+
+  constructor(routes: DataRouteObject[]) {
+    this.#routes = routes;
+    this.#branches = flattenAndRankRoutes(routes);
+  }
+
+  /** The stable route tree */
+  get stableRoutes(): DataRouteObject[] {
+    return this.#routes;
+  }
+
+  /** The in-flight route tree if one is active, otherwise the stable tree */
+  get activeRoutes(): DataRouteObject[] {
+    return this.#hmrRoutes ?? this.#routes;
+  }
+
+  /** Pre-computed branches */
+  get branches(): RouteBranch<DataRouteObject>[] {
+    return this.#hmrBranches ?? this.#branches;
+  }
+
+  get hasHMRRoutes(): boolean {
+    return this.#hmrRoutes != null;
+  }
+
+  /** Replace the stable route tree and recompute its branches */
+  setRoutes(routes: DataRouteObject[]): void {
+    this.#routes = routes;
+    this.#branches = flattenAndRankRoutes(routes);
+  }
+
+  /** Set a new in-flight route tree and recompute its branches */
+  setHmrRoutes(routes: DataRouteObject[]): void {
+    this.#hmrRoutes = routes;
+    this.#hmrBranches = flattenAndRankRoutes(routes);
+  }
+
+  /** Commit in-flight routes/branches to the stable slot and clear in-flight */
+  commitHmrRoutes(): void {
+    if (this.#hmrRoutes) {
+      this.#routes = this.#hmrRoutes;
+      this.#branches = this.#hmrBranches!;
+      this.#hmrRoutes = undefined;
+      this.#hmrBranches = undefined;
+    }
+  }
+}
+
+/**
  * Create a router and listen to history POP navigations
  */
 export function createRouter(init: RouterInit): Router {
@@ -952,14 +1024,16 @@ export function createRouter(init: RouterInit): Router {
 
   // Routes keyed by ID
   let manifest: RouteManifest = {};
-  // Routes in tree format for matching
-  let dataRoutes = convertRoutesToDataRoutes(
-    init.routes,
-    mapRouteProperties,
-    undefined,
-    manifest,
+  // Route tree, in-flight variant, and their pre-computed ranked branch caches.
+  // Always updated together via the Routes class to keep them in sync.
+  let dataRoutes = new DataRoutes(
+    convertRoutesToDataRoutes(
+      init.routes,
+      mapRouteProperties,
+      undefined,
+      manifest,
+    ),
   );
-  let inFlightDataRoutes: DataRouteObject[] | undefined;
   let basename = init.basename || "/";
   if (!basename.startsWith("/")) {
     basename = `/${basename}`;
@@ -971,6 +1045,7 @@ export function createRouter(init: RouterInit): Router {
     unstable_passThroughRequests: false,
     ...init.future,
   };
+
   // Cleanup function for history
   let unlistenHistory: (() => void) | null = null;
   // Externally-provided functions to call on all state changes
@@ -989,7 +1064,13 @@ export function createRouter(init: RouterInit): Router {
   // SSR did the initial scroll restoration.
   let initialScrollRestored = init.hydrationData != null;
 
-  let initialMatches = matchRoutes(dataRoutes, init.history.location, basename);
+  let initialMatches = matchRoutesImpl(
+    dataRoutes.activeRoutes,
+    init.history.location,
+    basename,
+    false,
+    dataRoutes.branches,
+  );
   let initialMatchesIsFOW = false;
   let initialErrors: RouteData | null = null;
   let initialized: boolean;
@@ -1001,7 +1082,7 @@ export function createRouter(init: RouterInit): Router {
     let error = getInternalRouterError(404, {
       pathname: init.history.location.pathname,
     });
-    let { matches, route } = getShortCircuitMatches(dataRoutes);
+    let { matches, route } = getShortCircuitMatches(dataRoutes.activeRoutes);
     initialized = true;
     renderFallback = !initialized;
     initialMatches = matches;
@@ -1016,7 +1097,7 @@ export function createRouter(init: RouterInit): Router {
     if (initialMatches && !init.hydrationData) {
       let fogOfWar = checkFogOfWar(
         initialMatches,
-        dataRoutes,
+        dataRoutes.activeRoutes,
         init.history.location.pathname,
       );
       if (fogOfWar.active) {
@@ -1034,7 +1115,7 @@ export function createRouter(init: RouterInit): Router {
       // the initial matches so we can properly render `HydrateFallback`'s
       let fogOfWar = checkFogOfWar(
         null,
-        dataRoutes,
+        dataRoutes.activeRoutes,
         init.history.location.pathname,
       );
       if (fogOfWar.active && fogOfWar.matches) {
@@ -1449,10 +1530,7 @@ export function createRouter(init: RouterInit): Router {
         location.state?._isRedirect !== true);
 
     // Commit any in-flight routes at the end of the HMR revalidation "navigation"
-    if (inFlightDataRoutes) {
-      dataRoutes = inFlightDataRoutes;
-      inFlightDataRoutes = undefined;
-    }
+    dataRoutes.commitHmrRoutes();
 
     if (isUninterruptedRevalidation) {
       // If this was an uninterrupted revalidation then do not touch history
@@ -1777,7 +1855,7 @@ export function createRouter(init: RouterInit): Router {
 
     pendingViewTransitionEnabled = (opts && opts.enableViewTransition) === true;
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let loadingNavigation = opts && opts.overrideNavigation;
     let matches =
       opts?.initialHydration &&
@@ -1786,7 +1864,13 @@ export function createRouter(init: RouterInit): Router {
       !initialMatchesIsFOW
         ? // `matchRoutes()` has already been called if we're in here via `router.initialize()`
           state.matches
-        : matchRoutes(routesToUse, location, basename);
+        : matchRoutesImpl(
+            routesToUse,
+            location,
+            basename,
+            false,
+            dataRoutes.branches,
+          );
     let flushSync = (opts && opts.flushSync) === true;
 
     // Short circuit if it's only a hash change and not a revalidation or
@@ -1978,7 +2062,9 @@ export function createRouter(init: RouterInit): Router {
         return { shortCircuited: true };
       } else if (discoverResult.type === "error") {
         if (discoverResult.partialMatches.length === 0) {
-          let { matches, route } = getShortCircuitMatches(dataRoutes);
+          let { matches, route } = getShortCircuitMatches(
+            dataRoutes.activeRoutes,
+          );
           return {
             matches,
             pendingActionResult: [
@@ -2190,7 +2276,9 @@ export function createRouter(init: RouterInit): Router {
         return { shortCircuited: true };
       } else if (discoverResult.type === "error") {
         if (discoverResult.partialMatches.length === 0) {
-          let { matches, route } = getShortCircuitMatches(dataRoutes);
+          let { matches, route } = getShortCircuitMatches(
+            dataRoutes.activeRoutes,
+          );
           return {
             matches,
             loaderData: {},
@@ -2225,7 +2313,7 @@ export function createRouter(init: RouterInit): Router {
       }
     }
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let { dsMatches, revalidatingFetchers } = getMatchesToLoad(
       request,
       scopedContext,
@@ -2246,6 +2334,7 @@ export function createRouter(init: RouterInit): Router {
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
+      dataRoutes.branches,
       pendingActionResult,
       callSiteDefaultShouldRevalidate,
     );
@@ -2436,7 +2525,7 @@ export function createRouter(init: RouterInit): Router {
 
     let flushSync = (opts && opts.flushSync) === true;
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let normalizedPath = normalizeTo(
       state.location,
       state.matches,
@@ -2445,7 +2534,13 @@ export function createRouter(init: RouterInit): Router {
       routeId,
       opts?.relative,
     );
-    let matches = matchRoutes(routesToUse, normalizedPath, basename);
+    let matches = matchRoutesImpl(
+      routesToUse,
+      normalizedPath,
+      basename,
+      false,
+      dataRoutes.branches,
+    );
 
     let fogOfWar = checkFogOfWar(matches, routesToUse, normalizedPath);
     if (fogOfWar.active && fogOfWar.matches) {
@@ -2666,10 +2761,16 @@ export function createRouter(init: RouterInit): Router {
       nextLocation,
       abortController.signal,
     );
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let matches =
       state.navigation.state !== "idle"
-        ? matchRoutes(routesToUse, state.navigation.location, basename)
+        ? matchRoutesImpl(
+            routesToUse,
+            state.navigation.location,
+            basename,
+            false,
+            dataRoutes.branches,
+          )
         : state.matches;
 
     invariant(matches, "Didn't find any matches after fetcher action");
@@ -2700,6 +2801,7 @@ export function createRouter(init: RouterInit): Router {
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
+      dataRoutes.branches,
       [match.route.id, actionResult],
       callSiteDefaultShouldRevalidate,
     );
@@ -3465,7 +3567,7 @@ export function createRouter(init: RouterInit): Router {
 
   function handleNavigational404(pathname: string) {
     let error = getInternalRouterError(404, { pathname });
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let { matches, route } = getShortCircuitMatches(routesToUse);
 
     return { notFoundMatches: matches, route, error };
@@ -3541,12 +3643,14 @@ export function createRouter(init: RouterInit): Router {
     pathname: string,
   ): { active: boolean; matches: DataRouteMatch[] | null } {
     if (init.patchRoutesOnNavigation) {
+      let activeBranches = dataRoutes.branches;
       if (!matches) {
         let fogMatches = matchRoutesImpl<DataRouteObject>(
           routesToUse,
           pathname,
           basename,
           true,
+          activeBranches,
         );
 
         return { active: true, matches: fogMatches || [] };
@@ -3560,6 +3664,7 @@ export function createRouter(init: RouterInit): Router {
             pathname,
             basename,
             true,
+            activeBranches,
           );
           return { active: true, matches: partialMatches };
         }
@@ -3596,8 +3701,6 @@ export function createRouter(init: RouterInit): Router {
 
     let partialMatches: DataRouteMatch[] | null = matches;
     while (true) {
-      let isNonHMR = inFlightDataRoutes == null;
-      let routesToUse = inFlightDataRoutes || dataRoutes;
       let localManifest = manifest;
       try {
         await init.patchRoutesOnNavigation({
@@ -3610,7 +3713,7 @@ export function createRouter(init: RouterInit): Router {
             patchRoutesImpl(
               routeId,
               children,
-              routesToUse,
+              dataRoutes,
               localManifest,
               mapRouteProperties,
               false,
@@ -3619,23 +3722,20 @@ export function createRouter(init: RouterInit): Router {
         });
       } catch (e) {
         return { type: "error", error: e, partialMatches };
-      } finally {
-        // If we are not in the middle of an HMR revalidation and we changed the
-        // routes, provide a new identity so when we `updateState` at the end of
-        // this navigation/fetch `router.routes` will be a new identity and
-        // trigger a re-run of memoized `router.routes` dependencies.
-        // HMR will already update the identity and reflow when it lands
-        // `inFlightDataRoutes` in `completeNavigation`
-        if (isNonHMR && !signal.aborted) {
-          dataRoutes = [...dataRoutes];
-        }
       }
 
       if (signal.aborted) {
         return { type: "aborted" };
       }
 
-      let newMatches = matchRoutes(routesToUse, pathname, basename);
+      let activeBranches = dataRoutes.branches;
+      let newMatches = matchRoutesImpl(
+        dataRoutes.activeRoutes,
+        pathname,
+        basename,
+        false,
+        activeBranches,
+      );
       let newPartialMatches: DataRouteMatch[] | null = null;
 
       if (newMatches) {
@@ -3645,10 +3745,11 @@ export function createRouter(init: RouterInit): Router {
         } else {
           // Dynamic match - confirm this is the best match.
           newPartialMatches = matchRoutesImpl(
-            routesToUse,
+            dataRoutes.activeRoutes,
             pathname,
             basename,
             true,
+            activeBranches,
           );
 
           // If we matched deeper into the same branch of `partialMatches` we were already
@@ -3671,10 +3772,11 @@ export function createRouter(init: RouterInit): Router {
       // Perform partial matching if we didn't already do it above
       if (!newPartialMatches) {
         newPartialMatches = matchRoutesImpl<DataRouteObject>(
-          routesToUse,
+          dataRoutes.activeRoutes,
           pathname,
           basename,
           true,
+          activeBranches,
         );
       }
 
@@ -3698,11 +3800,13 @@ export function createRouter(init: RouterInit): Router {
 
   function _internalSetRoutes(newRoutes: DataRouteObject[]) {
     manifest = {};
-    inFlightDataRoutes = convertRoutesToDataRoutes(
-      newRoutes,
-      mapRouteProperties,
-      undefined,
-      manifest,
+    dataRoutes.setHmrRoutes(
+      convertRoutesToDataRoutes(
+        newRoutes,
+        mapRouteProperties,
+        undefined,
+        manifest,
+      ),
     );
   }
 
@@ -3711,12 +3815,10 @@ export function createRouter(init: RouterInit): Router {
     children: RouteObject[],
     unstable_allowElementMutations = false,
   ): void {
-    let isNonHMR = inFlightDataRoutes == null;
-    let routesToUse = inFlightDataRoutes || dataRoutes;
     patchRoutesImpl(
       routeId,
       children,
-      routesToUse,
+      dataRoutes,
       manifest,
       mapRouteProperties,
       unstable_allowElementMutations,
@@ -3727,8 +3829,7 @@ export function createRouter(init: RouterInit): Router {
     // to re-run memoized `router.routes` dependencies.
     // HMR will already update the identity and reflow when it lands
     // `inFlightDataRoutes` in `completeNavigation`
-    if (isNonHMR) {
-      dataRoutes = [...dataRoutes];
+    if (!dataRoutes.hasHMRRoutes) {
       updateState({});
     }
   }
@@ -3744,7 +3845,13 @@ export function createRouter(init: RouterInit): Router {
       return state;
     },
     get routes() {
-      return dataRoutes;
+      return dataRoutes.stableRoutes;
+    },
+    get branches() {
+      return dataRoutes.branches;
+    },
+    get manifest() {
+      return manifest;
     },
     get window() {
       return routerWindow;
@@ -5057,6 +5164,7 @@ function getMatchesToLoad(
   routesToUse: DataRouteObject[],
   basename: string | undefined,
   hasPatchRoutesOnNavigation: boolean,
+  branches: RouteBranch<DataRouteObject>[] | undefined,
   pendingActionResult?: PendingActionResult,
   callSiteDefaultShouldRevalidate?: boolean,
 ): {
@@ -5216,7 +5324,13 @@ function getMatchesToLoad(
     let fetcher = state.fetchers.get(key);
     let isMidInitialLoad =
       fetcher && fetcher.state !== "idle" && fetcher.data === undefined;
-    let fetcherMatches = matchRoutes(routesToUse, f.path, basename);
+    let fetcherMatches = matchRoutesImpl(
+      routesToUse,
+      f.path,
+      basename ?? "/",
+      false,
+      branches,
+    );
 
     // If the fetcher path no longer matches, push it in with null matches so
     // we can trigger a 404 in callLoadersAndMaybeResolveData.  Note this is
@@ -5435,7 +5549,7 @@ function shouldRevalidateLoader(
 function patchRoutesImpl(
   routeId: string | null,
   children: RouteObject[],
-  routesToUse: DataRouteObject[],
+  dataRoutes: DataRoutes,
   manifest: RouteManifest,
   mapRouteProperties: MapRoutePropertiesFunction,
   allowElementMutations: boolean,
@@ -5452,7 +5566,7 @@ function patchRoutesImpl(
     }
     childrenToPatch = route.children;
   } else {
-    childrenToPatch = routesToUse;
+    childrenToPatch = dataRoutes.activeRoutes;
   }
 
   // Don't patch in routes we already know about so that `patch` is idempotent
@@ -5511,6 +5625,14 @@ function patchRoutesImpl(
           : existingRouteTyped.hydrateFallbackElement,
       });
     }
+  }
+
+  // If we are not in the middle of an HMR revalidation, provide a new identity
+  // so when we `updateState` at the end of this navigation/fetch `router.routes`
+  // will be a new identity and trigger a re-run of memoized `router.routes`
+  // dependencies.
+  if (!dataRoutes.hasHMRRoutes) {
+    dataRoutes.setRoutes([...dataRoutes.activeRoutes]);
   }
 }
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -62,7 +62,6 @@ import {
   isUnsupportedLazyRouteObjectKey,
   isUnsupportedLazyRouteFunctionKey,
   isRouteErrorResponse,
-  matchRoutes,
   matchRoutesImpl,
   prependBasename,
   resolveTo,
@@ -112,6 +111,22 @@ export interface Router {
    * Return the routes for this router instance
    */
   get routes(): DataRouteObject[];
+
+  /**
+   * @private
+   * PRIVATE - DO NOT USE
+   *
+   * Return the route branches for this router instance
+   */
+  get branches(): RouteBranch<DataRouteObject>[] | undefined;
+
+  /**
+   * @private
+   * PRIVATE - DO NOT USE
+   *
+   * Return the manifest for this router instance
+   */
+  get manifest(): RouteManifest;
 
   /**
    * @private
@@ -909,6 +924,63 @@ const ResetLoaderDataSymbol = Symbol("ResetLoaderData");
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
+ * Encapsulates the stable and in-flight route trees together with their
+ * pre-computed branch caches so the structures always stay in sync.
+ */
+class DataRoutes {
+  #routes: DataRouteObject[];
+  #branches: RouteBranch<DataRouteObject>[];
+  #hmrRoutes: DataRouteObject[] | undefined;
+  #hmrBranches: RouteBranch<DataRouteObject>[] | undefined;
+
+  constructor(routes: DataRouteObject[]) {
+    this.#routes = routes;
+    this.#branches = flattenAndRankRoutes(routes);
+  }
+
+  /** The stable route tree */
+  get stableRoutes(): DataRouteObject[] {
+    return this.#routes;
+  }
+
+  /** The in-flight route tree if one is active, otherwise the stable tree */
+  get activeRoutes(): DataRouteObject[] {
+    return this.#hmrRoutes ?? this.#routes;
+  }
+
+  /** Pre-computed branches */
+  get branches(): RouteBranch<DataRouteObject>[] {
+    return this.#hmrBranches ?? this.#branches;
+  }
+
+  get hasHMRRoutes(): boolean {
+    return this.#hmrRoutes != null;
+  }
+
+  /** Replace the stable route tree and recompute its branches */
+  setRoutes(routes: DataRouteObject[]): void {
+    this.#routes = routes;
+    this.#branches = flattenAndRankRoutes(routes);
+  }
+
+  /** Set a new in-flight route tree and recompute its branches */
+  setHmrRoutes(routes: DataRouteObject[]): void {
+    this.#hmrRoutes = routes;
+    this.#hmrBranches = flattenAndRankRoutes(routes);
+  }
+
+  /** Commit in-flight routes/branches to the stable slot and clear in-flight */
+  commitHmrRoutes(): void {
+    if (this.#hmrRoutes) {
+      this.#routes = this.#hmrRoutes;
+      this.#branches = this.#hmrBranches!;
+      this.#hmrRoutes = undefined;
+      this.#hmrBranches = undefined;
+    }
+  }
+}
+
+/**
  * Create a router and listen to history POP navigations
  */
 export function createRouter(init: RouterInit): Router {
@@ -952,14 +1024,16 @@ export function createRouter(init: RouterInit): Router {
 
   // Routes keyed by ID
   let manifest: RouteManifest = {};
-  // Routes in tree format for matching
-  let dataRoutes = convertRoutesToDataRoutes(
-    init.routes,
-    mapRouteProperties,
-    undefined,
-    manifest,
+  // Route tree, in-flight variant, and their pre-computed ranked branch caches.
+  // Always updated together via the Routes class to keep them in sync.
+  let dataRoutes = new DataRoutes(
+    convertRoutesToDataRoutes(
+      init.routes,
+      mapRouteProperties,
+      undefined,
+      manifest,
+    ),
   );
-  let inFlightDataRoutes: DataRouteObject[] | undefined;
   let basename = init.basename || "/";
   if (!basename.startsWith("/")) {
     basename = `/${basename}`;
@@ -971,6 +1045,7 @@ export function createRouter(init: RouterInit): Router {
     unstable_passThroughRequests: false,
     ...init.future,
   };
+
   // Cleanup function for history
   let unlistenHistory: (() => void) | null = null;
   // Externally-provided functions to call on all state changes
@@ -989,7 +1064,13 @@ export function createRouter(init: RouterInit): Router {
   // SSR did the initial scroll restoration.
   let initialScrollRestored = init.hydrationData != null;
 
-  let initialMatches = matchRoutes(dataRoutes, init.history.location, basename);
+  let initialMatches = matchRoutesImpl(
+    dataRoutes.activeRoutes,
+    init.history.location,
+    basename,
+    false,
+    dataRoutes.branches,
+  );
   let initialMatchesIsFOW = false;
   let initialErrors: RouteData | null = null;
   let initialized: boolean;
@@ -1001,7 +1082,7 @@ export function createRouter(init: RouterInit): Router {
     let error = getInternalRouterError(404, {
       pathname: init.history.location.pathname,
     });
-    let { matches, route } = getShortCircuitMatches(dataRoutes);
+    let { matches, route } = getShortCircuitMatches(dataRoutes.activeRoutes);
     initialized = true;
     renderFallback = !initialized;
     initialMatches = matches;
@@ -1016,7 +1097,7 @@ export function createRouter(init: RouterInit): Router {
     if (initialMatches && !init.hydrationData) {
       let fogOfWar = checkFogOfWar(
         initialMatches,
-        dataRoutes,
+        dataRoutes.activeRoutes,
         init.history.location.pathname,
       );
       if (fogOfWar.active) {
@@ -1034,7 +1115,7 @@ export function createRouter(init: RouterInit): Router {
       // the initial matches so we can properly render `HydrateFallback`'s
       let fogOfWar = checkFogOfWar(
         null,
-        dataRoutes,
+        dataRoutes.activeRoutes,
         init.history.location.pathname,
       );
       if (fogOfWar.active && fogOfWar.matches) {
@@ -1449,10 +1530,7 @@ export function createRouter(init: RouterInit): Router {
         location.state?._isRedirect !== true);
 
     // Commit any in-flight routes at the end of the HMR revalidation "navigation"
-    if (inFlightDataRoutes) {
-      dataRoutes = inFlightDataRoutes;
-      inFlightDataRoutes = undefined;
-    }
+    dataRoutes.commitHmrRoutes();
 
     if (isUninterruptedRevalidation) {
       // If this was an uninterrupted revalidation then do not touch history
@@ -1777,7 +1855,7 @@ export function createRouter(init: RouterInit): Router {
 
     pendingViewTransitionEnabled = (opts && opts.enableViewTransition) === true;
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let loadingNavigation = opts && opts.overrideNavigation;
     let matches =
       opts?.initialHydration &&
@@ -1786,7 +1864,13 @@ export function createRouter(init: RouterInit): Router {
       !initialMatchesIsFOW
         ? // `matchRoutes()` has already been called if we're in here via `router.initialize()`
           state.matches
-        : matchRoutes(routesToUse, location, basename);
+        : matchRoutesImpl(
+            routesToUse,
+            location,
+            basename,
+            false,
+            dataRoutes.branches,
+          );
     let flushSync = (opts && opts.flushSync) === true;
 
     // Short circuit if it's only a hash change and not a revalidation or
@@ -1978,7 +2062,9 @@ export function createRouter(init: RouterInit): Router {
         return { shortCircuited: true };
       } else if (discoverResult.type === "error") {
         if (discoverResult.partialMatches.length === 0) {
-          let { matches, route } = getShortCircuitMatches(dataRoutes);
+          let { matches, route } = getShortCircuitMatches(
+            dataRoutes.activeRoutes,
+          );
           return {
             matches,
             pendingActionResult: [
@@ -2190,7 +2276,9 @@ export function createRouter(init: RouterInit): Router {
         return { shortCircuited: true };
       } else if (discoverResult.type === "error") {
         if (discoverResult.partialMatches.length === 0) {
-          let { matches, route } = getShortCircuitMatches(dataRoutes);
+          let { matches, route } = getShortCircuitMatches(
+            dataRoutes.activeRoutes,
+          );
           return {
             matches,
             loaderData: {},
@@ -2225,7 +2313,7 @@ export function createRouter(init: RouterInit): Router {
       }
     }
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let { dsMatches, revalidatingFetchers } = getMatchesToLoad(
       request,
       scopedContext,
@@ -2246,6 +2334,7 @@ export function createRouter(init: RouterInit): Router {
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
+      dataRoutes.branches,
       pendingActionResult,
       callSiteDefaultShouldRevalidate,
     );
@@ -2436,7 +2525,7 @@ export function createRouter(init: RouterInit): Router {
 
     let flushSync = (opts && opts.flushSync) === true;
 
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let normalizedPath = normalizeTo(
       state.location,
       state.matches,
@@ -2445,7 +2534,13 @@ export function createRouter(init: RouterInit): Router {
       routeId,
       opts?.relative,
     );
-    let matches = matchRoutes(routesToUse, normalizedPath, basename);
+    let matches = matchRoutesImpl(
+      routesToUse,
+      normalizedPath,
+      basename,
+      false,
+      dataRoutes.branches,
+    );
 
     let fogOfWar = checkFogOfWar(matches, routesToUse, normalizedPath);
     if (fogOfWar.active && fogOfWar.matches) {
@@ -2666,10 +2761,16 @@ export function createRouter(init: RouterInit): Router {
       nextLocation,
       abortController.signal,
     );
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let matches =
       state.navigation.state !== "idle"
-        ? matchRoutes(routesToUse, state.navigation.location, basename)
+        ? matchRoutesImpl(
+            routesToUse,
+            state.navigation.location,
+            basename,
+            false,
+            dataRoutes.branches,
+          )
         : state.matches;
 
     invariant(matches, "Didn't find any matches after fetcher action");
@@ -2700,6 +2801,7 @@ export function createRouter(init: RouterInit): Router {
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
+      dataRoutes.branches,
       [match.route.id, actionResult],
       callSiteDefaultShouldRevalidate,
     );
@@ -3455,7 +3557,7 @@ export function createRouter(init: RouterInit): Router {
 
   function handleNavigational404(pathname: string) {
     let error = getInternalRouterError(404, { pathname });
-    let routesToUse = inFlightDataRoutes || dataRoutes;
+    let routesToUse = dataRoutes.activeRoutes;
     let { matches, route } = getShortCircuitMatches(routesToUse);
 
     return { notFoundMatches: matches, route, error };
@@ -3531,12 +3633,14 @@ export function createRouter(init: RouterInit): Router {
     pathname: string,
   ): { active: boolean; matches: DataRouteMatch[] | null } {
     if (init.patchRoutesOnNavigation) {
+      let activeBranches = dataRoutes.branches;
       if (!matches) {
         let fogMatches = matchRoutesImpl<DataRouteObject>(
           routesToUse,
           pathname,
           basename,
           true,
+          activeBranches,
         );
 
         return { active: true, matches: fogMatches || [] };
@@ -3550,6 +3654,7 @@ export function createRouter(init: RouterInit): Router {
             pathname,
             basename,
             true,
+            activeBranches,
           );
           return { active: true, matches: partialMatches };
         }
@@ -3586,8 +3691,6 @@ export function createRouter(init: RouterInit): Router {
 
     let partialMatches: DataRouteMatch[] | null = matches;
     while (true) {
-      let isNonHMR = inFlightDataRoutes == null;
-      let routesToUse = inFlightDataRoutes || dataRoutes;
       let localManifest = manifest;
       try {
         await init.patchRoutesOnNavigation({
@@ -3600,7 +3703,7 @@ export function createRouter(init: RouterInit): Router {
             patchRoutesImpl(
               routeId,
               children,
-              routesToUse,
+              dataRoutes,
               localManifest,
               mapRouteProperties,
               false,
@@ -3609,23 +3712,20 @@ export function createRouter(init: RouterInit): Router {
         });
       } catch (e) {
         return { type: "error", error: e, partialMatches };
-      } finally {
-        // If we are not in the middle of an HMR revalidation and we changed the
-        // routes, provide a new identity so when we `updateState` at the end of
-        // this navigation/fetch `router.routes` will be a new identity and
-        // trigger a re-run of memoized `router.routes` dependencies.
-        // HMR will already update the identity and reflow when it lands
-        // `inFlightDataRoutes` in `completeNavigation`
-        if (isNonHMR && !signal.aborted) {
-          dataRoutes = [...dataRoutes];
-        }
       }
 
       if (signal.aborted) {
         return { type: "aborted" };
       }
 
-      let newMatches = matchRoutes(routesToUse, pathname, basename);
+      let activeBranches = dataRoutes.branches;
+      let newMatches = matchRoutesImpl(
+        dataRoutes.activeRoutes,
+        pathname,
+        basename,
+        false,
+        activeBranches,
+      );
       let newPartialMatches: DataRouteMatch[] | null = null;
 
       if (newMatches) {
@@ -3635,10 +3735,11 @@ export function createRouter(init: RouterInit): Router {
         } else {
           // Dynamic match - confirm this is the best match.
           newPartialMatches = matchRoutesImpl(
-            routesToUse,
+            dataRoutes.activeRoutes,
             pathname,
             basename,
             true,
+            activeBranches,
           );
 
           // If we matched deeper into the same branch of `partialMatches` we were already
@@ -3661,10 +3762,11 @@ export function createRouter(init: RouterInit): Router {
       // Perform partial matching if we didn't already do it above
       if (!newPartialMatches) {
         newPartialMatches = matchRoutesImpl<DataRouteObject>(
-          routesToUse,
+          dataRoutes.activeRoutes,
           pathname,
           basename,
           true,
+          activeBranches,
         );
       }
 
@@ -3688,11 +3790,13 @@ export function createRouter(init: RouterInit): Router {
 
   function _internalSetRoutes(newRoutes: DataRouteObject[]) {
     manifest = {};
-    inFlightDataRoutes = convertRoutesToDataRoutes(
-      newRoutes,
-      mapRouteProperties,
-      undefined,
-      manifest,
+    dataRoutes.setHmrRoutes(
+      convertRoutesToDataRoutes(
+        newRoutes,
+        mapRouteProperties,
+        undefined,
+        manifest,
+      ),
     );
   }
 
@@ -3701,12 +3805,10 @@ export function createRouter(init: RouterInit): Router {
     children: RouteObject[],
     unstable_allowElementMutations = false,
   ): void {
-    let isNonHMR = inFlightDataRoutes == null;
-    let routesToUse = inFlightDataRoutes || dataRoutes;
     patchRoutesImpl(
       routeId,
       children,
-      routesToUse,
+      dataRoutes,
       manifest,
       mapRouteProperties,
       unstable_allowElementMutations,
@@ -3717,8 +3819,7 @@ export function createRouter(init: RouterInit): Router {
     // to re-run memoized `router.routes` dependencies.
     // HMR will already update the identity and reflow when it lands
     // `inFlightDataRoutes` in `completeNavigation`
-    if (isNonHMR) {
-      dataRoutes = [...dataRoutes];
+    if (!dataRoutes.hasHMRRoutes) {
       updateState({});
     }
   }
@@ -3734,7 +3835,13 @@ export function createRouter(init: RouterInit): Router {
       return state;
     },
     get routes() {
-      return dataRoutes;
+      return dataRoutes.stableRoutes;
+    },
+    get branches() {
+      return dataRoutes.branches;
+    },
+    get manifest() {
+      return manifest;
     },
     get window() {
       return routerWindow;
@@ -5047,6 +5154,7 @@ function getMatchesToLoad(
   routesToUse: DataRouteObject[],
   basename: string | undefined,
   hasPatchRoutesOnNavigation: boolean,
+  branches: RouteBranch<DataRouteObject>[] | undefined,
   pendingActionResult?: PendingActionResult,
   callSiteDefaultShouldRevalidate?: boolean,
 ): {
@@ -5206,7 +5314,13 @@ function getMatchesToLoad(
     let fetcher = state.fetchers.get(key);
     let isMidInitialLoad =
       fetcher && fetcher.state !== "idle" && fetcher.data === undefined;
-    let fetcherMatches = matchRoutes(routesToUse, f.path, basename);
+    let fetcherMatches = matchRoutesImpl(
+      routesToUse,
+      f.path,
+      basename ?? "/",
+      false,
+      branches,
+    );
 
     // If the fetcher path no longer matches, push it in with null matches so
     // we can trigger a 404 in callLoadersAndMaybeResolveData.  Note this is
@@ -5425,7 +5539,7 @@ function shouldRevalidateLoader(
 function patchRoutesImpl(
   routeId: string | null,
   children: RouteObject[],
-  routesToUse: DataRouteObject[],
+  dataRoutes: DataRoutes,
   manifest: RouteManifest,
   mapRouteProperties: MapRoutePropertiesFunction,
   allowElementMutations: boolean,
@@ -5442,7 +5556,7 @@ function patchRoutesImpl(
     }
     childrenToPatch = route.children;
   } else {
-    childrenToPatch = routesToUse;
+    childrenToPatch = dataRoutes.activeRoutes;
   }
 
   // Don't patch in routes we already know about so that `patch` is idempotent
@@ -5501,6 +5615,14 @@ function patchRoutesImpl(
           : existingRouteTyped.hydrateFallbackElement,
       });
     }
+  }
+
+  // If we are not in the middle of an HMR revalidation, provide a new identity
+  // so when we `updateState` at the end of this navigation/fetch `router.routes`
+  // will be a new identity and trigger a re-run of memoized `router.routes`
+  // dependencies.
+  if (!dataRoutes.hasHMRRoutes) {
+    dataRoutes.setRoutes([...dataRoutes.activeRoutes]);
   }
 }
 

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -559,6 +559,7 @@ async function handleDocumentRequest(
     };
     let entryContext: EntryContext = {
       manifest: build.assets,
+      branches: staticHandler._branches,
       routeModules: createEntryRouteModules(build.routes),
       staticHandlerContext: context,
       criticalCss,

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -559,7 +559,7 @@ async function handleDocumentRequest(
     };
     let entryContext: EntryContext = {
       manifest: build.assets,
-      branches: staticHandler._branches,
+      branches: staticHandler._internalRouteBranches,
       routeModules: createEntryRouteModules(build.routes),
       staticHandlerContext: context,
       criticalCss,


### PR DESCRIPTION
~~**Stacked on #14967**~~

Improve route matching performance in Framework/Data Mode

- Avoiding unnecessary calls to `matchRoutes` in data router scenarios
  - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
  - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
- Leverage pre-computed pre-computing flattened/cached route branches during client side route matching

Performance benchmark (~30% SSR improvement)

```
Original server optimizations branch (#14967)
- Throughput: 952.7 req/s
- Latency mean: 8.716ms
- Latency p50: 9.452ms
- Latency p95: 11.610ms
- Latency p99: 12.544ms
- Latency min: 1.656ms
- Latency max: 15.936ms

This branch
- Throughput: 1235.3 req/s
- Latency mean: 6.095ms
- Latency p50: 6.655ms
- Latency p95: 8.327ms
- Latency p99: 12.133ms
- Latency min: 1.066ms
- Latency max: 19.056ms
```