### PR TITLE
Fix fetcher loader redirects from parent middleware

### DIFF
--- a/packages/react-router/.changes/patch.fetcher-loader-parent-middleware-redirect.md
+++ b/packages/react-router/.changes/patch.fetcher-loader-parent-middleware-redirect.md
@@ -1,0 +1,1 @@
+Properly handle parent middleware redirects during `fetcher.load`

--- a/packages/react-router/__tests__/router/context-middleware-test.tsx
+++ b/packages/react-router/__tests__/router/context-middleware-test.tsx
@@ -1787,6 +1787,77 @@ describe("context/middleware", () => {
         await router.navigate("/redirect");
         expect(router.state.location.pathname).toBe("/target");
       });
+
+      it("allows fetcher.load to follow redirects thrown from parent middleware", async () => {
+        router = createRouter({
+          history: createMemoryHistory(),
+          routes: [
+            {
+              path: "/",
+            },
+            {
+              path: "/parent",
+              middleware: [
+                async () => {
+                  throw redirect("/target");
+                },
+              ],
+              children: [
+                {
+                  id: "child",
+                  path: "child",
+                  loader() {
+                    return "CHILD";
+                  },
+                },
+              ],
+            },
+            {
+              path: "/target",
+            },
+          ],
+        });
+
+        await router.fetch("key", "source", "/parent/child");
+        expect(router.state.location.pathname).toBe("/target");
+      });
+
+      it("allows fetcher.submit to follow redirects thrown from parent middleware", async () => {
+        router = createRouter({
+          history: createMemoryHistory(),
+          routes: [
+            {
+              path: "/",
+            },
+            {
+              path: "/parent",
+              middleware: [
+                async () => {
+                  throw redirect("/target");
+                },
+              ],
+              children: [
+                {
+                  id: "child",
+                  path: "child",
+                  action() {
+                    return "CHILD";
+                  },
+                },
+              ],
+            },
+            {
+              path: "/target",
+            },
+          ],
+        });
+
+        await router.fetch("key", "source", "/parent/child", {
+          formMethod: "POST",
+          formData: createFormData({}),
+        });
+        expect(router.state.location.pathname).toBe("/target");
+      });
     });
   });
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2871,6 +2871,16 @@ export function createRouter(init: RouterInit): Router {
     );
     let result = results[match.route.id];
 
+    if (!result) {
+      // If this error came from a parent middleware before the loader ran,
+      // then it won't be tied to the fetcher target route
+      for (let match of matches) {
+        if (results[match.route.id]) {
+          result = results[match.route.id];
+          break;
+        }
+      }
+    }
     // We can delete this so long as we weren't aborted by our our own fetcher
     // re-load which would have put _new_ controller is in fetchControllers
     if (fetchControllers.get(key) === abortController) {


### PR DESCRIPTION
Fixes https://github.com/remix-run/react-router/issues/14903
Replaces https://github.com/remix-run/react-router/pull/14939