### PR TITLE
docs: fix typo in remixing router decision doc

### DIFF
--- a/decisions/0005-remixing-react-router.md
+++ b/decisions/0005-remixing-react-router.md
@@ -300,7 +300,7 @@ if (import.meta.hot) {
 }
 ```
 
-And finally since `<RouterProvider>` accepts a router, it makes unit testing easer since you can create a fresh router with each test.
+And finally since `<RouterProvider>` accepts a router, it makes unit testing easier since you can create a fresh router with each test.
 
 [remixing router]: https://remix.run/blog/remixing-react-router
 [navigation api]: https://developer.chrome.com/docs/web-platform/navigation-api/


### PR DESCRIPTION
## Summary
- fix a typo in the remixing router decision document

## Related issue
- N/A (trivial docs typo)

## Validation
- `git diff --check`
