### PR TITLE
fix: prerender output paths should not include basename

### DIFF
--- a/.changeset/fix-prerender-basename-path.md
+++ b/.changeset/fix-prerender-basename-path.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Fix prerender output paths to not include basename

--- a/.changeset/fix-prerender-basename-path.md
+++ b/.changeset/fix-prerender-basename-path.md
@@ -1,5 +1,0 @@
----
-"@react-router/dev": patch
----
-
-Fix prerender output paths to not include basename

--- a/contributors.yml
+++ b/contributors.yml
@@ -230,6 +230,7 @@
 - kno-raziel
 - knownasilya
 - koojaa
+- korkt-kim
 - KostiantynPopovych
 - KubasuIvanSakwa
 - KutnerUri

--- a/packages/react-router-dev/.changes/patch.fix-prerender-basename-path.md
+++ b/packages/react-router-dev/.changes/patch.fix-prerender-basename-path.md
@@ -1,0 +1,1 @@
+Fix prerender output paths to not include basename when using basename in react-router.config.ts. ([#14989](https://github.com/remix-run/react-router/pull/14989))

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2934,7 +2934,7 @@ async function prerenderData(
   }
 
   // Write out the .data file
-  let outfile = path.join(clientBuildDirectory, ...normalizedPath.split("/"));
+  let outfile = path.join(clientBuildDirectory, ...dataRequestPath.split("/"));
   await mkdir(path.dirname(outfile), { recursive: true });
   await writeFile(outfile, data);
   viteConfig.logger.info(
@@ -2996,7 +2996,7 @@ async function prerenderRoute(
   // Write out the HTML file
   let outfile = path.join(
     clientBuildDirectory,
-    ...normalizedPath.split("/"),
+    ...prerenderPath.split("/"),
     "index.html",
   );
   await mkdir(path.dirname(outfile), { recursive: true });
@@ -3032,7 +3032,10 @@ async function prerenderResourceRoute(
   }
 
   // Write out the resource route file
-  let outfile = path.join(clientBuildDirectory, ...normalizedPath.split("/"));
+  let outfile = path.join(
+    clientBuildDirectory,
+    ...`${prerenderPath}/`.replace(/\/\/+/g, "/").replace(/\/$/g, "").split("/")
+  );
   await mkdir(path.dirname(outfile), { recursive: true });
   await writeFile(outfile, content);
   viteConfig.logger.info(


### PR DESCRIPTION
# Description                                                                                                                                                                     
                                                                                                                                                                                  
  When using basename in react-router.config.ts, prerendered files are incorrectly output to a subfolder matching the basename (e.g., build/client/base/index.html instead of     
  build/client/index.html).                                                                                                                                                       
                                                                                                                                                                                  
  The basename is meant to define the deployment path prefix, not the build output directory structure. The prerender logic was using normalizedPath (which includes basename)    
  instead of the actual route path for determining output file locations.                                                                                                         
                                                                                                                                                                                  
#  Changes                                                                                                                                                                         
                                                                                                                                                                                  
  - Use dataRequestPath instead of normalizedPath for .data file output paths                                                                                                     
  - Use prerenderPath instead of normalizedPath for HTML file output paths                                                                                                        
  - Use prerenderPath instead of normalizedPath for resource route output paths                                                                                                   
  - Add test for prerender with basename configuration                                                                                                                            
                                                                                                                                                                                  
# Impact                                                                                                                                                                          
                                                                                                                                                                                  
  No compatibility issues - This is a bug fix that corrects the output path behavior. Previously, prerendered files with basename would be placed in wrong directories, causing   
  404 errors when deployed.                                                                                                                                                       
                                                                                                                                                                                  
  Fixes #14587 
