### PR TITLE
fix: make unstable_mask optional in Location

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -349,6 +349,7 @@
 - pwdcd
 - pyitphyoaung
 - qu0b
+- Quatton
 - QzCurious
 - raphaelbronsveld
 - redabacha

--- a/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
+++ b/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
@@ -1,1 +1,1 @@
-Made unstable_mask optional in Location
+Mark `unstable_mask` as an optional field in `Location` for easier mocking in unit tests

--- a/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
+++ b/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
@@ -1,0 +1,1 @@
+Made unstable_mask optional in Location

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -74,7 +74,7 @@ export interface Location<State = any> extends Path {
    * The masked location displayed in the URL bar, which differs from the URL the
    * router is operating on
    */
-  unstable_mask: Path | undefined;
+  unstable_mask?: Path;
 }
 
 /**


### PR DESCRIPTION
Following the discussion in: https://github.com/remix-run/react-router/pull/14716,

Several people have their `useLocation` mocked in tests and the addition of required field `unstable_mask` breaks them.
This should not affect the behavior of `Location` interface nor `unstable_mask`.

The fix has been proposed by @jroru and this PR implements it.

> ```ts
> unstable_mask: Path | undefined
> ```
> 
> Wouldn't cause failure if modeled as:
> ```ts
> unstable_mask?: Path
> ```

_Originally posted by @jroru in https://github.com/remix-run/react-router/issues/14716#issuecomment-4092409473_