### PR TITLE
chore: update chokidar to v5

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -299,6 +299,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- MonstraG
 - morleytatro
 - ms10596
 - mspiess

--- a/packages/react-router-dev/__tests__/watcher-ignored-test.ts
+++ b/packages/react-router-dev/__tests__/watcher-ignored-test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 
-import { isIgnoredByWatcher } from "../config/config";
+import { isIgnoredByWatcher } from "../config/is-ignored-by-watcher";
 
 describe("isIgnoredByWatcher", () => {
   let tmpDir: string;

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -22,6 +22,7 @@ import {
   configRoutesToRouteManifest,
 } from "./routes";
 import { detectPackageManager } from "../cli/detectPackageManager";
+import { isIgnoredByWatcher } from "./is-ignored-by-watcher";
 
 const excludedConfigPresetKeys = ["presets"] as const satisfies ReadonlyArray<
   keyof ReactRouterConfig
@@ -1159,38 +1160,6 @@ function isEntryFileDependency(
     ) {
       return true;
     }
-  }
-
-  return false;
-}
-
-export function isIgnoredByWatcher(
-  path: string,
-  { root, appDirectory }: { root: string; appDirectory: string },
-): boolean {
-  let dirname = Path.dirname(path);
-
-  let ignoredByPath =
-    !dirname.startsWith(appDirectory) &&
-    // Ensure we're only watching files outside of the app directory
-    // that are at the root level, not nested in subdirectories
-    path !== root && // Watch the root directory itself
-    dirname !== root; // Watch files at the root level
-
-  if (ignoredByPath) {
-    return true;
-  }
-
-  // Filter out non-regular files (sockets, pipes, etc.) that
-  // crash `fs.watch()` on macOS with errno -102
-  // https://github.com/paulmillr/chokidar/issues/1391
-  try {
-    let stat = fs.statSync(path, { throwIfNoEntry: false });
-    if (stat && !stat.isFile() && !stat.isDirectory()) {
-      return true;
-    }
-  } catch {
-    return true;
   }
 
   return false;

--- a/packages/react-router-dev/config/is-ignored-by-watcher.ts
+++ b/packages/react-router-dev/config/is-ignored-by-watcher.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import Path from "pathe";
+
+export function isIgnoredByWatcher(
+  path: string,
+  { root, appDirectory }: { root: string; appDirectory: string },
+): boolean {
+  let dirname = Path.dirname(path);
+
+  let ignoredByPath =
+    !dirname.startsWith(appDirectory) &&
+    // Ensure we're only watching files outside of the app directory
+    // that are at the root level, not nested in subdirectories
+    path !== root && // Watch the root directory itself
+    dirname !== root; // Watch files at the root level
+
+  if (ignoredByPath) {
+    return true;
+  }
+
+  // Filter out non-regular files (sockets, pipes, etc.) that
+  // crash `fs.watch()` on macOS with errno -102
+  // https://github.com/paulmillr/chokidar/issues/1391
+  try {
+    let stat = fs.statSync(path, { throwIfNoEntry: false });
+    if (stat && !stat.isFile() && !stat.isDirectory()) {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -80,7 +80,7 @@
     "@remix-run/node-fetch-server": "^0.13.0",
     "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.6",
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "dedent": "^1.5.3",
     "es-module-lexer": "^1.3.1",
     "exit-hook": "2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,8 +1024,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.10
       chokidar:
-        specifier: ^4.0.0
-        version: 4.0.3
+        specifier: ^5.0.0
+        version: 5.0.0
       dedent:
         specifier: ^1.5.3
         version: 1.5.3(babel-plugin-macros@3.1.0)
@@ -5266,6 +5266,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -8021,6 +8025,10 @@ packages:
   readdirp@4.0.1:
     resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
     engines: {node: '>= 14.16.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -13025,6 +13033,10 @@ snapshots:
     dependencies:
       readdirp: 4.0.1
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
@@ -16750,6 +16762,8 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.0.1: {}
+
+  readdirp@5.0.0: {}
 
   rechoir@0.6.2:
     dependencies:


### PR DESCRIPTION
Actual change is just the update, but because chokidar is ESM-only, jest immideately died. So I had to move out `isIgnoredByWatcher` function which is used in `watcher-ignored-test.ts`. Now, `config.ts` is not opened by jest and we are happy.

Refs: #14991