### PR TITLE
Stabilize APIs

### DIFF
--- a/decisions/0015-observability.md
+++ b/decisions/0015-observability.md
@@ -234,7 +234,7 @@ let unInstrumentedHandler = createRequestHandler({
         ...m.entry,
         module: {
           ...m.entry.module,
-          unstable_instrumentations: undefined,
+          instrumentations: undefined,
         },
       },
     })),

--- a/docs/api/components/Form.md
+++ b/docs/api/components/Form.md
@@ -144,7 +144,7 @@ Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/Vie
 for this navigation. To apply specific styles during the transition, see
 [`useViewTransitionState`](../hooks/useViewTransitionState).
 
-### unstable_defaultShouldRevalidate
+### defaultShouldRevalidate
 
 Specify the default revalidation behavior after this submission
 

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -214,14 +214,14 @@ for this navigation.
 
 To apply specific styles for the transition, see [`useViewTransitionState`](../hooks/useViewTransitionState)
 
-### unstable_defaultShouldRevalidate
+### defaultShouldRevalidate
 
 [modes: framework, data, declarative]
 
 Specify the default revalidation behavior for the navigation.
 
 ```tsx
-<Link to="/some/path" unstable_defaultShouldRevalidate={false} />
+<Link to="/some/path" defaultShouldRevalidate={false} />
 ```
 
 If no `shouldRevalidate` functions are present on the active routes, then this

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -232,7 +232,7 @@ useful when updating search params and you don't want to trigger a revalidation.
 By default (when not specified), loaders will revalidate according to the routers
 standard revalidation behavior.
 
-### unstable_mask
+### mask
 
 [modes: framework, data]
 
@@ -265,7 +265,7 @@ export default function Gallery({ loaderData }: Route.ComponentProps) {
          <Link
            key={image.id}
            to={`/gallery?image=${image.id}`}
-           unstable_mask={`/images/${image.id}`}
+           mask={`/images/${image.id}`}
          >
            <img src={image.url} alt={image.alt} />
          </Link>

--- a/docs/api/data-routers/RouterProvider.md
+++ b/docs/api/data-routers/RouterProvider.md
@@ -49,7 +49,7 @@ function RouterProvider({
   router,
   flushSync: reactDomFlushSyncImpl,
   onError,
-  unstable_useTransitions,
+  useTransitions,
 }: RouterProviderProps): React.ReactElement
 ```
 
@@ -88,7 +88,7 @@ and is only present for render errors.
 
 The [`DataRouter`](https://api.reactrouter.com/v7/interfaces/react-router.DataRouter.html) instance to use for navigation and data fetching.
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/data-routers/RouterProvider.md
+++ b/docs/api/data-routers/RouterProvider.md
@@ -78,7 +78,7 @@ and is only present for render errors.
 
 ```tsx
 <RouterProvider onError=(error, info) => {
-  let { location, params, unstable_pattern, errorInfo } = info;
+  let { location, params, pattern, errorInfo } = info;
   console.error(error, location, errorInfo);
   reportToErrorService(error, location, errorInfo);
 }} />

--- a/docs/api/data-routers/createBrowserRouter.md
+++ b/docs/api/data-routers/createBrowserRouter.md
@@ -172,7 +172,7 @@ const router = createBrowserRouter(
 );
 ```
 
-### opts.unstable_instrumentations
+### opts.instrumentations
 
 Array of instrumentation objects allowing you to instrument the router and
 individual routes prior to router initialization (and on any subsequently
@@ -183,7 +183,7 @@ tracing.  See the [docs](../../how-to/instrumentation) for more information.
 
 ```tsx
 let router = createBrowserRouter(routes, {
-  unstable_instrumentations: [logging]
+  instrumentations: [logging]
 });
 
 

--- a/docs/api/data-routers/createHashRouter.md
+++ b/docs/api/data-routers/createHashRouter.md
@@ -142,7 +142,7 @@ const router = createBrowserRouter(
 );
 ```
 
-### opts.unstable_instrumentations
+### opts.instrumentations
 
 Array of instrumentation objects allowing you to instrument the router and
 individual routes prior to router initialization (and on any subsequently
@@ -153,7 +153,7 @@ tracing.  See the [docs](../../how-to/instrumentation) for more information.
 
 ```tsx
 let router = createBrowserRouter(routes, {
-  unstable_instrumentations: [logging]
+  instrumentations: [logging]
 });
 
 

--- a/docs/api/data-routers/createMemoryRouter.md
+++ b/docs/api/data-routers/createMemoryRouter.md
@@ -99,7 +99,7 @@ Initial entries in the in-memory history stack
 
 Index of `initialEntries` the application should initialize to
 
-### opts.unstable_instrumentations
+### opts.instrumentations
 
 Array of instrumentation objects allowing you to instrument the router and
 individual routes prior to router initialization (and on any subsequently
@@ -110,7 +110,7 @@ tracing.  See the [docs](../../how-to/instrumentation) for more information.
 
 ```tsx
 let router = createBrowserRouter(routes, {
-  unstable_instrumentations: [logging]
+  instrumentations: [logging]
 });
 
 

--- a/docs/api/declarative-routers/BrowserRouter.md
+++ b/docs/api/declarative-routers/BrowserRouter.md
@@ -31,7 +31,7 @@ API for client-side routing.
 function BrowserRouter({
   basename,
   children,
-  unstable_useTransitions,
+  useTransitions,
   window,
 }: BrowserRouterProps)
 ```
@@ -46,7 +46,7 @@ Application basename
 
 ``<Route>`` components describing your route configuration
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/declarative-routers/HashRouter.md
+++ b/docs/api/declarative-routers/HashRouter.md
@@ -32,7 +32,7 @@ of the URL so it is not sent to the server.
 function HashRouter({
   basename,
   children,
-  unstable_useTransitions,
+  useTransitions,
   window,
 }: HashRouterProps)
 ```
@@ -47,7 +47,7 @@ Application basename
 
 ``<Route>`` components describing your route configuration
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/declarative-routers/HistoryRouter.md
+++ b/docs/api/declarative-routers/HistoryRouter.md
@@ -43,7 +43,7 @@ function HistoryRouter({
   basename,
   children,
   history,
-  unstable_useTransitions,
+  useTransitions,
 }: HistoryRouterProps)
 ```
 
@@ -61,7 +61,7 @@ Application basename
 
 A `History` implementation for use by the router
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/declarative-routers/MemoryRouter.md
+++ b/docs/api/declarative-routers/MemoryRouter.md
@@ -32,7 +32,7 @@ function MemoryRouter({
   children,
   initialEntries,
   initialIndex,
-  unstable_useTransitions,
+  useTransitions,
 }: MemoryRouterProps): React.ReactElement
 ```
 
@@ -54,7 +54,7 @@ Initial entries in the in-memory history stack
 
 Index of `initialEntries` the application should initialize to
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/declarative-routers/Router.md
+++ b/docs/api/declarative-routers/Router.md
@@ -38,7 +38,7 @@ function Router({
   navigationType = NavigationType.Pop,
   navigator,
   static: staticProp = false,
-  unstable_useTransitions,
+  useTransitions,
 }: RouterProps): React.ReactElement | null
 ```
 
@@ -72,7 +72,7 @@ or a custom navigator that implements the [`Navigator`](https://api.reactrouter.
 Whether this router is static or not (used for SSR). If `true`, the router
 will not be reactive to location changes.
 
-### unstable_useTransitions
+### useTransitions
 
 Control whether router state updates are internally wrapped in
 [`React.startTransition`](https://react.dev/reference/react/startTransition).

--- a/docs/api/framework-conventions/react-router.config.ts.md
+++ b/docs/api/framework-conventions/react-router.config.ts.md
@@ -132,9 +132,7 @@ export default {
 
 ### `prerender`
 
-An array of URLs to prerender to HTML files at build time. Can also be a function returning an array to dynamically generate URLs.
-
-See [Pre-Rendering][pre-rendering] for more information.
+An array of URLs to prerender to HTML files at build time - see [Pre-Rendering][pre-rendering] for more information.
 
 ```tsx filename=react-router.config.ts
 export default {
@@ -146,6 +144,12 @@ export default {
     const paths = await getStaticPaths();
     return ["/", ...paths];
   },
+
+  // Or an object if you wish to enable concurrency
+  prerender: {
+    paths: ["/", "/about", "/contact"],
+    concurrency: 4,
+  }
 } satisfies Config;
 ```
 

--- a/docs/api/framework-routers/HydratedRouter.md
+++ b/docs/api/framework-routers/HydratedRouter.md
@@ -52,7 +52,7 @@ and is only present for render errors.
 
 ```tsx
 <HydratedRouter onError=(error, info) => {
-  let { location, params, unstable_pattern, errorInfo } = info;
+  let { location, params, pattern, errorInfo } = info;
   console.error(error, location, errorInfo);
   reportToErrorService(error, location, errorInfo);
 }} />

--- a/docs/api/hooks/useLinkClickHandler.md
+++ b/docs/api/hooks/useLinkClickHandler.md
@@ -40,7 +40,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     relative,
     viewTransition,
     defaultShouldRevalidate,
-    unstable_useTransitions,
+    useTransitions,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
@@ -50,7 +50,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     relative?: RelativeRoutingType;
     viewTransition?: boolean;
     defaultShouldRevalidate?: boolean;
-    unstable_useTransitions?: boolean;
+    useTransitions?: boolean;
   } = ,
 ): (event: React.MouseEvent<E, MouseEvent>) => void {}
 ```
@@ -95,7 +95,7 @@ Specify the default revalidation behavior for the navigation. Defaults to `true`
 
 Masked location to display in the browser instead of the router location. Defaults to `undefined`.
 
-### options.unstable_useTransitions
+### options.useTransitions
 
 Wraps the navigation in [`React.startTransition`](https://react.dev/reference/react/startTransition)
 for concurrent rendering. Defaults to `false`.

--- a/docs/api/hooks/useLinkClickHandler.md
+++ b/docs/api/hooks/useLinkClickHandler.md
@@ -39,7 +39,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     preventScrollReset,
     relative,
     viewTransition,
-    unstable_defaultShouldRevalidate,
+    defaultShouldRevalidate,
     unstable_useTransitions,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
@@ -49,7 +49,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
     viewTransition?: boolean;
-    unstable_defaultShouldRevalidate?: boolean;
+    defaultShouldRevalidate?: boolean;
     unstable_useTransitions?: boolean;
   } = ,
 ): (event: React.MouseEvent<E, MouseEvent>) => void {}
@@ -87,7 +87,7 @@ The target attribute for the link. Defaults to `undefined`.
 Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) for this navigation. To apply specific styles during the transition, see
 [`useViewTransitionState`](../hooks/useViewTransitionState). Defaults to `false`.
 
-### options.unstable_defaultShouldRevalidate
+### options.defaultShouldRevalidate
 
 Specify the default revalidation behavior for the navigation. Defaults to `true`.
 

--- a/docs/api/hooks/useLinkClickHandler.md
+++ b/docs/api/hooks/useLinkClickHandler.md
@@ -34,7 +34,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
   {
     target,
     replace: replaceProp,
-    unstable_mask,
+    mask,
     state,
     preventScrollReset,
     relative,
@@ -44,7 +44,7 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
-    unstable_mask?: To;
+    mask?: To;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
@@ -91,7 +91,7 @@ Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/Vie
 
 Specify the default revalidation behavior for the navigation. Defaults to `true`.
 
-### options.unstable_mask
+### options.mask
 
 Masked location to display in the browser instead of the router location. Defaults to `undefined`.
 

--- a/docs/explanation/react-transitions.md
+++ b/docs/explanation/react-transitions.md
@@ -1,6 +1,5 @@
 ---
 title: React Transitions
-unstable: true
 ---
 
 # React Transitions
@@ -9,10 +8,6 @@ unstable: true
 
 <br/>
 <br/>
-
-<docs-warning>The `unstable_useTransitions` prop is experimental and subject to breaking changes in
-minor/patch releases. Please use with caution and pay **very** close attention
-to release notes for relevant changes.</docs-warning>
 
 [React 18][react-18] introduced the concept of "transitions" which allow you to differentiate urgent from non-urgent UI updates. To learn more about React Transitions and "concurrent rendering" Please refer to React's official documentation:
 
@@ -27,13 +22,13 @@ to release notes for relevant changes.</docs-warning>
 
 The introduction of Transitions in React makes the story of how React Router manages your navigations and router state a bit more complicated. These are powerful APIs but they don't come without some nuance and added complexity. We aim to make React Router work seamlessly with the new React features, but in some cases there may exist some tension between the new React ways to do things and some patterns you are already using in your React Router apps (i.e., pending states, optimistic UI).
 
-To ensure a smooth adoption story, we've introduced changes related to Transitions behind an opt-in `unstable_useTransitions` flag so that you can upgrade in a non-breaking fashion.
+To ensure a smooth adoption story, we've introduced changes related to Transitions behind an opt-in `useTransitions` flag so that you can upgrade in a non-breaking fashion.
 
 ### Current Behavior
 
 We first leveraged `React.startTransition` to make React Router more Suspense-friendly in React Router [6.13.0][rr-6-13-0] via the `future.v7_startTransition` flag. In v7, that became the default behavior and all router state updates are currently wrapped in `React.startTransition`.
 
-This default behavior has 2 potential issues that `unstable_useTransitions` is designed to solve:
+This default behavior has 2 potential issues that `useTransitions` is designed to solve:
 
 - There are some valid use cases where you _don't_ want your updates wrapped in `startTransition`
   - One specific issue is that `React.useSyncExternalStore` updates can't be Transitions ([^1][uses-transition-issue], [^2][uses-transition-tweet]). `useSyncExternalStore` forces a sync update, which means fallbacks can be shown in update transitions that would otherwise avoid showing the fallback.
@@ -41,26 +36,26 @@ This default behavior has 2 potential issues that `unstable_useTransitions` is d
 - React 19 has added a new `startTransition(() => Promise))` API as well as a new `useOptimistic` hook to surface updates during Transitions
   - Without some updates to React Router, `startTransition(() => navigate(path))` doesn't work as you might expect, because we are not using `useOptimistic` internally so router state updates don't surface during the navigation, which breaks hooks like `useNavigation`
 
-To provide a solution to both of the above issues, we're introducing a new `unstable_useTransitions` prop to the router components that will let you opt-out of using `startTransition` for router state updates (solving the first issue), or opt-into a more enhanced usage of `startTransition` + `useOptimistic` (solving the second issue). Because the current behavior is a bit incomplete with the new React 19 APIs, we plan to make the opt-in behavior the default in React Router v8, but we will likely retain the opt-out flag for use cases such as `useSyncExternalStore`.
+To provide a solution to both of the above issues, we're introducing a new `useTransitions` prop to the router components that will let you opt-out of using `startTransition` for router state updates (solving the first issue), or opt-into a more enhanced usage of `startTransition` + `useOptimistic` (solving the second issue). Because the current behavior is a bit incomplete with the new React 19 APIs, we plan to make the opt-in behavior the default in React Router v8, but we will likely retain the opt-out flag for use cases such as `useSyncExternalStore`.
 
-### Opt-out via `unstable_useTransitions=false`
+### Opt-out via `useTransitions=false`
 
 If your application is not "Transition-friendly" due to the usage of `useSyncExternalStore` (or other reasons), then you can opt-out via the prop:
 
 ```tsx
 // Framework Mode (entry.client.tsx)
-<HydratedRouter unstable_useTransitions={false} />
+<HydratedRouter useTransitions={false} />
 
 // Data Mode
-<RouterProvider unstable_useTransitions={false} />
+<RouterProvider useTransitions={false} />
 
 // Declarative Mode
-<BrowserRouter unstable_useTransitions={false} />
+<BrowserRouter useTransitions={false} />
 ```
 
 This will stop the router from wrapping internal state updates in `startTransition`.
 
-### Opt-in via `unstable_useTransitions=true`
+### Opt-in via `useTransitions=true`
 
 <docs-info>Opting into this feature in Framework or Data Mode requires that you are using React 19 because it needs access to [`React.useOptimistic`][use-optimistic]</docs-info>
 
@@ -68,13 +63,13 @@ If you want to make your application play nicely with all of the new React 19 fe
 
 ```tsx
 // Framework Mode (entry.client.tsx)
-<HydratedRouter unstable_useTransitions />
+<HydratedRouter useTransitions />
 
 // Data Mode
-<RouterProvider unstable_useTransitions />
+<RouterProvider useTransitions />
 
 // Declarative Mode
-<BrowserRouter unstable_useTransitions />
+<BrowserRouter useTransitions />
 ```
 
 With this flag enabled:

--- a/docs/how-to/error-reporting.md
+++ b/docs/how-to/error-reporting.md
@@ -75,7 +75,7 @@ import { type ClientOnErrorFunction } from "react-router";
 
 const onError: ClientOnErrorFunction = (
   error,
-  { location, params, unstable_pattern, errorInfo },
+  { location, params, pattern, errorInfo },
 ) => {
   myReportError(error, location, errorInfo);
 
@@ -108,7 +108,7 @@ import { type ClientOnErrorFunction } from "react-router";
 
 const onError: ClientOnErrorFunction = (
   error,
-  { location, params, unstable_pattern, errorInfo },
+  { location, params, pattern, errorInfo },
 ) => {
   myReportError(error, location, errorInfo);
 

--- a/docs/how-to/instrumentation.md
+++ b/docs/how-to/instrumentation.md
@@ -1,6 +1,5 @@
 ---
 title: Instrumentation
-unstable: true
 ---
 
 # Instrumentation
@@ -9,10 +8,6 @@ unstable: true
 
 <br/>
 <br/>
-
-<docs-warning>The instrumentation APIs are experimental and subject to breaking changes in
-minor/patch releases. Please use with caution and pay **very** close attention
-to release notes for relevant changes.</docs-warning>
 
 Instrumentation allows you to add logging, error reporting, and performance tracing to your React Router application without modifying your actual route handlers. This enables comprehensive observability solutions for production applications on both the server and client.
 
@@ -41,7 +36,7 @@ As with any instrumentation approach, adding additional code execution at runtim
 Add instrumentations to your `entry.server.tsx`:
 
 ```tsx filename=app/entry.server.tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     // Instrument the server handler
     handler(handler) {
@@ -90,7 +85,7 @@ import { startTransition, StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
-const unstable_instrumentations = [
+const instrumentations = [
   {
     // Instrument router operations
     router(router) {
@@ -141,8 +136,8 @@ startTransition(() => {
     document,
     <StrictMode>
       <HydratedRouter
-        unstable_instrumentations={
-          unstable_instrumentations
+        instrumentations={
+          instrumentations
         }
       />
     </StrictMode>,
@@ -162,7 +157,7 @@ import {
   RouterProvider,
 } from "react-router";
 
-const unstable_instrumentations = [
+const instrumentations = [
   {
     // Instrument router operations
     router(router) {
@@ -209,7 +204,7 @@ const unstable_instrumentations = [
 ];
 
 const router = createBrowserRouter(routes, {
-  unstable_instrumentations,
+  instrumentations,
 });
 
 function App() {
@@ -230,7 +225,7 @@ There are different levels at which you can instrument your application. Each in
 Instruments the top-level request handler that processes all requests to your server:
 
 ```tsx filename=entry.server.tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     handler(handler) {
       handler.instrument({
@@ -251,7 +246,7 @@ export const unstable_instrumentations = [
 Instruments client-side router operations like navigations and fetcher calls:
 
 ```tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     router(router) {
       router.instrument({
@@ -273,12 +268,12 @@ export const unstable_instrumentations = [
 
 // Framework Mode (entry.client.tsx)
 <HydratedRouter
-  unstable_instrumentations={unstable_instrumentations}
+  instrumentations={instrumentations}
 />;
 
 // Data Mode
 const router = createBrowserRouter(routes, {
-  unstable_instrumentations,
+  instrumentations,
 });
 ```
 
@@ -289,27 +284,27 @@ const router = createBrowserRouter(routes, {
 Instruments individual route handlers:
 
 ```tsx
-const unstable_instrumentations = [
+const instrumentations = [
   {
     route(route) {
       route.instrument({
         async loader(
           callLoader,
-          { params, request, context, unstable_pattern },
+          { params, request, context, pattern },
         ) {
           // Runs around loader execution
           await callLoader();
         },
         async action(
           callAction,
-          { params, request, context, unstable_pattern },
+          { params, request, context, pattern },
         ) {
           // Runs around action execution
           await callAction();
         },
         async middleware(
           callMiddleware,
-          { params, request, context, unstable_pattern },
+          { params, request, context, pattern },
         ) {
           // Runs around middleware execution
           await callMiddleware();
@@ -341,7 +336,7 @@ To ensure that instrumentation code doesn't impact the runtime application, erro
 First, if a "handler" function (loader, action, request handler, navigation, etc.) throws an error, that error will not bubble out of the `callHandler` function invoked from your instrumentation. Instead, the `callHandler` function returns a discriminated union result of type `{ type: "success", error: undefined } | { type: "error", error: unknown }`. This ensures your entire instrumentation function runs without needing any try/catch/finally logic to handle application errors.
 
 ```tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     route(route) {
       route.instrument({
@@ -363,7 +358,7 @@ export const unstable_instrumentations = [
 Second, if your instrumentation function throws an error, React Router will gracefully swallow that so that it does not bubble outward and impact other instrumentations or application behavior. In both of these examples, the handlers and all other instrumentation functions will still run:
 
 ```tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     route(route) {
       route.instrument({
@@ -390,7 +385,7 @@ export const unstable_instrumentations = [
 You can compose multiple instrumentations by providing an array:
 
 ```tsx
-export const unstable_instrumentations = [
+export const instrumentations = [
   loggingInstrumentation,
   performanceInstrumentation,
   errorReportingInstrumentation,
@@ -404,7 +399,7 @@ Each instrumentation wraps the previous one, creating a nested execution chain.
 You can enable instrumentation conditionally based on environment or other factors:
 
 ```tsx
-export const unstable_instrumentations =
+export const instrumentations =
   process.env.NODE_ENV === "production"
     ? [productionInstrumentation]
     : [developmentInstrumentation];
@@ -412,7 +407,7 @@ export const unstable_instrumentations =
 
 ```tsx
 // Or conditionally within an instrumentation
-export const unstable_instrumentations = [
+export const instrumentations = [
   {
     route(route) {
       // Only instrument specific routes
@@ -437,7 +432,7 @@ export const unstable_instrumentations = [
 ### Request logging (server)
 
 ```tsx
-const logging: unstable_ServerInstrumentation = {
+const logging: ServerInstrumentation = {
   handler({ instrument }) {
     instrument({
       request: (fn, { request }) =>
@@ -455,7 +450,7 @@ const logging: unstable_ServerInstrumentation = {
 
 async function log(
   label: string,
-  cb: () => Promise<unstable_InstrumentationHandlerResult>,
+  cb: () => Promise<InstrumentationHandlerResult>,
 ) {
   let start = Date.now();
   console.log(`➡️ ${label}`);
@@ -463,7 +458,7 @@ async function log(
   console.log(`⬅️ ${label} (${Date.now() - start}ms)`);
 }
 
-export const unstable_instrumentations = [logging];
+export const instrumentations = [logging];
 ```
 
 ### OpenTelemetry Integration
@@ -473,7 +468,7 @@ import { trace, SpanStatusCode } from "@opentelemetry/api";
 
 const tracer = trace.getTracer("my-app");
 
-const otel: unstable_ServerInstrumentation = {
+const otel: ServerInstrumentation = {
   handler({ instrument }) {
     instrument({
       request: (fn, { request }) =>
@@ -482,22 +477,22 @@ const otel: unstable_ServerInstrumentation = {
   },
   route({ instrument, id }) {
     instrument({
-      middleware: (fn, { unstable_pattern }) =>
+      middleware: (fn, { pattern }) =>
         otelSpan(
           "middleware",
-          { routeId: id, pattern: unstable_pattern },
+          { routeId: id, pattern: pattern },
           fn,
         ),
-      loader: (fn, { unstable_pattern }) =>
+      loader: (fn, { pattern }) =>
         otelSpan(
           "loader",
-          { routeId: id, pattern: unstable_pattern },
+          { routeId: id, pattern: pattern },
           fn,
         ),
-      action: (fn, { unstable_pattern }) =>
+      action: (fn, { pattern }) =>
         otelSpan(
           "action",
-          { routeId: id, pattern: unstable_pattern },
+          { routeId: id, pattern: pattern },
           fn,
         ),
     });
@@ -507,7 +502,7 @@ const otel: unstable_ServerInstrumentation = {
 async function otelSpan(
   label: string,
   attributes: Record<string, string>,
-  cb: () => Promise<unstable_InstrumentationHandlerResult>,
+  cb: () => Promise<InstrumentationHandlerResult>,
 ) {
   return tracer.startActiveSpan(
     label,
@@ -525,13 +520,13 @@ async function otelSpan(
   );
 }
 
-export const unstable_instrumentations = [otel];
+export const instrumentations = [otel];
 ```
 
 ### Client-side Performance Tracking
 
 ```tsx
-const windowPerf: unstable_ClientInstrumentation = {
+const windowPerf: ClientInstrumentation = {
   router({ instrument }) {
     instrument({
       navigate: (fn, { to, currentUrl }) =>
@@ -551,7 +546,7 @@ const windowPerf: unstable_ClientInstrumentation = {
 
 async function measure(
   label: string,
-  cb: () => Promise<unstable_InstrumentationHandlerResult>,
+  cb: () => Promise<InstrumentationHandlerResult>,
 ) {
   performance.mark(`start:${label}`);
   await cb();
@@ -563,5 +558,5 @@ async function measure(
   );
 }
 
-<HydratedRouter unstable_instrumentations={[windowPerf]} />;
+<HydratedRouter instrumentations={[windowPerf]} />;
 ```

--- a/docs/how-to/pre-rendering.md
+++ b/docs/how-to/pre-rendering.md
@@ -59,15 +59,11 @@ export default {
 } satisfies Config;
 ```
 
-### Concurrency (unstable)
-
-<docs-warning>This API is experimental and subject to breaking changes in
-minor/patch releases. Please use with caution and pay **very** close attention
-to release notes for relevant changes.</docs-warning>
+### Concurrency
 
 By default, pages are pre-rendered one path at a time. You can enable concurrency to pre-render multiple paths in parallel which can speed up build times in many cases. You should experiment with the value that provides the best performance for your app.
 
-To specify concurrency, move your `prerender` config down into a `prerender.paths` field and you can specify the concurrency in `prerender.unstable_concurrency`:
+To specify concurrency, move your `prerender` config down into a `prerender.paths` field and you can specify the concurrency in `prerender.concurrency`:
 
 ```ts filename=react-router.config.ts
 import type { Config } from "@react-router/dev/config";
@@ -81,7 +77,7 @@ export default {
       "/blog",
       ...slugs.map((s) => `/blog/${s}`),
     ],
-    unstable_concurrency: 4,
+    concurrency: 4,
   },
 } satisfies Config;
 ```

--- a/docs/how-to/react-server-components.md
+++ b/docs/how-to/react-server-components.md
@@ -385,7 +385,7 @@ The following options from `react-router.config.ts` are not currently supported 
 - `presets`
 - `serverBundles`
 - `future.v8_splitRouteModules`
-- `future.unstable_subResourceIntegrity`
+- `subResourceIntegrity`
 
 ## RSC Data Mode
 

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -135,7 +135,7 @@ This flag eliminates that normalization and passes the raw HTTP `request` instan
 - Reduces server-side overhead by eliminating multiple `new Request()` calls on the critical path
 - Allows you to distinguish document from data requests in your handlers based on the presence of a `.data` suffix (useful for [observability] purposes)
 
-If you were previously relying on the normalization of `request.url`, you can switch to use the new sibling `unstable_url` parameter which contains a `URL` instance representing the normalized location.
+If you were previously relying on the normalization of `request.url`, you can switch to use the new sibling `url` parameter which contains a `URL` instance representing the normalized location.
 
 👉 **Enable the Flag**
 
@@ -179,13 +179,13 @@ export async function loader({
   }
 }
 
-// ✅ After: use `unstable_url` for normalized routing logic and `request.url`
+// ✅ After: use `url` for normalized routing logic and `request.url`
 // for raw routing logic
 export async function loader({
   request,
-  unstable_url,
+  url,
 }: Route.LoaderArgs) {
-  if (unstable_url.pathname === "/path") {
+  if (url.pathname === "/path") {
     // This will always have the `.data` suffix stripped
   }
 

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -121,7 +121,7 @@ No code changes are required unless you have custom Vite configuration that need
 
 ## `future.v8_passThroughRequests`
 
-[MODES: framework, data]
+[MODES: framework]
 
 <br/>
 <br/>
@@ -139,8 +139,6 @@ If you were previously relying on the normalization of `request.url`, you can sw
 
 👉 **Enable the Flag**
 
-In Framework mode:
-
 ```ts filename=react-router.config.ts
 import type { Config } from "@react-router/dev/config";
 
@@ -149,18 +147,6 @@ export default {
     v8_passThroughRequests: true,
   },
 } satisfies Config;
-```
-
-In Data mode:
-
-```ts
-import { createBrowserRouter } from "react-router/dom";
-
-const router = createBrowserRouter(routes, {
-  future: {
-    v8_passThroughRequests: true,
-  },
-});
 ```
 
 **Update your Code**
@@ -196,7 +182,14 @@ export async function loader({
 }
 ```
 
+## Unstable Future Flags (Optional)
+
+We document some [unstable] flags here as a reference for folks contributing to the project via beta testing, but they are not generally recommended for production use and may having breaking changes patch/minor releases - adopt with caution!
+
+_No current unstable flags to document_
+
 [api-development-strategy]: ../community/api-development-strategy
+[unstable]: ../community/api-development-strategy#unstable-flags
 [observability]: ../how-to/instrumentation
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [vite-environment]: https://vite.dev/guide/api-environment

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -119,13 +119,9 @@ export default {
 
 No code changes are required unless you have custom Vite configuration that needs to be updated for the [Environment API][vite-environment]. Most users won't need to make any changes.
 
-## Unstable Future Flags (Optional)
+## `future.v8_passThroughRequests`
 
-We document some [unstable] flags here as a reference for folks contributing to the project via beta testing, but they are not generally recommended for production use and may having breaking changes patch/minor releases - adopt with caution!
-
-### future.unstable_passThroughRequests
-
-[MODES: framework]
+[MODES: framework, data]
 
 <br/>
 <br/>
@@ -137,20 +133,34 @@ By default, React Router normalizes the `request.url` passed to your `loader`, `
 This flag eliminates that normalization and passes the raw HTTP `request` instance to your handlers. This provides a few benefits:
 
 - Reduces server-side overhead by eliminating multiple `new Request()` calls on the critical path
-- Allows you to distinguish document from data requests in your handlers base don the presence of a `.data` suffix (useful for [observability] purposes)
+- Allows you to distinguish document from data requests in your handlers based on the presence of a `.data` suffix (useful for [observability] purposes)
 
 If you were previously relying on the normalization of `request.url`, you can switch to use the new sibling `unstable_url` parameter which contains a `URL` instance representing the normalized location.
 
 👉 **Enable the Flag**
+
+In Framework mode:
 
 ```ts filename=react-router.config.ts
 import type { Config } from "@react-router/dev/config";
 
 export default {
   future: {
-    unstable_passThroughRequests: true,
+    v8_passThroughRequests: true,
   },
 } satisfies Config;
+```
+
+In Data mode:
+
+```ts
+import { createBrowserRouter } from "react-router/dom";
+
+const router = createBrowserRouter(routes, {
+  future: {
+    v8_passThroughRequests: true,
+  },
+});
 ```
 
 **Update your Code**
@@ -187,7 +197,6 @@ export async function loader({
 ```
 
 [api-development-strategy]: ../community/api-development-strategy
-[unstable]: ../community/api-development-strategy#unstable-flags
 [observability]: ../how-to/instrumentation
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [vite-environment]: https://vite.dev/guide/api-environment

--- a/examples/modal-data-router/src/App.tsx
+++ b/examples/modal-data-router/src/App.tsx
@@ -159,7 +159,7 @@ function Gallery() {
           <Link
             key={image.id}
             to={`?img=${image.id}`}
-            unstable_mask={`/img/${image.id}`}
+            mask={`/img/${image.id}`}
           >
             <img
               width={200}

--- a/integration/browser-entry-test.ts
+++ b/integration/browser-entry-test.ts
@@ -213,7 +213,7 @@ test("allows users to instrument the client side router via HydratedRouter", asy
             document,
             <StrictMode>
               <HydratedRouter
-                unstable_instrumentations={[{
+                instrumentations={[{
                   router(router) {
                     router.instrument({
                       async navigate(impl, info) {

--- a/integration/passthrough-requests-test.ts
+++ b/integration/passthrough-requests-test.ts
@@ -97,14 +97,14 @@ const files = {
 };
 
 test.describe("pass through requests", () => {
-  test("sends proper arguments to loaders when future.unstable_passThroughRequests is disabled", async ({
+  test("sends proper arguments to loaders when future.v8_passThroughRequests is disabled", async ({
     page,
   }) => {
     let fixture = await createFixture({
       files: {
         "react-router.config.ts": reactRouterConfig({
           future: {
-            unstable_passThroughRequests: false,
+            v8_passThroughRequests: false,
           },
         }),
         ...files,
@@ -160,14 +160,14 @@ test.describe("pass through requests", () => {
     requests = [];
   });
 
-  test("sends proper arguments to loaders when future.unstable_passThroughRequests is enabled", async ({
+  test("sends proper arguments to loaders when future.v8_passThroughRequests is enabled", async ({
     page,
   }) => {
     let fixture = await createFixture({
       files: {
         "react-router.config.ts": reactRouterConfig({
           future: {
-            unstable_passThroughRequests: true,
+            v8_passThroughRequests: true,
           },
         }),
         ...files,

--- a/integration/passthrough-requests-test.ts
+++ b/integration/passthrough-requests-test.ts
@@ -61,7 +61,7 @@ const files = {
           <Form method="post">
             <button type="submit">Submit</button>
           </Form>
-          <Link to="/page?b=2" unstable_defaultShouldRevalidate={false}>
+          <Link to="/page?b=2" defaultShouldRevalidate={false}>
             Go to new page
           </Link>
           <p data-loader-url>{loaderData.url}</p>

--- a/integration/passthrough-requests-test.ts
+++ b/integration/passthrough-requests-test.ts
@@ -39,17 +39,17 @@ const files = {
     import { Form, Link } from "react-router";
 
     export function loader({ request, url }) {
-      let url = new URL(request.url);
+      let passthroughUrl = new URL(request.url);
       return {
-        url: url.pathname + url.search,
+        url: passthroughUrl.pathname + passthroughUrl.search,
         path: url.pathname + url.search
       };
     }
 
     export function action({ request, url }) {
-      let url = new URL(request.url);
+      let passthroughUrl = new URL(request.url);
       return {
-        url: url.pathname + url.search,
+        url: passthroughUrl.pathname + passthroughUrl.search,
         path: url.pathname + url.search
       };
     }
@@ -78,9 +78,9 @@ const files = {
   `,
   "app/routes/page.tsx": js`
     export function loader({ request, url }) {
-      let url = new URL(request.url);
+      let passthroughUrl = new URL(request.url);
       return {
-        url: url.pathname + url.search,
+        url: passthroughUrl.pathname + passthroughUrl.search,
         path: url.pathname + url.search
       };
     }

--- a/integration/passthrough-requests-test.ts
+++ b/integration/passthrough-requests-test.ts
@@ -38,19 +38,19 @@ const files = {
   "app/routes/_index.tsx": js`
     import { Form, Link } from "react-router";
 
-    export function loader({ request, unstable_url }) {
+    export function loader({ request, url }) {
       let url = new URL(request.url);
       return {
         url: url.pathname + url.search,
-        path: unstable_url.pathname + unstable_url.search
+        path: url.pathname + url.search
       };
     }
 
-    export function action({ request, unstable_url }) {
+    export function action({ request, url }) {
       let url = new URL(request.url);
       return {
         url: url.pathname + url.search,
-        path: unstable_url.pathname + unstable_url.search
+        path: url.pathname + url.search
       };
     }
 
@@ -77,11 +77,11 @@ const files = {
     }
   `,
   "app/routes/page.tsx": js`
-    export function loader({ request, unstable_url }) {
+    export function loader({ request, url }) {
       let url = new URL(request.url);
       return {
         url: url.pathname + url.search,
-        path: unstable_url.pathname + unstable_url.search
+        path: url.pathname + url.search
       };
     }
 

--- a/integration/rsc/rsc-prerender-test.ts
+++ b/integration/rsc/rsc-prerender-test.ts
@@ -37,7 +37,7 @@ function prerender({
     | PrerenderPaths
     | {
         paths: PrerenderPaths;
-        unstable_concurrency?: number;
+        concurrency?: number;
       };
   ssr?: boolean;
   vitePreview: (

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1088,7 +1088,7 @@ test.describe("single-fetch", () => {
                   <nav>
                     <Link to="/">Home</Link>
                     <Link to="/page">Page (default)</Link>
-                    <Link to="/page?optout" unstable_defaultShouldRevalidate={false}>Page (opt-out)</Link>
+                    <Link to="/page?optout" defaultShouldRevalidate={false}>Page (opt-out)</Link>
                   </nav>
                   <pre id="data">
                     {JSON.stringify(useMatches().map(m => [m.id, m.data]))}

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -857,7 +857,7 @@ test.describe("single-fetch", () => {
 
           export default function Comp({ loaderData, actionData }) {
             return (
-              <Form method="post" unstable_defaultShouldRevalidate={false}>
+              <Form method="post" defaultShouldRevalidate={false}>
                 <button type="submit" name="name" value="value">Submit</button>
                 <p id="data">{loaderData.count}</p>
                 {actionData ? <p id="action-data">{actionData.count}</p> : null}
@@ -911,7 +911,7 @@ test.describe("single-fetch", () => {
           export default function Comp({ loaderData }) {
             let navigation = useNavigation();
             return (
-              <Form method="post" unstable_defaultShouldRevalidate={true}>
+              <Form method="post" defaultShouldRevalidate={true}>
                 <button type="submit" name="throw" value="5xx">Throw 5xx</button>
                 <p id="data">{loaderData.count}</p>
                 {navigation.state === "idle" ? <p id="idle">idle</p> : null}
@@ -970,7 +970,7 @@ test.describe("single-fetch", () => {
 
           export default function Comp({ loaderData, actionData }) {
             return (
-              <Form method="post" unstable_defaultShouldRevalidate={false}>
+              <Form method="post" defaultShouldRevalidate={false}>
                 <button type="submit" name="name" value="value">Submit</button>
                 <p id="data">{loaderData.count}</p>
                 {actionData ? <p id="action-data">{actionData.count}</p> : null}
@@ -1028,7 +1028,7 @@ test.describe("single-fetch", () => {
           export default function Comp({ loaderData }) {
             let navigation = useNavigation();
             return (
-              <Form method="post" unstable_defaultShouldRevalidate={true}>
+              <Form method="post" defaultShouldRevalidate={true}>
                 <button type="submit" name="throw" value="5xx">Throw 5xx</button>
                 <p id="data">{loaderData.count}</p>
                 {navigation.state === "idle" ? <p id="idle">idle</p> : null}

--- a/integration/sri-test.ts
+++ b/integration/sri-test.ts
@@ -19,7 +19,7 @@ test.describe("CSub-Resource Integrity", () => {
     fixture = await createFixture({
       files: {
         "react-router.config.ts": reactRouterConfig({
-          future: { unstable_subResourceIntegrity: true },
+          subResourceIntegrity: true,
         }),
         "app/root.tsx": js`
           import { Links, Meta, Outlet, Scripts } from "react-router";

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -626,7 +626,7 @@ for (let previewServerPrerendering of [false, true]) {
             "react-router.config.ts": reactRouterConfig({
               prerender: {
                 paths: ["/", "/about"],
-                unstable_concurrency: 2,
+                concurrency: 2,
               },
             }),
             "vite.config.ts": js`

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -245,11 +245,11 @@ test.describe("Vite / presets", async () => {
       // Ensure future flags from presets are properly merged
       expect(buildEndArgsMeta.futureFlags).toEqual({
         unstable_optimizeDeps: true,
-        unstable_passThroughRequests: false,
         unstable_subResourceIntegrity: false,
         unstable_trailingSlashAwareDataRequests: false,
         unstable_previewServerPrerendering: false,
         v8_middleware: true,
+        v8_passThroughRequests: false,
         v8_splitRouteModules: false,
         v8_viteEnvironmentApi: false,
       });

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -238,6 +238,7 @@ test.describe("Vite / presets", async () => {
         "serverBundles",
         "serverModuleFormat",
         "ssr",
+        "subResourceIntegrity",
         "allowedActionOrigins",
         "unstable_routeConfig",
       ]);
@@ -245,7 +246,6 @@ test.describe("Vite / presets", async () => {
       // Ensure future flags from presets are properly merged
       expect(buildEndArgsMeta.futureFlags).toEqual({
         unstable_optimizeDeps: true,
-        unstable_subResourceIntegrity: false,
         unstable_trailingSlashAwareDataRequests: false,
         unstable_previewServerPrerendering: false,
         v8_middleware: true,

--- a/packages/react-router-dev/.changes/minor.stabilize-pass-through-requests.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-pass-through-requests.md
@@ -1,0 +1,1 @@
+Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests`

--- a/packages/react-router-dev/.changes/minor.stabilize-prerender-concurrency.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-prerender-concurrency.md
@@ -1,0 +1,1 @@
+Stabilize `prerender.unstable_concurrency` as `prerender.concurrency`

--- a/packages/react-router-dev/.changes/minor.stabilize-sri.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-sri.md
@@ -1,0 +1,1 @@
+Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts`

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -553,6 +553,12 @@ async function resolveConfig({
       );
     }
 
+    if (typeof prerender === "object" && "unstable_concurrency" in prerender) {
+      return err(
+        "The `prerender.unstable_concurrency` config field has been stabilized as `prerender.concurrency`",
+      );
+    }
+
     let isValidConcurrencyConfig =
       typeof prerender != "object" ||
       !("concurrency" in prerender) ||
@@ -679,21 +685,28 @@ async function resolveConfig({
   }
 
   // Check for renamed flags and provide helpful error messages
-  let futureConfig = userAndPresetConfigs.future as any;
-  if (futureConfig?.unstable_splitRouteModules !== undefined) {
-    return err(
-      'The "future.unstable_splitRouteModules" flag has been stabilized as "future.v8_splitRouteModules"',
-    );
-  }
-  if (futureConfig?.unstable_viteEnvironmentApi !== undefined) {
-    return err(
-      'The "future.unstable_viteEnvironmentApi" flag has been stabilized as "future.v8_viteEnvironmentApi"',
-    );
-  }
-  if (futureConfig?.unstable_passThroughRequests !== undefined) {
-    return err(
-      'The "future.unstable_passThroughRequests" flag has been stabilized as "future.v8_passThroughRequests"',
-    );
+  let futureConfig = userAndPresetConfigs.future;
+  if (futureConfig) {
+    if ("unstable_splitRouteModules" in futureConfig) {
+      return err(
+        "The `future.unstable_splitRouteModules` flag has been stabilized as `future.v8_splitRouteModules`",
+      );
+    }
+    if ("unstable_viteEnvironmentApi" in futureConfig) {
+      return err(
+        "The `future.unstable_viteEnvironmentApi` flag has been stabilized as `future.v8_viteEnvironmentApi`",
+      );
+    }
+    if ("unstable_passThroughRequests" in futureConfig) {
+      return err(
+        "The `future.unstable_passThroughRequests` flag has been stabilized as `future.v8_passThroughRequests`",
+      );
+    }
+    if ("unstable_subResourceIntegrity" in futureConfig) {
+      return err(
+        "The `future.unstable_subResourceIntegrity` flag has been stabilized and moved to a top-level `config.subResourceIntegrity` field",
+      );
+    }
   }
 
   let future: FutureConfig = {

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -86,7 +86,7 @@ type ValidateConfigFunction = (config: ReactRouterConfig) => string | void;
 
 interface FutureConfig {
   unstable_optimizeDeps: boolean;
-  unstable_passThroughRequests: boolean;
+  v8_passThroughRequests: boolean;
   unstable_subResourceIntegrity: boolean;
   unstable_trailingSlashAwareDataRequests: boolean;
   /**
@@ -681,12 +681,17 @@ async function resolveConfig({
       'The "future.unstable_viteEnvironmentApi" flag has been stabilized as "future.v8_viteEnvironmentApi"',
     );
   }
+  if (futureConfig?.unstable_passThroughRequests !== undefined) {
+    return err(
+      'The "future.unstable_passThroughRequests" flag has been stabilized as "future.v8_passThroughRequests"',
+    );
+  }
 
   let future: FutureConfig = {
     unstable_optimizeDeps:
       userAndPresetConfigs.future?.unstable_optimizeDeps ?? false,
-    unstable_passThroughRequests:
-      userAndPresetConfigs.future?.unstable_passThroughRequests ?? false,
+    v8_passThroughRequests:
+      userAndPresetConfigs.future?.v8_passThroughRequests ?? false,
     unstable_subResourceIntegrity:
       userAndPresetConfigs.future?.unstable_subResourceIntegrity ?? false,
     unstable_trailingSlashAwareDataRequests:

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -87,7 +87,6 @@ type ValidateConfigFunction = (config: ReactRouterConfig) => string | void;
 interface FutureConfig {
   unstable_optimizeDeps: boolean;
   v8_passThroughRequests: boolean;
-  unstable_subResourceIntegrity: boolean;
   unstable_trailingSlashAwareDataRequests: boolean;
   /**
    * Prerender with Vite Preview server
@@ -218,6 +217,12 @@ export type ReactRouterConfig = {
   ssr?: boolean;
 
   /**
+   * Enable subresource integrity hashes on asset script tags. Defaults to
+   * `false`.
+   */
+  subResourceIntegrity?: boolean;
+
+  /**
    * An array of allowed origin hosts for action submissions to UI routes (does not apply
    * to resource routes). Supports micromatch glob patterns (`*` to match one segment,
    * `**` to match multiple).
@@ -324,6 +329,10 @@ export type ResolvedReactRouterConfig = Readonly<{
    * SPA without server-rendering. Default's to `true`.
    */
   ssr: boolean;
+  /**
+   * Whether to generate subresource integrity hashes for asset script tags.
+   */
+  subResourceIntegrity: boolean;
   /**
    * The allowed origins for actions / mutations. Does not apply to routes
    * without a component. micromatch glob patterns are supported.
@@ -692,8 +701,6 @@ async function resolveConfig({
       userAndPresetConfigs.future?.unstable_optimizeDeps ?? false,
     v8_passThroughRequests:
       userAndPresetConfigs.future?.v8_passThroughRequests ?? false,
-    unstable_subResourceIntegrity:
-      userAndPresetConfigs.future?.unstable_subResourceIntegrity ?? false,
     unstable_trailingSlashAwareDataRequests:
       userAndPresetConfigs.future?.unstable_trailingSlashAwareDataRequests ??
       false,
@@ -709,6 +716,7 @@ async function resolveConfig({
   };
 
   let allowedActionOrigins = userAndPresetConfigs.allowedActionOrigins ?? false;
+  let subResourceIntegrity = userAndPresetConfigs.subResourceIntegrity ?? false;
 
   let reactRouterConfig: ResolvedReactRouterConfig = deepFreeze({
     appDirectory,
@@ -723,6 +731,7 @@ async function resolveConfig({
     serverBundles,
     serverModuleFormat,
     ssr,
+    subResourceIntegrity,
     allowedActionOrigins,
     unstable_routeConfig: routeConfig,
   } satisfies ResolvedReactRouterConfig);

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -162,7 +162,7 @@ export type ReactRouterConfig = {
    * An array of URLs to prerender to HTML files at build time.  Can also be a
    * function returning an array to dynamically generate URLs.
    *
-   * `unstable_concurrency` defaults to 1, which means "no concurrency" - fully serial execution.
+   * `concurrency` defaults to 1, which means "no concurrency" - fully serial execution.
    * Setting it to a value more than 1 enables concurrent prerendering.
    * Setting it to a value higher than one can increase the speed of the build,
    * but may consume more resources, and send more concurrent requests to the
@@ -172,7 +172,7 @@ export type ReactRouterConfig = {
     | PrerenderPaths
     | {
         paths: PrerenderPaths;
-        unstable_concurrency?: number;
+        concurrency?: number;
       };
   /**
    * An array of React Router plugin config presets to ease integration with
@@ -546,14 +546,14 @@ async function resolveConfig({
 
     let isValidConcurrencyConfig =
       typeof prerender != "object" ||
-      !("unstable_concurrency" in prerender) ||
-      (typeof prerender.unstable_concurrency === "number" &&
-        Number.isInteger(prerender.unstable_concurrency) &&
-        prerender.unstable_concurrency > 0);
+      !("concurrency" in prerender) ||
+      (typeof prerender.concurrency === "number" &&
+        Number.isInteger(prerender.concurrency) &&
+        prerender.concurrency > 0);
 
     if (!isValidConcurrencyConfig) {
       return err(
-        "The `prerender.unstable_concurrency` config must be a positive integer if specified.",
+        "The `prerender.concurrency` config must be a positive integer if specified.",
       );
     }
   }

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3263,8 +3263,8 @@ async function handlePrerender(
 
   let concurrency = 1;
   let { prerender } = reactRouterConfig;
-  if (typeof prerender === "object" && "unstable_concurrency" in prerender) {
-    concurrency = prerender.unstable_concurrency ?? 1;
+  if (typeof prerender === "object" && "concurrency" in prerender) {
+    concurrency = prerender.concurrency ?? 1;
   }
 
   const pMap = await import("p-map");
@@ -4270,8 +4270,8 @@ function getPrerenderConcurrencyConfig(
 ): number {
   let concurrency = 1;
   let { prerender } = reactRouterConfig;
-  if (typeof prerender === "object" && "unstable_concurrency" in prerender) {
-    concurrency = prerender.unstable_concurrency ?? 1;
+  if (typeof prerender === "object" && "concurrency" in prerender) {
+    concurrency = prerender.concurrency ?? 1;
   }
   return concurrency;
 }

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1107,7 +1107,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     );
 
     let sri: ReactRouterManifest["sri"] = undefined;
-    if (ctx.reactRouterConfig.future.unstable_subResourceIntegrity) {
+    if (ctx.reactRouterConfig.subResourceIntegrity) {
       sri = await generateSriManifest(ctx);
     }
 

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -805,8 +805,8 @@ function getPrerenderConcurrencyConfig(
 ): number {
   let concurrency = 1;
   let { prerender } = reactRouterConfig;
-  if (typeof prerender === "object" && "unstable_concurrency" in prerender) {
-    concurrency = prerender.unstable_concurrency ?? 1;
+  if (typeof prerender === "object" && "concurrency" in prerender) {
+    concurrency = prerender.concurrency ?? 1;
   }
   return concurrency;
 }

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -166,8 +166,8 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
               errors.push("future.v8_middleware: false");
             if (userConfig.future?.v8_viteEnvironmentApi === false)
               errors.push("future.v8_viteEnvironmentApi: false");
-            if (userConfig.future?.unstable_subResourceIntegrity)
-              errors.push("future.unstable_subResourceIntegrity");
+            if (userConfig.subResourceIntegrity)
+              errors.push("subResourceIntegrity");
             if (errors.length) {
               return `RSC Framework Mode does not currently support the following React Router config:\n${errors.map((x) => ` - ${x}`).join("\n")}\n`;
             }

--- a/packages/react-router/.changes/minor.stabilize-default-should-revalidate.md
+++ b/packages/react-router/.changes/minor.stabilize-default-should-revalidate.md
@@ -1,0 +1,1 @@
+Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams`

--- a/packages/react-router/.changes/minor.stabilize-instrumentations.md
+++ b/packages/react-router/.changes/minor.stabilize-instrumentations.md
@@ -1,0 +1,3 @@
+Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern`
+
+- The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed

--- a/packages/react-router/.changes/minor.stabilize-mask.md
+++ b/packages/react-router/.changes/minor.stabilize-mask.md
@@ -1,0 +1,1 @@
+Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask`

--- a/packages/react-router/.changes/minor.stabilize-normalize-path.md
+++ b/packages/react-router/.changes/minor.stabilize-normalize-path.md
@@ -1,0 +1,1 @@
+Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath`

--- a/packages/react-router/.changes/minor.stabilize-pass-through-requests.md
+++ b/packages/react-router/.changes/minor.stabilize-pass-through-requests.md
@@ -1,0 +1,1 @@
+Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests`

--- a/packages/react-router/.changes/minor.stabilize-sri.md
+++ b/packages/react-router/.changes/minor.stabilize-sri.md
@@ -1,0 +1,1 @@
+Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts`

--- a/packages/react-router/.changes/minor.stabilize-url.md
+++ b/packages/react-router/.changes/minor.stabilize-url.md
@@ -1,0 +1,1 @@
+Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args

--- a/packages/react-router/.changes/minor.stabilize-use-transitions.md
+++ b/packages/react-router/.changes/minor.stabilize-use-transitions.md
@@ -1,0 +1,1 @@
+Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler`

--- a/packages/react-router/.changes/patch.made-mask-optional-in-location.md
+++ b/packages/react-router/.changes/patch.made-mask-optional-in-location.md
@@ -1,0 +1,1 @@
+Mark `mask` as an optional field in `Location` for easier mocking in unit tests

--- a/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
+++ b/packages/react-router/.changes/patch.made-unstablemask-optional-in-location.md
@@ -1,1 +1,0 @@
-Mark `unstable_mask` as an optional field in `Location` for easier mocking in unit tests

--- a/packages/react-router/__tests__/dom/client-on-error-test.tsx
+++ b/packages/react-router/__tests__/dom/client-on-error-test.tsx
@@ -51,7 +51,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("lazy error!"), {
       location: expect.objectContaining({ pathname: "/" }),
       params: {},
-      unstable_pattern: "/",
+      pattern: "/",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Unexpected Application Error!");
@@ -83,7 +83,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("middleware error!"), {
       location: expect.objectContaining({ pathname: "/" }),
       params: {},
-      unstable_pattern: "/",
+      pattern: "/",
     });
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -112,7 +112,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("loader error!"), {
       location: expect.objectContaining({ pathname: "/" }),
       params: {},
-      unstable_pattern: "/",
+      pattern: "/",
     });
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -143,7 +143,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("lazy error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     let html = getHtml(container);
@@ -179,7 +179,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("middleware error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -211,7 +211,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("loader error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -248,7 +248,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("action error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -278,7 +278,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("loader error!"), {
       location: expect.objectContaining({ pathname: "/" }),
       params: {},
-      unstable_pattern: "/",
+      pattern: "/",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -313,7 +313,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("action error!"), {
       location: expect.objectContaining({ pathname: "/" }),
       params: {},
-      unstable_pattern: "/",
+      pattern: "/",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -344,7 +344,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("render error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
       errorInfo: expect.objectContaining({
         componentStack: expect.any(String),
       }),
@@ -390,7 +390,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("await error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Await Error");
@@ -439,7 +439,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("await error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
       errorInfo: expect.objectContaining({
         componentStack: expect.any(String),
       }),
@@ -494,12 +494,12 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("await error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledWith(new Error("errorElement error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
       errorInfo: expect.objectContaining({
         componentStack: expect.any(String),
       }),
@@ -549,7 +549,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("loader error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
     });
     expect(spy).toHaveBeenCalledTimes(1);
     expect(getHtml(container)).toContain("Error");
@@ -600,7 +600,7 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledWith(new Error("render error!"), {
       location: expect.objectContaining({ pathname: "/page" }),
       params: {},
-      unstable_pattern: "/page",
+      pattern: "/page",
       errorInfo: expect.objectContaining({
         componentStack: expect.any(String),
       }),

--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -2697,7 +2697,7 @@ function testDomRouter(
     });
 
     describe("call-site revalidation opt-out", () => {
-      it("accepts unstable_defaultShouldRevalidate on <Link> navigations", async () => {
+      it("accepts defaultShouldRevalidate on <Link> navigations", async () => {
         let loaderDefer = createDeferred();
 
         let router = createTestRouter(
@@ -2715,7 +2715,7 @@ function testDomRouter(
           let navigation = useNavigation();
           return (
             <div>
-              <Link to="/?foo=bar" unstable_defaultShouldRevalidate={false}>
+              <Link to="/?foo=bar" defaultShouldRevalidate={false}>
                 Change Search Params
               </Link>
               <div id="output">
@@ -2761,7 +2761,7 @@ function testDomRouter(
       `);
       });
 
-      it("accepts unstable_defaultShouldRevalidate on setSearchParams navigations", async () => {
+      it("accepts defaultShouldRevalidate on setSearchParams navigations", async () => {
         let loaderDefer = createDeferred();
 
         let router = createTestRouter(
@@ -2783,7 +2783,7 @@ function testDomRouter(
               <button
                 onClick={() =>
                   setSearchParams(new URLSearchParams([["foo", "bar"]]), {
-                    unstable_defaultShouldRevalidate: false,
+                    defaultShouldRevalidate: false,
                   })
                 }
               >
@@ -2832,7 +2832,7 @@ function testDomRouter(
       `);
       });
 
-      it("accepts unstable_defaultShouldRevalidate on <Form method=post> navigations", async () => {
+      it("accepts defaultShouldRevalidate on <Form method=post> navigations", async () => {
         let loaderDefer = createDeferred();
         let actionDefer = createDeferred();
 
@@ -2858,7 +2858,7 @@ function testDomRouter(
           let navigation = useNavigation();
           return (
             <div>
-              <Form method="post" unstable_defaultShouldRevalidate={false}>
+              <Form method="post" defaultShouldRevalidate={false}>
                 <input name="test" value="value" />
                 <button type="submit">Submit Form</button>
               </Form>
@@ -2905,7 +2905,7 @@ function testDomRouter(
       `);
       });
 
-      it("accepts unstable_defaultShouldRevalidate on fetcher.submit", async () => {
+      it("accepts defaultShouldRevalidate on fetcher.submit", async () => {
         let loaderDefer = createDeferred();
         let actionDefer = createDeferred();
 
@@ -2937,7 +2937,7 @@ function testDomRouter(
                     {
                       method: "post",
                       action: "/",
-                      unstable_defaultShouldRevalidate: false,
+                      defaultShouldRevalidate: false,
                     },
                   )
                 }

--- a/packages/react-router/__tests__/react-transitions-test.tsx
+++ b/packages/react-router/__tests__/react-transitions-test.tsx
@@ -29,7 +29,7 @@ import { createDeferred, tick } from "./router/utils/utils";
 import getWindow from "./utils/getWindow";
 
 describe("react transitions", () => {
-  describe("<RouterProvider unstable_useTransitions={undefined} />", () => {
+  describe("<RouterProvider useTransitions={undefined} />", () => {
     it("normal navigations surface all updates", async () => {
       let loaderDfd = createDeferred();
       let router = createMemoryRouter([
@@ -333,7 +333,7 @@ describe("react transitions", () => {
     });
   });
 
-  describe("<RouterProvider unstable_useTransitions={false} />", () => {
+  describe("<RouterProvider useTransitions={false} />", () => {
     it("navigations are not transition-enabled", async () => {
       let loaderDfd = createDeferred();
       let router = createMemoryRouter([
@@ -381,7 +381,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={false} />,
+        <RouterProvider router={router} useTransitions={false} />,
       );
 
       await waitFor(() => screen.getByText("Go to page"));
@@ -487,7 +487,7 @@ describe("react transitions", () => {
     });
   });
 
-  describe("<RouterProvider unstable_useTransitions={true} />", () => {
+  describe("<RouterProvider useTransitions={true} />", () => {
     it("Link navigations are transition-enabled", async () => {
       let loaderDfd = createDeferred();
       let router = createMemoryRouter([
@@ -535,7 +535,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Go to page"));
@@ -607,7 +607,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Go to page"));
@@ -684,7 +684,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Go to page"));
@@ -760,7 +760,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Submit"));
@@ -843,7 +843,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Submit"));
@@ -930,7 +930,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Submit"));
@@ -1000,7 +1000,7 @@ describe("react transitions", () => {
       );
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Submit"));
@@ -1056,7 +1056,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Fetch"));
@@ -1120,7 +1120,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Fetch"));
@@ -1191,7 +1191,7 @@ describe("react transitions", () => {
       ]);
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Go to page"));
@@ -1263,7 +1263,7 @@ describe("react transitions", () => {
       );
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Revalidate"));
@@ -1338,7 +1338,7 @@ describe("react transitions", () => {
       );
 
       let { container } = render(
-        <RouterProvider router={router} unstable_useTransitions={true} />,
+        <RouterProvider router={router} useTransitions={true} />,
       );
 
       await waitFor(() => screen.getByText("Revalidate"));

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -177,7 +177,7 @@ describe("fetchers", () => {
         request: new Request("http://localhost/foo", {
           signal: A.loaders.foo.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/foo",
+        pattern: "/foo",
         unstable_url: new URL("http://localhost/foo"),
         context: {},
       });
@@ -226,7 +226,7 @@ describe("fetchers", () => {
         request: new Request("http://localhost/foo?key=value", {
           signal: A.loaders.foo.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/foo",
+        pattern: "/foo",
         unstable_url: new URL("http://localhost/foo?key=value"),
         context: {},
       });
@@ -280,7 +280,7 @@ describe("fetchers", () => {
       expect(A.actions.foo.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: "/foo",
+        pattern: "/foo",
         unstable_url: new URL("http://localhost/foo"),
         context: {},
       });
@@ -393,7 +393,7 @@ describe("fetchers", () => {
         request: new Request("http://localhost/foo", {
           signal: A.loaders.root.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3395,7 +3395,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3426,7 +3426,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3455,7 +3455,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3484,7 +3484,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3514,7 +3514,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3546,7 +3546,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -3577,7 +3577,7 @@ describe("fetchers", () => {
       expect(F.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -178,7 +178,7 @@ describe("fetchers", () => {
           signal: A.loaders.foo.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/foo",
-        unstable_url: new URL("http://localhost/foo"),
+        url: new URL("http://localhost/foo"),
         context: {},
       });
     });
@@ -227,7 +227,7 @@ describe("fetchers", () => {
           signal: A.loaders.foo.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/foo",
-        unstable_url: new URL("http://localhost/foo?key=value"),
+        url: new URL("http://localhost/foo?key=value"),
         context: {},
       });
 
@@ -281,7 +281,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: "/foo",
-        unstable_url: new URL("http://localhost/foo"),
+        url: new URL("http://localhost/foo"),
         context: {},
       });
 
@@ -394,7 +394,7 @@ describe("fetchers", () => {
           signal: A.loaders.root.stub.mock.calls[0][0].request.signal,
         }),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
     });
@@ -3396,7 +3396,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3427,7 +3427,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3456,7 +3456,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3485,7 +3485,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3515,7 +3515,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3547,7 +3547,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -3578,7 +3578,7 @@ describe("fetchers", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 

--- a/packages/react-router/__tests__/router/instrumentation-test.ts
+++ b/packages/react-router/__tests__/router/instrumentation-test.ts
@@ -43,7 +43,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -87,7 +87,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -135,7 +135,7 @@ describe("instrumentation", () => {
             index: "INDEX",
           },
         },
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -176,7 +176,7 @@ describe("instrumentation", () => {
             action: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -219,7 +219,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -263,7 +263,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -311,7 +311,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -363,7 +363,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -422,7 +422,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -487,7 +487,7 @@ describe("instrumentation", () => {
             },
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -551,7 +551,7 @@ describe("instrumentation", () => {
             },
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -613,7 +613,7 @@ describe("instrumentation", () => {
             },
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -682,7 +682,7 @@ describe("instrumentation", () => {
             action: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -763,7 +763,7 @@ describe("instrumentation", () => {
             lazy: () => lazyDfd.promise,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -838,7 +838,7 @@ describe("instrumentation", () => {
             },
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -931,7 +931,7 @@ describe("instrumentation", () => {
             ]);
           }
         },
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1009,7 +1009,7 @@ describe("instrumentation", () => {
             ]);
           }
         },
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1090,7 +1090,7 @@ describe("instrumentation", () => {
             ]);
           }
         },
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1169,7 +1169,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1228,7 +1228,7 @@ describe("instrumentation", () => {
             path: "/target",
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1295,7 +1295,7 @@ describe("instrumentation", () => {
             path: "/target",
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1365,7 +1365,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1408,7 +1408,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1451,7 +1451,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1488,7 +1488,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1530,7 +1530,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1554,7 +1554,7 @@ describe("instrumentation", () => {
       expect(args.request.headers.get).toBeDefined();
       expect(args.request.headers.set).not.toBeDefined();
       expect(args.params).toEqual({ slug: "a", extra: "extra" });
-      expect(args.unstable_pattern).toBe("/:slug");
+      expect(args.pattern).toBe("/:slug");
       expect(args.context.get).toBeDefined();
       expect(args.context.set).not.toBeDefined();
       expect(t.router.state.matches[0].params).toEqual({ slug: "a" });
@@ -1573,7 +1573,7 @@ describe("instrumentation", () => {
             loader: true,
           },
         ],
-        unstable_instrumentations: [
+        instrumentations: [
           {
             route(route) {
               route.instrument({
@@ -1624,7 +1624,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               router(router) {
                 router.instrument({
@@ -1666,7 +1666,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               router(router) {
                 router.instrument({
@@ -1719,7 +1719,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -1766,7 +1766,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -1811,7 +1811,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -1879,7 +1879,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -1922,7 +1922,7 @@ describe("instrumentation", () => {
           },
         ],
         {
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -1974,7 +1974,7 @@ describe("instrumentation", () => {
           handleDocumentRequest(request) {
             return new Response(`${request.method} ${request.url} COMPONENT`);
           },
-          unstable_instrumentations: [
+          instrumentations: [
             {
               handler(handler) {
                 handler.instrument({
@@ -2050,7 +2050,7 @@ describe("instrumentation", () => {
           handleDocumentRequest(request) {
             return new Response(`${request.method} ${request.url} COMPONENT`);
           },
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -2081,7 +2081,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {
               get: expect.any(Function),
             },
@@ -2100,7 +2100,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {
               get: expect.any(Function),
             },
@@ -2126,7 +2126,7 @@ describe("instrumentation", () => {
           handleDocumentRequest(request) {
             return new Response(`${request.method} ${request.url} COMPONENT`);
           },
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -2157,7 +2157,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {},
           },
         ],
@@ -2173,7 +2173,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {},
           },
         ],
@@ -2197,7 +2197,7 @@ describe("instrumentation", () => {
           handleDocumentRequest(request) {
             return new Response(`${request.method} ${request.url} COMPONENT`);
           },
-          unstable_instrumentations: [
+          instrumentations: [
             {
               route(route) {
                 route.instrument({
@@ -2230,7 +2230,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {},
           },
         ],
@@ -2246,7 +2246,7 @@ describe("instrumentation", () => {
               },
             },
             params: {},
-            unstable_pattern: "/",
+            pattern: "/",
             context: {},
           },
         ],

--- a/packages/react-router/__tests__/router/mask-test.ts
+++ b/packages/react-router/__tests__/router/mask-test.ts
@@ -16,7 +16,7 @@ describe("location masking", () => {
 
     // Navigate to /gallery?photo=123 but mask browser URL as /images/123
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
     });
 
     // The loader should receive the router location URL in the request
@@ -29,7 +29,7 @@ describe("location masking", () => {
     expect(t.router.state.location).toMatchObject({
       pathname: "/gallery",
       search: "?photo=123",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -54,7 +54,7 @@ describe("location masking", () => {
 
     // Navigate to /gallery?photo=123 with mask
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
     });
     await A.loaders.gallery.resolve("GALLERY DATA");
 
@@ -71,7 +71,7 @@ describe("location masking", () => {
     expect(t.router.state.location).toMatchObject({
       pathname: "/gallery",
       search: "?photo=123",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -91,7 +91,7 @@ describe("location masking", () => {
     });
 
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
       replace: true,
     });
 
@@ -101,7 +101,7 @@ describe("location masking", () => {
     expect(t.router.state.location).toMatchObject({
       pathname: "/gallery",
       search: "?photo=123",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -119,7 +119,7 @@ describe("location masking", () => {
     });
 
     let A = await t.navigate("/gallery?photo=123#header", {
-      unstable_mask: "/images/123#preview",
+      mask: "/images/123#preview",
     });
 
     expect(A.loaders.gallery).toBeDefined();
@@ -135,7 +135,7 @@ describe("location masking", () => {
       pathname: "/gallery",
       search: "?photo=123",
       hash: "#header",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "#preview",
@@ -153,7 +153,7 @@ describe("location masking", () => {
     });
 
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
       state: { customData: "test" },
     });
 
@@ -163,7 +163,7 @@ describe("location masking", () => {
       pathname: "/gallery",
       search: "?photo=123",
       state: { customData: "test" },
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -181,7 +181,7 @@ describe("location masking", () => {
     });
 
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
       formMethod: "post",
       formData: createFormData({ test: "value" }),
     });
@@ -204,7 +204,7 @@ describe("location masking", () => {
     expect(t.router.state.location).toMatchObject({
       pathname: "/gallery",
       search: "?photo=123",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -226,7 +226,7 @@ describe("location masking", () => {
     });
 
     let A = await t.navigate("/gallery?photo=123", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
     });
 
     expect(A.loaders.gallery).toBeDefined();
@@ -235,7 +235,7 @@ describe("location masking", () => {
     expect(t.router.state.location).toMatchObject({
       pathname: "/gallery",
       search: "?photo=123",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",
@@ -257,14 +257,14 @@ describe("location masking", () => {
 
     // Navigate to non-existent route with mask
     await t.navigate("/nonexistent", {
-      unstable_mask: "/images/123",
+      mask: "/images/123",
     });
 
     // Should get a 404 error
     expect(t.router.state.errors).toBeDefined();
     expect(t.router.state.location).toMatchObject({
       pathname: "/nonexistent",
-      unstable_mask: {
+      mask: {
         pathname: "/images/123",
         search: "",
         hash: "",

--- a/packages/react-router/__tests__/router/router-test.ts
+++ b/packages/react-router/__tests__/router/router-test.ts
@@ -1752,7 +1752,7 @@ describe("a router", () => {
           signal: nav.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/tasks",
-        unstable_url: new URL("http://localhost/tasks"),
+        url: new URL("http://localhost/tasks"),
         context: {},
       });
 
@@ -1763,7 +1763,7 @@ describe("a router", () => {
           signal: nav2.loaders.tasksId.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/tasks/:id",
-        unstable_url: new URL("http://localhost/tasks/1"),
+        url: new URL("http://localhost/tasks/1"),
         context: {},
       });
 
@@ -1774,7 +1774,7 @@ describe("a router", () => {
           signal: nav3.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/tasks",
-        unstable_url: new URL("http://localhost/tasks?foo=bar#hash"),
+        url: new URL("http://localhost/tasks?foo=bar#hash"),
         context: {},
       });
 
@@ -1787,7 +1787,7 @@ describe("a router", () => {
           signal: nav4.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
         pattern: "/tasks",
-        unstable_url: new URL("http://localhost/tasks?foo=bar#hash"),
+        url: new URL("http://localhost/tasks?foo=bar#hash"),
         context: {},
       });
 
@@ -2214,7 +2214,7 @@ describe("a router", () => {
         params: {},
         request: expect.any(Request),
         pattern: "/tasks",
-        unstable_url: new URL("http://localhost/tasks"),
+        url: new URL("http://localhost/tasks"),
         context: {},
       });
 
@@ -2260,7 +2260,7 @@ describe("a router", () => {
         params: {},
         request: expect.any(Request),
         pattern: "/tasks",
-        unstable_url: new URL("http://localhost/tasks?foo=bar"),
+        url: new URL("http://localhost/tasks?foo=bar"),
         context: {},
       });
       // Assert request internals, cannot do a deep comparison above since some
@@ -2295,7 +2295,7 @@ describe("a router", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 

--- a/packages/react-router/__tests__/router/router-test.ts
+++ b/packages/react-router/__tests__/router/router-test.ts
@@ -1751,7 +1751,7 @@ describe("a router", () => {
         request: new Request("http://localhost/tasks", {
           signal: nav.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/tasks",
+        pattern: "/tasks",
         unstable_url: new URL("http://localhost/tasks"),
         context: {},
       });
@@ -1762,7 +1762,7 @@ describe("a router", () => {
         request: new Request("http://localhost/tasks/1", {
           signal: nav2.loaders.tasksId.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/tasks/:id",
+        pattern: "/tasks/:id",
         unstable_url: new URL("http://localhost/tasks/1"),
         context: {},
       });
@@ -1773,7 +1773,7 @@ describe("a router", () => {
         request: new Request("http://localhost/tasks?foo=bar", {
           signal: nav3.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/tasks",
+        pattern: "/tasks",
         unstable_url: new URL("http://localhost/tasks?foo=bar#hash"),
         context: {},
       });
@@ -1786,7 +1786,7 @@ describe("a router", () => {
         request: new Request("http://localhost/tasks?foo=bar", {
           signal: nav4.loaders.tasks.stub.mock.calls[0][0].request.signal,
         }),
-        unstable_pattern: "/tasks",
+        pattern: "/tasks",
         unstable_url: new URL("http://localhost/tasks?foo=bar#hash"),
         context: {},
       });
@@ -2213,7 +2213,7 @@ describe("a router", () => {
       expect(nav.actions.tasks.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: "/tasks",
+        pattern: "/tasks",
         unstable_url: new URL("http://localhost/tasks"),
         context: {},
       });
@@ -2259,7 +2259,7 @@ describe("a router", () => {
       expect(nav.actions.tasks.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: "/tasks",
+        pattern: "/tasks",
         unstable_url: new URL("http://localhost/tasks?foo=bar"),
         context: {},
       });
@@ -2294,7 +2294,7 @@ describe("a router", () => {
       expect(nav.actions.tasks.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });

--- a/packages/react-router/__tests__/router/should-revalidate-test.ts
+++ b/packages/react-router/__tests__/router/should-revalidate-test.ts
@@ -1251,7 +1251,7 @@ describe("shouldRevalidate", () => {
       });
 
       let A = await t.navigate("/?foo=bar", {
-        unstable_defaultShouldRevalidate: false,
+        defaultShouldRevalidate: false,
       });
 
       A.loaders.index.resolve("SHOULD NOT BE CALLED");
@@ -1290,7 +1290,7 @@ describe("shouldRevalidate", () => {
       });
 
       let A = await t.navigate("/?foo=bar", {
-        unstable_defaultShouldRevalidate: false,
+        defaultShouldRevalidate: false,
       });
 
       A.loaders.index.resolve("SHOULD NOT BE CALLED");
@@ -1345,7 +1345,7 @@ describe("shouldRevalidate", () => {
         {
           formMethod: "post",
           formData: createFormData({}),
-          unstable_defaultShouldRevalidate: false,
+          defaultShouldRevalidate: false,
         },
         ["fetch"],
       );
@@ -1418,7 +1418,7 @@ describe("shouldRevalidate", () => {
         {
           formMethod: "post",
           formData: createFormData({}),
-          unstable_defaultShouldRevalidate: false,
+          defaultShouldRevalidate: false,
         },
         ["fetch"],
       );
@@ -1483,7 +1483,7 @@ describe("shouldRevalidate", () => {
       let B = await t.fetch("/fetch", actionKey, "index", {
         formMethod: "post",
         formData: createFormData({}),
-        unstable_defaultShouldRevalidate: false,
+        defaultShouldRevalidate: false,
       });
       t.shimHelper(B.loaders, "fetch", "loader", "fetch");
 
@@ -1552,7 +1552,7 @@ describe("shouldRevalidate", () => {
       let B = await t.fetch("/fetch", actionKey, "index", {
         formMethod: "post",
         formData: createFormData({}),
-        unstable_defaultShouldRevalidate: false,
+        defaultShouldRevalidate: false,
       });
       t.shimHelper(B.loaders, "fetch", "loader", "fetch");
 
@@ -1623,7 +1623,7 @@ describe("shouldRevalidate", () => {
       let B = await t.fetch("/fetch", actionKey, "index", {
         formMethod: "post",
         formData: createFormData({}),
-        unstable_defaultShouldRevalidate: false,
+        defaultShouldRevalidate: false,
       });
       t.shimHelper(B.loaders, "fetch", "loader", "fetch");
 

--- a/packages/react-router/__tests__/router/ssr-test.ts
+++ b/packages/react-router/__tests__/router/ssr-test.ts
@@ -841,7 +841,7 @@ describe("ssr", () => {
       expect(rootLoaderStub).toHaveBeenCalledWith({
         request: new Request("http://localhost/child"),
         pattern: "/child",
-        unstable_url: new URL("http://localhost/child"),
+        url: new URL("http://localhost/child"),
         params: {},
         context: {},
       });
@@ -854,7 +854,7 @@ describe("ssr", () => {
       expect(childLoaderStub).toHaveBeenCalledWith({
         request: new Request("http://localhost/child"),
         pattern: "/child",
-        unstable_url: new URL("http://localhost/child"),
+        url: new URL("http://localhost/child"),
         params: {},
         context: {},
       });
@@ -895,7 +895,7 @@ describe("ssr", () => {
       expect(actionStub).toHaveBeenCalledWith({
         request: expect.any(Request),
         pattern: "/child",
-        unstable_url: new URL("http://localhost/child"),
+        url: new URL("http://localhost/child"),
         params: {},
         context: {},
       });
@@ -912,7 +912,7 @@ describe("ssr", () => {
       expect(rootLoaderStub).toHaveBeenCalledWith({
         request: expect.any(Request),
         pattern: "/child",
-        unstable_url: new URL("http://localhost/child"),
+        url: new URL("http://localhost/child"),
         params: {},
         context: {},
       });
@@ -927,7 +927,7 @@ describe("ssr", () => {
       expect(childLoaderStub).toHaveBeenCalledWith({
         request: expect.any(Request),
         pattern: "/child",
-        unstable_url: new URL("http://localhost/child"),
+        url: new URL("http://localhost/child"),
         params: {},
         context: {},
       });

--- a/packages/react-router/__tests__/router/ssr-test.ts
+++ b/packages/react-router/__tests__/router/ssr-test.ts
@@ -840,7 +840,7 @@ describe("ssr", () => {
       expect(rootLoaderStub).toHaveBeenCalledTimes(1);
       expect(rootLoaderStub).toHaveBeenCalledWith({
         request: new Request("http://localhost/child"),
-        unstable_pattern: "/child",
+        pattern: "/child",
         unstable_url: new URL("http://localhost/child"),
         params: {},
         context: {},
@@ -853,7 +853,7 @@ describe("ssr", () => {
       expect(childLoaderStub).toHaveBeenCalledTimes(1);
       expect(childLoaderStub).toHaveBeenCalledWith({
         request: new Request("http://localhost/child"),
-        unstable_pattern: "/child",
+        pattern: "/child",
         unstable_url: new URL("http://localhost/child"),
         params: {},
         context: {},
@@ -894,7 +894,7 @@ describe("ssr", () => {
       expect(actionStub).toHaveBeenCalledTimes(1);
       expect(actionStub).toHaveBeenCalledWith({
         request: expect.any(Request),
-        unstable_pattern: "/child",
+        pattern: "/child",
         unstable_url: new URL("http://localhost/child"),
         params: {},
         context: {},
@@ -911,7 +911,7 @@ describe("ssr", () => {
       expect(rootLoaderStub).toHaveBeenCalledTimes(1);
       expect(rootLoaderStub).toHaveBeenCalledWith({
         request: expect.any(Request),
-        unstable_pattern: "/child",
+        pattern: "/child",
         unstable_url: new URL("http://localhost/child"),
         params: {},
         context: {},
@@ -926,7 +926,7 @@ describe("ssr", () => {
       expect(childLoaderStub).toHaveBeenCalledTimes(1);
       expect(childLoaderStub).toHaveBeenCalledWith({
         request: expect.any(Request),
-        unstable_pattern: "/child",
+        pattern: "/child",
         unstable_url: new URL("http://localhost/child"),
         params: {},
         context: {},

--- a/packages/react-router/__tests__/router/submission-test.ts
+++ b/packages/react-router/__tests__/router/submission-test.ts
@@ -949,7 +949,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -985,7 +985,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -1019,7 +1019,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -1125,7 +1125,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -1165,7 +1165,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 
@@ -1202,7 +1202,7 @@ describe("submissions", () => {
         params: {},
         request: expect.any(Request),
         pattern: expect.any(String),
-        unstable_url: expect.any(URL),
+        url: expect.any(URL),
         context: {},
       });
 

--- a/packages/react-router/__tests__/router/submission-test.ts
+++ b/packages/react-router/__tests__/router/submission-test.ts
@@ -948,7 +948,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -984,7 +984,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -1018,7 +1018,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -1124,7 +1124,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -1164,7 +1164,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });
@@ -1201,7 +1201,7 @@ describe("submissions", () => {
       expect(nav.actions.root.stub).toHaveBeenCalledWith({
         params: {},
         request: expect.any(Request),
-        unstable_pattern: expect.any(String),
+        pattern: expect.any(String),
         unstable_url: expect.any(URL),
         context: {},
       });

--- a/packages/react-router/__tests__/server-runtime/utils.ts
+++ b/packages/react-router/__tests__/server-runtime/utils.ts
@@ -15,7 +15,7 @@ import type {
   LoaderFunction,
   MiddlewareFunction,
 } from "../../lib/router/utils";
-import type { unstable_ServerInstrumentation } from "../../lib/router/instrumentation";
+import type { ServerInstrumentation } from "../../lib/router/instrumentation";
 
 export function mockServerBuild(
   routes: Record<
@@ -36,7 +36,7 @@ export function mockServerBuild(
     future?: Partial<FutureConfig>;
     handleError?: HandleErrorFunction;
     handleDocumentRequest?: HandleDocumentRequestFunction;
-    unstable_instrumentations?: unstable_ServerInstrumentation[];
+    instrumentations?: ServerInstrumentation[];
   } = {},
 ): ServerBuild {
   return {
@@ -98,7 +98,7 @@ export function mockServerBuild(
           ),
         handleDataRequest: jest.fn(async (response) => response),
         handleError: opts.handleError,
-        unstable_instrumentations: opts.unstable_instrumentations,
+        instrumentations: opts.instrumentations,
       },
     },
     routes: Object.entries(routes).reduce<ServerRouteManifest>(

--- a/packages/react-router/__tests__/server-runtime/utils.ts
+++ b/packages/react-router/__tests__/server-runtime/utils.ts
@@ -43,7 +43,6 @@ export function mockServerBuild(
     ssr: true,
     future: {
       v8_middleware: false,
-      unstable_subResourceIntegrity: false,
       ...opts.future,
     },
     prerender: [],

--- a/packages/react-router/__tests__/utils/framework.ts
+++ b/packages/react-router/__tests__/utils/framework.ts
@@ -31,7 +31,6 @@ export function mockFrameworkContext(
     },
     future: {
       v8_middleware: false,
-      unstable_subResourceIntegrity: false,
     },
     ssr: true,
     isSpaMode: false,

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -71,12 +71,12 @@ export {
   parsePath,
 } from "./lib/router/history";
 export type {
-  unstable_ServerInstrumentation,
-  unstable_ClientInstrumentation,
-  unstable_InstrumentRequestHandlerFunction,
-  unstable_InstrumentRouterFunction,
-  unstable_InstrumentRouteFunction,
-  unstable_InstrumentationHandlerResult,
+  ServerInstrumentation,
+  ClientInstrumentation,
+  InstrumentRequestHandlerFunction,
+  InstrumentRouterFunction,
+  InstrumentRouteFunction,
+  InstrumentationHandlerResult,
 } from "./lib/router/instrumentation";
 export {
   IDLE_NAVIGATION,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -1404,7 +1404,7 @@ export function Router({
     hash = "",
     state = null,
     key = "default",
-    unstable_mask,
+    mask,
   } = locationProp;
 
   let locationContext = React.useMemo(() => {
@@ -1421,7 +1421,7 @@ export function Router({
         hash,
         state,
         key,
-        unstable_mask,
+        mask,
       },
       navigationType,
     };
@@ -1433,7 +1433,7 @@ export function Router({
     state,
     key,
     navigationType,
-    unstable_mask,
+    mask,
   ]);
 
   warning(

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -423,7 +423,7 @@ export interface RouterProviderProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
 }
 
 /**
@@ -455,17 +455,17 @@ export interface RouterProviderProps {
  * @param {RouterProviderProps.flushSync} props.flushSync n/a
  * @param {RouterProviderProps.onError} props.onError n/a
  * @param {RouterProviderProps.router} props.router n/a
- * @param {RouterProviderProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {RouterProviderProps.useTransitions} props.useTransitions n/a
  * @returns React element for the rendered router
  */
 export function RouterProvider({
   router,
   flushSync: reactDomFlushSyncImpl,
   onError,
-  unstable_useTransitions,
+  useTransitions,
 }: RouterProviderProps): React.ReactElement {
   let unstable_rsc = useIsRSCRouterContext();
-  unstable_useTransitions = unstable_rsc || unstable_useTransitions;
+  useTransitions = unstable_rsc || useTransitions;
 
   let [_state, setStateImpl] = React.useState(router.state);
   let [state, setOptimisticState] = useOptimisticSafe(_state);
@@ -532,11 +532,11 @@ export function RouterProvider({
       if (!viewTransitionOpts || !isViewTransitionAvailable) {
         if (reactDomFlushSyncImpl && flushSync) {
           reactDomFlushSyncImpl(() => setStateImpl(newState));
-        } else if (unstable_useTransitions === false) {
+        } else if (useTransitions === false) {
           setStateImpl(newState);
         } else {
           React.startTransition(() => {
-            if (unstable_useTransitions === true) {
+            if (useTransitions === true) {
               setOptimisticState((s) => getOptimisticRouterState(s, newState));
             }
             setStateImpl(newState);
@@ -608,7 +608,7 @@ export function RouterProvider({
       reactDomFlushSyncImpl,
       transition,
       renderDfd,
-      unstable_useTransitions,
+      useTransitions,
       setOptimisticState,
       onError,
     ],
@@ -648,11 +648,11 @@ export function RouterProvider({
       let newState = pendingState;
       let renderPromise = renderDfd.promise;
       let transition = router.window.document.startViewTransition(async () => {
-        if (unstable_useTransitions === false) {
+        if (useTransitions === false) {
           setStateImpl(newState);
         } else {
           React.startTransition(() => {
-            if (unstable_useTransitions === true) {
+            if (useTransitions === true) {
               setOptimisticState((s) => getOptimisticRouterState(s, newState));
             }
             setStateImpl(newState);
@@ -672,7 +672,7 @@ export function RouterProvider({
     pendingState,
     renderDfd,
     router.window,
-    unstable_useTransitions,
+    useTransitions,
     setOptimisticState,
   ]);
 
@@ -752,7 +752,7 @@ export function RouterProvider({
                 location={state.location}
                 navigationType={state.historyAction}
                 navigator={navigator}
-                unstable_useTransitions={unstable_useTransitions}
+                useTransitions={useTransitions}
               >
                 <MemoizedDataRoutes
                   routes={router.routes}
@@ -851,7 +851,7 @@ export interface MemoryRouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
 }
 
 /**
@@ -865,7 +865,7 @@ export interface MemoryRouterProps {
  * @param {MemoryRouterProps.children} props.children n/a
  * @param {MemoryRouterProps.initialEntries} props.initialEntries n/a
  * @param {MemoryRouterProps.initialIndex} props.initialIndex n/a
- * @param {MemoryRouterProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {MemoryRouterProps.useTransitions} props.useTransitions n/a
  * @returns A declarative in-memory {@link Router | `<Router>`} for client-side
  * routing.
  */
@@ -874,7 +874,7 @@ export function MemoryRouter({
   children,
   initialEntries,
   initialIndex,
-  unstable_useTransitions,
+  useTransitions,
 }: MemoryRouterProps): React.ReactElement {
   let historyRef = React.useRef<MemoryHistory>();
   if (historyRef.current == null) {
@@ -892,13 +892,13 @@ export function MemoryRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      if (unstable_useTransitions === false) {
+      if (useTransitions === false) {
         setStateImpl(newState);
       } else {
         React.startTransition(() => setStateImpl(newState));
       }
     },
-    [unstable_useTransitions],
+    [useTransitions],
   );
 
   React.useLayoutEffect(() => history.listen(setState), [history, setState]);
@@ -910,7 +910,7 @@ export function MemoryRouter({
       location={state.location}
       navigationType={state.action}
       navigator={history}
-      unstable_useTransitions={unstable_useTransitions}
+      useTransitions={useTransitions}
     />
   );
 }
@@ -1341,7 +1341,7 @@ export interface RouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
 }
 
 /**
@@ -1361,7 +1361,7 @@ export interface RouterProps {
  * @param {RouterProps.navigationType} props.navigationType n/a
  * @param {RouterProps.navigator} props.navigator n/a
  * @param {RouterProps.static} props.static n/a
- * @param {RouterProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {RouterProps.useTransitions} props.useTransitions n/a
  * @returns React element for the rendered router or `null` if the location does
  * not match the {@link props.basename}
  */
@@ -1372,7 +1372,7 @@ export function Router({
   navigationType = NavigationType.Pop,
   navigator,
   static: staticProp = false,
-  unstable_useTransitions,
+  useTransitions,
 }: RouterProps): React.ReactElement | null {
   invariant(
     !useInRouterContext(),
@@ -1388,10 +1388,10 @@ export function Router({
       basename,
       navigator,
       static: staticProp,
-      unstable_useTransitions,
+      useTransitions,
       future: {},
     }),
-    [basename, navigator, staticProp, unstable_useTransitions],
+    [basename, navigator, staticProp, useTransitions],
   );
 
   if (typeof locationProp === "string") {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -422,7 +422,7 @@ export interface RouterProviderProps {
    * - When set to `false`, the router will not leverage `React.startTransition` or
    *   `React.useOptimistic` on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
 }
@@ -859,7 +859,7 @@ export interface MemoryRouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition`
    *   on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
 }
@@ -1349,7 +1349,7 @@ export interface RouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition`
    *   on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
 }

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -72,7 +72,7 @@ import {
 } from "./hooks";
 import type { ViewTransition } from "./dom/global";
 import { warnOnce } from "./server-runtime/warnings";
-import type { unstable_ClientInstrumentation } from "./router/instrumentation";
+import type { ClientInstrumentation } from "./router/instrumentation";
 
 /**
  * Webpack can fail to compile against react versions without this export -
@@ -210,7 +210,7 @@ export interface MemoryRouterOpts {
    *
    * ```tsx
    * let router = createBrowserRouter(routes, {
-   *   unstable_instrumentations: [logging]
+   *   instrumentations: [logging]
    * });
    *
    *
@@ -248,7 +248,7 @@ export interface MemoryRouterOpts {
    * }
    * ```
    */
-  unstable_instrumentations?: unstable_ClientInstrumentation[];
+  instrumentations?: ClientInstrumentation[];
   /**
    * Override the default data strategy of running loaders in parallel -
    * see the [docs](../../how-to/data-strategy) for more information.
@@ -301,7 +301,7 @@ export interface MemoryRouterOpts {
  * @param {MemoryRouterOpts.hydrationData} opts.hydrationData n/a
  * @param {MemoryRouterOpts.initialEntries} opts.initialEntries n/a
  * @param {MemoryRouterOpts.initialIndex} opts.initialIndex n/a
- * @param {MemoryRouterOpts.unstable_instrumentations} opts.unstable_instrumentations n/a
+ * @param {MemoryRouterOpts.instrumentations} opts.instrumentations n/a
  * @param {MemoryRouterOpts.patchRoutesOnNavigation} opts.patchRoutesOnNavigation n/a
  * @returns An initialized {@link DataRouter} to pass to {@link RouterProvider | `<RouterProvider>`}
  */
@@ -323,7 +323,7 @@ export function createMemoryRouter(
     mapRouteProperties,
     dataStrategy: opts?.dataStrategy,
     patchRoutesOnNavigation: opts?.patchRoutesOnNavigation,
-    unstable_instrumentations: opts?.unstable_instrumentations,
+    instrumentations: opts?.instrumentations,
   }).initialize();
 }
 
@@ -362,7 +362,7 @@ export interface ClientOnErrorFunction {
     info: {
       location: Location;
       params: Params;
-      unstable_pattern: string;
+      pattern: string;
       errorInfo?: React.ErrorInfo;
     },
   ): void;
@@ -398,7 +398,7 @@ export interface RouterProviderProps {
    *
    * ```tsx
    * <RouterProvider onError=(error, info) => {
-   *   let { location, params, unstable_pattern, errorInfo } = info;
+   *   let { location, params, pattern, errorInfo } = info;
    *   console.error(error, location, errorInfo);
    *   reportToErrorService(error, location, errorInfo);
    * }} />
@@ -493,7 +493,7 @@ export function RouterProvider({
           onError(error, {
             location: newState.location,
             params: newState.matches[0]?.params ?? {},
-            unstable_pattern: getRoutePattern(newState.matches),
+            pattern: getRoutePattern(newState.matches),
           }),
         );
       }
@@ -1674,7 +1674,7 @@ export function Await<Resolve>({
         dataRouterContext.onError(error, {
           location: dataRouterStateContext.location,
           params: dataRouterStateContext.matches[0]?.params || {},
-          unstable_pattern: getRoutePattern(dataRouterStateContext.matches),
+          pattern: getRoutePattern(dataRouterStateContext.matches),
           errorInfo,
         });
       }

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -74,7 +74,7 @@ export interface NavigateOptions {
   /** Replace the current entry in the history stack instead of pushing a new one */
   replace?: boolean;
   /** Masked URL */
-  unstable_mask?: To;
+  mask?: To;
   /** Adds persistent client side routing state to the next location */
   state?: any;
   /** If you are using {@link ScrollRestoration `<ScrollRestoration>`}, prevent the scroll position from being reset to the top of the window when navigating */

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -15,9 +15,9 @@ import type { TrackedPromise, RouteMatch } from "./router/utils";
 
 export interface DataRouterContextObject
   // Omit `future` since those can be pulled from the `router`
-  // `NavigationContext` needs `future`/`unstable_useTransitions` since it doesn't
+  // `NavigationContext` needs `future`/`useTransitions` since it doesn't
   // have a `router` in all cases
-  extends Omit<NavigationContextObject, "future" | "unstable_useTransitions"> {
+  extends Omit<NavigationContextObject, "future" | "useTransitions"> {
   router: Router;
   staticContext?: StaticHandlerContext;
   onError?: ClientOnErrorFunction;
@@ -111,7 +111,7 @@ interface NavigationContextObject {
   basename: string;
   navigator: Navigator;
   static: boolean;
-  unstable_useTransitions: boolean | undefined;
+  useTransitions: boolean | undefined;
   // TODO: Re-introduce a singular `FutureConfig` once we land our first
   // future.unstable_ or future.v8_ flag
   future: {};

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -86,7 +86,7 @@ export interface NavigateOptions {
   /** Enables a {@link https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API View Transition} for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the {@link useViewTransitionState `useViewTransitionState()`} hook.  */
   viewTransition?: boolean;
   /** Specifies the default revalidation behavior after this submission */
-  unstable_defaultShouldRevalidate?: boolean;
+  defaultShouldRevalidate?: boolean;
 }
 
 /**

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -328,7 +328,7 @@ export interface HydratedRouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition` or
    *   `React.useOptimistic` on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
 }

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -27,7 +27,7 @@ import {
 } from "react-router";
 import { CRITICAL_CSS_DATA_ATTRIBUTE } from "../dom/ssr/components";
 import { RouterProvider } from "./dom-router-provider";
-import type { unstable_ClientInstrumentation } from "../router/instrumentation";
+import type { ClientInstrumentation } from "../router/instrumentation";
 
 type SSRInfo = {
   context: NonNullable<(typeof window)["__reactRouterContext"]>;
@@ -79,10 +79,10 @@ function initSsrInfo(): void {
 
 function createHydratedRouter({
   getContext,
-  unstable_instrumentations,
+  instrumentations,
 }: {
   getContext?: RouterInit["getContext"];
-  unstable_instrumentations?: unstable_ClientInstrumentation[];
+  instrumentations?: ClientInstrumentation[];
 }): DataRouter {
   initSsrInfo();
 
@@ -185,7 +185,7 @@ function createHydratedRouter({
     getContext,
     hydrationData,
     hydrationRouteProperties,
-    unstable_instrumentations,
+    instrumentations,
     mapRouteProperties,
     future: {
       v8_passThroughRequests:
@@ -287,12 +287,12 @@ export interface HydratedRouterProps {
    * startTransition(() => {
    *   hydrateRoot(
    *     document,
-   *     <HydratedRouter unstable_instrumentations={[logging]} />
+   *     <HydratedRouter instrumentations={[logging]} />
    *   );
    * });
    * ```
    */
-  unstable_instrumentations?: unstable_ClientInstrumentation[];
+  instrumentations?: ClientInstrumentation[];
   /**
    * An error handler function that will be called for any middleware, loader, action,
    * or render errors that are encountered in your application.  This is useful for
@@ -305,7 +305,7 @@ export interface HydratedRouterProps {
    *
    * ```tsx
    * <HydratedRouter onError=(error, info) => {
-   *   let { location, params, unstable_pattern, errorInfo } = info;
+   *   let { location, params, pattern, errorInfo } = info;
    *   console.error(error, location, errorInfo);
    *   reportToErrorService(error, location, errorInfo);
    * }} />
@@ -349,7 +349,7 @@ export function HydratedRouter(props: HydratedRouterProps) {
   if (!router) {
     router = createHydratedRouter({
       getContext: props.getContext,
-      unstable_instrumentations: props.unstable_instrumentations,
+      instrumentations: props.instrumentations,
     });
   }
 

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -188,8 +188,8 @@ function createHydratedRouter({
     unstable_instrumentations,
     mapRouteProperties,
     future: {
-      unstable_passThroughRequests:
-        ssrInfo.context.future.unstable_passThroughRequests,
+      v8_passThroughRequests:
+        ssrInfo.context.future.v8_passThroughRequests,
     },
     dataStrategy: getTurboStreamSingleFetchDataStrategy(
       () => router,

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -330,7 +330,7 @@ export interface HydratedRouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
 }
 
 /**
@@ -437,7 +437,7 @@ export function HydratedRouter(props: HydratedRouterProps) {
         <RemixErrorBoundary location={location}>
           <RouterProvider
             router={router}
-            unstable_useTransitions={props.unstable_useTransitions}
+            useTransitions={props.useTransitions}
             onError={props.onError}
           />
         </RemixErrorBoundary>

--- a/packages/react-router/lib/dom/dom.ts
+++ b/packages/react-router/lib/dom/dom.ts
@@ -204,7 +204,7 @@ interface SharedSubmitOptions {
    * By default (when not specified), loaders will revalidate according to the routers
    * standard revalidation behavior.
    */
-  unstable_defaultShouldRevalidate?: boolean;
+  defaultShouldRevalidate?: boolean;
 }
 
 /**

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1249,7 +1249,7 @@ export interface LinkProps
    *          <Link
    *            key={image.id}
    *            to={`/gallery?image=${image.id}`}
-   *            unstable_mask={`/images/${image.id}`}
+   *            mask={`/images/${image.id}`}
    *          >
    *            <img src={image.url} alt={image.alt} />
    *          </Link>
@@ -1266,7 +1266,7 @@ export interface LinkProps
    * }
    * ```
    */
-  unstable_mask?: To;
+  mask?: To;
 }
 
 const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
@@ -1300,7 +1300,7 @@ const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
  * @param {LinkProps.to} props.to n/a
  * @param {LinkProps.viewTransition} props.viewTransition [modes: framework, data] n/a
  * @param {LinkProps.defaultShouldRevalidate} props.defaultShouldRevalidate n/a
- * @param {LinkProps.unstable_mask} props.unstable_mask [modes: framework, data] n/a
+ * @param {LinkProps.mask} props.mask [modes: framework, data] n/a
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
   function LinkWithRef(
@@ -1311,7 +1311,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       relative,
       reloadDocument,
       replace,
-      unstable_mask,
+      mask,
       state,
       target,
       to,
@@ -1335,13 +1335,13 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     let maskedHref: string | null = null;
 
-    if (unstable_mask) {
+    if (mask) {
       // Inlined version of the `useHref` logic operating off the masked location
       // instead of the current location
       let resolved = resolveTo(
-        unstable_mask,
+        mask,
         [],
-        location.unstable_mask ? location.unstable_mask.pathname : "/",
+        location.mask ? location.mask.pathname : "/",
         true,
       );
 
@@ -1366,7 +1366,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     let internalOnClick = useLinkClickHandler(to, {
       replace,
-      unstable_mask,
+      mask,
       state,
       target,
       preventScrollReset,
@@ -2190,7 +2190,7 @@ function useDataRouterState(hookName: DataRouterStateHook) {
  * {@link useViewTransitionState}. Defaults to `false`.
  * @param options.defaultShouldRevalidate Specify the default revalidation
  * behavior for the navigation. Defaults to `true`.
- * @param options.unstable_mask Masked location to display in the browser instead
+ * @param options.mask Masked location to display in the browser instead
  * of the router location. Defaults to `undefined`.
  * @param options.useTransitions Wraps the navigation in
  * [`React.startTransition`](https://react.dev/reference/react/startTransition)
@@ -2202,7 +2202,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
   {
     target,
     replace: replaceProp,
-    unstable_mask,
+    mask,
     state,
     preventScrollReset,
     relative,
@@ -2212,7 +2212,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
-    unstable_mask?: To;
+    mask?: To;
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
@@ -2240,7 +2240,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
         let doNavigate = () =>
           navigate(to, {
             replace,
-            unstable_mask,
+            mask,
             state,
             preventScrollReset,
             relative,
@@ -2261,7 +2261,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       navigate,
       path,
       replaceProp,
-      unstable_mask,
+      mask,
       state,
       target,
       to,

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -790,7 +790,7 @@ export interface BrowserRouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
   /**
    * [`Window`](https://developer.mozilla.org/en-US/docs/Web/API/Window) object
    * override. Defaults to the global `window` instance
@@ -808,7 +808,7 @@ export interface BrowserRouterProps {
  * @param props Props
  * @param {BrowserRouterProps.basename} props.basename n/a
  * @param {BrowserRouterProps.children} props.children n/a
- * @param {BrowserRouterProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {BrowserRouterProps.useTransitions} props.useTransitions n/a
  * @param {BrowserRouterProps.window} props.window n/a
  * @returns A declarative {@link Router | `<Router>`} using the browser [`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
  * API for client-side routing.
@@ -816,7 +816,7 @@ export interface BrowserRouterProps {
 export function BrowserRouter({
   basename,
   children,
-  unstable_useTransitions,
+  useTransitions,
   window,
 }: BrowserRouterProps) {
   let historyRef = React.useRef<BrowserHistory>();
@@ -831,13 +831,13 @@ export function BrowserRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      if (unstable_useTransitions === false) {
+      if (useTransitions === false) {
         setStateImpl(newState);
       } else {
         React.startTransition(() => setStateImpl(newState));
       }
     },
-    [unstable_useTransitions],
+    [useTransitions],
   );
 
   React.useLayoutEffect(() => history.listen(setState), [history, setState]);
@@ -849,7 +849,7 @@ export function BrowserRouter({
       location={state.location}
       navigationType={state.action}
       navigator={history}
-      unstable_useTransitions={unstable_useTransitions}
+      useTransitions={useTransitions}
     />
   );
 }
@@ -880,7 +880,7 @@ export interface HashRouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
   /**
    * [`Window`](https://developer.mozilla.org/en-US/docs/Web/API/Window) object
    * override. Defaults to the global `window` instance
@@ -899,7 +899,7 @@ export interface HashRouterProps {
  * @param props Props
  * @param {HashRouterProps.basename} props.basename n/a
  * @param {HashRouterProps.children} props.children n/a
- * @param {HashRouterProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {HashRouterProps.useTransitions} props.useTransitions n/a
  * @param {HashRouterProps.window} props.window n/a
  * @returns A declarative {@link Router | `<Router>`} using the URL [`hash`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash)
  * for client-side routing.
@@ -907,7 +907,7 @@ export interface HashRouterProps {
 export function HashRouter({
   basename,
   children,
-  unstable_useTransitions,
+  useTransitions,
   window,
 }: HashRouterProps) {
   let historyRef = React.useRef<HashHistory>();
@@ -922,13 +922,13 @@ export function HashRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      if (unstable_useTransitions === false) {
+      if (useTransitions === false) {
         setStateImpl(newState);
       } else {
         React.startTransition(() => setStateImpl(newState));
       }
     },
-    [unstable_useTransitions],
+    [useTransitions],
   );
 
   React.useLayoutEffect(() => history.listen(setState), [history, setState]);
@@ -940,7 +940,7 @@ export function HashRouter({
       location={state.location}
       navigationType={state.action}
       navigator={history}
-      unstable_useTransitions={unstable_useTransitions}
+      useTransitions={useTransitions}
     />
   );
 }
@@ -975,7 +975,7 @@ export interface HistoryRouterProps {
    *
    * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
    */
-  unstable_useTransitions?: boolean;
+  useTransitions?: boolean;
 }
 
 /**
@@ -993,7 +993,7 @@ export interface HistoryRouterProps {
  * @param {HistoryRouterProps.basename} props.basename n/a
  * @param {HistoryRouterProps.children} props.children n/a
  * @param {HistoryRouterProps.history} props.history n/a
- * @param {HistoryRouterProps.unstable_useTransitions} props.unstable_useTransitions n/a
+ * @param {HistoryRouterProps.useTransitions} props.useTransitions n/a
  * @returns A declarative {@link Router | `<Router>`} using the provided history
  * implementation for client-side routing.
  */
@@ -1001,7 +1001,7 @@ export function HistoryRouter({
   basename,
   children,
   history,
-  unstable_useTransitions,
+  useTransitions,
 }: HistoryRouterProps) {
   let [state, setStateImpl] = React.useState({
     action: history.action,
@@ -1009,13 +1009,13 @@ export function HistoryRouter({
   });
   let setState = React.useCallback(
     (newState: { action: NavigationType; location: Location }) => {
-      if (unstable_useTransitions === false) {
+      if (useTransitions === false) {
         setStateImpl(newState);
       } else {
         React.startTransition(() => setStateImpl(newState));
       }
     },
-    [unstable_useTransitions],
+    [useTransitions],
   );
 
   React.useLayoutEffect(() => history.listen(setState), [history, setState]);
@@ -1027,7 +1027,7 @@ export function HistoryRouter({
       location={state.location}
       navigationType={state.action}
       navigator={history}
-      unstable_useTransitions={unstable_useTransitions}
+      useTransitions={useTransitions}
     />
   );
 }
@@ -1322,7 +1322,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
     },
     forwardedRef,
   ) {
-    let { basename, navigator, unstable_useTransitions } =
+    let { basename, navigator, useTransitions } =
       React.useContext(NavigationContext);
     let isAbsolute = typeof to === "string" && ABSOLUTE_URL_REGEX.test(to);
 
@@ -1373,7 +1373,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       relative,
       viewTransition,
       defaultShouldRevalidate,
-      unstable_useTransitions,
+      useTransitions,
     });
     function handleClick(
       event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
@@ -1935,7 +1935,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
     },
     forwardedRef,
   ) => {
-    let { unstable_useTransitions } = React.useContext(NavigationContext);
+    let { useTransitions } = React.useContext(NavigationContext);
     let submit = useSubmit();
     let formAction = useFormAction(action, { relative });
     let formMethod: HTMLFormMethod =
@@ -1968,7 +1968,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
           defaultShouldRevalidate,
         });
 
-      if (unstable_useTransitions && navigate !== false) {
+      if (useTransitions && navigate !== false) {
         // @ts-expect-error Needs React 19 types
         React.startTransition(() => doSubmit());
       } else {
@@ -2192,7 +2192,7 @@ function useDataRouterState(hookName: DataRouterStateHook) {
  * behavior for the navigation. Defaults to `true`.
  * @param options.unstable_mask Masked location to display in the browser instead
  * of the router location. Defaults to `undefined`.
- * @param options.unstable_useTransitions Wraps the navigation in
+ * @param options.useTransitions Wraps the navigation in
  * [`React.startTransition`](https://react.dev/reference/react/startTransition)
  * for concurrent rendering. Defaults to `false`.
  * @returns A click handler function that can be used in a custom {@link Link} component.
@@ -2208,7 +2208,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     relative,
     viewTransition,
     defaultShouldRevalidate,
-    unstable_useTransitions,
+    useTransitions,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
     replace?: boolean;
@@ -2218,7 +2218,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     relative?: RelativeRoutingType;
     viewTransition?: boolean;
     defaultShouldRevalidate?: boolean;
-    unstable_useTransitions?: boolean;
+    useTransitions?: boolean;
   } = {},
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
@@ -2248,7 +2248,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
             defaultShouldRevalidate,
           });
 
-        if (unstable_useTransitions) {
+        if (useTransitions) {
           // @ts-expect-error Needs React 19 types
           React.startTransition(() => doNavigate());
         } else {
@@ -2269,7 +2269,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       relative,
       viewTransition,
       defaultShouldRevalidate,
-      unstable_useTransitions,
+      useTransitions,
     ],
   );
 }

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -95,7 +95,7 @@ import {
   useRouteId,
 } from "../hooks";
 import type { SerializeFrom } from "../types/route-data";
-import type { unstable_ClientInstrumentation } from "../router/instrumentation";
+import type { ClientInstrumentation } from "../router/instrumentation";
 import { escapeHtml } from "./ssr/markup";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -247,7 +247,7 @@ export interface DOMRouterOpts {
    *
    * ```tsx
    * let router = createBrowserRouter(routes, {
-   *   unstable_instrumentations: [logging]
+   *   instrumentations: [logging]
    * });
    *
    *
@@ -285,7 +285,7 @@ export interface DOMRouterOpts {
    * }
    * ```
    */
-  unstable_instrumentations?: unstable_ClientInstrumentation[];
+  instrumentations?: ClientInstrumentation[];
   /**
    * Override the default data strategy of running loaders in parallel -
    * see the [docs](../../how-to/data-strategy) for more information.
@@ -635,7 +635,7 @@ export interface DOMRouterOpts {
  * @param {DOMRouterOpts.future} opts.future n/a
  * @param {DOMRouterOpts.getContext} opts.getContext n/a
  * @param {DOMRouterOpts.hydrationData} opts.hydrationData n/a
- * @param {DOMRouterOpts.unstable_instrumentations} opts.unstable_instrumentations n/a
+ * @param {DOMRouterOpts.instrumentations} opts.instrumentations n/a
  * @param {DOMRouterOpts.patchRoutesOnNavigation} opts.patchRoutesOnNavigation n/a
  * @param {DOMRouterOpts.window} opts.window n/a
  * @returns An initialized {@link DataRouter| data router} to pass to {@link RouterProvider | `<RouterProvider>`}
@@ -656,7 +656,7 @@ export function createBrowserRouter(
     dataStrategy: opts?.dataStrategy,
     patchRoutesOnNavigation: opts?.patchRoutesOnNavigation,
     window: opts?.window,
-    unstable_instrumentations: opts?.unstable_instrumentations,
+    instrumentations: opts?.instrumentations,
   }).initialize();
 }
 
@@ -673,7 +673,7 @@ export function createBrowserRouter(
  * @param {DOMRouterOpts.future} opts.future n/a
  * @param {DOMRouterOpts.getContext} opts.getContext n/a
  * @param {DOMRouterOpts.hydrationData} opts.hydrationData n/a
- * @param {DOMRouterOpts.unstable_instrumentations} opts.unstable_instrumentations n/a
+ * @param {DOMRouterOpts.instrumentations} opts.instrumentations n/a
  * @param {DOMRouterOpts.dataStrategy} opts.dataStrategy n/a
  * @param {DOMRouterOpts.patchRoutesOnNavigation} opts.patchRoutesOnNavigation n/a
  * @param {DOMRouterOpts.window} opts.window n/a
@@ -695,7 +695,7 @@ export function createHashRouter(
     dataStrategy: opts?.dataStrategy,
     patchRoutesOnNavigation: opts?.patchRoutesOnNavigation,
     window: opts?.window,
-    unstable_instrumentations: opts?.unstable_instrumentations,
+    instrumentations: opts?.instrumentations,
   }).initialize();
 }
 

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1206,7 +1206,7 @@ export interface LinkProps
    * Specify the default revalidation behavior for the navigation.
    *
    * ```tsx
-   * <Link to="/some/path" unstable_defaultShouldRevalidate={false} />
+   * <Link to="/some/path" defaultShouldRevalidate={false} />
    * ```
    *
    * If no `shouldRevalidate` functions are present on the active routes, then this
@@ -1217,7 +1217,7 @@ export interface LinkProps
    * By default (when not specified), loaders will revalidate according to the routers
    * standard revalidation behavior.
    */
-  unstable_defaultShouldRevalidate?: boolean;
+  defaultShouldRevalidate?: boolean;
 
   /**
    * Masked path for this navigation, when you want to navigate the router to
@@ -1299,7 +1299,7 @@ const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
  * @param {LinkProps.state} props.state n/a
  * @param {LinkProps.to} props.to n/a
  * @param {LinkProps.viewTransition} props.viewTransition [modes: framework, data] n/a
- * @param {LinkProps.unstable_defaultShouldRevalidate} props.unstable_defaultShouldRevalidate n/a
+ * @param {LinkProps.defaultShouldRevalidate} props.defaultShouldRevalidate n/a
  * @param {LinkProps.unstable_mask} props.unstable_mask [modes: framework, data] n/a
  */
 export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
@@ -1317,7 +1317,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       to,
       preventScrollReset,
       viewTransition,
-      unstable_defaultShouldRevalidate,
+      defaultShouldRevalidate,
       ...rest
     },
     forwardedRef,
@@ -1372,7 +1372,7 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
       preventScrollReset,
       relative,
       viewTransition,
-      unstable_defaultShouldRevalidate,
+      defaultShouldRevalidate,
       unstable_useTransitions,
     });
     function handleClick(
@@ -1788,7 +1788,7 @@ interface SharedFormProps extends React.FormHTMLAttributes<HTMLFormElement> {
    * By default (when not specified), loaders will revalidate according to the routers
    * standard revalidation behavior.
    */
-  unstable_defaultShouldRevalidate?: boolean;
+  defaultShouldRevalidate?: boolean;
 }
 
 /**
@@ -1912,7 +1912,7 @@ type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
  * @param {FormProps.replace} replace n/a
  * @param {FormProps.state} state n/a
  * @param {FormProps.viewTransition} viewTransition n/a
- * @param {FormProps.unstable_defaultShouldRevalidate} unstable_defaultShouldRevalidate n/a
+ * @param {FormProps.defaultShouldRevalidate} defaultShouldRevalidate n/a
  * @returns A progressively enhanced [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) component
  */
 export const Form = React.forwardRef<HTMLFormElement, FormProps>(
@@ -1930,7 +1930,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
       relative,
       preventScrollReset,
       viewTransition,
-      unstable_defaultShouldRevalidate,
+      defaultShouldRevalidate,
       ...props
     },
     forwardedRef,
@@ -1965,7 +1965,7 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
           relative,
           preventScrollReset,
           viewTransition,
-          unstable_defaultShouldRevalidate,
+          defaultShouldRevalidate,
         });
 
       if (unstable_useTransitions && navigate !== false) {
@@ -2188,7 +2188,7 @@ function useDataRouterState(hookName: DataRouterStateHook) {
  * @param options.viewTransition Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
  * for this navigation. To apply specific styles during the transition, see
  * {@link useViewTransitionState}. Defaults to `false`.
- * @param options.unstable_defaultShouldRevalidate Specify the default revalidation
+ * @param options.defaultShouldRevalidate Specify the default revalidation
  * behavior for the navigation. Defaults to `true`.
  * @param options.unstable_mask Masked location to display in the browser instead
  * of the router location. Defaults to `undefined`.
@@ -2207,7 +2207,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     preventScrollReset,
     relative,
     viewTransition,
-    unstable_defaultShouldRevalidate,
+    defaultShouldRevalidate,
     unstable_useTransitions,
   }: {
     target?: React.HTMLAttributeAnchorTarget;
@@ -2217,7 +2217,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
     viewTransition?: boolean;
-    unstable_defaultShouldRevalidate?: boolean;
+    defaultShouldRevalidate?: boolean;
     unstable_useTransitions?: boolean;
   } = {},
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
@@ -2245,7 +2245,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
             preventScrollReset,
             relative,
             viewTransition,
-            unstable_defaultShouldRevalidate,
+            defaultShouldRevalidate,
           });
 
         if (unstable_useTransitions) {
@@ -2268,7 +2268,7 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
       preventScrollReset,
       relative,
       viewTransition,
-      unstable_defaultShouldRevalidate,
+      defaultShouldRevalidate,
       unstable_useTransitions,
     ],
   );
@@ -2591,8 +2591,8 @@ export function useSubmit(): SubmitFunction {
       if (options.navigate === false) {
         let key = options.fetcherKey || getUniqueFetcherId();
         await routerFetch(key, currentRouteId, options.action || action, {
-          unstable_defaultShouldRevalidate:
-            options.unstable_defaultShouldRevalidate,
+          defaultShouldRevalidate:
+            options.defaultShouldRevalidate,
           preventScrollReset: options.preventScrollReset,
           formData,
           body,
@@ -2602,8 +2602,8 @@ export function useSubmit(): SubmitFunction {
         });
       } else {
         await routerNavigate(options.action || action, {
-          unstable_defaultShouldRevalidate:
-            options.unstable_defaultShouldRevalidate,
+          defaultShouldRevalidate:
+            options.defaultShouldRevalidate,
           preventScrollReset: options.preventScrollReset,
           formData,
           body,

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -788,7 +788,7 @@ export interface BrowserRouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition`
    *   on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
   /**
@@ -878,7 +878,7 @@ export interface HashRouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition`
    *   on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
   /**
@@ -973,7 +973,7 @@ export interface HistoryRouterProps {
    * - When set to `false`, the router will not leverage `React.startTransition`
    *   on any navigations or state changes.
    *
-   * For more information, please see the [docs](https://reactrouter.com/explanation/react-transitions).
+   * For more information, please see the [docs](../../explanation/react-transitions).
    */
   useTransitions?: boolean;
 }

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -81,7 +81,7 @@ export function StaticRouter({
     hash: locationProp.hash || "",
     state: locationProp.state != null ? locationProp.state : null,
     key: locationProp.key || "default",
-    unstable_mask: undefined,
+    mask: undefined,
   };
 
   let staticNavigator = getStatelessNavigator();

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -410,7 +410,7 @@ export function createStaticRouter(
     get future() {
       return {
         v8_middleware: false,
-        unstable_passThroughRequests: false,
+        v8_passThroughRequests: false,
         ...opts?.future,
       };
     },

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -93,7 +93,7 @@ export function StaticRouter({
       navigationType={action}
       navigator={staticNavigator}
       static={true}
-      unstable_useTransitions={false}
+      useTransitions={false}
     />
   );
 }
@@ -204,7 +204,7 @@ export function StaticRouterProvider({
                 navigationType={state.historyAction}
                 navigator={dataRouterContext.navigator}
                 static={dataRouterContext.static}
-                unstable_useTransitions={false}
+                useTransitions={false}
               >
                 <DataRoutes
                   routes={router.routes}

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -44,7 +44,7 @@ export interface EntryContext extends FrameworkContextObject {
 }
 
 export interface FutureConfig {
-  unstable_passThroughRequests: boolean;
+  v8_passThroughRequests: boolean;
   unstable_subResourceIntegrity: boolean;
   unstable_trailingSlashAwareDataRequests: boolean;
   v8_middleware: boolean;

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -45,7 +45,6 @@ export interface EntryContext extends FrameworkContextObject {
 
 export interface FutureConfig {
   v8_passThroughRequests: boolean;
-  unstable_subResourceIntegrity: boolean;
   unstable_trailingSlashAwareDataRequests: boolean;
   v8_middleware: boolean;
 }

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -128,8 +128,6 @@ export function createRoutesStub(
         future: {
           v8_passThroughRequests:
             future?.v8_passThroughRequests === true,
-          unstable_subResourceIntegrity:
-            future?.unstable_subResourceIntegrity === true,
           v8_middleware: future?.v8_middleware === true,
           unstable_trailingSlashAwareDataRequests:
             future?.unstable_trailingSlashAwareDataRequests === true,

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -126,8 +126,8 @@ export function createRoutesStub(
     if (routerRef.current == null) {
       frameworkContextRef.current = {
         future: {
-          unstable_passThroughRequests:
-            future?.unstable_passThroughRequests === true,
+          v8_passThroughRequests:
+            future?.v8_passThroughRequests === true,
           unstable_subResourceIntegrity:
             future?.unstable_subResourceIntegrity === true,
           v8_middleware: future?.v8_middleware === true,

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -344,7 +344,7 @@ export function createClientRoutes(
           request,
           params,
           context,
-          unstable_pattern,
+          pattern,
           unstable_url,
         }: LoaderFunctionArgs,
         singleFetch?: unknown,
@@ -364,7 +364,7 @@ export function createClientRoutes(
               request,
               params,
               context,
-              unstable_pattern,
+              pattern,
               unstable_url,
               async serverLoader() {
                 preventInvalidServerHandlerCall("loader", route);
@@ -405,7 +405,7 @@ export function createClientRoutes(
           request,
           params,
           context,
-          unstable_pattern,
+          pattern,
           unstable_url,
         }: ActionFunctionArgs,
         singleFetch?: unknown,
@@ -426,7 +426,7 @@ export function createClientRoutes(
             request,
             params,
             context,
-            unstable_pattern,
+            pattern,
             unstable_url,
             async serverAction() {
               preventInvalidServerHandlerCall("action", route);

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -345,7 +345,7 @@ export function createClientRoutes(
           params,
           context,
           pattern,
-          unstable_url,
+          url,
         }: LoaderFunctionArgs,
         singleFetch?: unknown,
       ) => {
@@ -365,7 +365,7 @@ export function createClientRoutes(
               params,
               context,
               pattern,
-              unstable_url,
+              url,
               async serverLoader() {
                 preventInvalidServerHandlerCall("loader", route);
 
@@ -406,7 +406,7 @@ export function createClientRoutes(
           params,
           context,
           pattern,
-          unstable_url,
+          url,
         }: ActionFunctionArgs,
         singleFetch?: unknown,
       ) => {
@@ -427,7 +427,7 @@ export function createClientRoutes(
             params,
             context,
             pattern,
-            unstable_url,
+            url,
             async serverAction() {
               preventInvalidServerHandlerCall("action", route);
               return fetchServerAction(singleFetch);

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -936,7 +936,7 @@ export function useRoutesImpl(
             hash: "",
             state: null,
             key: "default",
-            unstable_mask: undefined,
+            mask: undefined,
             ...location,
           },
           navigationType: NavigationType.Pop,

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1283,7 +1283,7 @@ export function _renderMatches(
           onErrorHandler(error, {
             location: dataRouterState.location,
             params: dataRouterState.matches?.[0]?.params ?? {},
-            unstable_pattern: getRoutePattern(dataRouterState.matches),
+            pattern: getRoutePattern(dataRouterState.matches),
             errorInfo,
           });
         }

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -74,7 +74,7 @@ export interface Location<State = any> extends Path {
    * The masked location displayed in the URL bar, which differs from the URL the
    * router is operating on
    */
-  unstable_mask?: Path;
+  mask?: Path;
 }
 
 /**
@@ -256,7 +256,7 @@ export function createMemoryHistory(
       entry,
       typeof entry === "string" ? null : entry.state,
       index === 0 ? "default" : undefined,
-      typeof entry === "string" ? undefined : entry.unstable_mask,
+      typeof entry === "string" ? undefined : entry.mask,
     ),
   );
   let index = clampIndex(
@@ -275,14 +275,14 @@ export function createMemoryHistory(
     to: To,
     state: any = null,
     key?: string,
-    unstable_mask?: Path,
+    mask?: Path,
   ): Location {
     let location = createLocation(
       entries ? getCurrentLocation().pathname : "/",
       to,
       state,
       key,
-      unstable_mask,
+      mask,
     );
     warning(
       location.pathname.charAt(0) === "/",
@@ -552,7 +552,7 @@ function getHistoryState(location: Location, index: number): HistoryState {
     usr: location.state,
     key: location.key,
     idx: index,
-    masked: location.unstable_mask
+    masked: location.mask
       ? {
           pathname: location.pathname,
           search: location.search,
@@ -570,7 +570,7 @@ export function createLocation(
   to: To,
   state: any = null,
   key?: string,
-  unstable_mask?: Path,
+  mask?: Path,
 ): Readonly<Location> {
   let location: Readonly<Location> = {
     pathname: typeof current === "string" ? current : current.pathname,
@@ -583,7 +583,7 @@ export function createLocation(
     // But that's a pretty big refactor to the current test suite so going to
     // keep as is for the time being and just let any incoming keys take precedence
     key: (to && (to as Location).key) || key || createKey(),
-    unstable_mask,
+    mask,
   };
   return location;
 }
@@ -685,7 +685,7 @@ function getUrlBasedHistory(
 
     index = getIndex() + 1;
     let historyState = getHistoryState(location, index);
-    let url = history.createHref(location.unstable_mask || location);
+    let url = history.createHref(location.mask || location);
 
     // try...catch because iOS limits us to 100 pushState calls :/
     try {
@@ -717,7 +717,7 @@ function getUrlBasedHistory(
 
     index = getIndex();
     let historyState = getHistoryState(location, index);
-    let url = history.createHref(location.unstable_mask || location);
+    let url = history.createHref(location.mask || location);
     globalHistory.replaceState(historyState, "", url);
 
     if (v5Compat && listener) {

--- a/packages/react-router/lib/router/instrumentation.ts
+++ b/packages/react-router/lib/router/instrumentation.ts
@@ -18,35 +18,35 @@ import type {
 } from "./utils";
 
 // Public APIs
-export type unstable_ServerInstrumentation = {
-  handler?: unstable_InstrumentRequestHandlerFunction;
-  route?: unstable_InstrumentRouteFunction;
+export type ServerInstrumentation = {
+  handler?: InstrumentRequestHandlerFunction;
+  route?: InstrumentRouteFunction;
 };
 
-export type unstable_ClientInstrumentation = {
-  router?: unstable_InstrumentRouterFunction;
-  route?: unstable_InstrumentRouteFunction;
+export type ClientInstrumentation = {
+  router?: InstrumentRouterFunction;
+  route?: InstrumentRouteFunction;
 };
 
-export type unstable_InstrumentRequestHandlerFunction = (
+export type InstrumentRequestHandlerFunction = (
   handler: InstrumentableRequestHandler,
 ) => void;
 
-export type unstable_InstrumentRouterFunction = (
+export type InstrumentRouterFunction = (
   router: InstrumentableRouter,
 ) => void;
 
-export type unstable_InstrumentRouteFunction = (
+export type InstrumentRouteFunction = (
   route: InstrumentableRoute,
 ) => void;
 
-export type unstable_InstrumentationHandlerResult =
+export type InstrumentationHandlerResult =
   | { status: "success"; error: undefined }
   | { status: "error"; error: Error };
 
 // Shared
 type InstrumentFunction<T> = (
-  handler: () => Promise<unstable_InstrumentationHandlerResult>,
+  handler: () => Promise<InstrumentationHandlerResult>,
   info: T,
 ) => Promise<void>;
 
@@ -90,7 +90,7 @@ type RouteLazyInstrumentationInfo = undefined;
 type RouteHandlerInstrumentationInfo = Readonly<{
   request: ReadonlyRequest;
   params: LoaderFunctionArgs["params"];
-  unstable_pattern: string;
+  pattern: string;
   context: ReadonlyContext;
 }>;
 
@@ -140,7 +140,7 @@ type RequestHandlerInstrumentationInfo = Readonly<{
 const UninstrumentedSymbol = Symbol("Uninstrumented");
 
 export function getRouteInstrumentationUpdates(
-  fns: unstable_InstrumentRouteFunction[],
+  fns: InstrumentRouteFunction[],
   route: Readonly<DataRouteObject>,
 ) {
   let aggregated: {
@@ -255,7 +255,7 @@ export function getRouteInstrumentationUpdates(
 
 export function instrumentClientSideRouter(
   router: Router,
-  fns: unstable_InstrumentRouterFunction[],
+  fns: InstrumentRouterFunction[],
 ): Router {
   let aggregated: {
     navigate: InstrumentFunction<RouterNavigationInstrumentationInfo>[];
@@ -327,7 +327,7 @@ export function instrumentClientSideRouter(
 
 export function instrumentHandler(
   handler: RequestHandler,
-  fns: unstable_InstrumentRequestHandlerFunction[],
+  fns: InstrumentRequestHandlerFunction[],
 ): RequestHandler {
   let aggregated: {
     request: InstrumentFunction<RequestHandlerInstrumentationInfo>[];
@@ -407,7 +407,7 @@ async function recurseRight<T extends InstrumentationInfo>(
     // handler, we need to ensure the handlers still gets called
     let handlerPromise: ReturnType<typeof recurseRight> | undefined = undefined;
     let callHandler =
-      async (): Promise<unstable_InstrumentationHandlerResult> => {
+      async (): Promise<InstrumentationHandlerResult> => {
         if (handlerPromise) {
           console.error("You cannot call instrumented handlers more than once");
         } else {
@@ -451,11 +451,11 @@ function getHandlerInfo(
     | ActionFunctionArgs
     | Parameters<MiddlewareFunction>[0],
 ): RouteHandlerInstrumentationInfo {
-  let { request, context, params, unstable_pattern } = args;
+  let { request, context, params, pattern } = args;
   return {
     request: getReadonlyRequest(request),
     params: { ...params },
-    unstable_pattern,
+    pattern,
     context: getReadonlyContext(context),
   };
 }

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -585,7 +585,7 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
   state?: any;
   fromRouteId?: string;
   viewTransition?: boolean;
-  unstable_mask?: To;
+  mask?: To;
 };
 
 // Only allowed for submission navigations
@@ -1580,13 +1580,13 @@ export function createRouter(init: RouterInit): Router {
 
     // If mask is provided, normalize and create a separate path for the router
     let maskPath: Path | undefined;
-    if (opts?.unstable_mask) {
+    if (opts?.mask) {
       let partialPath =
-        typeof opts.unstable_mask === "string"
-          ? parsePath(opts.unstable_mask)
+        typeof opts.mask === "string"
+          ? parsePath(opts.mask)
           : {
-              ...state.location.unstable_mask,
-              ...opts.unstable_mask,
+              ...state.location.mask,
+              ...opts.mask,
             };
       maskPath = {
         pathname: "",

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -576,7 +576,7 @@ type BaseNavigateOrFetchOptions = {
   preventScrollReset?: boolean;
   relative?: RelativeRoutingType;
   flushSync?: boolean;
-  unstable_defaultShouldRevalidate?: boolean;
+  defaultShouldRevalidate?: boolean;
 };
 
 // Only allowed for navigations
@@ -1682,7 +1682,7 @@ export function createRouter(init: RouterInit): Router {
       enableViewTransition: opts && opts.viewTransition,
       flushSync,
       callSiteDefaultShouldRevalidate:
-        opts && opts.unstable_defaultShouldRevalidate,
+        opts && opts.defaultShouldRevalidate,
     });
   }
 
@@ -2490,7 +2490,7 @@ export function createRouter(init: RouterInit): Router {
         flushSync,
         preventScrollReset,
         submission,
-        opts && opts.unstable_defaultShouldRevalidate,
+        opts && opts.defaultShouldRevalidate,
       );
       return;
     }

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -412,7 +412,7 @@ export type HydrationState = Partial<
  * Future flags to toggle new feature behavior
  */
 export interface FutureConfig {
-  unstable_passThroughRequests: boolean;
+  v8_passThroughRequests: boolean;
 }
 
 /**
@@ -968,7 +968,7 @@ export function createRouter(init: RouterInit): Router {
 
   // Config driven behavior flags
   let future: FutureConfig = {
-    unstable_passThroughRequests: false,
+    v8_passThroughRequests: false,
     ...init.future,
   };
   // Cleanup function for history
@@ -3816,7 +3816,7 @@ export function createStaticHandler(
   // Currently unused in the static handler, but available for additional flags in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let future: FutureConfig = {
-    unstable_passThroughRequests: false, // unused in static handler
+    v8_passThroughRequests: false, // unused in static handler
     ...opts?.future,
   };
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -478,7 +478,7 @@ export interface StaticHandler {
    * @param opts.requestContext Context object to pass to loaders/actions
    * @param opts.skipLoaderErrorBubbling Skip loader error bubbling
    * @param opts.skipRevalidation Skip revalidation after action submission
-   * @param opts.unstable_normalizePath Normalize the request path
+   * @param opts.normalizePath Normalize the request path
    */
   query(
     request: Request,
@@ -496,7 +496,7 @@ export interface StaticHandler {
           },
         ) => Promise<StaticHandlerContext | Response>,
       ) => MaybePromise<Response>;
-      unstable_normalizePath?: (request: Request) => Path;
+      normalizePath?: (request: Request) => Path;
     },
   ): Promise<StaticHandlerContext | Response>;
   /**
@@ -509,7 +509,7 @@ export interface StaticHandler {
    * to generate a response to bubble back up the middleware chain
    * @param opts.requestContext Context object to pass to loaders/actions
    * @param opts.routeId The ID of the route to query
-   * @param opts.unstable_normalizePath Normalize the request path
+   * @param opts.normalizePath Normalize the request path
 
    */
   queryRoute(
@@ -521,7 +521,7 @@ export interface StaticHandler {
       generateMiddlewareResponse?: (
         queryRoute: (r: Request) => Promise<Response>,
       ) => MaybePromise<Response>;
-      unstable_normalizePath?: (request: Request) => Path;
+      normalizePath?: (request: Request) => Path;
     },
   ): Promise<any>;
 }
@@ -3883,12 +3883,17 @@ export function createStaticHandler(
       skipRevalidation,
       dataStrategy,
       generateMiddlewareResponse,
-      unstable_normalizePath,
+      normalizePath,
     }: Parameters<StaticHandler["query"]>[1] = {},
   ): Promise<StaticHandlerContext | Response> {
-    let normalizePath = unstable_normalizePath || defaultNormalizePath;
+    let normalizePathImpl = normalizePath || defaultNormalizePath;
     let method = request.method;
-    let location = createLocation("", normalizePath(request), null, "default");
+    let location = createLocation(
+      "",
+      normalizePathImpl(request),
+      null,
+      "default",
+    );
     let matches = matchRoutesImpl(
       dataRoutes,
       location,
@@ -4166,12 +4171,17 @@ export function createStaticHandler(
       requestContext,
       dataStrategy,
       generateMiddlewareResponse,
-      unstable_normalizePath,
+      normalizePath,
     }: Parameters<StaticHandler["queryRoute"]>[1] = {},
   ): Promise<any> {
-    let normalizePath = unstable_normalizePath || defaultNormalizePath;
+    let normalizePathImpl = normalizePath || defaultNormalizePath;
     let method = request.method;
-    let location = createLocation("", normalizePath(request), null, "default");
+    let location = createLocation(
+      "",
+      normalizePathImpl(request),
+      null,
+      "default",
+    );
     let matches = matchRoutesImpl(
       dataRoutes,
       location,

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -9,10 +9,10 @@ import {
   warning,
 } from "./history";
 import type {
-  unstable_ClientInstrumentation,
-  unstable_InstrumentRouteFunction,
-  unstable_InstrumentRouterFunction,
-  unstable_ServerInstrumentation,
+  ClientInstrumentation,
+  InstrumentRouteFunction,
+  InstrumentRouterFunction,
+  ServerInstrumentation,
 } from "./instrumentation";
 import {
   getRouteInstrumentationUpdates,
@@ -423,7 +423,7 @@ export interface RouterInit {
   history: History;
   basename?: string;
   getContext?: () => MaybePromise<RouterContextProvider>;
-  unstable_instrumentations?: unstable_ClientInstrumentation[];
+  instrumentations?: ClientInstrumentation[];
   mapRouteProperties?: MapRoutePropertiesFunction;
   future?: Partial<FutureConfig>;
   hydrationRouteProperties?: string[];
@@ -934,8 +934,8 @@ export function createRouter(init: RouterInit): Router {
 
   // Leverage the existing mapRouteProperties logic to execute instrumentRoute
   // (if it exists) on all routes in the application
-  if (init.unstable_instrumentations) {
-    let instrumentations = init.unstable_instrumentations;
+  if (init.instrumentations) {
+    let instrumentations = init.instrumentations;
 
     mapRouteProperties = (route: DataRouteObject) => {
       return {
@@ -943,7 +943,7 @@ export function createRouter(init: RouterInit): Router {
         ...getRouteInstrumentationUpdates(
           instrumentations
             .map((i) => i.route)
-            .filter(Boolean) as unstable_InstrumentRouteFunction[],
+            .filter(Boolean) as InstrumentRouteFunction[],
           route,
         ),
       };
@@ -3775,12 +3775,12 @@ export function createRouter(init: RouterInit): Router {
     },
   };
 
-  if (init.unstable_instrumentations) {
+  if (init.instrumentations) {
     router = instrumentClientSideRouter(
       router,
-      init.unstable_instrumentations
+      init.instrumentations
         .map((i) => i.router)
-        .filter(Boolean) as unstable_InstrumentRouterFunction[],
+        .filter(Boolean) as InstrumentRouterFunction[],
     );
   }
 
@@ -3795,7 +3795,7 @@ export function createRouter(init: RouterInit): Router {
 export interface CreateStaticHandlerOptions {
   basename?: string;
   mapRouteProperties?: MapRoutePropertiesFunction;
-  unstable_instrumentations?: Pick<unstable_ServerInstrumentation, "route">[];
+  instrumentations?: Pick<ServerInstrumentation, "route">[];
   future?: Partial<FutureConfig>;
 }
 
@@ -3822,8 +3822,8 @@ export function createStaticHandler(
 
   // Leverage the existing mapRouteProperties logic to execute instrumentRoute
   // (if it exists) on all routes in the application
-  if (opts?.unstable_instrumentations) {
-    let instrumentations = opts.unstable_instrumentations;
+  if (opts?.instrumentations) {
+    let instrumentations = opts.instrumentations;
 
     mapRouteProperties = (route: DataRouteObject) => {
       return {
@@ -3831,7 +3831,7 @@ export function createStaticHandler(
         ...getRouteInstrumentationUpdates(
           instrumentations
             .map((i) => i.route)
-            .filter(Boolean) as unstable_InstrumentRouteFunction[],
+            .filter(Boolean) as InstrumentRouteFunction[],
           route,
         ),
       };
@@ -3974,7 +3974,7 @@ export function createStaticHandler(
           {
             request,
             unstable_url: createDataFunctionUrl(request, location),
-            unstable_pattern: getRoutePattern(matches),
+            pattern: getRoutePattern(matches),
             matches,
             params: matches[0].params,
             // If we're calling middleware then it must be enabled so we can cast
@@ -4214,7 +4214,7 @@ export function createStaticHandler(
         {
           request,
           unstable_url: createDataFunctionUrl(request, location),
-          unstable_pattern: getRoutePattern(matches),
+          pattern: getRoutePattern(matches),
           matches,
           params: matches[0].params,
           // If we're calling middleware then it must be enabled so we can cast
@@ -6101,7 +6101,7 @@ function getDataStrategyMatch(
   manifest: RouteManifest,
   request: Request,
   path: To,
-  unstable_pattern: string,
+  pattern: string,
   match: DataRouteMatch,
   lazyRoutePropertiesToSkip: string[],
   scopedContext: unknown,
@@ -6172,7 +6172,7 @@ function getDataStrategyMatch(
         return callLoaderOrAction({
           request,
           path,
-          unstable_pattern,
+          pattern,
           match,
           lazyHandlerPromise: _lazyPromises?.handler,
           lazyRoutePromise: _lazyPromises?.route,
@@ -6254,7 +6254,7 @@ async function callDataStrategyImpl(
   > = {
     request,
     unstable_url: createDataFunctionUrl(request, path),
-    unstable_pattern: getRoutePattern(matches),
+    pattern: getRoutePattern(matches),
     params: matches[0].params,
     context: scopedContext,
     matches,
@@ -6313,7 +6313,7 @@ async function callDataStrategyImpl(
 async function callLoaderOrAction({
   request,
   path,
-  unstable_pattern,
+  pattern,
   match,
   lazyHandlerPromise,
   lazyRoutePromise,
@@ -6322,7 +6322,7 @@ async function callLoaderOrAction({
 }: {
   request: Request;
   path: To;
-  unstable_pattern: string;
+  pattern: string;
   match: DataRouteMatch;
   lazyHandlerPromise: Promise<void> | undefined;
   lazyRoutePromise: Promise<void> | undefined;
@@ -6357,7 +6357,7 @@ async function callLoaderOrAction({
         {
           request,
           unstable_url: createDataFunctionUrl(request, path),
-          unstable_pattern,
+          pattern,
           params: match.params,
           context: scopedContext,
         },

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -3973,7 +3973,7 @@ export function createStaticHandler(
         let response = await runServerMiddlewarePipeline(
           {
             request,
-            unstable_url: createDataFunctionUrl(request, location),
+            url: createDataFunctionUrl(request, location),
             pattern: getRoutePattern(matches),
             matches,
             params: matches[0].params,
@@ -4213,7 +4213,7 @@ export function createStaticHandler(
       let response = await runServerMiddlewarePipeline(
         {
           request,
-          unstable_url: createDataFunctionUrl(request, location),
+          url: createDataFunctionUrl(request, location),
           pattern: getRoutePattern(matches),
           matches,
           params: matches[0].params,
@@ -6253,7 +6253,7 @@ async function callDataStrategyImpl(
     "fetcherKey" | "runClientMiddleware"
   > = {
     request,
-    unstable_url: createDataFunctionUrl(request, path),
+    url: createDataFunctionUrl(request, path),
     pattern: getRoutePattern(matches),
     params: matches[0].params,
     context: scopedContext,
@@ -6356,7 +6356,7 @@ async function callLoaderOrAction({
       return handler(
         {
           request,
-          unstable_url: createDataFunctionUrl(request, path),
+          url: createDataFunctionUrl(request, path),
           pattern,
           params: match.params,
           context: scopedContext,
@@ -6656,7 +6656,7 @@ function createClientSideRequest(
   return new Request(url, init);
 }
 
-// Create the unstable_url object to pass to loaders/actions/middleware.
+// Create the normalized URL instance to pass to loaders/actions/middleware.
 // We strip the `?index` param because that is a React Router implementation detail.
 function createDataFunctionUrl(request: Request, path: To): URL {
   let url = new URL(request.url);

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -411,9 +411,7 @@ export type HydrationState = Partial<
 /**
  * Future flags to toggle new feature behavior
  */
-export interface FutureConfig {
-  v8_passThroughRequests: boolean;
-}
+export interface FutureConfig {}
 
 /**
  * Initialization options for createRouter
@@ -968,7 +966,6 @@ export function createRouter(init: RouterInit): Router {
 
   // Config driven behavior flags
   let future: FutureConfig = {
-    v8_passThroughRequests: false,
     ...init.future,
   };
   // Cleanup function for history
@@ -1681,8 +1678,7 @@ export function createRouter(init: RouterInit): Router {
       replace: opts && opts.replace,
       enableViewTransition: opts && opts.viewTransition,
       flushSync,
-      callSiteDefaultShouldRevalidate:
-        opts && opts.defaultShouldRevalidate,
+      callSiteDefaultShouldRevalidate: opts && opts.defaultShouldRevalidate,
     });
   }
 
@@ -3816,7 +3812,6 @@ export function createStaticHandler(
   // Currently unused in the static handler, but available for additional flags in the future
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let future: FutureConfig = {
-    v8_passThroughRequests: false, // unused in static handler
     ...opts?.future,
   };
 

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -278,7 +278,7 @@ interface DataFunctionArgs<Context> {
    * suffixes, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.
    */
-  unstable_url: URL;
+  url: URL;
   /**
    * Matched un-interpolated route pattern for the current path (i.e., /blog/:slug).
    * Mostly useful as a identifier to aggregate on for logging/tracing/etc.

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -271,12 +271,12 @@ interface DataFunctionArgs<Context> {
   /** A {@link https://developer.mozilla.org/en-US/docs/Web/API/Request Fetch Request instance} which you can use to read headers (like cookies, and {@link https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams URLSearchParams} from the request. */
   request: Request;
   /**
-   * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.v8_passThroughRequests` enabled, this is a normalized
-   * URL with React-Router-specific implementation details removed (`.data`
-   * suffixes, `index`/`_routes` search params).
-   * The URL includes the origin from the request for convenience.
+   * A URL instance representing the application location being navigated to or
+   * fetched. By default, this matches `request.url`.
+   *
+   * In Framework mode with `future.v8_passThroughRequests` enabled, this is a
+   * normalized URL with React-Router-specific implementation details removed
+   * (`.data` suffixes, `index`/`_routes` search params).
    */
   url: URL;
   /**
@@ -776,7 +776,7 @@ type Regex_w = Regex_az | Regex_AZ | Regex_09 | "_";
 
 // prettier-ignore
 /** Emulates Regex `+` operator */
-type RegexMatchPlus<char extends string, T extends string> = 
+type RegexMatchPlus<char extends string, T extends string> =
   _RegexMatchPlus<char, T> extends infer result extends string ?
     result extends '' ? never : result
   :

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -272,8 +272,8 @@ interface DataFunctionArgs<Context> {
   request: Request;
   /**
    * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.unstable_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.unstable_passThroughRequests` enabled, this is a normalized
+   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
+   * With `future.v8_passThroughRequests` enabled, this is a normalized
    * URL with React-Router-specific implementation details removed (`.data`
    * suffixes, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -283,7 +283,7 @@ interface DataFunctionArgs<Context> {
    * Matched un-interpolated route pattern for the current path (i.e., /blog/:slug).
    * Mostly useful as a identifier to aggregate on for logging/tracing/etc.
    */
-  unstable_pattern: string;
+  pattern: string;
   /**
    * {@link https://reactrouter.com/start/framework/routing#dynamic-segments Dynamic route params} for the current route.
    * @example

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -842,7 +842,6 @@ export function RSCHydratedRouter({
       // These flags have no runtime impact so can always be false.  If we add
       // flags that drive runtime behavior they'll need to be proxied through.
       v8_middleware: false,
-      unstable_subResourceIntegrity: false,
       unstable_trailingSlashAwareDataRequests: true, // always on for RSC
       v8_passThroughRequests: true, // always on for RSC
     },

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -844,7 +844,7 @@ export function RSCHydratedRouter({
       v8_middleware: false,
       unstable_subResourceIntegrity: false,
       unstable_trailingSlashAwareDataRequests: true, // always on for RSC
-      unstable_passThroughRequests: true, // always on for RSC
+      v8_passThroughRequests: true, // always on for RSC
     },
     isSpaMode: false,
     ssr: true,

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -748,7 +748,7 @@ async function generateResourceResponse(
           return generateErrorResponse(error);
         }
       },
-      unstable_normalizePath: (r) => getNormalizedPath(r, basename, null),
+      normalizePath: (r) => getNormalizedPath(r, basename, null),
     });
     return response;
   } catch (error) {
@@ -841,7 +841,7 @@ async function generateRenderResponse(
       ...(routeIdsToLoad
         ? { filterMatchesToLoad: (m) => routeIdsToLoad!.includes(m.route.id) }
         : {}),
-      unstable_normalizePath: (r) => getNormalizedPath(r, basename, null),
+      normalizePath: (r) => getNormalizedPath(r, basename, null),
       async generateMiddlewareResponse(query) {
         // If this is an RSC server action, process that and then call query as a
         // revalidation.  If this is a RR Form/Fetcher submission,

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -581,7 +581,6 @@ export function RSCStaticRouter({ getPayload }: RSCStaticRouterProps) {
       // These flags have no runtime impact so can always be false.  If we add
       // flags that drive runtime behavior they'll need to be proxied through.
       v8_middleware: false,
-      unstable_subResourceIntegrity: false,
       unstable_trailingSlashAwareDataRequests: true, // always on for RSC
       v8_passThroughRequests: true, // always on for RSC
     },

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -583,7 +583,7 @@ export function RSCStaticRouter({ getPayload }: RSCStaticRouterProps) {
       v8_middleware: false,
       unstable_subResourceIntegrity: false,
       unstable_trailingSlashAwareDataRequests: true, // always on for RSC
-      unstable_passThroughRequests: true, // always on for RSC
+      v8_passThroughRequests: true, // always on for RSC
     },
     isSpaMode: false,
     ssr: true,

--- a/packages/react-router/lib/server-runtime/build.ts
+++ b/packages/react-router/lib/server-runtime/build.ts
@@ -12,7 +12,7 @@ import type {
 import type { ServerRouteManifest } from "./routes";
 import type { AppLoadContext } from "./data";
 import type { MiddlewareEnabled } from "../types/future";
-import type { unstable_ServerInstrumentation } from "../router/instrumentation";
+import type { ServerInstrumentation } from "../router/instrumentation";
 
 type OptionalCriticalCss = CriticalCss | undefined;
 
@@ -87,6 +87,6 @@ export interface ServerEntryModule {
   default: HandleDocumentRequestFunction;
   handleDataRequest?: HandleDataRequestFunction;
   handleError?: HandleErrorFunction;
-  unstable_instrumentations?: unstable_ServerInstrumentation[];
+  instrumentations?: ServerInstrumentation[];
   streamTimeout?: number;
 }

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -28,7 +28,7 @@ export async function callRouteHandler(
     request: future.v8_passThroughRequests
       ? args.request
       : stripRoutesParam(stripIndexParam(args.request)),
-    unstable_url: args.unstable_url,
+    url: args.url,
     params: args.params,
     context: args.context,
     pattern: args.pattern,

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -4,8 +4,8 @@ import type {
   LoaderFunctionArgs,
   ActionFunctionArgs,
 } from "../router/utils";
-import type { FutureConfig } from "../router/router";
 import { isDataWithResponseInit, isRedirectStatusCode } from "../router/router";
+import type { FutureConfig } from "../dom/ssr/entry";
 
 /**
  * An object of unknown type for route loaders and actions provided by the

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -25,7 +25,7 @@ export async function callRouteHandler(
   future: FutureConfig,
 ) {
   let result = await handler({
-    request: future.unstable_passThroughRequests
+    request: future.v8_passThroughRequests
       ? args.request
       : stripRoutesParam(stripIndexParam(args.request)),
     unstable_url: args.unstable_url,

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -31,7 +31,7 @@ export async function callRouteHandler(
     unstable_url: args.unstable_url,
     params: args.params,
     context: args.context,
-    unstable_pattern: args.unstable_pattern,
+    pattern: args.pattern,
   });
 
   // If they returned a redirect via data(), re-throw it as a Response

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -40,7 +40,7 @@ import { getDocumentHeaders } from "./headers";
 import type { EntryRoute } from "../dom/ssr/routes";
 import type { MiddlewareEnabled } from "../types/future";
 import { URL_LIMIT, getManifestPath } from "../dom/ssr/fog-of-war";
-import type { unstable_InstrumentRequestHandlerFunction } from "../router/instrumentation";
+import type { InstrumentRequestHandlerFunction } from "../router/instrumentation";
 import { instrumentHandler } from "../router/instrumentation";
 import { throwIfPotentialCSRFAttack } from "../actions";
 import { getNormalizedPath } from "./urls";
@@ -62,7 +62,7 @@ function derive(build: ServerBuild, mode?: string) {
   let serverMode = isServerMode(mode) ? mode : ServerMode.Production;
   let staticHandler = createStaticHandler(dataRoutes, {
     basename: build.basename,
-    unstable_instrumentations: build.entry.module.unstable_instrumentations,
+    instrumentations: build.entry.module.instrumentations,
     future: build.future,
   });
 
@@ -304,12 +304,12 @@ function derive(build: ServerBuild, mode?: string) {
     return response;
   };
 
-  if (build.entry.module.unstable_instrumentations) {
+  if (build.entry.module.instrumentations) {
     requestHandler = instrumentHandler(
       requestHandler,
-      build.entry.module.unstable_instrumentations
+      build.entry.module.instrumentations
         .map((i) => i.handler)
-        .filter(Boolean) as unstable_InstrumentRequestHandlerFunction[],
+        .filter(Boolean) as InstrumentRequestHandlerFunction[],
     );
   }
 

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -510,7 +510,7 @@ async function handleDocumentRequest(
             }
           }
         : undefined,
-      unstable_normalizePath: (r) =>
+      normalizePath: (r) =>
         getNormalizedPath(r, build.basename, build.future),
     });
 
@@ -689,7 +689,7 @@ async function handleResourceRequest(
             }
           }
         : undefined,
-      unstable_normalizePath: (r) =>
+      normalizePath: (r) =>
         getNormalizedPath(r, build.basename, build.future),
     });
 

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -79,7 +79,7 @@ export async function singleFetchAction(
             }
           }
         : undefined,
-      unstable_normalizePath: (r) =>
+      normalizePath: (r) =>
         getNormalizedPath(r, build.basename, build.future),
     });
 
@@ -173,7 +173,7 @@ export async function singleFetchLoaders(
             }
           }
         : undefined,
-      unstable_normalizePath: (r) =>
+      normalizePath: (r) =>
         getNormalizedPath(r, build.basename, build.future),
     });
 

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -55,7 +55,7 @@ export async function singleFetchAction(
       return handleQueryError(new Error("Bad Request"), 400);
     }
 
-    let handlerRequest = build.future.unstable_passThroughRequests
+    let handlerRequest = build.future.v8_passThroughRequests
       ? request
       : new Request(handlerUrl, {
           method: request.method,
@@ -152,7 +152,7 @@ export async function singleFetchLoaders(
   let loadRouteIds = routesParam ? new Set(routesParam.split(",")) : null;
 
   try {
-    let handlerRequest = build.future.unstable_passThroughRequests
+    let handlerRequest = build.future.v8_passThroughRequests
       ? request
       : new Request(handlerUrl, {
           headers: request.headers,

--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -80,8 +80,8 @@ export type ClientDataFunctionArgs<Params> = {
   request: Request;
   /**
    * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.unstable_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.unstable_passThroughRequests` enabled, this is a normalized
+   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
+   * With `future.v8_passThroughRequests` enabled, this is a normalized
    * URL with React-Router-specific implementation details removed (`.data`
    * pathnames, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.
@@ -123,8 +123,8 @@ export type ServerDataFunctionArgs<Params> = {
   request: Request;
   /**
    * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.unstable_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.unstable_passThroughRequests` enabled, this is a normalized
+   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
+   * With `future.v8_passThroughRequests` enabled, this is a normalized
    * URL with React-Router-specific implementation details removed (`.data`
    * pathnames, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.

--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -79,12 +79,12 @@ export type ClientDataFunctionArgs<Params> = {
    **/
   request: Request;
   /**
-   * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.v8_passThroughRequests` enabled, this is a normalized
-   * URL with React-Router-specific implementation details removed (`.data`
-   * pathnames, `index`/`_routes` search params).
-   * The URL includes the origin from the request for convenience.
+   * A URL instance representing the application location being navigated to or
+   * fetched. By default, this matches `request.url`.
+   *
+   * In Framework mode with `future.v8_passThroughRequests` enabled, this is a
+   * normalized URL with React-Router-specific implementation details removed
+   * (`.data` suffixes, `index`/`_routes` search params).
    */
   url: URL;
   /**
@@ -122,12 +122,12 @@ export type ServerDataFunctionArgs<Params> = {
   /** A {@link https://developer.mozilla.org/en-US/docs/Web/API/Request Fetch Request instance} which you can use to read the url, method, headers (such as cookies), and request body from the request. */
   request: Request;
   /**
-   * A URL instance representing the application location being navigated to or fetched.
-   * Without `future.v8_passThroughRequests` enabled, this matches `request.url`.
-   * With `future.v8_passThroughRequests` enabled, this is a normalized
-   * URL with React-Router-specific implementation details removed (`.data`
-   * pathnames, `index`/`_routes` search params).
-   * The URL includes the origin from the request for convenience.
+   * A URL instance representing the application location being navigated to or
+   * fetched. By default, this matches `request.url`.
+   *
+   * In Framework mode with `future.v8_passThroughRequests` enabled, this is a
+   * normalized URL with React-Router-specific implementation details removed
+   * (`.data` suffixes, `index`/`_routes` search params).
    */
   url: URL;
   /**

--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -86,7 +86,7 @@ export type ClientDataFunctionArgs<Params> = {
    * pathnames, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.
    */
-  unstable_url: URL;
+  url: URL;
   /**
    * {@link https://reactrouter.com/start/framework/routing#dynamic-segments Dynamic route params} for the current route.
    * @example
@@ -129,7 +129,7 @@ export type ServerDataFunctionArgs<Params> = {
    * pathnames, `index`/`_routes` search params).
    * The URL includes the origin from the request for convenience.
    */
-  unstable_url: URL;
+  url: URL;
   /**
    * {@link https://reactrouter.com/start/framework/routing#dynamic-segments Dynamic route params} for the current route.
    * @example

--- a/packages/react-router/lib/types/route-data.ts
+++ b/packages/react-router/lib/types/route-data.ts
@@ -106,7 +106,7 @@ export type ClientDataFunctionArgs<Params> = {
    * Matched un-interpolated route pattern for the current path (i.e., /blog/:slug).
    * Mostly useful as a identifier to aggregate on for logging/tracing/etc.
    */
-  unstable_pattern: string;
+  pattern: string;
   /**
    * When `future.v8_middleware` is not enabled, this is undefined.
    *
@@ -149,7 +149,7 @@ export type ServerDataFunctionArgs<Params> = {
    * Matched un-interpolated route pattern for the current path (i.e., /blog/:slug).
    * Mostly useful as a identifier to aggregate on for logging/tracing/etc.
    */
-  unstable_pattern: string;
+  pattern: string;
   /**
    * Without `future.v8_middleware` enabled, this is the context passed in
    * to your server adapter's `getLoadContext` function. It's a way to bridge the

--- a/playground/framework-vite-6/react-router.config.ts
+++ b/playground/framework-vite-6/react-router.config.ts
@@ -1,7 +1,5 @@
 import type { Config } from "@react-router/dev/config";
 
 export default {
-  future: {
-    unstable_subResourceIntegrity: true,
-  },
+  subResourceIntegrity: true,
 } satisfies Config;

--- a/playground/framework-vite-7-beta/react-router.config.ts
+++ b/playground/framework-vite-7-beta/react-router.config.ts
@@ -1,8 +1,8 @@
 import type { Config } from "@react-router/dev/config";
 
 export default {
+  subResourceIntegrity: true,
   future: {
-    unstable_subResourceIntegrity: true,
     unstable_optimizeDeps: true,
     v8_viteEnvironmentApi: true,
   },

--- a/playground/framework/react-router.config.ts
+++ b/playground/framework/react-router.config.ts
@@ -1,8 +1,8 @@
 import type { Config } from "@react-router/dev/config";
 
 export default {
+  subResourceIntegrity: true,
   future: {
-    unstable_subResourceIntegrity: true,
     unstable_optimizeDeps: true,
     v8_viteEnvironmentApi: true,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2022,6 +2022,9 @@ importers:
       '@octokit/request':
         specifier: ^9.1.3
         version: 9.2.4
+      react-router:
+        specifier: workspace:^
+        version: link:../packages/react-router
       semver:
         specifier: ^7.7.2
         version: 7.7.4

--- a/scripts/bench/passthrough-requests.bench.mjs
+++ b/scripts/bench/passthrough-requests.bench.mjs
@@ -1,5 +1,5 @@
 /**
- * Benchmark: unstable_passThroughRequests flag
+ * Benchmark: passThroughRequests flag
  *
  * Measures the overhead of creating new Request objects on each server handler
  * invocation (default behavior) vs passing the original request through.
@@ -13,7 +13,7 @@
  */
 
 import { bench, describe } from "vitest";
-import { createRequestHandler } from "../../packages/react-router/dist/production/index.js";
+import { createRequestHandler } from "react-router";
 
 // ---------------------------------------------------------------------------
 // Minimal server build factory
@@ -24,12 +24,7 @@ function mockServerBuild(future = {}) {
 
   return {
     ssr: true,
-    future: {
-      v8_middleware: false,
-      unstable_subResourceIntegrity: false,
-      unstable_passThroughRequests: false,
-      ...future,
-    },
+    future,
     prerender: [],
     isSpaMode: false,
     routeDiscovery: { mode: "lazy", manifestPath: "/__manifest" },
@@ -64,8 +59,6 @@ function mockServerBuild(future = {}) {
         default: async (_request, statusCode, headers) =>
           new Response(null, { status: statusCode, headers }),
         handleDataRequest: async (response) => response,
-        handleError: undefined,
-        unstable_instrumentations: undefined,
       },
     },
     routes: {
@@ -91,12 +84,12 @@ function mockServerBuild(future = {}) {
 // ---------------------------------------------------------------------------
 
 const handlerDefault = createRequestHandler(
-  mockServerBuild({ unstable_passThroughRequests: false }),
+  mockServerBuild({ v8_passThroughRequests: false }),
   "production",
 );
 
 const handlerPassThrough = createRequestHandler(
-  mockServerBuild({ unstable_passThroughRequests: true }),
+  mockServerBuild({ v8_passThroughRequests: true }),
   "production",
 );
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@octokit/request": "^9.1.3",
+    "react-router": "workspace:^",
     "semver": "^7.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Stabilize a bunch of APIs in preparation for v8:

* `prerender.unstable_concurrency → prerender.concurrency`
* `future.unstable_passThroughRequests → future.v8_passThroughRequests` and `unstable_url -> url`
* `unstable_instrumentations` / `unstable_pattern` and associated types (`ServerInstrumentation`, `ClientInstrumentation`, etc.)
* `unstable_defaultShouldRevalidate → defaultShouldRevalidate`
* `unstable_useTransitions → useTransitions`
* `unstable_mask → mask` (on `<Link>`, `useLinkClickHandler`, `useNavigate`, and `Location`)
* `future.unstable_subResourceIntegrity` → top-level `config.subResourceIntegrity`