### PR TITLE
Add nonce to scripts `modulepreload`

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -3,6 +3,7 @@
 - 43081j
 - aarbi
 - abdallah-nour
+- abdulwahaab710
 - abeadam
 - abhi-kr-2100
 - abhijeetpandit7

--- a/integration/sri-test.ts
+++ b/integration/sri-test.ts
@@ -71,4 +71,17 @@ test.describe("CSub-Resource Integrity", () => {
       await page.locator('script[type="importmap"]').getAttribute("nonce"),
     ).toBe("test-nonce-123");
   });
+
+  test("includes a nonce on modulepreload links", async ({ page }) => {
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/");
+    let modulePreloads = page.locator('link[rel="modulepreload"]');
+    let count = await modulePreloads.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      expect(await modulePreloads.nth(i).getAttribute("nonce")).toBe(
+        "test-nonce-123",
+      );
+    }
+  });
 });

--- a/packages/react-router/.changes/patch.add-nonce-scripts-modulepreload.md
+++ b/packages/react-router/.changes/patch.add-nonce-scripts-modulepreload.md
@@ -1,0 +1,1 @@
+Add nonce to scripts modulepreload

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -390,6 +390,84 @@ describe("<Links />", () => {
   });
 });
 
+describe("<Scripts />", () => {
+  it("propagates nonce to modulepreload links", async () => {
+    let staticHandlerContext = await createStaticHandler([{ path: "/" }]).query(
+      new Request("http://localhost/"),
+    );
+
+    invariant(
+      !(staticHandlerContext instanceof Response),
+      "Expected a context",
+    );
+
+    let context = mockEntryContext({
+      manifest: {
+        routes: {
+          root: {
+            hasLoader: false,
+            hasAction: false,
+            hasErrorBoundary: false,
+            id: "root",
+            module: "root.js",
+            path: "/",
+          },
+        },
+        entry: {
+          imports: ["preload-a.js", "preload-b.js"],
+          module: "entry.js",
+        },
+        url: "manifest.js",
+        version: "",
+      },
+      routeDiscovery: { mode: "initial", manifestPath: "/__manifest" },
+      routeModules: {
+        root: {
+          default: () => (
+            <>
+              <h1>Root</h1>
+              <Scripts nonce="test-nonce" />
+            </>
+          ),
+        },
+      },
+    });
+
+    let { container } = render(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    let modulePreloads = container.ownerDocument.querySelectorAll(
+      'link[rel="modulepreload"]',
+    );
+    expect(modulePreloads.length).toBeGreaterThan(0);
+    modulePreloads.forEach((link) => {
+      expect(link).toHaveAttribute("nonce", "test-nonce");
+    });
+
+    expect(
+      container.ownerDocument.querySelector(
+        'link[rel="modulepreload"][href="manifest.js"]',
+      ),
+    ).toHaveAttribute("nonce", "test-nonce");
+    expect(
+      container.ownerDocument.querySelector(
+        'link[rel="modulepreload"][href="entry.js"]',
+      ),
+    ).toHaveAttribute("nonce", "test-nonce");
+    expect(
+      container.ownerDocument.querySelector(
+        'link[rel="modulepreload"][href="preload-a.js"]',
+      ),
+    ).toHaveAttribute("nonce", "test-nonce");
+    expect(
+      container.ownerDocument.querySelector(
+        'link[rel="modulepreload"][href="preload-b.js"]',
+      ),
+    ).toHaveAttribute("nonce", "test-nonce");
+  });
+});
+
 describe("usePrefetchBehavior", () => {
   function TestComponent({
     prefetch,

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -1011,6 +1011,7 @@ import(${JSON.stringify(manifest.entry.module)});`;
           href={manifest.url}
           crossOrigin={scriptProps.crossOrigin}
           integrity={sri[manifest.url]}
+          nonce={scriptProps.nonce}
           suppressHydrationWarning
         />
       ) : null}
@@ -1019,6 +1020,7 @@ import(${JSON.stringify(manifest.entry.module)});`;
         href={manifest.entry.module}
         crossOrigin={scriptProps.crossOrigin}
         integrity={sri[manifest.entry.module]}
+        nonce={scriptProps.nonce}
         suppressHydrationWarning
       />
       {preloads.map((path) => (
@@ -1028,6 +1030,7 @@ import(${JSON.stringify(manifest.entry.module)});`;
           href={path}
           crossOrigin={scriptProps.crossOrigin}
           integrity={sri[path]}
+          nonce={scriptProps.nonce}
           suppressHydrationWarning
         />
       ))}


### PR DESCRIPTION
### What are you trying to accomplish in this PR?

When `<Scripts nonce>` is set, the nonce is threaded to the `<script>` and `<script type="importmap">` tags, but the `<link rel="modulepreload">` tags `<Scripts>` emits during SSR are rendered without it. Under a strict CSP like `script-src 'nonce-...' 'strict-dynamic'`, those modulepreloads are blocked on first paint — the browser never warms the module cache, and (depending on the policy) the violation is reported on every navigation.

This PR passes `nonce` through to those `<link rel="modulepreload">` tags so they match the script tags they're preloading.


### How did you accomplish this and why did you choose this approach?

In [`packages/react-router/lib/dom/ssr/components.tsx`](https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/packages/react-router/lib/dom/ssr/components.tsx#L1008-L1036), the `<Scripts>` component already forwards `nonce` via `scriptProps.nonce` to the `<script>` and importmap tags. I set the same attribute on the three `<link rel="modulepreload">` branches emitted by `<Scripts>` (manifest, entry module, and per-route preloads):

- Manifest preload: https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/packages/react-router/lib/dom/ssr/components.tsx#L1008-L1017
- Entry module preload: https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/packages/react-router/lib/dom/ssr/components.tsx#L1018-L1025
- Per-route preloads: https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/packages/react-router/lib/dom/ssr/components.tsx#L1026-L1036

That keeps the propagation consistent with how nonce already flows through the component — no new prop plumbing, no API change.

Coverage:

- Unit test: [`packages/react-router/__tests__/dom/ssr/components-test.tsx` L393-L469](https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/packages/react-router/__tests__/dom/ssr/components-test.tsx#L393-L469) — renders `<Scripts nonce="test-nonce" />` through `ServerRouter` and asserts every `link[rel="modulepreload"]` (manifest, entry, and each route preload) carries the nonce.
- Integration test: [`integration/sri-test.ts` L74-L86](https://github.com/remix-run/react-router/blob/58f37462212367827bd7bce93c2f395f3d59e880/integration/sri-test.ts#L74-L86) — reuses the existing strict-CSP fixture and asserts the nonce attribute on every rendered modulepreload link in the browser.
