### PR TITLE
fix(dev): prune unused dot-server imports

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -231,6 +231,7 @@
 - kigawas
 - kilavvy
 - kiliman
+- KimHyeongRae0
 - kirillgroshkov
 - kkirsche
 - kno-raziel

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -76,6 +76,24 @@ test("Vite / dead-code elimination for server exports", async () => {
   expect(lines).toHaveLength(0);
 });
 
+test("Vite / unused route import from .server directory", async () => {
+  let cwd = await createProject({
+    "app/.server/fun.ts": serverOnlyModule,
+    "app/routes/_index.tsx": `
+      import { serverOnly } from "../.server/fun";
+
+      export default function Index() {
+        return <h1>Index</h1>;
+      }
+    `,
+  });
+  let { status } = build({ cwd });
+  expect(status).toBe(0);
+
+  let lines = grep(path.join(cwd, "build/client"), /SERVER_ONLY|\.server\/fun/);
+  expect(lines).toHaveLength(0);
+});
+
 test.describe("Vite / route / server-only module referenced by client", () => {
   let matrix = [
     { type: "file", path: "app/utils.server.ts", specifier: `~/utils.server` },

--- a/packages/react-router-dev/.changes/patch.dot-server-unused-imports.md
+++ b/packages/react-router-dev/.changes/patch.dot-server-unused-imports.md
@@ -1,0 +1,1 @@
+Avoid failing client builds for unused imports from `.server` directories in Framework mode

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2417,7 +2417,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
         let ast = parse(code, { sourceType: "module" });
         if (!options?.ssr) {
-          removeExports(ast, SERVER_ONLY_ROUTE_EXPORTS);
+          removeExports(ast, SERVER_ONLY_ROUTE_EXPORTS, {
+            removeUnusedImportSpecifiers: isDotServerImportPath,
+          });
         }
         decorateComponentExportsWithProps(ast);
         return generate(ast, {
@@ -2981,6 +2983,12 @@ function isRoute(
   file: string,
 ): boolean {
   return Boolean(getRoute(pluginConfig, file));
+}
+
+function isDotServerImportPath(specifier: string) {
+  let serverFileRE = /\.server(\.[cm]?[jt]sx?)?$/;
+  let serverDirRE = /(?:^|\/)\.server(?:\/|$)/;
+  return serverFileRE.test(specifier) || serverDirRE.test(specifier);
 }
 
 async function getRouteMetadata(

--- a/packages/react-router-dev/vite/remove-exports-test.ts
+++ b/packages/react-router-dev/vite/remove-exports-test.ts
@@ -1,9 +1,13 @@
 import { generate, parse } from "./babel";
 import { removeExports } from "./remove-exports";
 
-function transform(code: string, exportsToRemove: string[]) {
+function transform(
+  code: string,
+  exportsToRemove: string[],
+  options?: Parameters<typeof removeExports>[2],
+) {
   let ast = parse(code, { sourceType: "module" });
-  removeExports(ast, exportsToRemove);
+  removeExports(ast, exportsToRemove, options);
   return generate(ast);
 }
 
@@ -56,6 +60,53 @@ describe("transform", () => {
       export const keptExport_2 = () => keptUtil();"
     `);
     expect(result.code).not.toMatch(/removed/i);
+  });
+
+  test("unused import specifiers from matched sources", () => {
+    let result = transform(
+      `
+      import { serverOnly } from '../.server/fun'
+      import { unusedClientValue } from './client-module'
+
+      export default function Route() {
+        return null;
+      }
+    `,
+      ["loader"],
+      {
+        removeUnusedImportSpecifiers: (source) => source.includes("/.server/"),
+      },
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { unusedClientValue } from './client-module';
+      export default function Route() {
+        return null;
+      }"
+    `);
+    expect(result.code).not.toMatch(/serverOnly|\.server/);
+  });
+
+  test("used import specifiers from matched sources", () => {
+    let result = transform(
+      `
+      import { serverOnly, unusedServerOnly } from '../.server/fun'
+
+      export default function Route() {
+        return serverOnly;
+      }
+    `,
+      ["loader"],
+      {
+        removeUnusedImportSpecifiers: (source) => source.includes("/.server/"),
+      },
+    );
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { serverOnly } from '../.server/fun';
+      export default function Route() {
+        return serverOnly;
+      }"
+    `);
+    expect(result.code).not.toMatch(/unusedServerOnly/);
   });
 
   test("arrow function with property assignment", () => {

--- a/packages/react-router-dev/vite/remove-exports.ts
+++ b/packages/react-router-dev/vite/remove-exports.ts
@@ -9,6 +9,9 @@ import { traverse } from "./babel";
 export const removeExports = (
   ast: ParseResult<Babel.File>,
   exportsToRemove: readonly string[],
+  options?: {
+    removeUnusedImportSpecifiers?: (source: string) => boolean;
+  },
 ) => {
   let previouslyReferencedIdentifiers = findReferencedIdentifiers(ast);
   let exportsFiltered = false;
@@ -156,7 +159,43 @@ export const removeExports = (
     // Run dead code elimination on any newly unreferenced identifiers
     deadCodeElimination(ast, previouslyReferencedIdentifiers);
   }
+
+  if (options?.removeUnusedImportSpecifiers) {
+    removeUnusedImportSpecifiers(ast, options.removeUnusedImportSpecifiers);
+  }
 };
+
+function removeUnusedImportSpecifiers(
+  ast: ParseResult<Babel.File>,
+  shouldRemoveFromSource: (source: string) => boolean,
+) {
+  traverse(ast, {
+    Program(path) {
+      path.scope.crawl();
+    },
+    ImportDeclaration(path) {
+      if (!shouldRemoveFromSource(path.node.source.value)) {
+        return;
+      }
+
+      let removalsBefore = path.node.specifiers.length;
+      for (let specifier of path.get("specifiers")) {
+        let local = specifier.get("local");
+        let binding = local.scope.getBinding(local.node.name);
+
+        if (!binding?.referenced) {
+          specifier.remove();
+        }
+      }
+
+      if (removalsBefore > path.node.specifiers.length) {
+        if (path.node.specifiers.length === 0) {
+          path.remove();
+        }
+      }
+    },
+  });
+}
 
 function validateDestructuredExports(
   id: Babel.ArrayPattern | Babel.ObjectPattern,


### PR DESCRIPTION
Fixes #14997.

Summary: prunes unused `.server` imports from Framework client transforms while preserving used server-only errors.

Tests: remove-exports, dot-server integration, changes validation, diff check.
