### PR TITLE
fix(dev): isolate route config app directory context

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -352,6 +352,7 @@
 - Quatton
 - QzCurious
 - raphaelbronsveld
+- razakiau
 - redabacha
 - refusado
 - remorses

--- a/integration/route-config-test.ts
+++ b/integration/route-config-test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect } from "@playwright/test";
+import { resolveConfig } from "vite";
 
 import {
   type Files,
@@ -269,6 +270,151 @@ test.describe("route config", () => {
         await expect(page.locator("[data-test-route]")).toHaveText(
           "Test route",
         );
+      });
+
+      test.describe("concurrent Vite config resolution keeps route config isolated", () => {
+        async function expectConcurrentConfigResolution(
+          ...appDirectories: string[]
+        ) {
+          let results = await Promise.allSettled(
+            appDirectories.map((appDirectory) =>
+              resolveConfig(
+                {
+                  configFile: path.join(appDirectory, "vite.config.ts"),
+                  mode: "development",
+                  root: appDirectory,
+                },
+                "build",
+              ),
+            ),
+          );
+
+          let failures = results.filter(
+            (result): result is PromiseRejectedResult =>
+              result.status === "rejected",
+          );
+
+          expect(
+            failures.map((failure) => failure.reason?.stack ?? failure.reason),
+          ).toEqual([]);
+        }
+
+        test("when apps mix manual routes and flatRoutes", async () => {
+          let appA = await createProject(
+            {
+              "app/routes.ts": js`
+                import { route, type RouteConfig } from "@react-router/dev/routes";
+
+                export default [route("login", "./routes/login.tsx")] satisfies RouteConfig;
+              `,
+              "app/routes/login.tsx": js`
+                export default function Login() {
+                  return <h1>Login</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          let appB = await createProject(
+            {
+              "app/routes.ts": js`
+                import { type RouteConfig } from "@react-router/dev/routes";
+                import { flatRoutes } from "@react-router/fs-routes";
+
+                await new Promise((resolve) => setTimeout(resolve, 25));
+
+                export default flatRoutes() satisfies RouteConfig;
+              `,
+              "app/routes/dashboard.tsx": js`
+                export default function Dashboard() {
+                  return <h1>Dashboard</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          let appC = await createProject(
+            {
+              "app/routes.ts": js`
+                import { type RouteConfig } from "@react-router/dev/routes";
+                import { flatRoutes } from "@react-router/fs-routes";
+
+                await new Promise((resolve) => setTimeout(resolve, 50));
+
+                export default flatRoutes() satisfies RouteConfig;
+              `,
+              "app/routes/settings.tsx": js`
+                export default function Settings() {
+                  return <h1>Settings</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          await expectConcurrentConfigResolution(appC, appB, appA);
+        });
+
+        test("when all apps use flatRoutes", async () => {
+          let appA = await createProject(
+            {
+              "app/routes.ts": js`
+                import { type RouteConfig } from "@react-router/dev/routes";
+                import { flatRoutes } from "@react-router/fs-routes";
+
+                export default flatRoutes() satisfies RouteConfig;
+              `,
+              "app/routes/login.tsx": js`
+                export default function Login() {
+                  return <h1>Login</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          let appB = await createProject(
+            {
+              "app/routes.ts": js`
+                import { type RouteConfig } from "@react-router/dev/routes";
+                import { flatRoutes } from "@react-router/fs-routes";
+
+                await new Promise((resolve) => setTimeout(resolve, 25));
+
+                export default flatRoutes() satisfies RouteConfig;
+              `,
+              "app/routes/dashboard.tsx": js`
+                export default function Dashboard() {
+                  return <h1>Dashboard</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          let appC = await createProject(
+            {
+              "app/routes.ts": js`
+                import { type RouteConfig } from "@react-router/dev/routes";
+                import { flatRoutes } from "@react-router/fs-routes";
+
+                await new Promise((resolve) => setTimeout(resolve, 50));
+
+                export default flatRoutes() satisfies RouteConfig;
+              `,
+              "app/routes/settings.tsx": js`
+                export default function Settings() {
+                  return <h1>Settings</h1>;
+                }
+              `,
+            },
+            templateName,
+          );
+
+          await expectConcurrentConfigResolution(appC, appB, appA);
+        });
       });
     });
   });

--- a/packages/react-router-dev/.changes/patch.concurrent-route-config-state.md
+++ b/packages/react-router-dev/.changes/patch.concurrent-route-config-state.md
@@ -1,0 +1,3 @@
+Fix concurrent Framework Mode route config loading so `flatRoutes()` resolves files against the correct app directory when multiple Vite configs load in one process.
+
+- Isolate app-directory state with async context during route config execution.

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -17,7 +17,7 @@ import {
   type RouteManifest,
   type RouteManifestEntry,
   type RouteConfigEntry,
-  setAppDirectory,
+  withAppDirectory,
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
@@ -621,15 +621,20 @@ async function resolveConfig({
         );
       }
 
-      setAppDirectory(appDirectory);
-      let routeConfigExport = (
-        await viteNodeContext.runner.executeFile(
-          Path.join(appDirectory, routeConfigFile),
-        )
-      ).default;
+      let resolvedRouteConfig = await withAppDirectory(
+        appDirectory,
+        async () => {
+          let routeConfigExport = (
+            await viteNodeContext.runner.executeFile(
+              Path.join(appDirectory, routeConfigFile),
+            )
+          ).default;
+          return await routeConfigExport;
+        },
+      );
       let result = validateRouteConfig({
         routeConfigFile,
-        routeConfig: await routeConfigExport,
+        routeConfig: resolvedRouteConfig,
       });
 
       if (!result.valid) {

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as Path from "pathe";
 import * as v from "valibot";
 import pick from "lodash/pick";
@@ -5,11 +6,14 @@ import pick from "lodash/pick";
 import invariant from "../invariant";
 
 declare global {
-  var __reactRouterAppDirectory: string;
+  var __reactRouterAppDirectoryContext: AsyncLocalStorage<string> | undefined;
 }
 
-export function setAppDirectory(directory: string) {
-  globalThis.__reactRouterAppDirectory = directory;
+const appDirectoryContext = (globalThis.__reactRouterAppDirectoryContext ??=
+  new AsyncLocalStorage<string>());
+
+export function withAppDirectory<T>(directory: string, callback: () => T): T {
+  return appDirectoryContext.run(directory, callback);
 }
 
 /**
@@ -17,8 +21,9 @@ export function setAppDirectory(directory: string) {
  * This is designed to support resolving file system routes.
  */
 export function getAppDirectory() {
-  invariant(globalThis.__reactRouterAppDirectory);
-  return globalThis.__reactRouterAppDirectory;
+  let appDirectory = appDirectoryContext.getStore();
+  invariant(appDirectory);
+  return appDirectory;
 }
 
 export interface RouteManifestEntry {


### PR DESCRIPTION
Closes #15007

`flatRoutes()` gets its app directory from `getAppDirectory()`. That state was stored in a process-global string while `app/routes.ts` was being loaded, so overlapping Vite config resolution could make one app read another app's route files.

This moves the route config context to a shared `AsyncLocalStorage` instance. The storage object still lives on `globalThis` so the bundled Vite plugin and `@react-router/dev/routes` agree on the same context, but the app directory itself is now scoped to the current route-config execution.

I added regression coverage in `route-config-test.ts` for concurrent `resolveConfig()` calls across the Vite template matrix:

- mixed manual routes + `flatRoutes()`
- all apps using `flatRoutes()`

Verified with:

```sh
pnpm run --filter @react-router/dev... --filter @react-router/fs-routes... build
pnpm test:integration:run integration/route-config-test.ts --project chromium -g "concurrent Vite config resolution"
pnpm run --filter @react-router/dev typecheck
pnpm run --filter @react-router/fs-routes typecheck
pnpm --dir integration exec tsc
```