### PR TITLE
Remove unnecessary hasShouldRevalidate condition for opting out

### DIFF
--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1063,6 +1063,103 @@ test.describe("single-fetch", () => {
     expect(urls).toEqual([expect.stringMatching(/\/action\.data$/)]);
   });
 
+  test("call-site revalidation opt-out handles parent routes w/o shouldRevalidate", async ({
+    page,
+  }) => {
+    let fixture = await createFixture({
+      files: {
+        ...files,
+        "app/root.tsx": js`
+          import { Links, Meta, Outlet, Scripts } from "react-router";
+          let count = 0
+          export function loader() {
+            return {
+              count: ++count
+            };
+          }
+      
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+        "app/routes/parent.tsx": js`
+          import { Link, Outlet, unstable_useRoute } from "react-router";
+
+          export function loader() {
+            return {
+              count: 0
+            }
+          }
+
+          export default function Component() {
+            const rootRoute = unstable_useRoute('root')
+            return (
+              <>
+                <Link to='/parent/a' unstable_defaultShouldRevalidate={false}>Click</Link>
+                <p id="root-data-parent">{rootRoute.loaderData.count}</p>
+                <Outlet/>
+              </>
+            );
+          }
+        `,
+        "app/routes/parent.a.tsx": js`
+          import { unstable_useRoute } from "react-router";
+
+          let count = 0
+          export function loader() {
+            return {
+              count: ++count
+            }
+          }
+          export default function Component({ loaderData }) {
+            const rootRoute = unstable_useRoute('root')
+            return (
+              <>
+                <p id="data">{loaderData.count}</p>
+                <p id="root-data-child">{rootRoute.loaderData.count}</p>
+              </>
+            );
+          }
+        `,
+      },
+    });
+
+    let urls: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes(".data")) {
+        urls.push(req.url());
+      }
+    });
+
+    console.error = () => {};
+
+    let appFixture = await createAppFixture(fixture);
+    let app = new PlaywrightFixture(appFixture, page);
+    await app.goto("/parent");
+    expect(await app.getHtml("#root-data-parent")).toContain("1");
+
+    expect(urls).toEqual([]);
+    await app.clickLink("/parent/a");
+
+    await page.waitForSelector("#root-data-child");
+    expect(await app.getHtml("#root-data-parent")).toContain("1");
+    expect(await app.getHtml("#root-data-child")).toContain("1");
+    expect(await app.getHtml("#data")).toContain("1");
+    expect(urls.length).toBe(1);
+    expect(urls[0]).toContain(".data?_routes=routes%2Fparent.a");
+  });
+
   test("returns headers correctly for singular loader and action calls", async () => {
     let fixture = await createFixture({
       files: {

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -1068,16 +1068,15 @@ test.describe("single-fetch", () => {
   }) => {
     let fixture = await createFixture({
       files: {
-        ...files,
         "app/root.tsx": js`
-          import { Links, Meta, Outlet, Scripts } from "react-router";
+          import { Link, Links, Meta, Outlet, Scripts, useMatches } from "react-router";
+
           let count = 0
+
           export function loader() {
-            return {
-              count: ++count
-            };
+            return { count: ++count };
           }
-      
+
           export default function Root() {
             return (
               <html lang="en">
@@ -1086,6 +1085,14 @@ test.describe("single-fetch", () => {
                   <Links />
                 </head>
                 <body>
+                  <nav>
+                    <Link to="/">Home</Link>
+                    <Link to="/page">Page (default)</Link>
+                    <Link to="/page?optout" unstable_defaultShouldRevalidate={false}>Page (opt-out)</Link>
+                  </nav>
+                  <pre id="data">
+                    {JSON.stringify(useMatches().map(m => [m.id, m.data]))}
+                  </pre>
                   <Outlet />
                   <Scripts />
                 </body>
@@ -1093,43 +1100,15 @@ test.describe("single-fetch", () => {
             );
           }
         `,
-        "app/routes/parent.tsx": js`
-          import { Link, Outlet, unstable_useRoute } from "react-router";
+        "app/routes/page.tsx": js`
+          let count = 0
 
           export function loader() {
-            return {
-              count: 0
-            }
+            return { count: ++count }
           }
 
           export default function Component() {
-            const rootRoute = unstable_useRoute('root')
-            return (
-              <>
-                <Link to='/parent/a' unstable_defaultShouldRevalidate={false}>Click</Link>
-                <p id="root-data-parent">{rootRoute.loaderData.count}</p>
-                <Outlet/>
-              </>
-            );
-          }
-        `,
-        "app/routes/parent.a.tsx": js`
-          import { unstable_useRoute } from "react-router";
-
-          let count = 0
-          export function loader() {
-            return {
-              count: ++count
-            }
-          }
-          export default function Component({ loaderData }) {
-            const rootRoute = unstable_useRoute('root')
-            return (
-              <>
-                <p id="data">{loaderData.count}</p>
-                <p id="root-data-child">{rootRoute.loaderData.count}</p>
-              </>
-            );
+            return <h2>Page</h2>
           }
         `,
       },
@@ -1138,7 +1117,8 @@ test.describe("single-fetch", () => {
     let urls: string[] = [];
     page.on("request", (req) => {
       if (req.url().includes(".data")) {
-        urls.push(req.url());
+        let url = new URL(req.url());
+        urls.push(url.pathname + url.search);
       }
     });
 
@@ -1146,18 +1126,31 @@ test.describe("single-fetch", () => {
 
     let appFixture = await createAppFixture(fixture);
     let app = new PlaywrightFixture(appFixture, page);
-    await app.goto("/parent");
-    expect(await app.getHtml("#root-data-parent")).toContain("1");
+    await app.goto("/"); // root increments to 1
+    expect(await page.locator("#data").innerText()).toBe(
+      '[["root",{"count":1}],["routes/_index",null]]',
+    );
 
-    expect(urls).toEqual([]);
-    await app.clickLink("/parent/a");
+    await app.clickLink("/page"); // root increments to 2
+    expect(await page.locator("#data").innerText()).toBe(
+      '[["root",{"count":2}],["routes/page",{"count":1}]]',
+    );
+    expect(urls).toEqual(["/page.data"]);
+    urls.splice(0, urls.length);
 
-    await page.waitForSelector("#root-data-child");
-    expect(await app.getHtml("#root-data-parent")).toContain("1");
-    expect(await app.getHtml("#root-data-child")).toContain("1");
-    expect(await app.getHtml("#data")).toContain("1");
-    expect(urls.length).toBe(1);
-    expect(urls[0]).toContain(".data?_routes=routes%2Fparent.a");
+    await app.clickLink("/"); // root increments to 3
+    expect(await page.locator("#data").innerText()).toBe(
+      '[["root",{"count":3}],["routes/_index",null]]',
+    );
+    expect(urls).toEqual(["/_root.data"]);
+    urls.splice(0, urls.length);
+
+    await app.clickLink("/page?optout");
+    // root stays at 3, page is a fresh load so increments to 2
+    expect(await page.locator("#data").innerText()).toBe(
+      '[["root",{"count":3}],["routes/page",{"count":2}]]',
+    );
+    expect(urls).toEqual(["/page.data?optout=&_routes=routes%2Fpage"]);
   });
 
   test("returns headers correctly for singular loader and action calls", async () => {

--- a/packages/react-router/.changes/minor.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
+++ b/packages/react-router/.changes/minor.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
@@ -1,0 +1,1 @@
+This fixes a bug when unstable_defaultShouldRevalidate={false} is used and a matched route does not export a shouldRevalidate function. The current code skips counting the route as a route to opt out when determining when to set the _routes query param.

--- a/packages/react-router/.changes/minor.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
+++ b/packages/react-router/.changes/minor.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
@@ -1,1 +1,0 @@
-This fixes a bug when unstable_defaultShouldRevalidate={false} is used and a matched route does not export a shouldRevalidate function. The current code skips counting the route as a route to opt out when determining when to set the _routes query param.

--- a/packages/react-router/.changes/patch.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
+++ b/packages/react-router/.changes/patch.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
@@ -1,0 +1,1 @@
+Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -428,8 +428,7 @@ async function singleFetchLoaderNavigationStrategy(
           // If this route opted out, don't include in the .data request
           foundOptOutRoute ||=
             m.shouldRevalidateArgs != null && // This is a revalidation,
-            hasLoader && // for a route with a server loader,
-            hasShouldRevalidate === true; // and a shouldRevalidate function
+            hasLoader; // for a route with a server loader
           return;
         }
 

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -415,8 +415,7 @@ async function singleFetchLoaderNavigationStrategy(
       m.resolve(async (handler) => {
         routeDfds[i].resolve();
         let routeId = m.route.id;
-        let { hasLoader, hasClientLoader, hasShouldRevalidate } =
-          getRouteInfo(m);
+        let { hasLoader, hasClientLoader } = getRouteInfo(m);
 
         let defaultShouldRevalidate =
           !m.shouldRevalidateArgs ||

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -166,7 +166,6 @@ export function StreamTransfer({
 type GetRouteInfoFunction = (match: DataRouteMatch) => {
   hasLoader: boolean;
   hasClientLoader: boolean;
-  hasShouldRevalidate: boolean;
 };
 
 type ShouldAllowOptOutFunction = (match: DataRouteMatch) => boolean;
@@ -192,11 +191,9 @@ export function getTurboStreamSingleFetchDataStrategy(
     (match: DataRouteMatch) => {
       let manifestRoute = manifest.routes[match.route.id];
       invariant(manifestRoute, "Route not found in manifest");
-      let routeModule = routeModules[match.route.id];
       return {
         hasLoader: manifestRoute.hasLoader,
         hasClientLoader: manifestRoute.hasClientLoader,
-        hasShouldRevalidate: Boolean(routeModule?.shouldRevalidate),
       };
     },
     fetchAndDecodeViaTurboStream,

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -460,7 +460,6 @@ export function getRSCSingleFetchDataStrategy(
       hasComponent: boolean;
       hasAction: boolean;
       hasClientAction: boolean;
-      hasShouldRevalidate: boolean;
     };
   };
 
@@ -475,7 +474,6 @@ export function getRSCSingleFetchDataStrategy(
         hasComponent: M.route.hasComponent,
         hasAction: M.route.hasAction,
         hasClientAction: M.route.hasClientAction,
-        hasShouldRevalidate: M.route.hasShouldRevalidate,
       };
     },
     // pass map into fetchAndDecode so it can add payloads
@@ -889,7 +887,6 @@ type DataRouteObjectWithManifestInfo = DataRouteObject & {
   hasClientLoader: boolean;
   hasAction: boolean;
   hasClientAction: boolean;
-  hasShouldRevalidate: boolean;
 };
 
 function createRouteFromServerManifest(
@@ -976,7 +973,6 @@ function createRouteFromServerManifest(
     hasClientLoader: match.clientLoader != null,
     hasAction: match.hasAction,
     hasClientAction: match.clientAction != null,
-    hasShouldRevalidate: match.shouldRevalidate != null,
   };
 
   if (typeof dataRoute.loader === "function") {


### PR DESCRIPTION
This fixes a bug when `unstable_defaultShouldRevalidate={false}` is used and a matched route does _not_ export a `shouldRevalidate` function. The current code skips counting the route as a route to opt out when determining when to set the `_routes` query param.

I wrote a test with 3 routes, all with their own loaders and no `shouldRevalidate` functions.
```
app/root.tsx
app/parent.tsx
app/parent.a.tsx
```
When on the `/parent` route, i'm clicking a link with `unstable_defaultShouldRevalidate={false}` to navigate to `/parent/a`. This _should_ trigger a data call for only `app/parent.a.tsx`'s loader. However, the data call that's executed does not have the `_routes` query param, so all loaders are revalidated. 

This PR makes it so that the data call is only to fetch `app/parent.a.tsx`'s loader data.
