### PR TITLE
fix: transform TSX before es-module-lexer when bundledDev is active

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -2,6 +2,7 @@
 - 3fuyang
 - 43081j
 - aarbi
+- aayushbaluni
 - abdallah-nour
 - abdulwahaab710
 - abeadam

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -82,6 +82,7 @@
     "babel-dead-code-elimination": "^1.0.6",
     "chokidar": "^4.0.0",
     "dedent": "^1.5.3",
+    "esbuild": "^0.25.0",
     "es-module-lexer": "^1.3.1",
     "exit-hook": "2.2.1",
     "isbot": "^5.1.11",

--- a/packages/react-router-dev/tsup.config.ts
+++ b/packages/react-router-dev/tsup.config.ts
@@ -19,6 +19,7 @@ const entry = [
 const external = [
   "./static/refresh-utils.mjs",
   "./static/rsc-refresh-utils.mjs",
+  "esbuild",
   /\.json$/,
 ];
 

--- a/packages/react-router-dev/vite/babel.ts
+++ b/packages/react-router-dev/vite/babel.ts
@@ -1,6 +1,11 @@
+import * as path from "node:path";
 import type { NodePath } from "@babel/traverse";
 import type { types as Babel } from "@babel/core";
-import { parse, type ParseResult } from "@babel/parser";
+import {
+  parse,
+  type ParseResult,
+  type ParserPlugin,
+} from "@babel/parser";
 import * as t from "@babel/types";
 
 // These `require`s were needed to support building within vite-ecosystem-ci,
@@ -9,6 +14,29 @@ const traverse = require("@babel/traverse")
   .default as typeof import("@babel/traverse").default;
 const generate = require("@babel/generator")
   .default as typeof import("@babel/generator").default;
+
+/** Parse route/module sources that may still contain TS or JSX (e.g. Vite bundledDev). */
+export function parseModulePreservingSyntax(
+  code: string,
+  moduleId: string,
+): ParseResult<Babel.File> {
+  let ext = path.extname(moduleId.split("?")[0]).toLowerCase();
+
+  let plugins: ParserPlugin[] = [];
+
+  if (ext === ".tsx") {
+    plugins.push(["typescript", { isTSX: true }] as ParserPlugin);
+  } else if (ext === ".ts" || ext === ".mts" || ext === ".cts") {
+    plugins.push(["typescript", { isTSX: false }] as ParserPlugin);
+  } else if (ext === ".jsx") {
+    plugins.push("jsx");
+  }
+
+  return parse(code, {
+    sourceType: "module",
+    ...(plugins.length > 0 ? { plugins } : {}),
+  });
+}
 
 export { traverse, generate, parse, t };
 export type { Babel, NodePath, ParseResult };

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -44,7 +44,7 @@ import type {
 } from "../manifest";
 import invariant from "../invariant";
 import type { Cache } from "./cache";
-import { generate, parse } from "./babel";
+import { generate, parseModulePreservingSyntax } from "./babel";
 import type { NodeRequestHandler } from "./node-adapter";
 import { fromNodeRequest } from "./node-adapter";
 import {
@@ -70,6 +70,7 @@ import {
   getRouteChunkModuleId,
   getRouteChunkNameFromModuleId,
 } from "./route-chunks";
+import { stripForEsModuleLexer } from "./strip-for-es-module-lexer";
 import { preloadVite, getVite, defineCompilerOptions } from "./vite";
 import {
   type ResolvedReactRouterConfig,
@@ -512,8 +513,13 @@ const writeFileSafe = async (file: string, contents: string): Promise<void> => {
 };
 
 const getExportNames = (code: string): string[] => {
-  let [, exportSpecifiers] = esModuleLexer(code);
-  return exportSpecifiers.map(({ n: name }) => name);
+  try {
+    let [, exportSpecifiers] = esModuleLexer(code);
+    return exportSpecifiers.map(({ n: name }) => name);
+  } catch {
+    let [, exportSpecifiers] = esModuleLexer(stripForEsModuleLexer(code));
+    return exportSpecifiers.map(({ n: name }) => name);
+  }
 };
 
 const getRouteManifestModuleExports = async (
@@ -2084,7 +2090,12 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }
 
         let { hasRouteChunks, chunkedExports } =
-          await detectRouteChunksIfEnabled(cache, ctx, id, code);
+          await detectRouteChunksIfEnabled(
+            cache,
+            ctx,
+            id,
+            routeTransformInputFromHook(viteChildCompiler, ctx, id, code),
+          );
 
         // If there are no chunks, we can let this resolve to the raw route
         // module since there's no risk of duplication
@@ -2140,7 +2151,17 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
         let { chunkedExports = [] } = options?.ssr
           ? {}
-          : await detectRouteChunksIfEnabled(cache, ctx, id, code);
+          : await detectRouteChunksIfEnabled(
+              cache,
+              ctx,
+              routeModuleId,
+              routeTransformInputFromHook(
+                viteChildCompiler,
+                ctx,
+                routeModuleId,
+                code,
+              ),
+            );
 
         let reexports = sourceExports
           .filter((exportName) => {
@@ -2185,7 +2206,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           ctx,
           id,
           chunkName,
-          code,
+          routeTransformInputFromHook(viteChildCompiler, ctx, id, code),
         );
 
         let preventEmptyChunkSnippet = ({ reason }: { reason: string }) =>
@@ -2415,7 +2436,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
         let [filepath] = id.split("?");
 
-        let ast = parse(code, { sourceType: "module" });
+        let ast = parseModulePreservingSyntax(code, id);
         if (!options?.ssr) {
           removeExports(ast, SERVER_ONLY_ROUTE_EXPORTS);
         }
@@ -3720,6 +3741,23 @@ type ResolveRouteFileCodeInput =
       readRouteFile?: () => string | Promise<string>;
       viteChildCompiler: Vite.ViteDevServer | null;
     };
+
+function routeTransformInputFromHook(
+  viteChildCompiler: Vite.ViteDevServer | null,
+  ctx: ReactRouterPluginContext,
+  moduleId: string,
+  code: string,
+): ResolveRouteFileCodeInput {
+  return {
+    viteChildCompiler,
+    routeFile: normalizeRelativeFilePath(
+      moduleId.split("?")[0],
+      ctx.reactRouterConfig,
+    ),
+    readRouteFile: () => code,
+  };
+}
+
 const resolveRouteFileCode = async (
   ctx: ReactRouterPluginContext,
   input: ResolveRouteFileCodeInput,

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -7,6 +7,7 @@ import type * as Vite from "vite";
 import * as babel from "../babel";
 import type { Cache } from "../cache";
 import { removeExports } from "../remove-exports";
+import { stripForEsModuleLexer } from "../strip-for-es-module-lexer";
 import {
   type RouteChunkExportName,
   type RouteChunkName,
@@ -386,7 +387,12 @@ function createId(
 
 export async function parseRouteExports(code: string) {
   await initEsModuleLexer;
-  const [, exportSpecifiers] = esModuleLexer(code);
+  let exportSpecifiers;
+  try {
+    [, exportSpecifiers] = esModuleLexer(code);
+  } catch {
+    [, exportSpecifiers] = esModuleLexer(stripForEsModuleLexer(code));
+  }
   const staticExports = exportSpecifiers.map(({ n: name }) => name);
   return {
     staticExports,

--- a/packages/react-router-dev/vite/strip-for-es-module-lexer.ts
+++ b/packages/react-router-dev/vite/strip-for-es-module-lexer.ts
@@ -1,0 +1,16 @@
+import { transformSync } from "esbuild";
+
+/**
+ * Produce lexer-safe JavaScript from TS/TSX sources when Vite hands plugins
+ * raw TypeScript or JSX (for example `experimental.bundledDev`).
+ */
+export function stripForEsModuleLexer(code: string): string {
+  return transformSync(code, {
+    loader: "tsx",
+    format: "esm",
+    target: "esnext",
+    platform: "neutral",
+    sourcemap: false,
+    legalComments: "none",
+  }).code;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,16 +27,6 @@ catalogs:
     wireit:
       specifier: 0.14.9
       version: 0.14.9
-  react-canary:
-    react:
-      specifier: ^19.2.2
-      version: 19.2.3
-    react-dom:
-      specifier: ^19.2.2
-      version: 19.2.3
-    react-server-dom-webpack:
-      specifier: ^19.2.2
-      version: 19.2.3
 
 overrides:
   '@types/react': ^18.0.27
@@ -135,7 +125,7 @@ importers:
         version: 7.37.5(eslint@10.1.0(jiti@2.4.2))
       eslint-plugin-react-hooks:
         specifier: next
-        version: 7.1.1-canary-d1727fbf-20260417(eslint@10.1.0(jiti@2.4.2))
+        version: 7.1.1-canary-f4e0d4ed-20260429(eslint@10.1.0(jiti@2.4.2))
       fast-glob:
         specifier: 3.2.11
         version: 3.2.11
@@ -1032,6 +1022,9 @@ importers:
       es-module-lexer:
         specifier: ^1.3.1
         version: 1.7.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.0
       exit-hook:
         specifier: 2.2.1
         version: 2.2.1
@@ -1064,7 +1057,7 @@ importers:
         version: 0.14.2
       react-server-dom-webpack:
         specifier: 'catalog:'
-        version: 19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4))
+        version: 19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0))
       semver:
         specifier: ^7.3.7
         version: 7.7.4
@@ -1116,10 +1109,10 @@ importers:
         version: 7.7.0
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)))(react@19.3.0-canary-d763f313-20251210)(vite@6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0))
+        version: 0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)))(react@19.3.0-canary-d763f313-20251210)(vite@6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0))
       esbuild-register:
         specifier: ^3.6.0
-        version: 3.6.0(esbuild@0.27.4)
+        version: 3.6.0(esbuild@0.25.0)
       execa:
         specifier: 5.1.1
         version: 5.1.1
@@ -1146,7 +1139,7 @@ importers:
         version: 0.14.9
       wrangler:
         specifier: ^4.23.0
-        version: 4.73.0(@cloudflare/workers-types@4.20250805.0)
+        version: 4.73.0
 
   packages/react-router-dom:
     dependencies:
@@ -5886,8 +5879,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
 
-  eslint-plugin-react-hooks@7.1.1-canary-d1727fbf-20260417:
-    resolution: {integrity: sha512-lGcF2qMJEgVLjyqMqoYUWjMqIqyd09FfXpbw9yVyvsVz6rcPdoPZheTReIiNtC/CaF5YKpGlVhyRw2VnpFwuRQ==}
+  eslint-plugin-react-hooks@7.1.1-canary-f4e0d4ed-20260429:
+    resolution: {integrity: sha512-owCmCBsGpoYmugCly//Z9DDTRyf6+mDupOCd5tyHF03jqf4cAbpHM+T+W/FwqjBSStbbPJM3oFHTushw6Q0uhw==}
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
@@ -8936,7 +8929,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -12339,7 +12332,7 @@ snapshots:
     optionalDependencies:
       react-server-dom-webpack: 19.2.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(webpack@5.103.0)
 
-  '@vitejs/plugin-rsc@0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)))(react@19.3.0-canary-d763f313-20251210)(vite@6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0))':
+  '@vitejs/plugin-rsc@0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)))(react@19.3.0-canary-d763f313-20251210)(vite@6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.5
       es-module-lexer: 2.0.0
@@ -12354,7 +12347,7 @@ snapshots:
       vite: 6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0)
       vitefu: 1.1.2(vite@6.4.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.19.3)(yaml@2.8.0))
     optionalDependencies:
-      react-server-dom-webpack: 19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4))
+      react-server-dom-webpack: 19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -13520,13 +13513,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-register@3.6.0(esbuild@0.27.4):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.27.4
-    transitivePeerDependencies:
-      - supports-color
-
   esbuild@0.19.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.19.12
@@ -13843,7 +13829,7 @@ snapshots:
     dependencies:
       eslint: 10.1.0(jiti@2.4.2)
 
-  eslint-plugin-react-hooks@7.1.1-canary-d1727fbf-20260417(eslint@10.1.0(jiti@2.4.2)):
+  eslint-plugin-react-hooks@7.1.1-canary-f4e0d4ed-20260429(eslint@10.1.0(jiti@2.4.2)):
     dependencies:
       '@babel/core': 7.27.7
       '@babel/parser': 7.27.7
@@ -15168,7 +15154,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 20.19.37
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -16702,13 +16688,13 @@ snapshots:
       webpack: 5.103.0
       webpack-sources: 3.3.3
 
-  react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)):
+  react-server-dom-webpack@19.2.3(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
       react: 19.3.0-canary-d763f313-20251210
       react-dom: 19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210)
-      webpack: 5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)
+      webpack: 5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)
       webpack-sources: 3.3.3
 
   react-test-renderer@19.1.0(react@19.2.3):
@@ -17448,17 +17434,17 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.3.15(@swc/core@1.11.24)(esbuild@0.27.4)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)):
+  terser-webpack-plugin@5.3.15(@swc/core@1.11.24)(esbuild@0.25.0)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.103.0(@swc/core@1.11.24)(esbuild@0.27.4)
+      webpack: 5.103.0(@swc/core@1.11.24)(esbuild@0.25.0)
     optionalDependencies:
       '@swc/core': 1.11.24
-      esbuild: 0.27.4
+      esbuild: 0.25.0
 
   terser-webpack-plugin@5.3.15(esbuild@0.27.4)(webpack@5.103.0(esbuild@0.27.4)):
     dependencies:
@@ -18268,7 +18254,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4):
+  webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18292,7 +18278,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.15(@swc/core@1.11.24)(esbuild@0.27.4)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.27.4))
+      terser-webpack-plugin: 5.3.15(@swc/core@1.11.24)(esbuild@0.25.0)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.25.0))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -18420,6 +18406,22 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20250705.0
       '@cloudflare/workerd-linux-arm64': 1.20250705.0
       '@cloudflare/workerd-windows-64': 1.20250705.0
+
+  wrangler@4.73.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20250705.0)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260312.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20250705.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   wrangler@4.73.0(@cloudflare/workers-types@4.20250805.0):
     dependencies:


### PR DESCRIPTION
## Problem
When using Vite 8's `experimental.bundledDev`, `es-module-lexer` receives raw TSX code that hasn't been transformed, causing build failures since the lexer can't parse JSX syntax.

## Change
- Route modules are now run through the Vite child compiler before chunk analysis
- `getExportNames` falls back to `esbuild` transform when `es-module-lexer` fails on untransformed code
- Babel route-exports plugin uses TypeScript/JSX parser plugins to handle raw TSX

Fixes #14947.

Made with [Cursor](https://cursor.com)