### PR TITLE
Release 7.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v7.15.0](#v7150)
   - [v7.14.2](#v7142)
   - [v7.14.1](#v7141)
   - [v7.14.0](#v7140)
@@ -168,6 +169,81 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v6.0.0](#v600)
 
 </details>
+
+## v7.15.0
+
+Date: 2026-05-05
+
+### Minor Changes
+
+- `react-router` - Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `react-router` - Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `@react-router/dev` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `@react-router/dev` - Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- `@react-router/dev` - Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+### Patch Changes
+
+- `react-router` - Add `nonce` to `<Scripts>` `<link rel="modulepreload">` elements (if provided) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+- `react-router` - Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))
+
+- `react-router` - Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+  - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance
+
+- `react-router` - Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
+
+- `react-router` - Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))
+
+- `react-router` - Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+  - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
+    - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
+    - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
+  - Leverage pre-computed pre-computing flattened/cached route branches during client side route matching
+  - Performance benchmarks showed roughly a 15-30% improvement in server-side request handling performance
+
+**Full Changelog**: [`v7.14.2...v7.15.0`](https://github.com/remix-run/react-router/compare/react-router@7.14.2...react-router@7.15.0)
 
 ## v7.14.2
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v7.15.0
+
+### Patch Changes
+
+- _No changes_
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-router",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/architect`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/architect",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/cloudflare",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/.changes/minor.stabilize-pass-through-requests.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-pass-through-requests.md
@@ -1,3 +1,0 @@
-Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router-dev/.changes/minor.stabilize-prerender-concurrency.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-prerender-concurrency.md
@@ -1,3 +1,0 @@
-Stabilize `prerender.unstable_concurrency` as `prerender.concurrency`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router-dev/.changes/minor.stabilize-sri.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-sri.md
@@ -1,3 +1,0 @@
-Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,28 @@
 # `@react-router/dev`
 
+## v7.15.0
+
+### Minor Changes
+
+- Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)
+  - [`@react-router/serve@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/dev",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Dev tools and CLI for React Router",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-dom/CHANGELOG.md
+++ b/packages/react-router-dom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # react-router-dom
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Declarative routing for React web applications",
   "keywords": [
     "react",

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/express`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/express",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/fs-routes",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/node`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/node",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/serve`
 
+## v7.15.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
+  - [`@react-router/express@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.15.0)
+  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/serve",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/minor.stabilize-default-should-revalidate.md
+++ b/packages/react-router/.changes/minor.stabilize-default-should-revalidate.md
@@ -1,3 +1,0 @@
-Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-instrumentations.md
+++ b/packages/react-router/.changes/minor.stabilize-instrumentations.md
@@ -1,4 +1,0 @@
-Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern`
-
-- The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-mask.md
+++ b/packages/react-router/.changes/minor.stabilize-mask.md
@@ -1,3 +1,0 @@
-Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-normalize-path.md
+++ b/packages/react-router/.changes/minor.stabilize-normalize-path.md
@@ -1,3 +1,0 @@
-Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-pass-through-requests.md
+++ b/packages/react-router/.changes/minor.stabilize-pass-through-requests.md
@@ -1,3 +1,0 @@
-Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-sri.md
+++ b/packages/react-router/.changes/minor.stabilize-sri.md
@@ -1,3 +1,0 @@
-Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-url.md
+++ b/packages/react-router/.changes/minor.stabilize-url.md
@@ -1,3 +1,0 @@
-Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/minor.stabilize-use-transitions.md
+++ b/packages/react-router/.changes/minor.stabilize-use-transitions.md
@@ -1,3 +1,0 @@
-Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler`
-
-- ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

--- a/packages/react-router/.changes/patch.add-nonce-scripts-modulepreload.md
+++ b/packages/react-router/.changes/patch.add-nonce-scripts-modulepreload.md
@@ -1,1 +1,0 @@
-Add `nonce` to `<Scripts>` `<link rel="modulepreload">` elements (if provided)

--- a/packages/react-router/.changes/patch.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
+++ b/packages/react-router/.changes/patch.fixes-bug-when-unstabledefaultshouldrevalidatefalse-used-matched.md
@@ -1,1 +1,0 @@
-Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data

--- a/packages/react-router/.changes/patch.hot-bottles-mix.md
+++ b/packages/react-router/.changes/patch.hot-bottles-mix.md
@@ -1,3 +1,0 @@
-Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967))
-
-- Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance

--- a/packages/react-router/.changes/patch.made-mask-optional-in-location.md
+++ b/packages/react-router/.changes/patch.made-mask-optional-in-location.md
@@ -1,1 +1,0 @@
-Mark `mask` as an optional field in `Location` for easier mocking in unit tests

--- a/packages/react-router/.changes/patch.optimize-serverside-toute-matching-caching-flattenedranked.md
+++ b/packages/react-router/.changes/patch.optimize-serverside-toute-matching-caching-flattenedranked.md
@@ -1,1 +1,0 @@
-Cache flattened/ranked route branches to optimize server-side route matching

--- a/packages/react-router/.changes/patch.tough-needles-doubt.md
+++ b/packages/react-router/.changes/patch.tough-needles-doubt.md
@@ -1,7 +1,0 @@
-Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971))
-
-- Avoiding unnecessary calls to `matchRoutes` in data router scenarios
-  - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
-  - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
-- Leverage pre-computed pre-computing flattened/cached route branches during client side route matching
-- Performance benchmarks showed roughly a 15-30% improvement in server-side request handling performance

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,64 @@
 # `react-router`
 
+## v7.15.0
+
+### Minor Changes
+
+- Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+- Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+
+  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
+
+### Patch Changes
+
+- Add `nonce` to `<Scripts>` `<link rel="modulepreload">` elements (if provided) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+- Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))
+
+- Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+  - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance
+
+- Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
+
+- Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))
+
+- Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
+
+  - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
+    - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
+    - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
+  - Leverage pre-computed pre-computing flattened/cached route branches during client side route matching
+  - Performance benchmarks showed roughly a 15-30% improvement in server-side request handling performance
+
 ## v7.14.2
 
 ### Patch Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "7.14.2",
+  "version": "7.15.0",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `7.14.2` → `7.15.0` |
| react-router-dom | `7.14.2` → `7.15.0` |
| @react-router/architect | `7.14.2` → `7.15.0` |
| @react-router/cloudflare | `7.14.2` → `7.15.0` |
| @react-router/dev | `7.14.2` → `7.15.0` |
| @react-router/express | `7.14.2` → `7.15.0` |
| @react-router/fs-routes | `7.14.2` → `7.15.0` |
| @react-router/node | `7.14.2` → `7.15.0` |
| @react-router/remix-routes-option-adapter | `7.14.2` → `7.15.0` |
| @react-router/serve | `7.14.2` → `7.15.0` |
| create-react-router | `7.14.2` → `7.15.0` |

# Changelogs

## react-router v7.15.0

### Minor Changes

- Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

### Patch Changes

- Add `nonce` to `<Scripts>` `<link rel="modulepreload">` elements (if provided) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))

- Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))

- Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))

  - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance

- Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))

- Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))

- Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))

  - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
    - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
    - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`
  - Leverage pre-computed pre-computing flattened/cached route branches during client side route matching
  - Performance benchmarks showed roughly a 15-30% improvement in server-side request handling performance


## react-router-dom v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)


## @react-router/architect v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)


## @react-router/cloudflare v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)


## @react-router/dev v7.15.0

### Minor Changes

- Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

- Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))

  - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)
  - [`@react-router/serve@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.15.0)


## @react-router/express v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)


## @react-router/fs-routes v7.15.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.15.0)


## @react-router/node v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)


## @react-router/remix-routes-option-adapter v7.15.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.15.0)


## @react-router/serve v7.15.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.15.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.15.0)
  - [`@react-router/express@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.15.0)
  - [`@react-router/node@7.15.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.15.0)


## create-react-router v7.15.0

### Patch Changes

- _No changes_
