### PR TITLE
Fix stale SSR data when hydration is aborted by a same-route navigation

### DIFF
--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -1351,7 +1351,7 @@ test.describe("Client Data", () => {
             // When a same-route navigation aborts the pending hydration
             // POP, serverLoader() must fetch fresh data — not return the
             // stale SSR initialData captured for the original URL.
-            test.only("serverLoader() fetches fresh data when a same-route navigation aborts hydration", async ({
+            test("serverLoader() fetches fresh data when a same-route navigation aborts hydration", async ({
               page,
             }) => {
               let app = new PlaywrightFixture(appFixture, page);

--- a/integration/client-data-test.ts
+++ b/integration/client-data-test.ts
@@ -960,6 +960,49 @@ test.describe("Client Data", () => {
                         return <p id="b">Hi!</p>;
                       }
                     `,
+
+                    "app/routes/client-loader-critical.aborted-hydration-fetches-fresh-data.tsx": js`
+                      import { Link } from "react-router";
+
+                      export function loader({ request }) {
+                        return { query: new URL(request.url).searchParams.get("q") || "empty" };
+                      }
+
+                      export async function clientLoader({ serverLoader, request }) {
+                        let q = new URL(request.url).searchParams.get("q") || "empty";
+
+                        // Delay the initial invocation
+                        if (q === "initial") {
+                          if (!window.__hydrationBlock) {
+                            let { promise, resolve } = Promise.withResolvers();
+                            window.__resolveHydrationBlock = resolve
+                            window.__hydrationBlock = promise;
+                            await window.__hydrationBlock;
+                          }
+                        }
+
+                        let serverData = await serverLoader();
+                        return {
+                          ...serverData,
+                          clientLoaderRan: true,
+                          clientLoaderQuery: q,
+                        };
+                      }
+
+                      clientLoader.hydrate = true;
+
+                      export default function Component({ loaderData }) {
+                        return (
+                          <div>
+                            <p data-server-query>{loaderData.query}</p>
+                            <p data-client-loader-query>{String(loaderData.clientLoaderQuery ?? "none")}</p>
+                            <Link to="/client-loader-critical/aborted-hydration-fetches-fresh-data?q=updated">
+                              Update query
+                            </Link>
+                          </div>
+                        );
+                      }
+                    `,
                   },
                 },
                 ServerMode.Development, // Avoid error sanitization
@@ -1303,6 +1346,56 @@ test.describe("Client Data", () => {
               // But 2nd parent opted out of revalidation
               await expect(page.locator("#parent-2-data")).toHaveText("1");
               await expect(page.locator("#b")).toHaveText("Hi!");
+            });
+
+            // When a same-route navigation aborts the pending hydration
+            // POP, serverLoader() must fetch fresh data — not return the
+            // stale SSR initialData captured for the original URL.
+            test.only("serverLoader() fetches fresh data when a same-route navigation aborts hydration", async ({
+              page,
+            }) => {
+              let app = new PlaywrightFixture(appFixture, page);
+
+              await app.goto(
+                "/client-loader-critical/aborted-hydration-fetches-fresh-data?q=initial",
+              );
+
+              // SSR shows the server loader's data; clientLoader hasn't completed yet
+              await expect(page.locator("[data-server-query]")).toHaveText(
+                "initial",
+              );
+              await expect(
+                page.locator("[data-client-loader-query]"),
+              ).toHaveText("none");
+
+              // Click before hydration completes to abort the hydration clientLoader call before it calls serverLoader
+              await app.clickLink(
+                "/client-loader-critical/aborted-hydration-fetches-fresh-data?q=updated",
+                { wait: false },
+              );
+
+              await page.waitForURL(/q=updated/);
+
+              // PUSH ran the clientLoader as call #2 and saw the new URL and the serverLoader
+              // invocation doesn't return hydrationData
+              await expect(page.locator("[data-server-query]")).toHaveText(
+                "updated",
+              );
+              await expect(
+                page.locator("[data-client-loader-query]"),
+              ).toHaveText("updated");
+
+              // Release the still-pending hydration call so it can unwind.
+              await page.evaluate(() =>
+                (window as any).__resolveHydrationBlock(),
+              );
+
+              await expect(page.locator("[data-server-query]")).toHaveText(
+                "updated",
+              );
+              await expect(
+                page.locator("[data-client-loader-query]"),
+              ).toHaveText("updated");
             });
           });
 

--- a/packages/react-router/.changes/patch.fix-hydration-request-stale.md
+++ b/packages/react-router/.changes/patch.fix-hydration-request-stale.md
@@ -1,0 +1,1 @@
+Fix `serverLoader()` returning stale SSR data when a client navigation aborts pending hydration before the hydration `clientLoader` resolves

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -343,47 +343,46 @@ export function createClientRoutes(
         { request, params, context, pattern, url }: LoaderFunctionArgs,
         singleFetch?: unknown,
       ) => {
-        try {
-          let result = await prefetchStylesAndCallHandler(async () => {
-            invariant(
-              routeModule,
-              "No `routeModule` available for critical-route loader",
-            );
-            if (!routeModule.clientLoader) {
-              // Call the server when no client loader exists
-              return fetchServerLoader(singleFetch);
-            }
+        // Capture and clear immediately so that if this call is aborted
+        // mid-flight, subsequent calls won't see a stale `true` value
+        let _isHydrationRequest = isHydrationRequest;
+        isHydrationRequest = false;
 
-            return routeModule.clientLoader({
-              request,
-              params,
-              context,
-              pattern,
-              url,
-              async serverLoader() {
-                preventInvalidServerHandlerCall("loader", route);
+        let result = await prefetchStylesAndCallHandler(async () => {
+          invariant(
+            routeModule,
+            "No `routeModule` available for critical-route loader",
+          );
+          if (!routeModule.clientLoader) {
+            // Call the server when no client loader exists
+            return fetchServerLoader(singleFetch);
+          }
 
-                // On the first call, resolve with the server result
-                if (isHydrationRequest) {
-                  if (hasInitialData) {
-                    return initialData;
-                  }
-                  if (hasInitialError) {
-                    throw initialError;
-                  }
+          return routeModule.clientLoader({
+            request,
+            params,
+            context,
+            pattern,
+            url,
+            async serverLoader() {
+              preventInvalidServerHandlerCall("loader", route);
+
+              // On the first call, resolve with the server result
+              if (_isHydrationRequest) {
+                if (hasInitialData) {
+                  return initialData;
                 }
+                if (hasInitialError) {
+                  throw initialError;
+                }
+              }
 
-                // Call the server loader for client-side navigations
-                return fetchServerLoader(singleFetch);
-              },
-            });
+              // Call the server loader for client-side navigations
+              return fetchServerLoader(singleFetch);
+            },
           });
-          return result;
-        } finally {
-          // Whether or not the user calls `serverLoader`, we only let this
-          // stick around as true for one loader call
-          isHydrationRequest = false;
-        }
+        });
+        return result;
       };
 
       // Let React Router know whether to run this on hydration

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -917,31 +917,32 @@ function createRouteFromServerManifest(
     index: match.index,
     loader: match.clientLoader
       ? async (args, singleFetch) => {
-          try {
-            let result = await match.clientLoader!({
-              ...args,
-              serverLoader: () => {
-                preventInvalidServerHandlerCall(
-                  "loader",
-                  match.id,
-                  match.hasLoader,
-                );
-                // On the first call, resolve with the server result
-                if (isHydrationRequest) {
-                  if (hasInitialData) {
-                    return initialData;
-                  }
-                  if (hasInitialError) {
-                    throw initialError;
-                  }
+          // Capture and clear immediately so that if this call is aborted
+          // mid-flight, subsequent calls won't see a stale `true` value
+          let _isHydrationRequest = isHydrationRequest;
+          isHydrationRequest = false;
+
+          let result = await match.clientLoader!({
+            ...args,
+            serverLoader: () => {
+              preventInvalidServerHandlerCall(
+                "loader",
+                match.id,
+                match.hasLoader,
+              );
+              // On the first call, resolve with the server result
+              if (_isHydrationRequest) {
+                if (hasInitialData) {
+                  return initialData;
                 }
-                return callSingleFetch(singleFetch);
-              },
-            });
-            return result;
-          } finally {
-            isHydrationRequest = false;
-          }
+                if (hasInitialError) {
+                  throw initialError;
+                }
+              }
+              return callSingleFetch(singleFetch);
+            },
+          });
+          return result;
         }
       : // We always make the call in this RSC world since even if we don't
         // have a `loader` we may need to get the `element` implementation


### PR DESCRIPTION
Need to clear the `isHydrationRequest` variable at invocation time, not completion time, in case it's aborted by another navigation prior to the `clientLoader` calling `serverLoader`

Closes #14871
