### PR TITLE
fix(react-router): prevent request.signal GC causing aborts to be missed in loaders/actions

### DIFF
--- a/packages/react-router/.changes/patch.fix-request-signal-gc.md
+++ b/packages/react-router/.changes/patch.fix-request-signal-gc.md
@@ -1,0 +1,5 @@
+Fix `request.signal` not aborting in loaders/actions when the client disconnects
+
+- undici (Node.js's built-in fetch implementation) wraps the `AbortSignal` passed to the `Request` constructor. When the `Request` object is garbage collected, the wrapped signal stops working.
+- This caused `request.signal` to never abort in long-lived server responses such as SSE (Server-Sent Events), because the intermediate `Request` objects created during request processing were GC'd before the response stream closed.
+- Fixed by holding a reference to each `Request` on its own signal, preventing GC while the signal is in use.

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -26,8 +26,8 @@ export async function callRouteHandler(
 ) {
   let result = await handler({
     request: future.v8_passThroughRequests
-      ? args.request
-      : stripRoutesParam(stripIndexParam(args.request)),
+      ? makeRequestSignalGcSafe(args.request)
+      : makeRequestSignalGcSafe(stripRoutesParam(stripIndexParam(args.request))),
     url: args.url,
     params: args.params,
     context: args.context,
@@ -45,6 +45,17 @@ export async function callRouteHandler(
   }
 
   return result;
+}
+
+// undici wraps the signal passed to the Request constructor. When the request
+// object is garbage collected, the wrapped signal stops working. This is
+// problematic when a loader or action holds the signal while waiting for it to
+// be aborted (e.g., for SSE). To fix this, we hold a reference to the request
+// in its own signal so that the request is not garbage collected while the
+// signal is still in use.
+export function makeRequestSignalGcSafe(request: Request): Request {
+  Object.defineProperty(request.signal, "__request", { value: request });
+  return request;
 }
 
 function stripIndexParam(request: Request) {
@@ -65,7 +76,7 @@ function stripIndexParam(request: Request) {
     method: request.method,
     body: request.body,
     headers: request.headers,
-    signal: request.signal,
+    signal: makeRequestSignalGcSafe(request).signal,
   };
 
   if (init.body) {
@@ -82,7 +93,7 @@ function stripRoutesParam(request: Request) {
     method: request.method,
     body: request.body,
     headers: request.headers,
-    signal: request.signal,
+    signal: makeRequestSignalGcSafe(request).signal,
   };
 
   if (init.body) {

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -19,6 +19,7 @@ import {
   SingleFetchRedirectSymbol,
 } from "../dom/ssr/single-fetch";
 import type { AppLoadContext } from "./data";
+import { makeRequestSignalGcSafe } from "./data";
 import { sanitizeError, sanitizeErrors } from "./errors";
 import { ServerMode } from "./mode";
 import { getDocumentHeaders } from "./headers";
@@ -56,12 +57,12 @@ export async function singleFetchAction(
     }
 
     let handlerRequest = build.future.v8_passThroughRequests
-      ? request
+      ? makeRequestSignalGcSafe(request)
       : new Request(handlerUrl, {
           method: request.method,
           body: request.body,
           headers: request.headers,
-          signal: request.signal,
+          signal: makeRequestSignalGcSafe(request).signal,
           ...(request.body ? { duplex: "half" } : undefined),
         });
 
@@ -152,10 +153,10 @@ export async function singleFetchLoaders(
 
   try {
     let handlerRequest = build.future.v8_passThroughRequests
-      ? request
+      ? makeRequestSignalGcSafe(request)
       : new Request(handlerUrl, {
           headers: request.headers,
-          signal: request.signal,
+          signal: makeRequestSignalGcSafe(request).signal,
         });
 
     let result = await staticHandler.query(handlerRequest, {


### PR DESCRIPTION
## Problem

Closes #13601

`undici` (Node.js's built-in fetch implementation) **wraps** the `AbortSignal` passed to `new Request(url, { signal })`. The wrapped signal uses a `WeakRef` to track the associated `AbortController`. When the `Request` object is garbage collected, the internal `AbortController` is also GC'd, the `WeakRef` becomes null, and the abort chain silently breaks.

During SSE streaming (and other long-lived responses), the server runtime creates several intermediate `Request` objects (`handlerRequest`, `stripIndexParam(...)`, `stripRoutesParam(...)`) which go out of scope once the loader returns its `ReadableStream` response. The loader only holds `request.signal`, not the request itself — so when those intermediate requests are GC'd, `request.signal` stops receiving abort events.

This can be reproduced reliably:

```js
node --expose-gc -e "
const ac = new AbortController();
let req = new Request('https://example.com', { signal: ac.signal });
const signal = req.signal;

let fired = false;
signal.addEventListener('abort', () => { fired = true; });

req = null;
global.gc();
await new Promise(r => setTimeout(r, 100));
global.gc();

ac.abort();
console.log('listener fired:', fired); // false ❌
"
```

## Solution

Added `makeRequestSignalGcSafe(request)` which sets `request.signal.__request = request`. This creates a strong reference from the signal back to the request, so as long as any code holds `request.signal`, the `Request` object (and its internal `AbortController`) stays alive.

Applied at every level of the request chain:
- `stripIndexParam` / `stripRoutesParam` — makes each input request GC-safe before extracting its signal
- `singleFetchAction` / `singleFetchLoaders` — makes the `handlerRequest` GC-safe
- `callRouteHandler` — makes the final request passed to loaders/actions GC-safe

This is the same fix applied in remix v2: https://github.com/remix-run/remix/pull/10030
