### PR TITLE
docs: fix typo in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -118,7 +118,7 @@ This table gives a high-level overview of the stages, but please see the individ
 - A proposal enters **Stage 2 — Alpha** once a PR has been opened implementing the feature in an `unstable_` state
 - At this stage, we should open an Issue for the Proposal and add it to the [Roadmap](https://github.com/orgs/remix-run/projects/5)
 - We will remove any `accepting-prs` label and add the `🗺️ Roadmap` label to indicate that this RFc is officially on the roadmap
-- At this stage, we are looking for early community testing _before_ merging any work to the React Router repo — so these PRs should provide a mechanism for community members to opt into to alpha testing
+- At this stage, we are looking for early community testing _before_ merging any work to the React Router repo — so these PRs should provide a mechanism for community members to opt into alpha testing
   - Maintainers can trigger an alpha release from the PR branch by adding the `alpha-release` label, which will kick off an experimental release and comment it back on the PR
   - Because the alpha release may contain other work committed to `dev` but not yet released in a stable version, it may not be ideal for testing in all cases
   - In these cases, PR authors may also add the contents for a `.patch` file in a comment that folks can use via [patch-package](https://www.npmjs.com/package/patch-package) or [pnpm patch](https://pnpm.io/cli/patch)

--- a/contributors.yml
+++ b/contributors.yml
@@ -108,6 +108,7 @@
 - dchenk
 - decadentsavant
 - developit
+- dfedoryshchev
 - dgrijuela
 - DigitalNaut
 - DimaAmega


### PR DESCRIPTION
Drop duplicate "to" in `GOVERNANCE.md` ("opt into to alpha testing" -> "opt into alpha testing").
