### PR TITLE
fix: resolve basename/base conflict when basename matches app directory name

### DIFF
--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -221,6 +221,13 @@ test.describe("Vite base + React Router basename", () => {
           await workflowDev({ page, cwd, port, basename: "/mybase/app/" });
         });
 
+        test("works when base and basename match the app directory name", async ({
+          page,
+        }) => {
+          await setup({ base: "/app/", basename: "/app/" });
+          await workflowDev({ page, cwd, port, base: "/app/", basename: "/app/" });
+        });
+
         test("errors if basename does not start with base", async ({
           page,
         }) => {
@@ -419,6 +426,13 @@ test.describe("Vite base + React Router basename", () => {
             port,
             basename: "/mybase/dashboard/",
           });
+        });
+
+        test("works when base and basename match the app directory name", async ({
+          page,
+        }) => {
+          await setup({ base: "/app/", basename: "/app/" });
+          await workflowBuild({ page, port, base: "/app/", basename: "/app/" });
         });
 
         test("works when basename does not start with base", async ({

--- a/packages/react-router-dev/.changes/patch.fix-basename-app-directory-conflict.md
+++ b/packages/react-router-dev/.changes/patch.fix-basename-app-directory-conflict.md
@@ -1,0 +1,7 @@
+Fix `basename` conflicting with `app` directory name when Vite `base` is set
+
+When the Vite `base` config and React Router `basename` both match the
+app directory name (e.g. `base: "/app/"`, `basename: "/app/"`), Vite would
+strip the base prefix from server-build virtual module import paths, causing
+"Failed to load url /root.tsx" errors. The fix uses `/@fs/` absolute paths
+for those imports to bypass Vite's base-stripping logic.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -818,7 +818,9 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
     return `
     import * as entryServer from ${JSON.stringify(
-      resolveFileUrl(ctx, ctx.entryServerFilePath),
+      resolveFileUrl(ctx, ctx.entryServerFilePath, {
+        publicPath: ctx.publicPath,
+      }),
     )};
     ${Object.keys(routes)
       .map((key, index) => {
@@ -834,6 +836,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             resolveFileUrl(
               ctx,
               resolveRelativeRouteFilePath(route, ctx.reactRouterConfig),
+              { publicPath: ctx.publicPath },
             ),
           )};`;
         }

--- a/packages/react-router-dev/vite/resolve-file-url.ts
+++ b/packages/react-router-dev/vite/resolve-file-url.ts
@@ -5,6 +5,7 @@ import { getVite } from "./vite";
 export const resolveFileUrl = (
   { rootDirectory }: { rootDirectory: string },
   filePath: string,
+  { publicPath }: { publicPath?: string } = {},
 ) => {
   let vite = getVite();
   let relativePath = path.relative(rootDirectory, filePath);
@@ -18,5 +19,16 @@ export const resolveFileUrl = (
     return path.posix.join("/@fs", vite.normalizePath(filePath));
   }
 
-  return "/" + vite.normalizePath(relativePath);
+  let url = "/" + vite.normalizePath(relativePath);
+
+  // When the Vite base config (publicPath) matches the start of the
+  // root-relative file URL, Vite strips the base prefix during SSR module
+  // loading, causing the file to not be found (e.g. basename "/app/" with
+  // appDirectory "app/" makes "/app/root.tsx" resolve to "/root.tsx"). Use
+  // the /@fs/ absolute path form to bypass Vite's base stripping.
+  if (publicPath && publicPath !== "/" && url.startsWith(publicPath)) {
+    return path.posix.join("/@fs", vite.normalizePath(filePath));
+  }
+
+  return url;
 };


### PR DESCRIPTION
Fixes #13716

## Problem

When Vite's `base` config and React Router's `basename` both resolve to the same path segment as the app directory (e.g. `base: "/app/"`, `basename: "/app/"`), the dev server and build fail with:

```
Failed to load url /root.tsx (resolved id: /root.tsx) in virtual:react-router/server-build. Does the file exist?
```

**Root cause**: `resolveFileUrl` generates root-relative URLs for route file imports in the virtual server-build module. With `appDirectory: "app/"` and `base: "/app/"`, it produces `/app/root.tsx`. During SSR module loading, Vite strips its `base` prefix from all URLs — turning `/app/root.tsx` → `/root.tsx` — which doesn't exist.

This was a long-standing issue also present in Remix v2 (remix-run/remix#9382). The existing workaround is to rename the `app` folder and set `appDirectory` explicitly — but the framework should handle this transparently.

## Fix

In `resolveFileUrl`, accept an optional `publicPath` parameter. When the generated root-relative URL starts with the Vite base path, fall back to the `/@fs/<absolute-path>` form, which bypasses Vite's base-stripping logic.

Pass `{ publicPath: ctx.publicPath }` when calling `resolveFileUrl` in `getServerEntry` (for the entry server and all route module imports in the virtual server-build).

## Changes

- **`packages/react-router-dev/vite/resolve-file-url.ts`** — added optional `publicPath` option; uses `/@fs/` path when URL would conflict with the Vite base
- **`packages/react-router-dev/vite/plugin.ts`** — passes `publicPath` to `resolveFileUrl` in `getServerEntry`
- **`integration/vite-basename-test.ts`** — adds test cases for `base: "/app/"` + `basename: "/app/"` in both dev and build scenarios
- **`packages/react-router-dev/.changes/`** — changeset
