### PR TITLE
feat(@react-router/dev): log future flag warnings for upcoming v8 flags

### DIFF
--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -109,10 +109,20 @@ test.describe("cli", () => {
     expect(status).toBe(0);
   });
 
-  test("routes", async () => {
+  test.only("routes", async () => {
     const cwd = await createProject();
     let { stdout, stderr, status } = run(["routes"], { cwd });
-    expect(stdout.toString().trim()).toBe(dedent`
+
+    // Filter out future flag warnings for the format:
+    // ⚠️  Future Flag Warning: Route module splitting behavior is changing in React Router v8.
+    //     You can use the `future.v8_splitRouteModules` flag to opt in early.
+    //     -> https://reactrouter.com/upgrading/future-flags#v8_splitRouteModules
+    let filteredStdOut = stdout.toString().split("\n");
+    while (filteredStdOut[0]?.includes("Future Flag Warning:")) {
+      filteredStdOut.splice(0, 3);
+    }
+
+    expect(filteredStdOut.join("\n").trim()).toBe(dedent`
       <Routes>
         <Route file="root.tsx">
           <Route index file="routes/_index.tsx" />

--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -109,7 +109,7 @@ test.describe("cli", () => {
     expect(status).toBe(0);
   });
 
-  test.only("routes", async () => {
+  test("routes", async () => {
     const cwd = await createProject();
     let { stdout, stderr, status } = run(["routes"], { cwd });
 

--- a/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
+++ b/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
@@ -1,0 +1,3 @@
+Log future flag warnings for upcoming React Router v8 flags
+
+- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`

--- a/packages/react-router-dev/__tests__/future-flags-test.ts
+++ b/packages/react-router-dev/__tests__/future-flags-test.ts
@@ -1,0 +1,57 @@
+import { logFutureFlagWarnings } from "../config/config";
+
+describe("logFutureFlagWarnings", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns about all stable v8_ flags when none are set", () => {
+    logFutureFlagWarnings({});
+
+    expect(warnSpy).toHaveBeenCalledTimes(4);
+    expect(warnSpy.mock.calls[0][0]).toContain("v8_middleware");
+    expect(warnSpy.mock.calls[1][0]).toContain("v8_splitRouteModules");
+    expect(warnSpy.mock.calls[2][0]).toContain("v8_viteEnvironmentApi");
+    expect(warnSpy.mock.calls[3][0]).toContain("v8_passThroughRequests");
+  });
+
+  it("does not warn about flags that are already opted in (true)", () => {
+    logFutureFlagWarnings({
+      v8_middleware: true,
+      v8_splitRouteModules: true,
+      v8_viteEnvironmentApi: true,
+      v8_passThroughRequests: true,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn about flags that are explicitly opted out (false)", () => {
+    logFutureFlagWarnings({
+      v8_middleware: false,
+      v8_splitRouteModules: false,
+      v8_viteEnvironmentApi: false,
+      v8_passThroughRequests: false,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("only warns about flags that are not yet set", () => {
+    logFutureFlagWarnings({
+      v8_middleware: true,
+      v8_passThroughRequests: false,
+    });
+
+    // Only v8_splitRouteModules and v8_viteEnvironmentApi are missing
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0][0]).toContain("v8_splitRouteModules");
+    expect(warnSpy.mock.calls[1][0]).toContain("v8_viteEnvironmentApi");
+  });
+});

--- a/packages/react-router-dev/__tests__/future-flags-test.ts
+++ b/packages/react-router-dev/__tests__/future-flags-test.ts
@@ -1,24 +1,24 @@
 import { logFutureFlagWarnings } from "../config/config";
 
 describe("logFutureFlagWarnings", () => {
-  let warnSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    logSpy.mockRestore();
   });
 
   it("warns about all stable v8_ flags when none are set", () => {
     logFutureFlagWarnings({});
 
-    expect(warnSpy).toHaveBeenCalledTimes(4);
-    expect(warnSpy.mock.calls[0][0]).toContain("v8_middleware");
-    expect(warnSpy.mock.calls[1][0]).toContain("v8_splitRouteModules");
-    expect(warnSpy.mock.calls[2][0]).toContain("v8_viteEnvironmentApi");
-    expect(warnSpy.mock.calls[3][0]).toContain("v8_passThroughRequests");
+    expect(logSpy).toHaveBeenCalledTimes(4);
+    expect(logSpy.mock.calls[0][0]).toContain("v8_middleware");
+    expect(logSpy.mock.calls[1][0]).toContain("v8_splitRouteModules");
+    expect(logSpy.mock.calls[2][0]).toContain("v8_viteEnvironmentApi");
+    expect(logSpy.mock.calls[3][0]).toContain("v8_passThroughRequests");
   });
 
   it("does not warn about flags that are already opted in (true)", () => {
@@ -29,7 +29,7 @@ describe("logFutureFlagWarnings", () => {
       v8_passThroughRequests: true,
     });
 
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it("does not warn about flags that are explicitly opted out (false)", () => {
@@ -40,7 +40,7 @@ describe("logFutureFlagWarnings", () => {
       v8_passThroughRequests: false,
     });
 
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
   });
 
   it("only warns about flags that are not yet set", () => {
@@ -50,8 +50,8 @@ describe("logFutureFlagWarnings", () => {
     });
 
     // Only v8_splitRouteModules and v8_viteEnvironmentApi are missing
-    expect(warnSpy).toHaveBeenCalledTimes(2);
-    expect(warnSpy.mock.calls[0][0]).toContain("v8_splitRouteModules");
-    expect(warnSpy.mock.calls[1][0]).toContain("v8_viteEnvironmentApi");
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0][0]).toContain("v8_splitRouteModules");
+    expect(logSpy.mock.calls[1][0]).toContain("v8_viteEnvironmentApi");
   });
 });

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -753,7 +753,46 @@ async function resolveConfig({
     await preset.reactRouterConfigResolved?.({ reactRouterConfig });
   }
 
+  logFutureFlagWarnings(userAndPresetConfigs.future || {});
+
   return ok(reactRouterConfig);
+}
+
+function logFutureFlagWarning(flag: string, message: string): void {
+  console.warn(
+    colors.yellow(
+      `  ⚠️  Future Flag Warning: ${message}\n` +
+        `     You can use the \`future.${flag}\` flag to opt in early.\n` +
+        `     -> https://reactrouter.com/upgrading/future-flags#${flag}`,
+    ),
+  );
+}
+
+export function logFutureFlagWarnings(future: Partial<FutureConfig>): void {
+  if (future.v8_middleware === undefined) {
+    logFutureFlagWarning(
+      "v8_middleware",
+      "Route middleware support is changing in React Router v8.",
+    );
+  }
+  if (future.v8_splitRouteModules === undefined) {
+    logFutureFlagWarning(
+      "v8_splitRouteModules",
+      "Route module splitting behavior is changing in React Router v8.",
+    );
+  }
+  if (future.v8_viteEnvironmentApi === undefined) {
+    logFutureFlagWarning(
+      "v8_viteEnvironmentApi",
+      "Vite Environment API usage is changing in React Router v8.",
+    );
+  }
+  if (future.v8_passThroughRequests === undefined) {
+    logFutureFlagWarning(
+      "v8_passThroughRequests",
+      "Request handling behavior is changing in React Router v8.",
+    );
+  }
 }
 
 type ChokidarEventName = ChokidarEmitArgs[0];

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -759,7 +759,7 @@ async function resolveConfig({
 }
 
 function logFutureFlagWarning(flag: string, message: string): void {
-  console.warn(
+  console.log(
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +


### PR DESCRIPTION
Adds future flag deprecation warnings for v7 in preparation for v8.  Warnings are suppressed when a flag is explicitly set to either `true` or `false` — only `undefined` (i.e., not yet configured) triggers a warning.
