### PR TITLE
fix(dev): isolate app directory during route config loading

### DIFF
--- a/packages/react-router-dev/.changes/patch.concurrent-flat-routes-app-directory.md
+++ b/packages/react-router-dev/.changes/patch.concurrent-flat-routes-app-directory.md
@@ -1,0 +1,3 @@
+Prevent concurrent route config loads from sharing app directory state.
+
+This fixes route resolution for Framework Mode apps that use `flatRoutes()` while multiple Vite configs are resolved at the same time.

--- a/packages/react-router-dev/__tests__/route-config-test.ts
+++ b/packages/react-router-dev/__tests__/route-config-test.ts
@@ -9,17 +9,41 @@ import {
   prefix,
   relative,
 } from "../config/routes";
+import {
+  getAppDirectory,
+  setAppDirectory,
+  withAppDirectory,
+} from "../config/app-directory";
 
+const cwd = normalizePath(process.cwd());
 const cleanPathsForSnapshot = (obj: any): any =>
   JSON.parse(
     JSON.stringify(obj, (_key, value) =>
       typeof value === "string" && path.isAbsolute(value)
-        ? normalizePath(value.replace(process.cwd(), "{{CWD}}"))
+        ? normalizePath(value).replace(cwd, "{{CWD}}")
         : value,
     ),
   );
 
 describe("route config", () => {
+  describe("app directory context", () => {
+    it("isolates concurrent async route config loads", async () => {
+      setAppDirectory("global-app");
+
+      let first = withAppDirectory("app-a", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return getAppDirectory();
+      });
+      let second = withAppDirectory("app-b", async () => getAppDirectory());
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        "app-a",
+        "app-b",
+      ]);
+      expect(getAppDirectory()).toBe("global-app");
+    });
+  });
+
   describe("validateRouteConfig", () => {
     it("validates a route config", () => {
       const routeConfig = prefix("prefix", [

--- a/packages/react-router-dev/config/app-directory.ts
+++ b/packages/react-router-dev/config/app-directory.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import invariant from "../invariant";
+
+declare global {
+  var __reactRouterAppDirectory: string;
+}
+
+const appDirectoryStorage = new AsyncLocalStorage<string>();
+
+export function setAppDirectory(directory: string) {
+  globalThis.__reactRouterAppDirectory = directory;
+}
+
+export function getAppDirectory() {
+  const appDirectory =
+    appDirectoryStorage.getStore() ?? globalThis.__reactRouterAppDirectory;
+  invariant(appDirectory);
+  return appDirectory;
+}
+
+export function withAppDirectory<T>(directory: string, callback: () => T): T {
+  return appDirectoryStorage.run(directory, callback);
+}

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -17,10 +17,10 @@ import {
   type RouteManifest,
   type RouteManifestEntry,
   type RouteConfigEntry,
-  setAppDirectory,
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
+import { withAppDirectory } from "./app-directory";
 import { detectPackageManager } from "../cli/detectPackageManager";
 
 const excludedConfigPresetKeys = ["presets"] as const satisfies ReadonlyArray<
@@ -636,15 +636,17 @@ async function resolveConfig({
         );
       }
 
-      setAppDirectory(appDirectory);
-      let routeConfigExport = (
-        await viteNodeContext.runner.executeFile(
-          Path.join(appDirectory, routeConfigFile),
-        )
-      ).default;
-      let result = validateRouteConfig({
-        routeConfigFile,
-        routeConfig: await routeConfigExport,
+      let result = await withAppDirectory(appDirectory, async () => {
+        let routeConfigExport = (
+          await viteNodeContext.runner.executeFile(
+            Path.join(appDirectory, routeConfigFile),
+          )
+        ).default;
+
+        return validateRouteConfig({
+          routeConfigFile,
+          routeConfig: await routeConfigExport,
+        });
       });
 
       if (!result.valid) {

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -2,24 +2,7 @@ import * as Path from "pathe";
 import * as v from "valibot";
 import pick from "lodash/pick";
 
-import invariant from "../invariant";
-
-declare global {
-  var __reactRouterAppDirectory: string;
-}
-
-export function setAppDirectory(directory: string) {
-  globalThis.__reactRouterAppDirectory = directory;
-}
-
-/**
- * Provides the absolute path to the app directory, for use within `routes.ts`.
- * This is designed to support resolving file system routes.
- */
-export function getAppDirectory() {
-  invariant(globalThis.__reactRouterAppDirectory);
-  return globalThis.__reactRouterAppDirectory;
-}
+export { getAppDirectory, setAppDirectory } from "./app-directory";
 
 export interface RouteManifestEntry {
   /**


### PR DESCRIPTION
Fixes #15007.

## Summary

- move the app-directory lookup used by `routes.ts` helpers into an async-local context
- run route config module execution and awaited route config exports inside that per-config context
- keep the existing global app-directory fallback for compatibility with current `getAppDirectory()` / `setAppDirectory()` usage
- make the route config snapshot helper normalize `process.cwd()` so the full test file passes on Windows too

This prevents concurrent Framework Mode config loads from sharing app-directory state when route configs call `flatRoutes()` asynchronously.

## Validation

- `corepack pnpm exec jest packages/react-router-dev/__tests__/route-config-test.ts`
- `corepack pnpm --filter react-router build`
- `corepack pnpm --filter @react-router/fs-routes build`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm changes:validate`
- `git diff --check`