### PR TITLE
Fix prerendered Suspense fallback swap artifacts

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -934,6 +934,65 @@ for (let previewServerPrerendering of [false, true]) {
         expect(await app.getHtml()).toMatch("Index: INDEX");
       });
 
+      test("Prerenders complete suspense boundaries without shell swap markup", async () => {
+        fixture = await createFixture({
+          files: {
+            ...files,
+            "app/root.tsx": js`
+            import * as React from "react";
+            import { Links, Meta, Scripts, Outlet } from "react-router";
+
+            const LazyRoute = React.lazy(() => {
+              return new Promise((resolve) => {
+                setTimeout(() => resolve(import("./lazy-route")), 1);
+              });
+            });
+
+            export function Layout({ children }) {
+              return (
+                <html lang="en">
+                  <head>
+                    <Meta />
+                    <Links />
+                  </head>
+                  <body>
+                    <h1>Root</h1>
+                    <React.Suspense fallback={<p id="fallback">Loading</p>}>
+                      <LazyRoute />
+                    </React.Suspense>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+
+            export default function Root() {
+              return <Outlet />;
+            }
+          `,
+            "app/routes/_index.tsx": js`
+            export default function Component() {
+              return <p id="index-route">Index Route</p>;
+            }
+          `,
+            "app/lazy-route.tsx": js`
+            export default function LazyRoute() {
+              return <p id="lazy-route">Deferred Route</p>;
+            }
+          `,
+          },
+        });
+        appFixture = await createAppFixture(fixture);
+
+        let res = await fixture.requestDocument("/");
+        let html = await res.text();
+        expect(html).toContain('<p id="lazy-route">Deferred Route</p>');
+        expect(html).toContain('<p id="index-route">Index Route</p>');
+        expect(html).not.toContain("<!--$?-->");
+        expect(html).not.toContain('$RC("B:0",');
+      });
+
       test("Ignores build-time headers at runtime", async () => {
         fixture = await createFixture({ files });
         let res = await fixture.requestSingleFetchData("/_root.data", {

--- a/packages/react-router-dev/config/defaults/entry.server.node.tsx
+++ b/packages/react-router-dev/config/defaults/entry.server.node.tsx
@@ -29,11 +29,14 @@ export default function handleRequest(
   return new Promise((resolve, reject) => {
     let shellRendered = false;
     let userAgent = request.headers.get("user-agent");
+    let isPrerendering = process.env.IS_RR_BUILD_REQUEST === "yes";
 
     // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
     // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
     let readyOption: keyof RenderToPipeableStreamOptions =
-      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+      (userAgent && isbot(userAgent)) ||
+      routerContext.isSpaMode ||
+      isPrerendering
         ? "onAllReady"
         : "onShellReady";
 


### PR DESCRIPTION
## Summary
- Use `onAllReady` for prerender build requests so prerendered HTML waits for Suspense content instead of shipping the shell fallback plus `$RC()` swap script.
- Add integration coverage for a Suspense-backed lazy route to assert prerendered output contains concrete route content and excludes shell swap markers.

Fixes #15025.

## Validation
- `corepack pnpm --filter react-router build`
- `corepack pnpm --filter @react-router/node build`
- `corepack pnpm --filter @react-router/express build`
- `corepack pnpm exec prettier --check integration/vite-prerender-test.ts packages/react-router-dev/config/defaults/entry.server.node.tsx`
- `corepack pnpm exec eslint integration/vite-prerender-test.ts packages/react-router-dev/config/defaults/entry.server.node.tsx`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm exec playwright test integration/vite-prerender-test.ts --project=chromium --config ./integration/playwright.config.ts --grep "Prerenders complete suspense boundaries" --workers=1` (blocked locally by Windows `EPERM` when the integration fixture copies workspace package symlinks)