### PR TITLE
docs: fix duplicated words in test names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,55 +174,63 @@ We manage release notes in this file instead of the paginated Github Releases Pa
 
 Date: 2026-05-05
 
+### What's Changed
+
+#### Stabilizations
+
+We've stabilized a bunch of APIs in this release in preparation for a React Router v8 release hopefully in the next month or two. These flag/prop renames are breaking changes if you've already opted into the unstable APIs so please make sure you make the appropriate changes if so.
+
+- `future.unstable_passThroughRequests` → `future.v8_passThroughRequests`
+- `future.unstable_subResourceIntegrity` → top-level `config.subResourceIntegrity`
+- `prerender.unstable_concurrency` → `prerender.concurrency`
+- `unstable_url` → `url` (loader, action, middleware, instrumentation args)
+- `unstable_instrumentations` → `instrumentations`
+  - Plus associated types (`ServerInstrumentation`, `ClientInstrumentation`, etc.)
+- `unstable_pattern` → `pattern` (loader, action, middleware, instrumentation args)
+- `unstable_defaultShouldRevalidate` → `defaultShouldRevalidate`
+- `unstable_useTransitions` → `useTransitions`
+- `unstable_mask` → `mask` (on `<Link>`, `useLinkClickHandler`, `useNavigate`, and `Location`)
+
+#### Route matching optimizations
+
+We've added a handful of route matching optimizations in this release for Framework and Data mode. The changes are mostly related to caching the internal flattened/ranked route branches and reducing additional calls to `matchRoutes` along the critical path. This should result in improved performance during both server-side request handling and client-side navigations.
+
 ### Minor Changes
 
-- `react-router` - Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize the instrumentation APIs ([14999](https://github.com/remix-run/react-router/pull/14999))
+  - `unstable_instrumentations` is now `instrumentations`
+  - `unstable_pattern` is now `pattern`
   - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `react-router` - Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `react-router` - Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `@react-router/dev` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `@react-router/dev` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `@react-router/dev` - Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `@react-router/dev` - Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
-
-- `@react-router/dev` - Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
+- `@react-router/dev` - Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([14999](https://github.com/remix-run/react-router/pull/14999))
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 ### Patch Changes
 
 - `react-router` - Add `nonce` to `<Scripts>` `<link rel="modulepreload">` elements (if provided) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
-
 - `react-router` - Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))
-
+- `react-router` - Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
 - `react-router` - Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
   - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance
-
-- `react-router` - Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
-
 - `react-router` - Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))
-
 - `react-router` - Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
   - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
     - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,48 +177,37 @@ Date: 2026-05-05
 ### Minor Changes
 
 - `react-router` - Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `react-router` - Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `@react-router/dev` - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `@react-router/dev` - Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - `@react-router/dev` - Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 ### Patch Changes
@@ -228,7 +217,6 @@ Date: 2026-05-05
 - `react-router` - Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))
 
 - `react-router` - Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
-
   - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance
 
 - `react-router` - Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
@@ -236,7 +224,6 @@ Date: 2026-05-05
 - `react-router` - Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))
 
 - `react-router` - Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
-
   - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
     - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
     - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -118,7 +118,7 @@ This table gives a high-level overview of the stages, but please see the individ
 - A proposal enters **Stage 2 — Alpha** once a PR has been opened implementing the feature in an `unstable_` state
 - At this stage, we should open an Issue for the Proposal and add it to the [Roadmap](https://github.com/orgs/remix-run/projects/5)
 - We will remove any `accepting-prs` label and add the `🗺️ Roadmap` label to indicate that this RFc is officially on the roadmap
-- At this stage, we are looking for early community testing _before_ merging any work to the React Router repo — so these PRs should provide a mechanism for community members to opt into to alpha testing
+- At this stage, we are looking for early community testing _before_ merging any work to the React Router repo — so these PRs should provide a mechanism for community members to opt into alpha testing
   - Maintainers can trigger an alpha release from the PR branch by adding the `alpha-release` label, which will kick off an experimental release and comment it back on the PR
   - Because the alpha release may contain other work committed to `dev` but not yet released in a stable version, it may not be ideal for testing in all cases
   - In these cases, PR authors may also add the contents for a `.patch` file in a comment that folks can use via [patch-package](https://www.npmjs.com/package/patch-package) or [pnpm patch](https://pnpm.io/cli/patch)

--- a/contributors.yml
+++ b/contributors.yml
@@ -109,6 +109,7 @@
 - dchenk
 - decadentsavant
 - developit
+- dfedoryshchev
 - dgrijuela
 - DigitalNaut
 - DimaAmega

--- a/contributors.yml
+++ b/contributors.yml
@@ -378,12 +378,12 @@
 - ryanhiebert
 - saengmotmi
 - SailorStat
-- SAY-5
 - samimsu
 - sanjai451
 - sanketshah19
 - sapphi-red
 - saul-atomrigs
+- SAY-5
 - sbolel
 - scarf005
 - sealer3

--- a/contributors.yml
+++ b/contributors.yml
@@ -378,6 +378,7 @@
 - ryanhiebert
 - saengmotmi
 - SailorStat
+- SAY-5
 - samimsu
 - sanjai451
 - sanketshah19

--- a/docs/api/hooks/useFormAction.md
+++ b/docs/api/hooks/useFormAction.md
@@ -28,7 +28,7 @@ the current URL of the app.
 This is used internally by [`Form`](../components/Form) to resolve the `action` to the closest
 route, but can be used generically as well.
 
-```tsx
+```ts
 import { useFormAction } from "react-router";
 
 function SomeComponent() {
@@ -39,6 +39,12 @@ function SomeComponent() {
   let destroyAction = useFormAction("destroy");
 }
 ```
+
+<docs-info>This hook adds a `basename` if your app specifies one, so that it
+can be used with raw `<form>` elements in a progressively enhanced way.  If
+you are using this to provide an `action` to `<Form>` or `fetcher.submit`, you
+will need to remove the `basename` since both of those will prepend it
+internally.</docs-info>
 
 ## Signature
 

--- a/docs/api/other-api/serve.md
+++ b/docs/api/other-api/serve.md
@@ -14,18 +14,28 @@ You can see the underlying `express` server configuration in [packages/react-rou
 - [`express.static`][express-static] (and thus [`serve-static`][serve-static])
 - [`morgan`][morgan]
 
+## Usage
+
+Install `@react-router/serve`:
+
+```sh nonumber
+npm install @react-router/serve
+```
+
+Run the server with your server build:
+
+```sh nonumber
+react-router-serve <server-build-path>
+# e.g.
+react-router-serve build/index.js
+```
+
 ## `HOST` environment variable
 
 You can configure the hostname for your Express app via `process.env.HOST` and that value will be passed to the internal [`app.listen`][express-listen] method when starting the server.
 
 ```shellscript nonumber
 HOST=127.0.0.1 npx react-router-serve build/index.js
-```
-
-```shellscript nonumber
-react-router-serve <server-build-path>
-# e.g.
-react-router-serve build/index.js
 ```
 
 ## `PORT` environment variable

--- a/docs/api/other-api/serve.md
+++ b/docs/api/other-api/serve.md
@@ -54,7 +54,7 @@ The `server-build-path` needs to point to the `serverBuildPath` defined in [`rea
 
 Because only the build artifacts (`build/`, `public/build/`) need to be deployed to production, the `react-router.config.ts` is not guaranteed to be available in production, so you need to tell React Router where your server build is with this option.
 
-In development, `react-router-serve` will ensure the latest code is run by purging the `require` cache for every request. This has some effects on your code you might need to be aware of:
+In development, `@react-router/serve` will ensure the latest code is run by purging the `require` cache for every request. This has some effects on your code you might need to be aware of:
 
 - Any values in the module scope will be "reset"
 

--- a/docs/how-to/headers.md
+++ b/docs/how-to/headers.md
@@ -9,9 +9,27 @@ title: HTTP Headers
 <br/>
 <br/>
 
+## Reading request headers
+
+The `request` sent to route handlers is a standard Web Fetch [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request), so you can read headers directly from the [`request.headers`](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers) property:
+
+```tsx filename=some-route.tsx
+export async function loader({
+  request,
+}: Route.LoaderArgs) {
+  // Standard Headers methods are available
+  const userAgent = request.headers.get("User-Agent");
+  const hasCookies = request.headers.has("Cookie");
+
+  // ...
+}
+```
+
+## Setting response headers
+
 Headers are primarily defined with the route module `headers` export. You can also set headers in `entry.server.tsx`.
 
-## From Route Modules
+### From Route Modules
 
 ```tsx filename=some-route.tsx
 import { Route } from "./+types/some-route";
@@ -28,11 +46,11 @@ export function headers(_: Route.HeadersArgs) {
 
 You can return either a [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) instance or `HeadersInit`.
 
-## From loaders and actions
+### From loaders and actions
 
 When the header is dependent on loader data, loaders and actions can also set headers.
 
-### 1. Wrap your return value in `data`
+**1. Wrap your return value in `data`**
 
 ```tsx lines=[1,8]
 import { data } from "react-router";
@@ -50,7 +68,7 @@ export async function loader({ params }: LoaderArgs) {
 }
 ```
 
-### 2. Return from `headers` export
+**2. Return from `headers` export**
 
 Headers from loaders and actions are not sent automatically. You must explicitly return them from the `headers` export.
 
@@ -71,7 +89,7 @@ export function headers({
 
 One notable exception is `Set-Cookie` headers, which are automatically preserved from `headers`, `loader`, and `action` in parent routes, even without exporting `headers` from the child route.
 
-## Merging with parent headers
+### Merging with parent headers
 
 Consider these nested routes
 
@@ -85,7 +103,7 @@ If both route modules want to set headers, the headers from the deepest matching
 
 When you need to keep both the parent and the child headers, you need to merge them in the child route.
 
-### Appending
+#### Appending
 
 The easiest way is to simply append to the parent headers. This avoids overwriting a header the parent may have set and both are important.
 
@@ -98,7 +116,7 @@ export function headers({ parentHeaders }: HeadersArgs) {
 }
 ```
 
-### Setting
+#### Setting
 
 Sometimes it's important to overwrite the parent header. Do this with `set` instead of `append`:
 
@@ -114,7 +132,7 @@ export function headers({ parentHeaders }: HeadersArgs) {
 
 You can avoid the need to merge headers by only defining headers in "leaf routes" (index routes and child routes without children) and not in parent routes.
 
-## From `entry.server.tsx`
+### From `entry.server.tsx`
 
 The `handleRequest` export receives the headers from the route module as an argument. You can append global headers here.
 

--- a/docs/how-to/suspense.md
+++ b/docs/how-to/suspense.md
@@ -68,7 +68,7 @@ export default function MyComponent({
 
 ## With React 19
 
-If you're experimenting with React 19, you can use `React.use` instead of `Await`, but you'll need to create a new component and pass the promise down to trigger the suspense fallback.
+If you're using React 19, you can use `React.use` instead of `Await`, but you'll need to create a new component and pass the promise down to trigger the suspense fallback.
 
 ```tsx
 <React.Suspense fallback={<div>Loading...</div>}>
@@ -90,4 +90,43 @@ By default, loaders and actions reject any outstanding promises after 4950ms. Yo
 ```ts filename=entry.server.tsx
 // Reject all pending promises from handler functions after 10 seconds
 export const streamTimeout = 10_000;
+```
+
+## Handling early rejections (Node)
+
+React Router waits for all loaders to settle (via `Promise.all`) before it begins streaming the response. Once streaming has started, React Router catches subsequent rejections of your streamed promises and surfaces them to your `<Await>` (or React 19 `React.use`) error UI.
+
+However, if a streamed promise rejects _before_ all of the route's loaders have settled, React Router has not yet been able to attach a handler to it. In Node, an unhandled promise rejection will crash the process unless you have a top-level handler registered.
+
+For example, this can happen if a parent route's loader takes longer to resolve than a child route's streamed promise takes to reject:
+
+```tsx
+// parent.tsx — slow loader
+export async function loader() {
+  await new Promise((r) => setTimeout(r, 1000));
+  return { parent: "data" };
+}
+
+// child.tsx — fast-rejecting streamed promise
+export async function loader() {
+  let lazy = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("boom")), 100),
+  );
+  return { lazy };
+}
+```
+
+When `lazy` rejects before the parent loader resolves, the rejection bubbles to the node process as an unhandled rejection, which will crash the process without a user-defined handler.
+
+To prevent this, register a process-level `unhandledRejection` handler in your server entry:
+
+```ts filename=entry.server.ts
+process.on("unhandledRejection", (reason, promise) => {
+  console.error(
+    "Unhandled Rejection at:",
+    promise,
+    "reason:",
+    reason,
+  );
+});
 ```

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -114,7 +114,7 @@ You should now see a `build` folder containing a `server` folder (the server ver
 
 👉 **Run the app with `react-router-serve`**
 
-Now you can run your app with `react-router-serve`:
+Now you can run your app with `react-router-serve`, provided by the `@react-router/serve` package:
 
 ```shellscript nonumber
 npx react-router-serve build/server/index.js
@@ -142,9 +142,9 @@ You can also use React Router as a Single Page Application with no server. For m
 
 </docs-info>
 
-If you don't care to set up your own server, you can use `react-router-serve`. It's a simple `express`-based server maintained by the React Router maintainers. However, React Router is specifically designed to run in _any_ JavaScript environment so that you own your stack. It is expected many —if not most— production apps will have their own server.
+If you don't care to set up your own server, you can use `@react-router/serve`. It's a simple `express`-based server maintained by the React Router maintainers. However, React Router is specifically designed to run in _any_ JavaScript environment so that you own your stack. It is expected many —if not most— production apps will have their own server.
 
-Just for kicks, let's stop using `react-router-serve` and use `express` instead.
+Just for kicks, let's stop using `@react-router/serve` and use `express` instead.
 
 👉 **Install Express, the React Router Express adapter, and [cross-env] for running in production mode**
 

--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -501,7 +501,7 @@ test.describe("Vite base + React Router basename", () => {
           await workflowBuild({ page, port, basename: "/notmybase/" });
         });
 
-        test("works when when base is an absolute external URL", async ({
+        test("works when base is an absolute external URL", async ({
           page,
         }) => {
           test.skip(

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -5,15 +5,12 @@
 ### Minor Changes
 
 - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `prerender.unstable_concurrency` as `prerender.concurrency` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `future.unstable_subResourceIntegrity` as a top-level `subResourceIntegrity` config option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 ### Patch Changes

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -5,36 +5,28 @@
 ### Minor Changes
 
 - Stabilize `unstable_defaultShouldRevalidate` as `defaultShouldRevalidate` on `<Link>`, `<Form>`, `useLinkClickHandler`, `useSubmit`, `fetcher.submit`, and `setSearchParams` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize the instrumentation APIs. `unstable_instrumentations` is now `instrumentations` and `unstable_pattern` is now `pattern` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - The `unstable_ServerInstrumentation`, `unstable_ClientInstrumentation`, `unstable_InstrumentRequestHandlerFunction`, `unstable_InstrumentRouterFunction`, `unstable_InstrumentRouteFunction`, and `unstable_InstrumentationHandlerResult` types have had their `unstable_` prefixes removed
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `unstable_mask` as `mask` on `<Link>`, `useLinkClickHandler`, and `useNavigate`, and rename the corresponding `Location.unstable_mask` field to `Location.mask` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize the `unstable_normalizePath` option on `staticHandler.query` and `staticHandler.queryRoute` as `normalizePath` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `future.unstable_passThroughRequests` as `future.v8_passThroughRequests` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Remove `unstable_subResourceIntegrity` from the runtime `FutureConfig` type; the flag is now controlled by the top-level `subResourceIntegrity` option in `react-router.config.ts` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `unstable_url` as `url` on `loader`, `action`, and `middleware` function args ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 - Stabilize `unstable_useTransitions` as `useTransitions` on `<BrowserRouter>`, `<HashRouter>`, `<HistoryRouter>`, `<MemoryRouter>`, `<Router>`, `<RouterProvider>`, `<HydratedRouter>`, and `useLinkClickHandler` ([a993f09](https://github.com/remix-run/react-router/commit/a993f09))
-
   - ⚠️ This is a breaking change if you have already opted into the unstable version - you will need to update your code accordingly
 
 ### Patch Changes
@@ -44,7 +36,6 @@
 - Fix a bug with `unstable_defaultShouldRevalidate={false}` where parent routes that did not export a `shouldRevalidate` function could be incorrectly included in the single fetch call for new child route data ([#15012](https://github.com/remix-run/react-router/pull/15012))
 
 - Improve server-side route matching performance by pre-computing flattened/cached route branches ([#14967](https://github.com/remix-run/react-router/pull/14967)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
-
   - Performance benchmarks showed roughly a 10-15% improvement in server-side request handling performance
 
 - Mark `mask` as an optional field in `Location` for easier mocking in unit tests ([#14999](https://github.com/remix-run/react-router/pull/14999))
@@ -52,7 +43,6 @@
 - Cache flattened/ranked route branches to optimize server-side route matching ([#14967](https://github.com/remix-run/react-router/pull/14967))
 
 - Improve route matching performance in Framework/Data Mode ([#14971](https://github.com/remix-run/react-router/pull/14971)) ([af5d49b](https://github.com/remix-run/react-router/commit/af5d49b))
-
   - Avoiding unnecessary calls to `matchRoutes` in data router scenarios
     - This includes adding back the optimization that was removed in `7.6.0` ([#13562](https://github.com/remix-run/react-router/pull/13562))
     - The issues that prompted the revert have been addressed by using the available router `matches` but always updating `match.route` to the latest route in the `manifest`

--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -141,7 +141,7 @@ describe("generatePath", () => {
     });
   });
 
-  it("throws only on on missing named parameters, but not missing splat params", () => {
+  it("throws only on missing named parameters, but not missing splat params", () => {
     expect(() => generatePath(":foo")).toThrow();
     expect(() => generatePath("/:foo")).toThrow();
     expect(() => generatePath("*")).not.toThrow();

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2628,7 +2628,7 @@ export function useSubmit(): SubmitFunction {
  * This is used internally by {@link Form} to resolve the `action` to the closest
  * route, but can be used generically as well.
  *
- * @example
+ * ```ts
  * import { useFormAction } from "react-router";
  *
  * function SomeComponent() {
@@ -2638,6 +2638,14 @@ export function useSubmit(): SubmitFunction {
  *   // closest route URL + "destroy"
  *   let destroyAction = useFormAction("destroy");
  * }
+ * ```
+ *
+ * <docs-info>This hook adds a `basename` if your app specifies one, so that it
+ * can be used with raw `<form>` elements in a progressively enhanced way.  If
+ * you are using this to provide an `action` to `<Form>` or `fetcher.submit`, you
+ * will need to remove the `basename` since both of those will prepend it
+ * internally.</docs-info>
+ *
  *
  * @public
  * @category Hooks


### PR DESCRIPTION
Fixes two duplicated words in test description strings.

This only changes test names; test logic is unchanged.