### PR TITLE
Fire onError for initial-load errors when RouterProvider mounts late

### DIFF
--- a/packages/react-router/.changes/patch.fix-onerror-initial-errors.md
+++ b/packages/react-router/.changes/patch.fix-onerror-initial-errors.md
@@ -1,1 +1,1 @@
-Fix `RouterProvider` `onError` callback not being called for synchronous initial loader errors in SPA mode
+Fix `RouterProvider` `onError` callback not being called for synchronous initial loader errors in SPA mode ([#15039](https://github.com/remix-run/react-router/pull/15039))

--- a/packages/react-router/__tests__/dom/client-on-error-test.tsx
+++ b/packages/react-router/__tests__/dom/client-on-error-test.tsx
@@ -642,6 +642,37 @@ describe(`handleError`, () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it("handles initial load synchronous loader errors in SPA mode (delayed render)", async () => {
+    let spy = jest.fn();
+    let router = createMemoryRouter([
+      {
+        path: "/",
+        loader() {
+          throw new Error("immediate loader error!");
+        },
+        Component: () => <h1>Home</h1>,
+        HydrateFallback: () => <h1>Loading...</h1>,
+        ErrorBoundary: () => (
+          <h1>Error:{(useRouteError() as Error).message}</h1>
+        ),
+      },
+    ]);
+
+    // Make sure the router completely initializes
+    await tick();
+
+    render(<RouterProvider router={router} onError={spy} />);
+
+    await waitFor(() => screen.getByText("Error:immediate loader error!"));
+
+    expect(spy).toHaveBeenCalledWith(new Error("immediate loader error!"), {
+      location: expect.objectContaining({ pathname: "/" }),
+      params: {},
+      pattern: "/",
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it("does not fire onError for errors from hydrationData", async () => {
     let spy = jest.fn();
     let router = createMemoryRouter(
@@ -664,6 +695,39 @@ describe(`handleError`, () => {
         },
       },
     );
+
+    render(<RouterProvider router={router} onError={spy} />);
+
+    await waitFor(() => screen.getByText("Error:hydration error!"));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onError for errors from hydrationData (delayed render)", async () => {
+    let spy = jest.fn();
+    let router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          loader() {
+            throw new Error("hydration error!");
+          },
+          Component: () => <h1>Home</h1>,
+          ErrorBoundary: () => (
+            <h1>Error:{(useRouteError() as Error).message}</h1>
+          ),
+        },
+      ],
+      {
+        hydrationData: {
+          errors: { "0": new Error("hydration error!") },
+          loaderData: {},
+        },
+      },
+    );
+
+    // Make sure the router completely initializes
+    await tick();
 
     render(<RouterProvider router={router} onError={spy} />);
 

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -616,22 +616,11 @@ export function RouterProvider({
   );
 
   // Need to use a layout effect here so we are subscribed early enough to
-  // pick up on any render-driven redirects/navigations (useEffect/<Navigate>)
+  // pick up on any render-driven redirects/navigations (useEffect/<Navigate>).
+  // If the router finished initializing (and emitted errors) before this
+  // subscriber was attached, `subscribe()` replays that notification so
+  // `onError` still fires for initial data load errors.
   React.useLayoutEffect(() => router.subscribe(setState), [router, setState]);
-
-  // Track race conditions where we finish initializing prior to the layout
-  // effect above running to register our listener.  If we manually detect a
-  // change in `state.initialized`, automatically sync state.
-  let initialized = state.initialized;
-  React.useLayoutEffect(() => {
-    if (!initialized && router.state.initialized) {
-      setState(router.state, {
-        deletedFetchers: [],
-        flushSync: false,
-        newErrors: router.state.errors, // Initial data load errors
-      });
-    }
-  }, [initialized, setState, router.state]);
 
   // When we start a view transition, create a Deferred we can use for the
   // eventual "completed" render

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1059,6 +1059,11 @@ export function createRouter(init: RouterInit): Router {
   let unlistenHistory: (() => void) | null = null;
   // Externally-provided functions to call on all state changes
   let subscribers = new Set<RouterSubscriber>();
+  // Buffer the most recent state update when there are no subscribers, so
+  // the first subscriber to attach gets caught up. Without this, states
+  // that update during `initialize()` (before <RouterProvider>
+  // mounts and registers its subscriber) would be silently lost
+  let bufferedInitialStateUpdate: { newErrors: RouteData | null } | null = null;
   // Externally-provided object to hold scroll restoration locations during routing
   let savedScrollPositions: Record<string, number> | null = null;
   // Externally-provided function to get scroll restoration keys
@@ -1388,6 +1393,16 @@ export function createRouter(init: RouterInit): Router {
   // Subscribe to state updates for the router
   function subscribe(fn: RouterSubscriber) {
     subscribers.add(fn);
+    if (bufferedInitialStateUpdate) {
+      let { newErrors } = bufferedInitialStateUpdate;
+      bufferedInitialStateUpdate = null;
+      fn(state, {
+        deletedFetchers: [],
+        newErrors,
+        viewTransitionOpts: undefined,
+        flushSync: false,
+      });
+    }
     return () => subscribers.delete(fn);
   }
 
@@ -1451,6 +1466,10 @@ export function createRouter(init: RouterInit): Router {
         unmountedFetchers.push(key);
       }
     });
+
+    if (subscribers.size === 0) {
+      bufferedInitialStateUpdate = { newErrors: newState.errors ?? null };
+    }
 
     // Iterate over a local copy so that if flushSync is used and we end up
     // removing and adding a new subscriber due to the useCallback dependencies,


### PR DESCRIPTION
## Summary

Builds on #14942 (a907779) to handle an edge case the original fix missed: when a router is fully initialized (loaders complete with errors) **before** `RouterProvider` mounts, the `onError` callback was never fired because the React subscriber registers too late and misses the `updateState` notification.

The fix moves the recovery from `RouterProvider` into the router itself: when `updateState` runs with no subscribers attached, the notification's `newErrors` is buffered, and the first subscriber to attach via `subscribe()` drains it. This subsumes the layout-effect race-condition workaround from #14942 and now also handles the "init completed before mount" case uniformly.

Hydration errors are unaffected — they're set at state construction (not via `updateState`), so the buffer is never populated for them.

## Test plan

- [x] New test: `handles initial load synchronous loader errors in SPA mode (delayed render)` — uses `await tick()` before render so the router has fully settled at mount; verifies `onError` still fires.
- [x] New test: `does not fire onError for errors from hydrationData (delayed render)` — confirms hydrated errors stay silent even when render is delayed.
- [x] All 18 existing `client-on-error-test.tsx` tests still pass.
- [x] Full `packages/react-router` test suite passes (2157 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)