### PR TITLE
fix(dev): allow mdx frontmatter during hmr

### DIFF
--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -109,6 +109,8 @@ templates.forEach((template) => {
         "app/routes/mdx.mdx": mdx`
           import { Counter } from "../component";
 
+          export const frontmatter = { title: "MDX frontmatter" };
+
           # MDX Title (HMR: 0)
 
           <Counter />

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -135,6 +135,7 @@ const CLIENT_NON_COMPONENT_EXPORTS = [
   "clientMiddleware",
   "handle",
   "meta",
+  "frontmatter",
   "links",
   "shouldRevalidate",
 ];

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -400,6 +400,7 @@ export const CLIENT_NON_COMPONENT_EXPORTS = [
   "clientMiddleware",
   "handle",
   "meta",
+  "frontmatter",
   "links",
   "shouldRevalidate",
 ] as const;


### PR DESCRIPTION
## Summary

MDX frontmatter tooling such as `remark-mdx-frontmatter` emits a named `frontmatter` export from `.mdx` route modules. React Router's Vite refresh wrapper only treats known route exports as acceptable non-component exports, so saving an MDX route with frontmatter can invalidate Fast Refresh with the `consistent-components-exports` error.

This adds `frontmatter` to the non-component route export allowlist used by the standard Vite plugin and the RSC virtual route module path. The existing MDX HMR integration test now includes a `frontmatter` export so the route keeps component state across HMR with that export present.

Fixes #14082.

## Validation

- `corepack pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/rsc/virtual-route-modules.ts integration/vite-hmr-hdr-test.ts`
- `corepack pnpm exec eslint packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/rsc/virtual-route-modules.ts integration/vite-hmr-hdr-test.ts` (passes with existing warning-level lint noise in `plugin.ts`)
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/node --filter @react-router/dev build`
- `corepack pnpm --filter integration typecheck`

Attempted `corepack pnpm exec playwright test --config ./integration/playwright.config.ts integration/vite-hmr-hdr-test.ts --project=chromium -g "mdx"`; it is blocked in this Windows environment by `EPERM` while the integration fixture copies workspace package symlinks into `.tmp/integration`.