### PR TITLE
Normalize generated assets build paths for portable builds

### DIFF
--- a/packages/react-router-dev/.changes/patch.portable-assets-build-directory.md
+++ b/packages/react-router-dev/.changes/patch.portable-assets-build-directory.md
@@ -1,0 +1,1 @@
+Normalize assets build directory paths generated on Windows for portable production builds.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -56,6 +56,7 @@ import * as VirtualModule from "./virtual-module";
 import { resolveFileUrl } from "./resolve-file-url";
 import { resolveRelativeRouteFilePath } from "./resolve-relative-route-file-path";
 import { combineURLs } from "./combine-urls";
+import { toPortablePath } from "./portable-path";
 import { removeExports } from "./remove-exports";
 import { ssrExternals } from "./ssr-externals";
 import { hasDependency } from "./has-dependency";
@@ -843,9 +844,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         virtual.serverManifest.id,
       )};
       export const assetsBuildDirectory = ${JSON.stringify(
-        path.relative(
-          ctx.rootDirectory,
-          getClientBuildDirectory(ctx.reactRouterConfig),
+        toPortablePath(
+          path.relative(
+            ctx.rootDirectory,
+            getClientBuildDirectory(ctx.reactRouterConfig),
+          ),
         ),
       )};
       export const basename = ${JSON.stringify(ctx.reactRouterConfig.basename)};

--- a/packages/react-router-dev/vite/portable-path-test.ts
+++ b/packages/react-router-dev/vite/portable-path-test.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+
+import { toPortablePath } from "./portable-path";
+
+describe("toPortablePath", () => {
+  test("converts Windows path separators to portable slashes", () => {
+    expect(
+      toPortablePath(path.win32.relative("C:\\app", "C:\\app\\build\\client")),
+    ).toBe("build/client");
+  });
+
+  test("preserves relative parent segments", () => {
+    expect(
+      toPortablePath(
+        path.win32.relative("C:\\app\\build\\server", "C:\\app\\build\\client"),
+      ),
+    ).toBe("../client");
+  });
+
+  test("preserves POSIX paths", () => {
+    expect(
+      toPortablePath(path.posix.relative("/app", "/app/build/client")),
+    ).toBe("build/client");
+  });
+});

--- a/packages/react-router-dev/vite/portable-path.ts
+++ b/packages/react-router-dev/vite/portable-path.ts
@@ -1,0 +1,3 @@
+export function toPortablePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/");
+}

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -30,6 +30,7 @@ import { validatePluginOrder } from "../plugins/validate-plugin-order";
 import { warnOnClientSourceMaps } from "../plugins/warn-on-client-source-maps";
 import { prerender } from "../plugins/prerender";
 import { getPrerenderPaths } from "../plugin";
+import { toPortablePath } from "../portable-path";
 
 const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
 
@@ -604,7 +605,9 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           const clientOutDir =
             resolvedViteConfig.environments.client?.build?.outDir;
           invariant(clientOutDir, "Client build directory config not found");
-          const assetsBuildDirectory = Path.relative(rscOutDir, clientOutDir);
+          const assetsBuildDirectory = toPortablePath(
+            Path.relative(rscOutDir, clientOutDir),
+          );
           const publicPath = resolvedViteConfig.base;
 
           return `export default ${JSON.stringify({


### PR DESCRIPTION
## Summary

Fixes #14950 by normalizing the `assetsBuildDirectory` value embedded in generated server builds to use portable `/` separators.

When a React Router app is built on Windows, `path.relative(...)` can serialize backslashes into the server build. If that build output is copied to Linux, `react-router-serve` treats those backslashes as literal filename characters and static assets can 404. This change converts the generated relative path to portable slashes before it is written into the server build, and applies the same guard to the RSC serve config path.

## Validation

- `corepack pnpm exec jest packages/react-router-dev/vite/portable-path-test.ts --runInBand`
- `corepack pnpm exec eslint packages/react-router-dev/vite/portable-path.ts packages/react-router-dev/vite/portable-path-test.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/rsc/plugin.ts`
- `corepack pnpm exec prettier --check packages/react-router-dev/vite/portable-path.ts packages/react-router-dev/vite/portable-path-test.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/rsc/plugin.ts packages/react-router-dev/.changes/patch.portable-assets-build-directory.md`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm run changes:validate`
- `git diff --check origin/main...HEAD`
