### PR TITLE
fix(dev): scope app directory during route config loading

### DIFF
--- a/packages/react-router-dev/.changes/patch.concurrent-route-config-app-directory.md
+++ b/packages/react-router-dev/.changes/patch.concurrent-route-config-app-directory.md
@@ -1,0 +1,1 @@
+Scope route config app directories to concurrent config loads.

--- a/packages/react-router-dev/__tests__/route-config-test.ts
+++ b/packages/react-router-dev/__tests__/route-config-test.ts
@@ -8,18 +8,39 @@ import {
   index,
   prefix,
   relative,
+  getAppDirectory,
+  withAppDirectory,
 } from "../config/routes";
 
 const cleanPathsForSnapshot = (obj: any): any =>
   JSON.parse(
     JSON.stringify(obj, (_key, value) =>
       typeof value === "string" && path.isAbsolute(value)
-        ? normalizePath(value.replace(process.cwd(), "{{CWD}}"))
+        ? normalizePath(value).replace(normalizePath(process.cwd()), "{{CWD}}")
         : value,
     ),
   );
 
 describe("route config", () => {
+  describe("app directory scope", () => {
+    it("keeps the app directory scoped to concurrent async route config work", async () => {
+      let appA = path.resolve("app-a");
+      let appB = path.resolve("app-b");
+
+      let readAppDirectory = async () => {
+        await Promise.resolve();
+        return getAppDirectory();
+      };
+
+      await expect(
+        Promise.all([
+          withAppDirectory(appA, readAppDirectory),
+          withAppDirectory(appB, readAppDirectory),
+        ]),
+      ).resolves.toEqual([appA, appB]);
+    });
+  });
+
   describe("validateRouteConfig", () => {
     it("validates a route config", () => {
       const routeConfig = prefix("prefix", [

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -17,7 +17,7 @@ import {
   type RouteManifest,
   type RouteManifestEntry,
   type RouteConfigEntry,
-  setAppDirectory,
+  withAppDirectory,
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
@@ -636,15 +636,15 @@ async function resolveConfig({
         );
       }
 
-      setAppDirectory(appDirectory);
-      let routeConfigExport = (
-        await viteNodeContext.runner.executeFile(
+      let routeConfigExport = await withAppDirectory(appDirectory, async () => {
+        let routeConfigModule = await viteNodeContext.runner.executeFile(
           Path.join(appDirectory, routeConfigFile),
-        )
-      ).default;
+        );
+        return await routeConfigModule.default;
+      });
       let result = validateRouteConfig({
         routeConfigFile,
-        routeConfig: await routeConfigExport,
+        routeConfig: routeConfigExport,
       });
 
       if (!result.valid) {

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as Path from "pathe";
 import * as v from "valibot";
 import pick from "lodash/pick";
@@ -8,8 +9,14 @@ declare global {
   var __reactRouterAppDirectory: string;
 }
 
+const appDirectoryStorage = new AsyncLocalStorage<string>();
+
 export function setAppDirectory(directory: string) {
   globalThis.__reactRouterAppDirectory = directory;
+}
+
+export function withAppDirectory<T>(directory: string, callback: () => T): T {
+  return appDirectoryStorage.run(directory, callback);
 }
 
 /**
@@ -17,8 +24,11 @@ export function setAppDirectory(directory: string) {
  * This is designed to support resolving file system routes.
  */
 export function getAppDirectory() {
-  invariant(globalThis.__reactRouterAppDirectory);
-  return globalThis.__reactRouterAppDirectory;
+  let appDirectory =
+    appDirectoryStorage.getStore() ?? globalThis.__reactRouterAppDirectory;
+
+  invariant(appDirectory);
+  return appDirectory;
 }
 
 export interface RouteManifestEntry {


### PR DESCRIPTION
## Summary

Fixes #15007.

`flatRoutes()` reads the active app directory through `@react-router/dev/routes`. That directory was stored in a module-global value before `routes.ts` execution, so concurrent config loads could interleave and make one app's `routes.ts` resolve file-system routes against another app's directory.

This scopes the app directory with `AsyncLocalStorage` while executing and awaiting the route config export. The existing global setter remains as a fallback for compatibility, but concurrent route config work now sees its own app directory.

The route config unit test also normalizes `process.cwd()` before replacing absolute paths so the existing inline snapshots pass on Windows.

## Testing

- `corepack pnpm exec jest packages/react-router-dev/__tests__/route-config-test.ts --runInBand`
- `corepack pnpm exec prettier --check packages/react-router-dev/config/routes.ts packages/react-router-dev/config/config.ts packages/react-router-dev/__tests__/route-config-test.ts packages/react-router-dev/.changes/patch.concurrent-route-config-app-directory.md`
- `corepack pnpm exec eslint packages/react-router-dev/config/routes.ts packages/react-router-dev/config/config.ts packages/react-router-dev/__tests__/route-config-test.ts` (passes with existing `helpers` warning in `routes.ts`)
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm run changes:validate`