### PR TITLE
fix(router): preserve in-flight fetcher revalidations

### DIFF
--- a/packages/react-router/.changes/patch.preserve-fetcher-revalidations.md
+++ b/packages/react-router/.changes/patch.preserve-fetcher-revalidations.md
@@ -1,0 +1,1 @@
+Avoid restarting fetcher revalidations during GET navigations.

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -1976,27 +1976,27 @@ describe("fetchers", () => {
         data: "FOO",
       });
 
-      // Interrupt revalidation with GEt navigation
-      // TODO: This shouldn't actually abort the revalidation but it does currently
-      // which then causes the invalid invariant error.  This test is to ensure
-      // the invariant doesn't throw, but we'll fix the unnecessary revalidation
-      // in https://github.com/remix-run/react-router/issues/14115
+      // Interrupt revalidation with GET navigation
       let C = await t.navigate("/baz", undefined, ["foo"]);
-      expect(B.loaders.foo.signal.aborted).toBe(true);
+      expect(B.loaders.foo.signal.aborted).toBe(false);
       expect(t.fetchers[keyA]).toMatchObject({
         state: "loading",
         data: "FOO",
       });
 
-      // Complete the aborted fetcher revalidation calls
+      // Complete the original fetcher revalidation calls
       await B.loaders.root.resolve("NOPE");
       await B.loaders.index.resolve("NOPE");
-      await B.loaders.foo.resolve("NOPE");
+      await B.loaders.foo.resolve("FOO*");
+      expect(t.fetchers[keyA]).toMatchObject({
+        state: "idle",
+        data: "FOO*",
+      });
 
-      // Complete the navigation
+      // Complete the navigation without reloading the already-revalidating
+      // fetcher a second time
       await C.loaders.root.resolve("ROOT*");
       await C.loaders.baz.resolve("BAZ");
-      await C.loaders.foo.resolve("FOO*");
       expect(t.router.state).toMatchObject({
         navigation: IDLE_NAVIGATION,
         location: { pathname: "/baz" },
@@ -2004,10 +2004,6 @@ describe("fetchers", () => {
           root: "ROOT*",
           baz: "BAZ",
         },
-      });
-      expect(t.fetchers[keyA]).toMatchObject({
-        state: "idle",
-        data: "FOO*",
       });
     });
   });

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1236,6 +1236,9 @@ export function createRouter(init: RouterInit): Router {
   // Fetchers that triggered data reloads as a result of their actions
   let fetchReloadIds = new Map<string, number>();
 
+  // Fetchers that are actively revalidating as a result of another action
+  let fetchersInFlightRevalidations = new Set<string>();
+
   // Fetchers that triggered redirect navigations
   let fetchRedirectIds = new Set<string>();
 
@@ -2327,6 +2330,7 @@ export function createRouter(init: RouterInit): Router {
       fetchersQueuedForDeletion,
       fetchLoadMatches,
       fetchRedirectIds,
+      fetchersInFlightRevalidations,
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
@@ -2794,6 +2798,7 @@ export function createRouter(init: RouterInit): Router {
       fetchersQueuedForDeletion,
       fetchLoadMatches,
       fetchRedirectIds,
+      new Set<string>(),
       routesToUse,
       basename,
       init.patchRoutesOnNavigation != null,
@@ -2801,6 +2806,10 @@ export function createRouter(init: RouterInit): Router {
       [match.route.id, actionResult],
       callSiteDefaultShouldRevalidate,
     );
+
+    revalidatingFetchers.forEach((rf) => {
+      fetchersInFlightRevalidations.add(rf.key);
+    });
 
     // Put all revalidating fetchers into the loading state, except for the
     // current fetcher which we want to keep in it's current loading state which
@@ -2824,7 +2833,10 @@ export function createRouter(init: RouterInit): Router {
     updateState({ fetchers: new Map(state.fetchers) });
 
     let abortPendingFetchRevalidations = () =>
-      revalidatingFetchers.forEach((rf) => abortFetcher(rf.key));
+      revalidatingFetchers.forEach((rf) => {
+        fetchersInFlightRevalidations.delete(rf.key);
+        abortFetcher(rf.key);
+      });
 
     abortController.signal.addEventListener(
       "abort",
@@ -2841,6 +2853,9 @@ export function createRouter(init: RouterInit): Router {
       );
 
     if (abortController.signal.aborted) {
+      revalidatingFetchers.forEach((r) =>
+        fetchersInFlightRevalidations.delete(r.key),
+      );
       return;
     }
 
@@ -2851,7 +2866,10 @@ export function createRouter(init: RouterInit): Router {
 
     fetchReloadIds.delete(key);
     fetchControllers.delete(key);
-    revalidatingFetchers.forEach((r) => fetchControllers.delete(r.key));
+    revalidatingFetchers.forEach((r) => {
+      fetchControllers.delete(r.key);
+      fetchersInFlightRevalidations.delete(r.key);
+    });
 
     // Since we let revalidations complete even if the submitting fetcher was
     // deleted, only put it back to idle if it hasn't been deleted
@@ -5166,6 +5184,7 @@ function getMatchesToLoad(
   fetchersQueuedForDeletion: Set<string>,
   fetchLoadMatches: Map<string, FetchLoadMatch>,
   fetchRedirectIds: Set<string>,
+  fetchersInFlightRevalidations: Set<string>,
   routesToUse: DataRouteObject[],
   basename: string | undefined,
   hasPatchRoutesOnNavigation: boolean,
@@ -5323,6 +5342,10 @@ function getMatchesToLoad(
       !matches.some((m) => m.route.id === f.routeId) ||
       fetchersQueuedForDeletion.has(key)
     ) {
+      return;
+    }
+
+    if (fetchersInFlightRevalidations.has(key)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Track fetchers that are already revalidating because of a fetcher action.
- Skip restarting those in-flight fetcher revalidations when a navigation selects revalidation work.
- Update the fetcher regression test for GET navigations so the original revalidation completes instead of being aborted and reloaded.

Fixes #14115.

## Validation

- `corepack pnpm exec jest packages/react-router/__tests__/router/fetchers-test.ts --runInBand -t "properly ignores aborted action revalidation fetchers"`
- `corepack pnpm exec jest packages/react-router/__tests__/router/fetchers-test.ts --runInBand -t "Remix Github Issue 8298"`
- `corepack pnpm exec jest packages/react-router/__tests__/router/fetchers-test.ts --runInBand`
- `corepack pnpm exec prettier --check packages/react-router/lib/router/router.ts packages/react-router/__tests__/router/fetchers-test.ts packages/react-router/.changes/patch.preserve-fetcher-revalidations.md`
- `corepack pnpm exec eslint packages/react-router/lib/router/router.ts packages/react-router/__tests__/router/fetchers-test.ts`
- `corepack pnpm --filter react-router typecheck`
- `corepack pnpm --filter react-router build`
- `corepack pnpm run changes:validate`

Note: ESLint reports existing unused-variable warnings in `router.ts`; it reports no errors.