### PR TITLE
fix: create browser URLs from configured window

### DIFF
--- a/packages/react-router/__tests__/router/browser-test.ts
+++ b/packages/react-router/__tests__/router/browser-test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/expect-expect */
 
+import { JSDOM } from "jsdom";
 import {
   type BrowserHistory,
   createBrowserHistory,
@@ -57,6 +58,15 @@ describe("a browser history", () => {
       pathname: "/#abc",
     });
     expect(unencodedHref).toEqual("/#abc");
+  });
+
+  it("creates URLs using the configured window", () => {
+    let customWindow = new JSDOM("<!DOCTYPE html>", {
+      url: "https://example.test/current",
+    }).window as unknown as Window;
+    history = createBrowserHistory({ window: customWindow });
+
+    expect(history.createURL("/next").href).toBe("https://example.test/next");
   });
 
   describe("listen", () => {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -726,7 +726,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -771,16 +771,23 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  windowOverride?: Window,
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  let windowInstance =
+    windowOverride ?? (typeof window !== "undefined" ? window : undefined);
+
+  if (windowInstance) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      windowInstance.location.origin !== "null"
+        ? windowInstance.location.origin
+        : windowInstance.location.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");


### PR DESCRIPTION
## Summary

`getUrlBasedHistory` stores the configured `window` from `createBrowserHistory({ window })`, but `history.createURL()` called `createBrowserURLImpl()` without passing that window through. That meant URL creation could fall back to the global window instead of the history instance's configured window.

This threads the configured window into `createBrowserURLImpl` and adds a regression test with a custom JSDOM origin.

Fixes #15044.

## Testing

- `corepack pnpm exec jest packages/react-router/__tests__/router/browser-test.ts --runInBand`
- `corepack pnpm --filter react-router typecheck`
- `corepack pnpm exec prettier --check packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts`
- `corepack pnpm exec eslint packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts` (warning-only existing unused catch binding in `history.ts`)
- `git diff --check`