### PR TITLE
fix: remove unused dot-server route imports

### DIFF
--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -76,6 +76,24 @@ test("Vite / dead-code elimination for server exports", async () => {
   expect(lines).toHaveLength(0);
 });
 
+test("Vite / unused .server directory imports in routes", async () => {
+  let cwd = await createProject({
+    "app/.server/utils.ts": serverOnlyModule,
+    "app/routes/_index.tsx": `
+      import { serverOnly } from "../.server/utils";
+
+      export default function() {
+        return <h1>Hello</h1>;
+      }
+    `,
+  });
+  let { status } = build({ cwd });
+  expect(status).toBe(0);
+
+  let lines = grep(path.join(cwd, "build/client"), /SERVER_ONLY/);
+  expect(lines).toHaveLength(0);
+});
+
 test.describe("Vite / route / server-only module referenced by client", () => {
   let matrix = [
     { type: "file", path: "app/utils.server.ts", specifier: `~/utils.server` },

--- a/packages/react-router-dev/__tests__/remove-exports-test.ts
+++ b/packages/react-router-dev/__tests__/remove-exports-test.ts
@@ -1,0 +1,55 @@
+import { generate, parse } from "../vite/babel";
+import {
+  removeExports,
+  removeUnusedDotServerImports,
+} from "../vite/remove-exports";
+
+function removeClientOnlyRouteCode(code: string) {
+  let ast = parse(code, { sourceType: "module" });
+  removeExports(ast, ["loader", "action", "middleware", "headers"]);
+  removeUnusedDotServerImports(ast);
+  return generate(ast).code;
+}
+
+describe("removeUnusedDotServerImports", () => {
+  it("removes unused .server directory imports", () => {
+    let code = removeClientOnlyRouteCode(`
+      import { serverOnly } from "../.server/utils";
+
+      export default function Component() {
+        return "Hello";
+      }
+    `);
+
+    expect(code).not.toContain("../.server/utils");
+    expect(code).not.toContain("serverOnly");
+  });
+
+  it("removes .server imports that become unused after server exports are removed", () => {
+    let code = removeClientOnlyRouteCode(`
+      import { serverOnly } from "../.server/utils";
+
+      export const loader = () => serverOnly;
+
+      export default function Component() {
+        return "Hello";
+      }
+    `);
+
+    expect(code).not.toContain("../.server/utils");
+    expect(code).not.toContain("serverOnly");
+  });
+
+  it("keeps referenced .server directory imports", () => {
+    let code = removeClientOnlyRouteCode(`
+      import { serverOnly } from "../.server/utils";
+
+      export default function Component() {
+        return serverOnly;
+      }
+    `);
+
+    expect(code).toContain("../.server/utils");
+    expect(code).toContain("serverOnly");
+  });
+});

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -56,7 +56,7 @@ import * as VirtualModule from "./virtual-module";
 import { resolveFileUrl } from "./resolve-file-url";
 import { resolveRelativeRouteFilePath } from "./resolve-relative-route-file-path";
 import { combineURLs } from "./combine-urls";
-import { removeExports } from "./remove-exports";
+import { removeExports, removeUnusedDotServerImports } from "./remove-exports";
 import { ssrExternals } from "./ssr-externals";
 import { hasDependency } from "./has-dependency";
 import {
@@ -2418,6 +2418,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         let ast = parse(code, { sourceType: "module" });
         if (!options?.ssr) {
           removeExports(ast, SERVER_ONLY_ROUTE_EXPORTS);
+          removeUnusedDotServerImports(ast);
         }
         decorateComponentExportsWithProps(ast);
         return generate(ast, {

--- a/packages/react-router-dev/vite/remove-exports.ts
+++ b/packages/react-router-dev/vite/remove-exports.ts
@@ -158,6 +158,33 @@ export const removeExports = (
   }
 };
 
+export const removeUnusedDotServerImports = (ast: ParseResult<Babel.File>) => {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      if (!isDotServerImport(path.node.source.value)) {
+        return;
+      }
+
+      if (path.node.specifiers.length === 0) {
+        return;
+      }
+
+      path.node.specifiers = path.node.specifiers.filter((specifier) => {
+        let binding = path.scope.getBinding(specifier.local.name);
+        return binding?.referenced;
+      });
+
+      if (path.node.specifiers.length === 0) {
+        path.remove();
+      }
+    },
+  });
+};
+
+function isDotServerImport(source: string) {
+  return /(^|[/\\])\.server([/\\]|$)|\.server(\.[cm]?[jt]sx?)?$/.test(source);
+}
+
 function validateDestructuredExports(
   id: Babel.ArrayPattern | Babel.ObjectPattern,
   exportsToRemove: readonly string[],


### PR DESCRIPTION
## Summary

Route client transforms already remove server-only route exports before browser bundling. If a route also has an unused import from an unprefixed `.server` directory, that import can remain in the transformed client module as a value import, so the `react-router:dot-server` resolver still throws even though no client export depends on it.

This removes unreferenced `.server` import bindings during the client route transform after server-only exports are stripped. Referenced `.server` imports are preserved so the existing resolver error still catches real client references. The integration coverage adds the exact unused `../.server/utils` route import case, and the Jest coverage verifies unused imports are removed while referenced imports stay in place.

Fixes #14997.

## Validation

- `corepack pnpm test -- packages/react-router-dev/__tests__/remove-exports-test.ts --runInBand`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm exec prettier --check packages/react-router-dev/vite/remove-exports.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/__tests__/remove-exports-test.ts integration/vite-dot-server-test.ts`
- `corepack pnpm exec eslint packages/react-router-dev/vite/remove-exports.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/__tests__/remove-exports-test.ts integration/vite-dot-server-test.ts` (0 errors; existing warnings in `plugin.ts` only)
- `git diff --check`

Attempted but blocked locally:

- `corepack pnpm playwright:integration integration/vite-dot-server-test.ts --project=chromium` fails during setup on Windows with `EPERM: operation not permitted, symlink ... packages/react-router-dev -> .tmp/integration/.../node_modules/@react-router/dev` before any assertions run.

authored-by: codex