### PR TITLE
Use configured window when creating history URLs

### DIFF
--- a/packages/react-router/__tests__/router/browser-test.ts
+++ b/packages/react-router/__tests__/router/browser-test.ts
@@ -4,6 +4,7 @@ import {
   type BrowserHistory,
   createBrowserHistory,
 } from "../../lib/router/history";
+import { JSDOM } from "jsdom";
 
 import InitialLocationDefaultKey from "./TestSequences/InitialLocationDefaultKey";
 import Listen from "./TestSequences/Listen";
@@ -57,6 +58,19 @@ describe("a browser history", () => {
       pathname: "/#abc",
     });
     expect(unencodedHref).toEqual("/#abc");
+  });
+
+  it("creates URLs from the configured window", () => {
+    let dom = new JSDOM(`<!DOCTYPE html>`, {
+      url: "https://example.com/current",
+    });
+    history = createBrowserHistory({
+      window: dom.window as unknown as Window,
+    });
+
+    expect(history.createURL("/the/path?the=query#the-hash").href).toEqual(
+      "https://example.com/the/path?the=query#the-hash",
+    );
   });
 
   describe("listen", () => {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -726,7 +726,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -771,16 +771,24 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  windowArg?: Window,
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  let urlWindow =
+    windowArg ??
+    (typeof globalThis.window !== "undefined" ? globalThis.window : undefined);
+
+  if (urlWindow) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      urlWindow.location.origin !== "null"
+        ? urlWindow.location.origin
+        : urlWindow.location.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");


### PR DESCRIPTION
## Summary

Fixes #15044.

`getUrlBasedHistory` already captures the `window` option used by browser/hash histories, but `history.createURL()` delegated to `createBrowserURLImpl()` without passing that window through. In custom-window environments this made URL construction fall back to the global window origin.

This threads the configured window into `createBrowserURLImpl()` for history-created URLs while preserving the existing global-window fallback for direct calls. The regression test uses a JSDOM window at `https://example.com/current` and verifies `createBrowserHistory({ window }).createURL(...)` uses that origin.

## Validation

- `corepack pnpm jest packages/react-router/__tests__/router/browser-test.ts --runInBand`
- `corepack pnpm prettier --check packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts`
- `corepack pnpm exec eslint packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts` (passes; existing warning in history.ts)
- `corepack pnpm --filter react-router typecheck`
- `corepack pnpm --filter react-router build`
- `git diff --check`