### PR TITLE
fix(node): honor writable backpressure when streaming to Node writables

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -174,6 +174,7 @@
 - hsbtr
 - hyesungoh
 - iamnishanth
+- ianduvall
 - ianflynnwork
 - IbraRouisDev
 - igniscyan

--- a/packages/react-router-node/.changes/patch.writable-backpressure.md
+++ b/packages/react-router-node/.changes/patch.writable-backpressure.md
@@ -1,0 +1,4 @@
+Honor Node writable backpressure in `writeReadableStreamToWritable`
+
+- Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
+- Reject (rather than hang) if the writable errors or closes mid-stream.

--- a/packages/react-router-node/.changes/patch.writable-backpressure.md
+++ b/packages/react-router-node/.changes/patch.writable-backpressure.md
@@ -1,4 +1,4 @@
-Honor Node writable backpressure in `writeReadableStreamToWritable`
+Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable`
 
 - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
 - Reject (rather than hang) if the writable errors or closes mid-stream.

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -4,29 +4,45 @@
 
 import { Writable } from "node:stream";
 
-import { writeReadableStreamToWritable } from "../stream";
+import {
+  writeAsyncIterableToWritable,
+  writeReadableStreamToWritable,
+} from "../stream";
+
+function createBackpressureSamplingWritable(
+  highWaterMark: number,
+  writeDelayMs: number,
+) {
+  let writable: Writable = new Writable({
+    highWaterMark,
+    write(_chunk, _encoding, callback) {
+      setTimeout(callback, writeDelayMs);
+    },
+  });
+
+  let maxBufferedLength = 0;
+  let originalWrite = writable.write.bind(writable);
+  writable.write = function (chunk: any, ...rest: any[]) {
+    let result = originalWrite(chunk, ...rest);
+    maxBufferedLength = Math.max(maxBufferedLength, writable.writableLength);
+    return result;
+  } as typeof writable.write;
+
+  return {
+    writable,
+    getMaxBufferedLength: () => maxBufferedLength,
+  };
+}
 
 describe("writeReadableStreamToWritable", () => {
   it("respects writable backpressure", async () => {
     let highWaterMark = 16;
     let chunkSize = 8;
     let numChunks = 100;
-    let writeDelayMs = 5;
-
-    let writable: Writable = new Writable({
+    let { writable, getMaxBufferedLength } = createBackpressureSamplingWritable(
       highWaterMark,
-      write(_chunk, _encoding, callback) {
-        setTimeout(callback, writeDelayMs);
-      },
-    });
-
-    let maxBufferedLength = 0;
-    let originalWrite = writable.write.bind(writable);
-    writable.write = function (chunk: any, ...rest: any[]) {
-      let result = originalWrite(chunk, ...rest);
-      maxBufferedLength = Math.max(maxBufferedLength, writable.writableLength);
-      return result;
-    } as typeof writable.write;
+      5,
+    );
 
     let readable = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -39,6 +55,32 @@ describe("writeReadableStreamToWritable", () => {
 
     await writeReadableStreamToWritable(readable, writable);
 
-    expect(maxBufferedLength).toBeLessThanOrEqual(highWaterMark + chunkSize);
+    expect(getMaxBufferedLength()).toBeLessThanOrEqual(
+      highWaterMark + chunkSize,
+    );
+  });
+});
+
+describe("writeAsyncIterableToWritable", () => {
+  it("respects writable backpressure", async () => {
+    let highWaterMark = 16;
+    let chunkSize = 8;
+    let numChunks = 100;
+    let { writable, getMaxBufferedLength } = createBackpressureSamplingWritable(
+      highWaterMark,
+      5,
+    );
+
+    async function* chunks() {
+      for (let i = 0; i < numChunks; i++) {
+        yield new Uint8Array(chunkSize);
+      }
+    }
+
+    await writeAsyncIterableToWritable(chunks(), writable);
+
+    expect(getMaxBufferedLength()).toBeLessThanOrEqual(
+      highWaterMark + chunkSize,
+    );
   });
 });

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+
+import { Writable } from "node:stream";
+
+import { writeReadableStreamToWritable } from "../stream";
+
+describe("writeReadableStreamToWritable", () => {
+  it("respects writable backpressure", async () => {
+    let highWaterMark = 16;
+    let chunkSize = 8;
+    let numChunks = 100;
+    let writeDelayMs = 5;
+
+    let writable: Writable = new Writable({
+      highWaterMark,
+      write(_chunk, _encoding, callback) {
+        setTimeout(callback, writeDelayMs);
+      },
+    });
+
+    let maxBufferedLength = 0;
+    let originalWrite = writable.write.bind(writable);
+    writable.write = function (chunk: any, ...rest: any[]) {
+      let result = originalWrite(chunk, ...rest);
+      maxBufferedLength = Math.max(maxBufferedLength, writable.writableLength);
+      return result;
+    } as typeof writable.write;
+
+    let readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < numChunks; i++) {
+          controller.enqueue(new Uint8Array(chunkSize));
+        }
+        controller.close();
+      },
+    });
+
+    await writeReadableStreamToWritable(readable, writable);
+
+    expect(maxBufferedLength).toBeLessThanOrEqual(highWaterMark + chunkSize);
+  });
+});

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -17,15 +17,50 @@ export async function writeReadableStreamToWritable(
         break;
       }
 
-      writable.write(value);
+      if (writable.destroyed || writable.writableEnded) {
+        throw new Error(
+          "Cannot write to a destroyed or ended writable stream",
+        );
+      }
+
+      let canContinueWriting = writable.write(value);
       if (typeof flushable.flush === "function") {
         flushable.flush();
+      }
+
+      if (!canContinueWriting) {
+        await waitForDrain(writable);
       }
     }
   } catch (error: unknown) {
     writable.destroy(error as Error);
     throw error;
   }
+}
+
+function waitForDrain(writable: Writable): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    function cleanup() {
+      writable.off("drain", onDrain);
+      writable.off("error", onError);
+      writable.off("close", onClose);
+    }
+    function onDrain() {
+      cleanup();
+      resolve();
+    }
+    function onError(error: Error) {
+      cleanup();
+      reject(error);
+    }
+    function onClose() {
+      cleanup();
+      reject(new Error("Writable closed before drain"));
+    }
+    writable.once("drain", onDrain);
+    writable.once("error", onError);
+    writable.once("close", onClose);
+  });
 }
 
 export async function writeAsyncIterableToWritable(

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -69,7 +69,17 @@ export async function writeAsyncIterableToWritable(
 ) {
   try {
     for await (let chunk of iterable) {
-      writable.write(chunk);
+      if (writable.destroyed || writable.writableEnded) {
+        throw new Error(
+          "Cannot write to a destroyed or ended writable stream",
+        );
+      }
+
+      let canContinueWriting = writable.write(chunk);
+
+      if (!canContinueWriting) {
+        await waitForDrain(writable);
+      }
     }
     writable.end();
   } catch (error: any) {


### PR DESCRIPTION
SSR responses to slow clients no longer balloon server memory while waiting for the socket to drain. Both `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` were calling `writable.write(chunk)` in a loop and ignoring the boolean return value, so when the writable signaled backpressure (slow socket, compression middleware, slow disk) chunks accumulated unbounded in its internal buffer.

The fix honors the standard Node streams backpressure contract: when `writable.write()` returns `false`, await `'drain'` before writing the next chunk. The shared `waitForDrain` helper also listens for `'error'` and `'close'` so a failed or destroyed writable rejects the wait instead of hanging the producer. A pre-write guard against `writable.destroyed` / `writable.writableEnded` surfaces consumer aborts through the existing `destroy(error); throw` path.

The Express-style `flush()` call after each write in `writeReadableStreamToWritable`, both function signatures, and the behavior of the other exports in the file (`readableStreamToString`, `createReadableStreamFromReadable`) are preserved.

Closes #15049

## Test plan

Per-function unit tests in `packages/react-router-node/__tests__/stream-test.ts` synchronously enqueue 100 8-byte chunks into a `Writable` with `highWaterMark: 16` whose `_write` defers `callback()` by 5ms. Each test wraps `writable.write` so it samples `writableLength` synchronously after every call, then asserts that the peak stays bounded by `highWaterMark + chunkSize` (24) rather than climbing to the full stream size (800). Without the fix each test fails with a peak near 800.