### PR TITLE
Pass configured window when creating browser URLs

### DIFF
--- a/packages/react-router/__tests__/router/browser-test.ts
+++ b/packages/react-router/__tests__/router/browser-test.ts
@@ -47,6 +47,15 @@ describe("a browser history", () => {
     expect(href).toEqual("/the/path?the=query#the-hash");
   });
 
+  it("uses the configured window to create URLs", () => {
+    let testWindow = getWindow("/", false, "https://custom.example");
+    let history = createBrowserHistory({ window: testWindow });
+
+    expect(history.createURL("/the/path").href).toBe(
+      "https://custom.example/the/path",
+    );
+  });
+
   it("does not encode the generated path", () => {
     const encodedHref = history.createHref({
       pathname: "/%23abc",

--- a/packages/react-router/__tests__/utils/getWindow.ts
+++ b/packages/react-router/__tests__/utils/getWindow.ts
@@ -1,8 +1,14 @@
 import { JSDOM } from "jsdom";
 
-export default function getWindow(initialUrl: string, isHash = false): Window {
+export default function getWindow(
+  initialUrl: string,
+  isHash = false,
+  origin = "http://localhost",
+): Window {
   // Need to use our own custom DOM in order to get a working history
-  const dom = new JSDOM(`<!DOCTYPE html>`, { url: "http://localhost/" });
+  const dom = new JSDOM(`<!DOCTYPE html>`, {
+    url: new URL("/", origin).href,
+  });
   dom.window.history.replaceState(null, "", (isHash ? "#" : "") + initialUrl);
   return dom.window as unknown as Window;
 }

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -729,7 +729,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -774,16 +774,25 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  window_?: Window,
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  let windowLocation = window_?.location;
+  if (!windowLocation && typeof window !== "undefined") {
+    windowLocation = window.location;
+  }
+
+  if (windowLocation) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      windowLocation.origin !== "null"
+        ? windowLocation.origin
+        : windowLocation.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -3228,7 +3228,7 @@ export function createRouter(init: RouterInit): Router {
       } else if (isAbsoluteUrl(location)) {
         // We skip `history.createURL` here for absolute URLs because we don't
         // want to inherit the current `window.location` base URL
-        const url = createBrowserURLImpl(location, true);
+        const url = createBrowserURLImpl(location, true, routerWindow);
         isDocumentReload =
           // Hard reload if it's an absolute URL to a new origin
           url.origin !== routerWindow.location.origin ||


### PR DESCRIPTION
## Summary

Fixes #15044.

`createBrowserHistory({ window })` already stores the configured browser window for location and href handling, but `history.createURL()` still called `createBrowserURLImpl()` without passing that window. In jsdom/custom-window environments this caused URL creation to use the global window origin instead of the configured history window.

This updates `createBrowserURLImpl` to accept an optional window, passes the configured window from URL-based histories, and keeps the router redirect path aligned with the router's window. A regression test covers a browser history whose configured window has a non-default origin.

## Validation

- `corepack pnpm exec jest packages/react-router/__tests__/router/browser-test.ts --runInBand`
- `corepack pnpm exec eslint packages/react-router/lib/router/history.ts packages/react-router/lib/router/router.ts packages/react-router/__tests__/router/browser-test.ts packages/react-router/__tests__/utils/getWindow.ts`
- `corepack pnpm exec prettier --check packages/react-router/lib/router/history.ts packages/react-router/lib/router/router.ts packages/react-router/__tests__/router/browser-test.ts packages/react-router/__tests__/utils/getWindow.ts`
- `corepack pnpm --filter react-router typecheck`
- `git diff --check`