### PR TITLE
fix(dev): allow frontmatter exports during HMR

### DIFF
--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -109,6 +109,10 @@ templates.forEach((template) => {
         "app/routes/mdx.mdx": mdx`
           import { Counter } from "../component";
 
+          export const frontmatter = {
+            title: "MDX route",
+          };
+
           # MDX Title (HMR: 0)
 
           <Counter />

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -136,6 +136,7 @@ const CLIENT_NON_COMPONENT_EXPORTS = [
   "handle",
   "meta",
   "links",
+  "frontmatter",
   "shouldRevalidate",
 ];
 const CLIENT_ROUTE_EXPORTS = [


### PR DESCRIPTION
Fixes #14082.

MDX frontmatter plugins commonly emit a route module export named `frontmatter`. React Router already tells the React Refresh boundary validator to accept route metadata exports such as `meta`, `links`, and `handle`, but `frontmatter` was missing from that non-component export list. As a result, editing an MDX route with frontmatter could invalidate the HMR boundary instead of applying the update in place.

This adds `frontmatter` to the accepted non-component route exports and extends the existing MDX HMR integration fixture so the test route includes a `frontmatter` export while still asserting that component state is preserved after an MDX edit.

Validation:
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm exec eslint packages/react-router-dev/vite/plugin.ts integration/vite-hmr-hdr-test.ts`
- `corepack pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts integration/vite-hmr-hdr-test.ts`
- `corepack pnpm exec jest packages/react-router-dev/__tests__/rsc-virtual-route-modules-test.ts --runInBand`
- `git diff --check`

I also attempted the focused Chromium integration run:

`corepack pnpm exec playwright test --config ./integration/playwright.config.ts integration/vite-hmr-hdr-test.ts --project=chromium -g "mdx"`

It did not reach the test body on this Windows checkout because fixture setup failed while copying workspace symlinks: `EPERM: operation not permitted, symlink ... packages/react-router-dev -> .tmp/integration/.../node_modules/@react-router/dev`.