### PR TITLE
test: fix typo in test description

### DIFF
--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -141,7 +141,7 @@ describe("generatePath", () => {
     });
   });
 
-  it("throws only on on missing named parameters, but not missing splat params", () => {
+  it("throws only on missing named parameters, but not missing splat params", () => {
     expect(() => generatePath(":foo")).toThrow();
     expect(() => generatePath("/:foo")).toThrow();
     expect(() => generatePath("*")).not.toThrow();


### PR DESCRIPTION
Fix a duplicate "on" in a test description (`packages/react-router/__tests__/generatePath-test.tsx`).
