### PR TITLE
fix(dev): allow frontmatter exports during HMR

### DIFF
--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -109,6 +109,10 @@ templates.forEach((template) => {
         "app/routes/mdx.mdx": mdx`
           import { Counter } from "../component";
 
+          export const frontmatter = {
+            title: "MDX route",
+          };
+
           # MDX Title (HMR: 0)
 
           <Counter />

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -136,6 +136,7 @@ const CLIENT_NON_COMPONENT_EXPORTS = [
   "handle",
   "meta",
   "links",
+  "frontmatter",
   "shouldRevalidate",
 ];
 const CLIENT_ROUTE_EXPORTS = [


### PR DESCRIPTION
## Summary
Fixes #14082.

MDX frontmatter plugins can add a `frontmatter` route export. React Refresh treated that export as incompatible with route HMR because it was not in the client non-component export allowlist. This adds `frontmatter` to the allowlist and covers it in the Vite HMR/HDR MDX integration fixture.

## Validation
- `corepack pnpm exec eslint packages/react-router-dev/vite/plugin.ts integration/vite-hmr-hdr-test.ts`
- `corepack pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts integration/vite-hmr-hdr-test.ts`
- `corepack pnpm --filter @react-router/dev typecheck`
- `git diff --check origin/main...HEAD`

Local integration note:
- `corepack pnpm exec playwright test --config ./integration/playwright.config.ts integration/vite-hmr-hdr-test.ts --project=chromium` is blocked in this Windows environment before test execution because fixture copying attempts to create package symlinks and fails with `EPERM: operation not permitted, symlink ... @react-router/dev`.