### PR TITLE
fix(react-router): skip single fetch for client loaders without server loaders

### DIFF
--- a/packages/react-router/__tests__/router/data-strategy-test.ts
+++ b/packages/react-router/__tests__/router/data-strategy-test.ts
@@ -3,6 +3,7 @@ import type {
   DataStrategyMatch,
   DataStrategyResult,
 } from "../../lib/router/utils";
+import { getSingleFetchDataStrategyImpl } from "../../lib/dom/ssr/single-fetch";
 import {
   createDeferred,
   createAsyncStub,
@@ -1187,6 +1188,46 @@ describe("router dataStrategy", () => {
         parent: "PARENT",
         child: "CHILD",
       });
+    });
+
+    it("does not single-fetch for clientLoader-only routes without a server loader", async () => {
+      let fetchAndDecode = jest.fn(async () => {
+        return { status: 200, data: { routes: {} } };
+      });
+
+      let t: ReturnType<typeof setup>;
+      t = setup({
+        routes: [
+          {
+            id: "root",
+            path: "/",
+            children: [
+              {
+                id: "parent",
+                path: "parent",
+                loader: true,
+              },
+            ],
+          },
+        ],
+        dataStrategy: getSingleFetchDataStrategyImpl(
+          () => t.router,
+          (match) =>
+            match.route.id === "parent"
+              ? { hasLoader: false, hasClientLoader: true }
+              : { hasLoader: false, hasClientLoader: false },
+          fetchAndDecode,
+          true,
+          undefined,
+          false,
+        ),
+      });
+
+      let A = await t.navigate("/parent");
+      await A.loaders.parent.resolve("CLIENT_LOADER");
+
+      expect(fetchAndDecode).toHaveBeenCalledTimes(0);
+      expect(A.loaders.parent.stub).toHaveBeenCalledTimes(1);
     });
 
     it("allows middleware/context implementations", async () => {

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -435,15 +435,17 @@ async function singleFetchLoaderNavigationStrategy(
             foundOptOutRoute = true;
           }
           try {
-            let result = await handler(async () => {
-              let { data } = await fetchAndDecode(
-                args,
-                basename,
-                trailingSlashAware,
-                [routeId],
-              );
-              return unwrapSingleFetchResult(data, routeId);
-            });
+            let result = await (hasLoader
+              ? handler(async () => {
+                  let { data } = await fetchAndDecode(
+                    args,
+                    basename,
+                    trailingSlashAware,
+                    [routeId],
+                  );
+                  return unwrapSingleFetchResult(data, routeId);
+                })
+              : handler(async () => null));
 
             results[routeId] = { type: "data", result };
           } catch (e) {


### PR DESCRIPTION
## Summary

Fixes #13873.

- Avoid issuing a per-route `_routes` single-fetch for routes that have a `clientLoader` but no server loader.
- Preserve the route handler path by passing a no-op server-loader callback for clientLoader-only routes.
- Add regression coverage for the clientLoader-only case so `fetchAndDecode` is not called.

## Validation

- `corepack pnpm -w exec prettier --check packages/react-router/lib/dom/ssr/single-fetch.tsx packages/react-router/__tests__/router/data-strategy-test.ts`
- `corepack pnpm -w exec eslint packages/react-router/lib/dom/ssr/single-fetch.tsx packages/react-router/__tests__/router/data-strategy-test.ts`
- `corepack pnpm -w run test packages/react-router/__tests__/router/data-strategy-test.ts`
- `corepack pnpm -C packages/react-router run typecheck`
- `git diff --check`