### PR TITLE
Fix Windows-built asset paths for react-router-serve

### DIFF
--- a/packages/react-router-dev/__tests__/to-posix-path-test.ts
+++ b/packages/react-router-dev/__tests__/to-posix-path-test.ts
@@ -1,0 +1,11 @@
+import { toPosixPath } from "../vite/to-posix-path";
+
+describe("toPosixPath", () => {
+  it("normalizes Windows path separators", () => {
+    expect(toPosixPath("build\\client\\assets")).toBe("build/client/assets");
+  });
+
+  it("leaves POSIX path separators unchanged", () => {
+    expect(toPosixPath("build/client/assets")).toBe("build/client/assets");
+  });
+});

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -55,6 +55,7 @@ import {
 import * as VirtualModule from "./virtual-module";
 import { resolveFileUrl } from "./resolve-file-url";
 import { resolveRelativeRouteFilePath } from "./resolve-relative-route-file-path";
+import { toPosixPath } from "./to-posix-path";
 import { combineURLs } from "./combine-urls";
 import { removeExports } from "./remove-exports";
 import { ssrExternals } from "./ssr-externals";
@@ -843,9 +844,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         virtual.serverManifest.id,
       )};
       export const assetsBuildDirectory = ${JSON.stringify(
-        path.relative(
-          ctx.rootDirectory,
-          getClientBuildDirectory(ctx.reactRouterConfig),
+        toPosixPath(
+          path.relative(
+            ctx.rootDirectory,
+            getClientBuildDirectory(ctx.reactRouterConfig),
+          ),
         ),
       )};
       export const basename = ${JSON.stringify(ctx.reactRouterConfig.basename)};

--- a/packages/react-router-dev/vite/to-posix-path.ts
+++ b/packages/react-router-dev/vite/to-posix-path.ts
@@ -1,0 +1,3 @@
+export function toPosixPath(path: string): string {
+  return path.replace(/\\/g, "/");
+}


### PR DESCRIPTION
## Summary

Fixes #14950.

When a non-RSC server build is produced on Windows, the virtual server build module serializes `assetsBuildDirectory` from `node:path.relative(...)`. That produces values like `build\client`. If the build output is copied to Linux and served with `react-router-serve`, Express receives that backslash-containing path literally and static `/assets/*` requests miss the client build directory.

This normalizes the emitted relative asset directory to POSIX separators before writing it into the server build module, so the runtime config remains portable across operating systems.

## Changes

- Add a small `toPosixPath` helper for emitted runtime paths.
- Use it when serializing `assetsBuildDirectory` from the Vite plugin's virtual server build.
- Add unit coverage for Windows and POSIX separators.

## Validation

- `corepack pnpm jest packages/react-router-dev/__tests__/to-posix-path-test.ts --runInBand`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm exec eslint packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/to-posix-path.ts packages/react-router-dev/__tests__/to-posix-path-test.ts`
- `corepack pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/to-posix-path.ts packages/react-router-dev/__tests__/to-posix-path-test.ts`
- `corepack pnpm --filter @react-router/dev build`
- `corepack pnpm run --filter="./packages/**/*" build`
- `git diff --check`

I also attempted `corepack pnpm exec playwright test integration/react-router-serve-test.ts --config=integration/playwright.config.ts --project=chromium`; it was blocked locally on Windows by `EPERM` while copying template symlinks into `.tmp/integration`, before any test assertions ran.