### PR TITLE
fix(rsc): export route data hooks

### DIFF
--- a/packages/react-router/__tests__/rsc-exports-test.tsx
+++ b/packages/react-router/__tests__/rsc-exports-test.tsx
@@ -1,0 +1,48 @@
+import {
+  unstable_useRoute,
+  useRouteLoaderData,
+} from "../index-react-server-client";
+import * as ReactServerExports from "../index-react-server";
+
+jest.mock(
+  "react-router/internal/react-server-client",
+  () => ({
+    BrowserRouter: "BrowserRouter",
+    Form: "Form",
+    HashRouter: "HashRouter",
+    Link: "Link",
+    Links: "Links",
+    MemoryRouter: "MemoryRouter",
+    Meta: "Meta",
+    Navigate: "Navigate",
+    NavLink: "NavLink",
+    Outlet: "Outlet",
+    Route: "Route",
+    Router: "Router",
+    RouterProvider: "RouterProvider",
+    Routes: "Routes",
+    ScrollRestoration: "ScrollRestoration",
+    StaticRouter: "StaticRouter",
+    StaticRouterProvider: "StaticRouterProvider",
+    UNSAFE_AwaitContextProvider: "UNSAFE_AwaitContextProvider",
+    UNSAFE_WithComponentProps: "UNSAFE_WithComponentProps",
+    UNSAFE_WithErrorBoundaryProps: "UNSAFE_WithErrorBoundaryProps",
+    UNSAFE_WithHydrateFallbackProps: "UNSAFE_WithHydrateFallbackProps",
+    unstable_HistoryRouter: "unstable_HistoryRouter",
+    unstable_useRoute: "unstable_useRoute",
+    useRouteLoaderData: "useRouteLoaderData",
+  }),
+  { virtual: true },
+);
+
+describe("RSC exports", () => {
+  it("exposes route data hooks as client references", () => {
+    expect(useRouteLoaderData).toBeDefined();
+    expect(unstable_useRoute).toBeDefined();
+  });
+
+  it("re-exports route data hooks from the React Server entry", () => {
+    expect(ReactServerExports.useRouteLoaderData).toBe("useRouteLoaderData");
+    expect(ReactServerExports.unstable_useRoute).toBe("unstable_useRoute");
+  });
+});

--- a/packages/react-router/index-react-server-client.ts
+++ b/packages/react-router/index-react-server-client.ts
@@ -24,3 +24,4 @@ export {
 } from "./lib/dom/lib";
 export { StaticRouter, StaticRouterProvider } from "./lib/dom/server";
 export { Meta, Links } from "./lib/dom/ssr/components";
+export { useRouteLoaderData, useRoute as unstable_useRoute } from "./lib/hooks";

--- a/packages/react-router/index-react-server.ts
+++ b/packages/react-router/index-react-server.ts
@@ -28,6 +28,7 @@ export {
 } from "./lib/rsc/server.rsc";
 
 // Client references
+// @ts-ignore There are no types before the tsup build when used internally.
 export {
   BrowserRouter,
   Form,
@@ -47,6 +48,8 @@ export {
   StaticRouter,
   StaticRouterProvider,
   unstable_HistoryRouter,
+  unstable_useRoute,
+  useRouteLoaderData,
 } from "react-router/internal/react-server-client";
 
 // Shared implementation of agnostic APIs


### PR DESCRIPTION
## Summary

Fixes #14911.

The React Server entry re-exports client references from `react-router/internal/react-server-client`. `useRouteLoaderData` and `unstable_useRoute` were part of the normal public entry but were missing from the RSC client-reference entry, so RSC plugin users could import them from `react-router` and receive `undefined`.

This adds those hooks to the client-reference entry and re-exports them from the React Server entry. The regression test covers both export layers.

## Validation

- `corepack pnpm exec jest packages/react-router/__tests__/rsc-exports-test.tsx --runInBand`
- `corepack pnpm exec eslint packages/react-router/index-react-server.ts packages/react-router/index-react-server-client.ts packages/react-router/__tests__/rsc-exports-test.tsx`
- `corepack pnpm exec prettier --check packages/react-router/index-react-server.ts packages/react-router/index-react-server-client.ts packages/react-router/__tests__/rsc-exports-test.tsx`
- `corepack pnpm --filter react-router typecheck`
- `corepack pnpm --filter react-router build`
- `git diff --check`

Local note: commands ran under Node v24.12.0, while `scripts` warns it expects Node `^22.18`; the checks above still passed.