### PR TITLE
fix: default package exports to production builds

### DIFF
--- a/packages/react-router/.changes/patch.production-build-exports.md
+++ b/packages/react-router/.changes/patch.production-build-exports.md
@@ -1,0 +1,1 @@
+Default React Router package exports to production builds while preserving development condition overrides for dev servers.

--- a/packages/react-router/__tests__/package-exports-test.ts
+++ b/packages/react-router/__tests__/package-exports-test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+type ConditionalExport =
+  | string
+  | {
+      [condition: string]: ConditionalExport;
+    };
+
+let packageJson = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "../package.json"), "utf8"),
+);
+
+function resolveExport(target: ConditionalExport, conditions: Set<string>) {
+  if (typeof target === "string") {
+    return target;
+  }
+
+  for (let [condition, value] of Object.entries(target)) {
+    if (condition === "types") {
+      continue;
+    }
+
+    if (condition === "default" || conditions.has(condition)) {
+      return resolveExport(value, conditions);
+    }
+  }
+
+  throw new Error(`No export matched conditions: ${[...conditions].join(",")}`);
+}
+
+describe("package exports", () => {
+  it("defaults legacy entry fields to the production build", () => {
+    expect(packageJson.main).toBe("./dist/production/index.js");
+    expect(packageJson.module).toBe("./dist/production/index.mjs");
+  });
+
+  it.each([
+    [".", ["node", "module", "production"], "./dist/production/index.mjs"],
+    [".", ["development", "node", "module"], "./dist/development/index.mjs"],
+    [".", ["node", "default", "production"], "./dist/production/index.js"],
+    [
+      "./dom",
+      ["node", "module", "production"],
+      "./dist/production/dom-export.mjs",
+    ],
+    [
+      "./dom",
+      ["development", "node", "module"],
+      "./dist/development/dom-export.mjs",
+    ],
+    [
+      "./dom",
+      ["node", "default", "production"],
+      "./dist/production/dom-export.js",
+    ],
+    [
+      ".",
+      ["react-server", "module", "production"],
+      "./dist/production/index-react-server.mjs",
+    ],
+    [
+      ".",
+      ["development", "react-server", "module"],
+      "./dist/development/index-react-server.mjs",
+    ],
+    [
+      "./internal/react-server-client",
+      ["react-server", "module", "production"],
+      "./dist/production/index-react-server-client.mjs",
+    ],
+    [
+      "./internal/react-server-client",
+      ["development", "react-server", "module"],
+      "./dist/development/index-react-server-client.mjs",
+    ],
+  ])("resolves %s for %s", (subpath, conditions, expected) => {
+    expect(
+      resolveExport(
+        packageJson.exports[subpath as keyof typeof packageJson.exports],
+        new Set(conditions),
+      ),
+    ).toBe(expected);
+  });
+});

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -19,51 +19,91 @@
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
   "types": "./dist/development/index.d.ts",
-  "main": "./dist/development/index.js",
-  "module": "./dist/development/index.mjs",
+  "main": "./dist/production/index.js",
+  "module": "./dist/production/index.mjs",
   "exports": {
     ".": {
       "react-server": {
-        "module": "./dist/development/index-react-server.mjs",
-        "default": "./dist/development/index-react-server.js"
+        "development": {
+          "module": "./dist/development/index-react-server.mjs",
+          "default": "./dist/development/index-react-server.js"
+        },
+        "module": "./dist/production/index-react-server.mjs",
+        "default": "./dist/production/index-react-server.js"
       },
       "node": {
+        "development": {
+          "types": "./dist/development/index.d.ts",
+          "module": "./dist/development/index.mjs",
+          "module-sync": "./dist/development/index.mjs",
+          "default": "./dist/development/index.js"
+        },
         "types": "./dist/development/index.d.ts",
-        "module": "./dist/development/index.mjs",
-        "module-sync": "./dist/development/index.mjs",
-        "default": "./dist/development/index.js"
+        "module": "./dist/production/index.mjs",
+        "module-sync": "./dist/production/index.mjs",
+        "default": "./dist/production/index.js"
       },
       "module": {
+        "development": {
+          "types": "./dist/development/index.d.mts",
+          "default": "./dist/development/index.mjs"
+        },
         "types": "./dist/development/index.d.mts",
-        "default": "./dist/development/index.mjs"
+        "default": "./dist/production/index.mjs"
       },
       "import": {
+        "development": {
+          "types": "./dist/development/index.d.mts",
+          "default": "./dist/development/index.mjs"
+        },
         "types": "./dist/development/index.d.mts",
-        "default": "./dist/development/index.mjs"
+        "default": "./dist/production/index.mjs"
       },
       "default": {
+        "development": {
+          "types": "./dist/development/index.d.ts",
+          "default": "./dist/development/index.js"
+        },
         "types": "./dist/development/index.d.ts",
-        "default": "./dist/development/index.js"
+        "default": "./dist/production/index.js"
       }
     },
     "./dom": {
       "node": {
+        "development": {
+          "types": "./dist/development/dom-export.d.ts",
+          "module": "./dist/development/dom-export.mjs",
+          "module-sync": "./dist/development/dom-export.mjs",
+          "default": "./dist/development/dom-export.js"
+        },
         "types": "./dist/development/dom-export.d.ts",
-        "module": "./dist/development/dom-export.mjs",
-        "module-sync": "./dist/development/dom-export.mjs",
-        "default": "./dist/development/dom-export.js"
+        "module": "./dist/production/dom-export.mjs",
+        "module-sync": "./dist/production/dom-export.mjs",
+        "default": "./dist/production/dom-export.js"
       },
       "module": {
+        "development": {
+          "types": "./dist/development/dom-export.d.mts",
+          "default": "./dist/development/dom-export.mjs"
+        },
         "types": "./dist/development/dom-export.d.mts",
-        "default": "./dist/development/dom-export.mjs"
+        "default": "./dist/production/dom-export.mjs"
       },
       "import": {
+        "development": {
+          "types": "./dist/development/dom-export.d.mts",
+          "default": "./dist/development/dom-export.mjs"
+        },
         "types": "./dist/development/dom-export.d.mts",
-        "default": "./dist/development/dom-export.mjs"
+        "default": "./dist/production/dom-export.mjs"
       },
       "default": {
+        "development": {
+          "types": "./dist/development/dom-export.d.ts",
+          "default": "./dist/development/dom-export.js"
+        },
         "types": "./dist/development/dom-export.d.ts",
-        "default": "./dist/development/dom-export.js"
+        "default": "./dist/production/dom-export.js"
       }
     },
     "./internal": {
@@ -79,26 +119,48 @@
     },
     "./internal/react-server-client": {
       "react-server": {
-        "module": "./dist/development/index-react-server-client.mjs",
-        "default": "./dist/development/index-react-server-client.js"
+        "development": {
+          "module": "./dist/development/index-react-server-client.mjs",
+          "default": "./dist/development/index-react-server-client.js"
+        },
+        "module": "./dist/production/index-react-server-client.mjs",
+        "default": "./dist/production/index-react-server-client.js"
       },
       "node": {
+        "development": {
+          "types": "./dist/development/index.d.ts",
+          "module": "./dist/development/index.mjs",
+          "module-sync": "./dist/development/index.mjs",
+          "default": "./dist/development/index.js"
+        },
         "types": "./dist/development/index.d.ts",
-        "module": "./dist/development/index.mjs",
-        "module-sync": "./dist/development/index.mjs",
-        "default": "./dist/development/index.js"
+        "module": "./dist/production/index.mjs",
+        "module-sync": "./dist/production/index.mjs",
+        "default": "./dist/production/index.js"
       },
       "module": {
+        "development": {
+          "types": "./dist/development/index.d.mts",
+          "default": "./dist/development/index.mjs"
+        },
         "types": "./dist/development/index.d.mts",
-        "default": "./dist/development/index.mjs"
+        "default": "./dist/production/index.mjs"
       },
       "import": {
+        "development": {
+          "types": "./dist/development/index.d.mts",
+          "default": "./dist/development/index.mjs"
+        },
         "types": "./dist/development/index.d.mts",
-        "default": "./dist/development/index.mjs"
+        "default": "./dist/production/index.mjs"
       },
       "default": {
+        "development": {
+          "types": "./dist/development/index.d.ts",
+          "default": "./dist/development/index.js"
+        },
         "types": "./dist/development/index.d.ts",
-        "default": "./dist/development/index.js"
+        "default": "./dist/production/index.js"
       }
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
## Summary

- Default `react-router` runtime package exports to `dist/production`.
- Preserve `development` condition branches so dev servers still resolve development builds.
- Cover the expected export resolution for node, DOM, and RSC entrypoints.
- Add a patch change file for `react-router`.

Fixes #14102.

## Tests

- `corepack pnpm exec jest packages/react-router/__tests__/package-exports-test.ts --runInBand`
- `corepack pnpm exec prettier --check packages/react-router/package.json packages/react-router/__tests__/package-exports-test.ts packages/react-router/.changes/patch.production-build-exports.md`
- `corepack pnpm exec eslint packages/react-router/__tests__/package-exports-test.ts`
- `corepack pnpm --filter react-router build`
- `corepack pnpm changes:validate`
- `node --input-type=module -e "console.log(import.meta.resolve('react-router')); console.log(import.meta.resolve('react-router/dom'))"` from `packages/react-router`
- `node --conditions=development --input-type=module -e "console.log(import.meta.resolve('react-router')); console.log(import.meta.resolve('react-router/dom'))"` from `packages/react-router`
- `node --conditions=react-server --input-type=module -e "console.log(import.meta.resolve('react-router')); console.log(import.meta.resolve('react-router/internal/react-server-client'))"` from `packages/react-router`
- `node --conditions=development --conditions=react-server --input-type=module -e "console.log(import.meta.resolve('react-router')); console.log(import.meta.resolve('react-router/internal/react-server-client'))"` from `packages/react-router`
- `git diff --check`

Note: `corepack pnpm --filter react-router typecheck` currently fails on `main` with `index-react-server.ts(50,8): Cannot find module 'react-router/internal/react-server-client' or its corresponding type declarations.`