### PR TITLE
fix: isolate app directory context for async route configs

### DIFF
--- a/integration/vite-config-concurrency-test.ts
+++ b/integration/vite-config-concurrency-test.ts
@@ -1,0 +1,65 @@
+import * as Path from "pathe";
+import dedent from "dedent";
+import { expect } from "@playwright/test";
+import { resolveConfig } from "vite";
+
+import { createProject, test } from "./helpers/vite.js";
+
+const js = String.raw;
+
+function routesConfig(delayMs: number) {
+  return dedent(js`
+    import { flatRoutes } from "@react-router/fs-routes";
+    import type { RouteConfig } from "@react-router/dev/routes";
+
+    await new Promise((resolve) => setTimeout(resolve, ${delayMs}));
+    let routes = await flatRoutes();
+
+    export default routes satisfies RouteConfig;
+  `);
+}
+
+async function resolveReactRouterRoutes(root: string) {
+  let config = await resolveConfig(
+    {
+      configFile: Path.join(root, "vite.config.ts"),
+      root,
+      logLevel: "silent",
+    },
+    "build",
+  );
+
+  return (config as any).__reactRouterPluginContext.reactRouterConfig.routes;
+}
+
+test.describe("Vite config", () => {
+  test("isolates flatRoutes app directory state during concurrent config resolution", async () => {
+    let projectA = await createProject({
+      "app/routes.ts": routesConfig(50),
+      "app/routes/dashboard.tsx": js`
+        export default function Dashboard() {
+          return <h1>Dashboard</h1>;
+        }
+      `,
+    });
+    let projectB = await createProject({
+      "app/routes.ts": routesConfig(0),
+      "app/routes/login.tsx": js`
+        export default function Login() {
+          return <h1>Login</h1>;
+        }
+      `,
+    });
+
+    let resolvingA = resolveReactRouterRoutes(projectA);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    let resolvingB = resolveReactRouterRoutes(projectB);
+
+    let [routesA, routesB] = await Promise.all([resolvingA, resolvingB]);
+
+    expect(routesA["routes/dashboard"]?.file).toBe("routes/dashboard.tsx");
+    expect(routesA["routes/login"]).toBeUndefined();
+    expect(routesB["routes/login"]?.file).toBe("routes/login.tsx");
+    expect(routesB["routes/dashboard"]).toBeUndefined();
+  });
+});

--- a/packages/react-router-dev/__tests__/route-config-test.ts
+++ b/packages/react-router-dev/__tests__/route-config-test.ts
@@ -8,18 +8,43 @@ import {
   index,
   prefix,
   relative,
+  getAppDirectory,
+  withAppDirectory,
 } from "../config/routes";
 
-const cleanPathsForSnapshot = (obj: any): any =>
-  JSON.parse(
+const cleanPathsForSnapshot = (obj: any): any => {
+  let cwd = normalizePath(process.cwd());
+  return JSON.parse(
     JSON.stringify(obj, (_key, value) =>
       typeof value === "string" && path.isAbsolute(value)
-        ? normalizePath(value.replace(process.cwd(), "{{CWD}}"))
+        ? normalizePath(value).replace(cwd, "{{CWD}}")
         : value,
     ),
   );
+};
 
 describe("route config", () => {
+  describe("app directory context", () => {
+    it("isolates concurrent app directory reads", async () => {
+      let appA = path.resolve("app-a");
+      let appB = path.resolve("app-b");
+      let releaseA!: () => void;
+      let aCanRead = new Promise<void>((resolve) => {
+        releaseA = resolve;
+      });
+
+      let readA = withAppDirectory(appA, async () => {
+        await aCanRead;
+        return getAppDirectory();
+      });
+      let readB = withAppDirectory(appB, async () => getAppDirectory());
+
+      await expect(readB).resolves.toBe(appB);
+      releaseA();
+      await expect(readA).resolves.toBe(appA);
+    });
+  });
+
   describe("validateRouteConfig", () => {
     it("validates a route config", () => {
       const routeConfig = prefix("prefix", [

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -17,7 +17,7 @@ import {
   type RouteManifest,
   type RouteManifestEntry,
   type RouteConfigEntry,
-  setAppDirectory,
+  withAppDirectory,
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
@@ -636,15 +636,17 @@ async function resolveConfig({
         );
       }
 
-      setAppDirectory(appDirectory);
-      let routeConfigExport = (
-        await viteNodeContext.runner.executeFile(
-          Path.join(appDirectory, routeConfigFile),
-        )
-      ).default;
+      let routeConfigExport = await withAppDirectory(appDirectory, async () => {
+        let routeConfigExport = (
+          await viteNodeContext.runner.executeFile(
+            Path.join(appDirectory, routeConfigFile),
+          )
+        ).default;
+        return await routeConfigExport;
+      });
       let result = validateRouteConfig({
         routeConfigFile,
-        routeConfig: await routeConfigExport,
+        routeConfig: routeConfigExport,
       });
 
       if (!result.valid) {

--- a/packages/react-router-dev/config/routes.ts
+++ b/packages/react-router-dev/config/routes.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as Path from "pathe";
 import * as v from "valibot";
 import pick from "lodash/pick";
@@ -8,8 +9,15 @@ declare global {
   var __reactRouterAppDirectory: string;
 }
 
+const appDirectoryStorage = new AsyncLocalStorage<string>();
+
 export function setAppDirectory(directory: string) {
   globalThis.__reactRouterAppDirectory = directory;
+}
+
+export function withAppDirectory<T>(directory: string, callback: () => T): T {
+  globalThis.__reactRouterAppDirectory = directory;
+  return appDirectoryStorage.run(directory, callback);
 }
 
 /**
@@ -17,8 +25,10 @@ export function setAppDirectory(directory: string) {
  * This is designed to support resolving file system routes.
  */
 export function getAppDirectory() {
-  invariant(globalThis.__reactRouterAppDirectory);
-  return globalThis.__reactRouterAppDirectory;
+  let appDirectory =
+    appDirectoryStorage.getStore() ?? globalThis.__reactRouterAppDirectory;
+  invariant(appDirectory);
+  return appDirectory;
 }
 
 export interface RouteManifestEntry {


### PR DESCRIPTION
## Summary

Fixes #15007.

`flatRoutes()` reads the current app directory through React Router's route config helpers. That state was stored globally, so concurrent Vite config resolution could let one app's `routes.ts` continue after another app had overwritten the app directory.

This wraps route config execution in `AsyncLocalStorage`, keeps the existing global fallback for compatibility, and makes `getAppDirectory()` prefer the async-local app directory when one is active. The regression coverage checks both direct concurrent reads and concurrent Vite config resolution using `flatRoutes()`.

## Validation

- `corepack pnpm exec jest packages/react-router-dev/__tests__/route-config-test.ts --runInBand`
- `corepack pnpm exec eslint packages/react-router-dev/config/config.ts packages/react-router-dev/config/routes.ts packages/react-router-dev/__tests__/route-config-test.ts integration/vite-config-concurrency-test.ts`
- `corepack pnpm exec prettier --check packages/react-router-dev/config/config.ts packages/react-router-dev/config/routes.ts packages/react-router-dev/__tests__/route-config-test.ts integration/vite-config-concurrency-test.ts`
- `corepack pnpm --filter @react-router/dev typecheck`
- `corepack pnpm --filter @react-router/fs-routes typecheck`
- `corepack pnpm --filter @react-router/dev build`
- `git diff --check`

## Local integration note

- `corepack pnpm exec playwright test --config ./integration/playwright.config.ts integration/vite-config-concurrency-test.ts --project=chromium` could not run to assertion on this Windows machine because the fixture helper failed while copying the template `node_modules/@react-router/dev` junction into `.tmp` with `EPERM: operation not permitted, symlink ...`.