### PR TITLE
fix: use configured window for browser history URLs

### DIFF
--- a/packages/react-router/__tests__/router/browser-test.ts
+++ b/packages/react-router/__tests__/router/browser-test.ts
@@ -4,6 +4,7 @@ import {
   type BrowserHistory,
   createBrowserHistory,
 } from "../../lib/router/history";
+import { JSDOM } from "jsdom";
 
 import InitialLocationDefaultKey from "./TestSequences/InitialLocationDefaultKey";
 import Listen from "./TestSequences/Listen";
@@ -57,6 +58,17 @@ describe("a browser history", () => {
       pathname: "/#abc",
     });
     expect(unencodedHref).toEqual("/#abc");
+  });
+
+  it("creates URLs relative to the configured window", () => {
+    let customWindow = new JSDOM(`<!DOCTYPE html>`, {
+      url: "https://example.com/current",
+    }).window as unknown as Window;
+    let customHistory = createBrowserHistory({ window: customWindow });
+
+    expect(customHistory.createURL("/target").href).toBe(
+      "https://example.com/target",
+    );
   });
 
   describe("listen", () => {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -729,7 +729,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -774,16 +774,23 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  targetWindow?: Window,
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  let urlWindow =
+    targetWindow ?? (typeof window !== "undefined" ? window : undefined);
+
+  if (urlWindow) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      urlWindow.location.origin !== "null"
+        ? urlWindow.location.origin
+        : urlWindow.location.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");


### PR DESCRIPTION
## Summary

Fixes #15044.

`createBrowserHistory({ window })` correctly uses the configured window for href creation and history state, but `history.createURL()` delegated to `createBrowserURLImpl()` without passing that window. The helper then fell back to the global `window`, so custom-window environments created URLs against the wrong origin.

This passes the configured history window through to `createBrowserURLImpl()` while preserving the existing global-window fallback for direct helper calls. A browser history regression test now uses a custom-origin JSDOM window and asserts `createURL()` resolves against that origin.

## Validation

- `corepack pnpm exec jest packages/react-router/__tests__/router/browser-test.ts --runInBand`
- `corepack pnpm exec prettier --check packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts`
- `corepack pnpm exec eslint packages/react-router/lib/router/history.ts packages/react-router/__tests__/router/browser-test.ts`
- `corepack pnpm --filter react-router build`
- `corepack pnpm --filter react-router typecheck`
- `git diff --check`

Local note: commands ran under Node v24.12.0, while the repo scripts warn that they expect Node `^22.18`; the checks above still passed.