### PR TITLE
fix: remove stale unpkg field from react-router-dom

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -164,6 +164,7 @@
 - harucn
 - HelpMe-Pls
 - HenriqueLimas
+- henryqdineen
 - hernanif1
 - HeyyyNeo
 - hi-ogawa

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -19,7 +19,6 @@
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
   "main": "./dist/main.js",
-  "unpkg": "./dist/umd/react-router-dom.production.min.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
The `unpkg` field in `packages/react-router-dom/package.json` points to
`./dist/umd/react-router-dom.production.min.js`, but no UMD build is
produced — the tsup config only outputs CJS and ESM formats.

Noticed this because visiting https://unpkg.com/react-router-dom returns:

  Not found: /react-router-dom@7.15.1/dist/umd/react-router-dom.production.min.js

The field was carried over when the package was re-added in 83e668edc (April
2024) and then survived the rollup→tsup migration in 2d5924f56 (October 2024)
which dropped UMD output entirely but left the `unpkg` pointer in place.