### PR TITLE
fix(router): pass configured window to createBrowserURLImpl

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -199,6 +199,7 @@
 - jb-1980
 - jclarkin
 - jdufresne
+- jeevan6996
 - jenseng
 - JeraldVin
 - JesusTheHun

--- a/packages/react-router/.changes/patch.fix-browser-history-window-url-base.md
+++ b/packages/react-router/.changes/patch.fix-browser-history-window-url-base.md
@@ -1,0 +1,3 @@
+Fix browser URL creation to use the configured history window instead of the global window.
+
+- Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.

--- a/packages/react-router/__tests__/router/browser-test.ts
+++ b/packages/react-router/__tests__/router/browser-test.ts
@@ -4,6 +4,7 @@ import {
   type BrowserHistory,
   createBrowserHistory,
 } from "../../lib/router/history";
+import { JSDOM } from "jsdom";
 
 import InitialLocationDefaultKey from "./TestSequences/InitialLocationDefaultKey";
 import Listen from "./TestSequences/Listen";
@@ -57,6 +58,15 @@ describe("a browser history", () => {
       pathname: "/#abc",
     });
     expect(unencodedHref).toEqual("/#abc");
+  });
+
+  it("uses the configured window when creating URLs", () => {
+    const customWindow = new JSDOM(`<!DOCTYPE html>`, {
+      url: "https://example.com/",
+    }).window as unknown as Window;
+    const customHistory = createBrowserHistory({ window: customWindow });
+
+    expect(customHistory.createURL("/test").origin).toBe("https://example.com");
   });
 
   describe("listen", () => {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -726,7 +726,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to, false, window);
+    return createBrowserURLImpl(window, to);
   }
 
   let history: History = {
@@ -772,9 +772,9 @@ function getUrlBasedHistory(
 }
 
 export function createBrowserURLImpl(
+  windowImpl: Window,
   to: To,
   isAbsolute = false,
-  windowImpl: Window
 ): URL {
   let base = "http://localhost";
   if (windowImpl) {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -726,7 +726,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -771,16 +771,20 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  windowImpl: Window | undefined = typeof window !== "undefined" ? window : undefined,
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  if (windowImpl) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      windowImpl.location.origin !== "null"
+        ? windowImpl.location.origin
+        : windowImpl.location.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -774,7 +774,7 @@ function getUrlBasedHistory(
 export function createBrowserURLImpl(
   to: To,
   isAbsolute = false,
-  windowImpl: Window | undefined = typeof window !== "undefined" ? window : undefined,
+  windowImpl: Window
 ): URL {
   let base = "http://localhost";
   if (windowImpl) {

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2992,7 +2992,7 @@ export function createRouter(init: RouterInit): Router {
       } else if (isAbsoluteUrl(location)) {
         // We skip `history.createURL` here for absolute URLs because we don't
         // want to inherit the current `window.location` base URL
-        const url = createBrowserURLImpl(location, true);
+        const url = createBrowserURLImpl(location, true, routerWindow);
         isDocumentReload =
           // Hard reload if it's an absolute URL to a new origin
           url.origin !== routerWindow.location.origin ||

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2992,7 +2992,7 @@ export function createRouter(init: RouterInit): Router {
       } else if (isAbsoluteUrl(location)) {
         // We skip `history.createURL` here for absolute URLs because we don't
         // want to inherit the current `window.location` base URL
-        const url = createBrowserURLImpl(location, true, routerWindow);
+        const url = createBrowserURLImpl(routerWindow, location, true);
         isDocumentReload =
           // Hard reload if it's an absolute URL to a new origin
           url.origin !== routerWindow.location.origin ||


### PR DESCRIPTION
## Summary
- pass the configured history window into `createBrowserURLImpl` so `createBrowserHistory({ window })` resolves URLs against that window
- pass `routerWindow` into the absolute redirect URL check in `createRouter` for consistency
- add a browser history regression test that asserts `history.createURL()` uses the custom window origin
- add a patch change file for `react-router`

## Testing
- `pnpm test packages/react-router/__tests__/router/browser-test.ts`
- `pnpm test packages/react-router/__tests__/router/redirects-test.ts`

Closes #15044
