### PR TITLE
fix(react-router): propagate custom window to createBrowserURLImpl

### DIFF
--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -729,7 +729,7 @@ function getUrlBasedHistory(
   }
 
   function createURL(to: To): URL {
-    return createBrowserURLImpl(to);
+    return createBrowserURLImpl(to, false, window);
   }
 
   let history: History = {
@@ -774,16 +774,21 @@ function getUrlBasedHistory(
   return history;
 }
 
-export function createBrowserURLImpl(to: To, isAbsolute = false): URL {
+export function createBrowserURLImpl(
+  to: To,
+  isAbsolute = false,
+  _window?: Window
+): URL {
   let base = "http://localhost";
-  if (typeof window !== "undefined") {
+  let win = _window ?? (typeof window !== "undefined" ? window : undefined);
+  if (win) {
     // window.location.origin is "null" (the literal string value) in Firefox
     // under certain conditions, notably when serving from a local HTML file
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=878297
     base =
-      window.location.origin !== "null"
-        ? window.location.origin
-        : window.location.href;
+      win.location.origin !== "null"
+        ? win.location.origin
+        : win.location.href;
   }
 
   invariant(base, "No window.location.(origin|href) available to create URL");


### PR DESCRIPTION
## Summary

Fixes #15044 — `createBrowserURLImpl` was ignoring the custom `window` object passed via `options` to `getUrlBasedHistory`, always falling back to the global `window`. This broke URL creation in environments where a specific window context is needed (e.g., iframe sandboxes, testing environments).

## Root Cause

When `getUrlBasedHistory` is called with a custom `window` in options, the internal `createURL` function (which calls `createBrowserURLImpl`) was not passing the correct `window` from the closure. `createBrowserURLImpl` then used the **global** `window` unconditionally, ignoring the custom context.

## What Was Fixed

- Added an optional `_window?: Window` parameter to `createBrowserURLImpl`
- When provided, `createBrowserURLImpl` uses the custom window; otherwise falls back to global `window` (preserving backward compatibility)
- Updated the `createURL` closure in `getUrlBasedHistory` to pass the captured `window` from options

## Testing Done

- Verified the existing `createBrowserURLImpl` call in `router.ts` (line ~3231) is unaffected — it doesn't pass `_window`, so it correctly falls back to the global `window`
- Verified the change is purely additive — existing behavior is preserved when no custom window is used

## Before/After

**Before:** `createBrowserURLImpl` always uses global `window`
**After:** Can accept a custom `window` parameter; falls back to global `window` when not provided