### PR TITLE
Move change file workflow to 2-step run

### DIFF
--- a/.github/workflows/change-file-comment.yml
+++ b/.github/workflows/change-file-comment.yml
@@ -1,0 +1,52 @@
+name: 📝 Change File (Comment)
+
+# Runs after the "Change File (Check)" workflow completes. That workflow runs
+# under the `pull_request` trigger with a read-only token (safe for PRs from
+# forks); this workflow runs under `workflow_run` with write permissions to
+# post the sticky comment, but never executes any PR code — it only reads
+# the artifact produced by the upstream workflow.
+
+on:
+  workflow_run:
+    workflows: ["📝 Change File (Check)"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: 📝 Post Comment
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'remix-run/react-router'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read # Read artifact
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v6
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: 📥 Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: 📥 Download result from upstream workflow
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-check-result
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: 💬 Post comment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/changes/check-pr.ts comment pr-check-result.json

--- a/.github/workflows/change-file.yml
+++ b/.github/workflows/change-file.yml
@@ -1,4 +1,4 @@
-name: 📝 Change File Check
+name: 📝 Change File (Check)
 
 on:
   pull_request:
@@ -16,8 +16,8 @@ jobs:
     if: github.repository == 'remix-run/react-router'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
 
     steps:
       - name: ⬇️ Checkout repo
@@ -35,7 +35,14 @@ jobs:
       - name: 📥 Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: 📝 Check change file and update PR comment
+      - name: 📝 Check for change file
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/changes/check-pr.ts ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/changes/check-pr.ts check "$PR_NUMBER"
+
+      - name: 📤 Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-check-result
+          path: pr-check-result.json

--- a/scripts/changes/check-pr.ts
+++ b/scripts/changes/check-pr.ts
@@ -2,15 +2,25 @@
  * Checks whether the current PR contains a change file and posts (or
  * updates) a sticky comment on the PR with the result.
  *
- * Usage (called by the changes-file GitHub Actions workflow):
- *   node scripts/changes/check-pr.ts
+ * Two-phase to avoid running with write permissions in PRs from forks
+ * See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+ *
+ *   check    Reads the PR file list and writes pr-check-result.json.
+ *            Safe to run with a read-only token (Workflow A).
+ *
+ *   comment  Reads pr-check-result.json and posts/updates the sticky
+ *            comment. Runs in Workflow B (workflow_run) with write
+ *            permissions; never sees PR contents.
  *
  * Usage:
- *   node scripts/changes/check-pr.ts <pr-number>
+ *   node scripts/changes/check-pr.ts check <pr-number>
+ *   node scripts/changes/check-pr.ts comment <result-file>
  *
  * Environment:
- *   GITHUB_TOKEN - Required. GitHub token with pull-requests:write permission.
+ *   GITHUB_TOKEN - Required. GitHub token with appropriate permissions
+ *                  for the selected mode.
  */
+import * as fs from "node:fs";
 import {
   createPrComment,
   getPrComments,
@@ -43,21 +53,36 @@ pnpm run changes:add
 // Matches packages/*/.changes/*.md but not .gitkeep
 const CHANGE_FILE_RE = /^packages\/[^/]+\/\.changes\/[^/]+\.md$/;
 
-async function main() {
-  let arg = process.argv[2];
-  let prNumber = arg ? parseInt(arg, 10) : NaN;
-  if (!arg || isNaN(prNumber)) {
-    console.error("Usage: node scripts/changes/check-pr.ts <pr-number>");
-    process.exit(1);
-  }
+// Needs to match change-file.yml/change-file-comment.yml
+const ARTIFACT_FILE = "pr-check-result.json"; //
 
-  // Check for change files via the GitHub API — no git fetch needed
+let [mode, arg] = process.argv.slice(2);
+
+if (mode === "check") {
+  let prNumber = parseInt(arg ?? "", 10);
+  if (isNaN(prNumber)) usage();
+  await check(prNumber);
+} else if (mode === "comment") {
+  if (!arg) usage();
+  await comment(arg);
+} else {
+  usage();
+}
+
+async function check(prNumber: number) {
   let files = await getPrFiles(prNumber);
   let found = files.some((f) => CHANGE_FILE_RE.test(f.filename));
-  let body = found ? COMMENT_FOUND : COMMENT_MISSING;
-  console.log(`Change files found: ${found}`);
+  console.log(
+    `Writing artifact to ${ARTIFACT_FILE}:`,
+    JSON.stringify({ prNumber, found }),
+  );
+  fs.writeFileSync(ARTIFACT_FILE, JSON.stringify({ prNumber, found }));
+}
 
-  // Find existing sticky comment
+async function comment(resultPath: string) {
+  let { prNumber, found } = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+  let body = found ? COMMENT_FOUND : COMMENT_MISSING;
+
   let comments = await getPrComments(prNumber);
   let existing = comments.find(
     (c) =>
@@ -74,7 +99,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Error:", err.message);
+function usage(): never {
+  console.error(
+    "Usage:\n" +
+      "  node scripts/changes/check-pr.ts check <pr-number>\n" +
+      "  node scripts/changes/check-pr.ts comment <result-file>",
+  );
   process.exit(1);
-});
+}


### PR DESCRIPTION
Fixing Change file comment workflow on PRs from forked repos

<img width="588" height="82" alt="Screenshot 2026-05-18 at 11 34 57 AM" src="https://github.com/user-attachments/assets/fa0ef3f9-81ec-4f85-905e-6cc8bf7608fc" />

<img width="856" height="191" alt="Screenshot 2026-05-18 at 11 35 12 AM" src="https://github.com/user-attachments/assets/ffdb185e-f4fb-45cc-86ed-685e611c0be3" />

These fail because `pull_request` workflows on PRs from forked repos run with a read only github token.  `pull_request_target` upgrades the token but is a security risk, so this type of 2 step workflow is the recommended secure solution recommneded by github: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
