### PR TITLE
fix: remove stale unpkg field from react-router-dom

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -164,6 +164,7 @@
 - harucn
 - HelpMe-Pls
 - HenriqueLimas
+- henryqdineen
 - hernanif1
 - HeyyyNeo
 - hi-ogawa

--- a/packages/react-router-dom/.changes/patch.remove-staleinvalid-unpkg-field-packagejson-removed.md
+++ b/packages/react-router-dom/.changes/patch.remove-staleinvalid-unpkg-field-packagejson-removed.md
@@ -1,0 +1,1 @@
+Remove stale/invalid `unpkg` field from `package.json`.  This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -19,7 +19,6 @@
   "author": "Remix Software <hello@remix.run>",
   "sideEffects": false,
   "main": "./dist/main.js",
-  "unpkg": "./dist/umd/react-router-dom.production.min.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Replaces https://github.com/remix-run/react-router/pull/15065