### PR TITLE
Support array of objects for `script:ld+json` meta descriptor

### DIFF
--- a/packages/react-router/.changes/patch.support-array-script-ld-json.md
+++ b/packages/react-router/.changes/patch.support-array-script-ld-json.md
@@ -1,3 +1,1 @@
-Support arrays of objects for the `script:ld+json` meta descriptor
-
-- Widen `"script:ld+json"` in `MetaDescriptor` from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` so a route can declare multiple JSON-LD schemas (e.g. `Organization` + `BreadcrumbList`) in a single `<script type="application/ld+json">` tag emitted by `<Meta />`.
+Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />`

--- a/packages/react-router/.changes/patch.support-array-script-ld-json.md
+++ b/packages/react-router/.changes/patch.support-array-script-ld-json.md
@@ -1,0 +1,3 @@
+Support arrays of objects for the `script:ld+json` meta descriptor
+
+- Widen `"script:ld+json"` in `MetaDescriptor` from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` so a route can declare multiple JSON-LD schemas (e.g. `Organization` + `BreadcrumbList`) in a single `<script type="application/ld+json">` tag emitted by `<Meta />`.

--- a/packages/react-router/__tests__/dom/ssr/meta-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/meta-test.tsx
@@ -279,6 +279,48 @@ describe("meta", () => {
     );
   });
 
+  it("{ 'script:ld+json': [...] } adds a <script type='application/ld+json' /> with an array of objects", () => {
+    let jsonLd = [
+      {
+        "@context": "http://schema.org",
+        "@type": "Organization",
+        name: "Acme Inc.",
+        url: "https://acme.example.com",
+      },
+      {
+        "@context": "http://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: "https://acme.example.com",
+          },
+        ],
+      },
+    ];
+
+    let RoutesStub = createRoutesStub([
+      {
+        path: "/",
+        meta: () => [
+          {
+            "script:ld+json": jsonLd,
+          },
+        ],
+        Component: Meta,
+      },
+    ]);
+
+    let { container } = render(<RoutesStub />);
+
+    let scriptTagContents =
+      container.querySelector('script[type="application/ld+json"]')
+        ?.innerHTML || "{}";
+    expect(JSON.parse(scriptTagContents)).toEqual(jsonLd);
+  });
+
   it("{ tagName: 'link' } adds a <link />", () => {
     let RoutesStub = createRoutesStub([
       {

--- a/packages/react-router/lib/dom/ssr/routeModules.ts
+++ b/packages/react-router/lib/dom/ssr/routeModules.ts
@@ -248,7 +248,7 @@ export type MetaDescriptor =
   | { name: string; content: string }
   | { property: string; content: string }
   | { httpEquiv: string; content: string }
-  | { "script:ld+json": LdJsonObject }
+  | { "script:ld+json": LdJsonObject | LdJsonObject[] }
   | { tagName: "meta" | "link"; [name: string]: string }
   | { [name: string]: unknown };
 


### PR DESCRIPTION
## Summary

Allow the `script:ld+json` meta descriptor to accept an array of `LdJsonObject` in addition to a single object, so a route can declare multiple JSON-LD schemas (e.g. `Organization` + `BreadcrumbList`) within a single `<script type="application/ld+json">` tag emitted by `<Meta />`.

`JSON.stringify` is already used to serialize the value in `packages/react-router/lib/dom/ssr/components.tsx`, so the renderer handles arrays without any further changes — this PR only widens the `MetaDescriptor` type and adds a test for the array case.

## Changes

- `packages/react-router/lib/dom/ssr/routeModules.ts`: widen `"script:ld+json"` from `LdJsonObject` to `LdJsonObject | LdJsonObject[]`.
- `packages/react-router/__tests__/dom/ssr/meta-test.tsx`: add a test that passes an array of two JSON-LD objects and asserts the rendered `<script>` contents.

## Test plan

- [x] `pnpm jest packages/react-router/__tests__/dom/ssr/meta-test.tsx` — all tests pass
