### PR TITLE
Fix typegen for star folder fs routes

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -1,3 +1,4 @@
+- puneetdixit200
 - 0xEddie
 - 3fuyang
 - 43081j

--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -257,6 +257,32 @@ test.describe("typegen", () => {
     await $("pnpm typecheck");
   });
 
+  test("route file in literal star folder", async ({ cwd, edit, $ }) => {
+    test.skip(
+      process.platform === "win32",
+      'Windows does not support literal "*" path segments.',
+    );
+
+    await fs.mkdir(Path.join(cwd, "app/routes/*"), { recursive: true });
+    await edit({
+      "app/routes/*/route.tsx": tsx`
+        import type { Expect, Equal } from "../../expect-type"
+        import type { Route } from "./+types/route"
+
+        export function loader({ params }: Route.LoaderArgs) {
+          type Test = Expect<Equal<typeof params, { "*": string }>>
+          return { value: params["*"] }
+        }
+
+        export default function Component({ loaderData }: Route.ComponentProps) {
+          type Test = Expect<Equal<typeof loaderData.value, string>>
+          return <h1>{loaderData.value}</h1>
+        }
+      `,
+    });
+    await $("pnpm typecheck");
+  });
+
   test("clientLoader.hydrate = true", async ({ edit, $ }) => {
     await edit({
       "app/routes/_index.tsx": tsx`

--- a/packages/react-router-fs-routes/.changes/patch.star-folder-splat.md
+++ b/packages/react-router-fs-routes/.changes/patch.star-folder-splat.md
@@ -1,0 +1,1 @@
+Support route modules in folders named `*` as splat filesystem routes.

--- a/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
+++ b/packages/react-router-fs-routes/__tests__/flatRoutes-test.ts
@@ -99,6 +99,26 @@ describe("flatRoutes", () => {
       });
     }
 
+    test("folder named * creates a splat route", () => {
+      let manifest = flatRoutesUniversal(APP_DIR, [
+        path.join(APP_DIR, "routes", "*", "route.tsx"),
+      ]);
+
+      let routeInfo = manifest["routes/*"];
+      expect(routeInfo.id).toBe("routes/*");
+      expect(routeInfo.file).toBe("routes/*/route.tsx");
+      expect(routeInfo.path).toBe("*");
+    });
+
+    test("file named * is still unsupported", () => {
+      expect(() =>
+        flatRoutesUniversal(APP_DIR, [path.join(APP_DIR, "routes", "*.tsx")]),
+      ).toThrow(
+        'Route segment "*" for "*" cannot contain "*".\n' +
+          "If this is something you need, upvote this proposal for React Router https://github.com/remix-run/react-router/discussions/9822.",
+      );
+    });
+
     let invalidSlashFiles = [
       "($[$dollabills]).([.]lol)[/](what)/([$]).$",
       "$[$dollabills].[.]lol[/]what/[$].$",

--- a/packages/react-router-fs-routes/flatRoutes.ts
+++ b/packages/react-router-fs-routes/flatRoutes.ts
@@ -171,7 +171,20 @@ export function flatRoutesUniversal(
 
   for (let [routeId, file] of sortedRouteIds) {
     let index = routeId.endsWith("_index");
-    let [segments, raw] = getRouteSegments(routeId.slice(prefix.length + 1));
+    let routePath = routeId.slice(prefix.length + 1);
+    let fileExt = path.posix.extname(file);
+    let fileName = path.posix.basename(file, fileExt);
+    let isFolderRouteModule =
+      path.posix.dirname(file) !== appWithPrefix &&
+      (fileName === "route" || fileName === "index");
+    if (isFolderRouteModule) {
+      routePath = routePath
+        .split("/")
+        .map((segment) => (segment === "*" ? paramPrefixChar : segment))
+        .join("/");
+    }
+
+    let [segments, raw] = getRouteSegments(routePath);
     let pathname = createRoutePath(segments, raw, index);
 
     routeManifest[routeId] = {


### PR DESCRIPTION
Fixes #14744.

This updates filesystem route path generation so a folder route module in `routes/*/route.tsx` is treated as a splat route while keeping the route id and file path unchanged for generated type imports. Filenames like `routes/*.tsx` remain unsupported, matching the existing raw `*` filename rules.

Tests run:
- `pnpm --filter @react-router/fs-routes build`
- `pnpm --filter @react-router/fs-routes typecheck`
- `pnpm test -- --selectProjects fs-routes --runTestsByPath packages/react-router-fs-routes/__tests__/flatRoutes-test.ts`
- `pnpm test:integration:run integration/typegen-test.ts --project=chromium -g "splat|route file in literal star folder"`
- `pnpm exec prettier --check packages/react-router-fs-routes/flatRoutes.ts packages/react-router-fs-routes/__tests__/flatRoutes-test.ts integration/typegen-test.ts packages/react-router-fs-routes/.changes/patch.star-folder-splat.md`
- `pnpm changes:validate`
- `git diff --check`