### PR TITLE
Align Node type dependencies

### DIFF
--- a/integration/helpers/rsc-vite-framework/package.json
+++ b/integration/helpers/rsc-vite-framework/package.json
@@ -15,7 +15,7 @@
     "@react-router/dev": "workspace:*",
     "@react-router/fs-routes": "workspace:*",
     "@types/express": "^5.0.6",
-    "@types/node": "^22.13.1",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vanilla-extract/css": "^1.20.1",

--- a/integration/helpers/rsc-vite/package.json
+++ b/integration/helpers/rsc-vite/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "@types/node": "^22.13.1",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^4.5.2",

--- a/integration/helpers/vite-plugin-cloudflare-template/package.json
+++ b/integration/helpers/vite-plugin-cloudflare-template/package.json
@@ -22,7 +22,7 @@
     "@cloudflare/vite-plugin": "^1.28.0",
     "@react-router/dev": "workspace:*",
     "@react-router/fs-routes": "workspace:*",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "eslint": "^8.38.0",

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@react-router/node": "workspace:*",
     "@types/lambda-tester": "^3.6.1",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.0",
     "lambda-tester": "^4.0.1",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -105,7 +105,7 @@
     "@types/jest": "^29.5.4",
     "@types/jsesc": "^3.0.1",
     "@types/lodash": "^4.17.24",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.0",
     "@types/npmcli__package-json": "^4.0.0",
     "@types/semver": "^7.7.1",
     "@vitejs/plugin-rsc": "catalog:",

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.9",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.0",
     "@types/supertest": "^2.0.10",
     "express": "^4.19.2",
     "node-mocks-http": "^1.17.2",

--- a/playground/middleware/package.json
+++ b/playground/middleware/package.json
@@ -29,7 +29,7 @@
     "@types/express": "^4.17.21",
     "@types/express-serve-static-core": "^5.1.1",
     "@types/morgan": "^1.9.10",
-    "@types/node": "^20.19.0",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "tsx": "^4.22.3",

--- a/playground/rsc-vite-7-framework/package.json
+++ b/playground/rsc-vite-7-framework/package.json
@@ -17,7 +17,7 @@
     "@react-router/fs-routes": "workspace:*",
     "@react-router/serve": "workspace:*",
     "@types/express": "^5.0.6",
-    "@types/node": "^22.13.1",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-rsc": "catalog:",

--- a/playground/rsc-vite-framework/package.json
+++ b/playground/rsc-vite-framework/package.json
@@ -17,7 +17,7 @@
     "@react-router/fs-routes": "workspace:*",
     "@react-router/serve": "workspace:*",
     "@types/express": "^5.0.6",
-    "@types/node": "^22.13.1",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^6.0.1",

--- a/playground/rsc-vite/package.json
+++ b/playground/rsc-vite/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "@types/node": "^22.13.1",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "^4.5.2",

--- a/playground/vite-plugin-cloudflare/package.json
+++ b/playground/vite-plugin-cloudflare/package.json
@@ -22,7 +22,7 @@
     "@cloudflare/vite-plugin": "^1.28.0",
     "@react-router/dev": "workspace:*",
     "@react-router/fs-routes": "workspace:*",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.19.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "eslint": "^8.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 10.4.0(jiti@2.4.2)
       eslint-config-react-app:
         specifier: ^7.0.1
-        version: 7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
+        version: 7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
       eslint-plugin-flowtype:
         specifier: ^8.0.3
         version: 8.0.3(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))
@@ -104,7 +104,7 @@ importers:
         version: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))
       eslint-plugin-jest:
         specifier: ^29.15.0
-        version: 29.15.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
+        version: 29.15.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
       eslint-plugin-jsdoc:
         specifier: ^62.8.0
         version: 62.8.1(eslint@10.4.0(jiti@2.4.2))
@@ -125,7 +125,7 @@ importers:
         version: 5.1.40
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-environment-jsdom:
         specifier: ^29.6.2
         version: 29.6.2
@@ -149,10 +149,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.1(@types/node@20.19.37)(jsdom@29.1.1)(msw@2.14.6(@types/node@20.19.37)(typescript@5.4.5))(vite@7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.1(@types/node@22.19.18)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.18)(typescript@5.4.5))(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
 
   integration:
     dependencies:
@@ -311,8 +311,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^22.13.1
-        version: 22.14.0
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -321,16 +321,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.5.2(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.5.2(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 5.4.5
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   integration/helpers/rsc-vite-framework:
     dependencies:
@@ -372,8 +372,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^22.13.1
-        version: 22.14.0
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -385,13 +385,13 @@ importers:
         version: 1.20.1(babel-plugin-macros@3.1.0)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.2.0
-        version: 5.2.1(@types/node@22.14.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+        version: 5.2.1(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -400,10 +400,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^8.0.0
-        version: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-env-only:
         specifier: ^3.0.1
-        version: 3.0.1(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 3.0.1(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
 
   integration/helpers/vite-7-template:
     dependencies:
@@ -559,7 +559,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.28.0
-        version: 1.37.3(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))
+        version: 1.37.3(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))
       '@react-router/dev':
         specifier: workspace:*
         version: link:../../../packages/react-router-dev
@@ -567,8 +567,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/react-router-fs-routes
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.11.30
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -583,10 +583,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.93.1
         version: 4.93.1(@cloudflare/workers-types@4.20260520.1)
@@ -717,8 +717,8 @@ importers:
         specifier: ^3.6.1
         version: 3.6.2
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.11.30
+        specifier: ^22.19.0
+        version: 22.19.18
       lambda-tester:
         specifier: ^4.0.1
         version: 4.0.1
@@ -847,7 +847,7 @@ importers:
         version: 1.4.0(typescript@5.4.5)
       vite-node:
         specifier: ^3.2.2
-        version: 3.2.4(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
     devDependencies:
       '@react-router/serve':
         specifier: workspace:*
@@ -877,8 +877,8 @@ importers:
         specifier: ^4.17.24
         version: 4.17.24
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.11.30
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/npmcli__package-json':
         specifier: ^4.0.0
         version: 4.0.4
@@ -887,7 +887,7 @@ importers:
         version: 7.7.1
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.6(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.28.0)))(react@19.3.0-canary-d763f313-20251210)(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.6(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.28.0)))(react@19.3.0-canary-d763f313-20251210)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       esbuild-register:
         specifier: ^3.6.0
         version: 3.6.0(esbuild@0.28.0)
@@ -911,7 +911,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       wireit:
         specifier: 'catalog:'
         version: 0.14.9
@@ -932,8 +932,8 @@ importers:
         specifier: ^4.17.9
         version: 4.17.21
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.11.30
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/supertest':
         specifier: ^2.0.10
         version: 2.0.16
@@ -942,7 +942,7 @@ importers:
         version: 4.21.2
       node-mocks-http:
         specifier: ^1.17.2
-        version: 1.17.2(@types/express@4.17.21)(@types/node@20.11.30)
+        version: 1.17.2(@types/express@4.17.21)(@types/node@22.19.18)
       supertest:
         specifier: ^6.3.3
         version: 6.3.4
@@ -1310,8 +1310,8 @@ importers:
         specifier: ^1.9.10
         version: 1.9.10
       '@types/node':
-        specifier: ^20.19.0
-        version: 20.19.37
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1326,7 +1326,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^8.0.0
-        version: 8.0.2(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   playground/performance:
     dependencies:
@@ -1393,8 +1393,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^22.13.1
-        version: 22.14.0
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1403,10 +1403,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.5.2(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.5.2(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1415,7 +1415,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^6.3.0
-        version: 6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   playground/rsc-vite-7-framework:
     dependencies:
@@ -1460,8 +1460,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^22.13.1
-        version: 22.14.0
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1470,7 +1470,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1485,7 +1485,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   playground/rsc-vite-framework:
     dependencies:
@@ -1530,8 +1530,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: ^22.13.1
-        version: 22.14.0
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1540,10 +1540,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 6.0.1(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1558,7 +1558,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^8.0.0
-        version: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   playground/split-route-modules:
     dependencies:
@@ -1654,7 +1654,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.28.0
-        version: 1.37.3(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))
+        version: 1.37.3(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))
       '@react-router/dev':
         specifier: workspace:*
         version: link:../../packages/react-router-dev
@@ -1662,8 +1662,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-router-fs-routes
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.11.30
+        specifier: ^22.19.0
+        version: 22.19.18
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -1678,10 +1678,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^7.0.0
-        version: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       wrangler:
         specifier: ^4.93.1
         version: 4.93.1(@cloudflare/workers-types@4.20260520.1)
@@ -1699,7 +1699,7 @@ importers:
         version: 7.8.0
     devDependencies:
       '@types/node':
-        specifier: ^22.18.0
+        specifier: ^22.19.0
         version: 22.19.18
       '@types/prompts':
         specifier: ^2.4.9
@@ -4479,15 +4479,6 @@ packages:
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
-
-  '@types/node@20.11.30':
-    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
-
-  '@types/node@20.19.37':
-    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
-
-  '@types/node@22.14.0':
-    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/node@22.19.18':
     resolution: {integrity: sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==}
@@ -9045,9 +9036,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -10791,12 +10779,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260520.1
 
-  '@cloudflare/vite-plugin@1.37.3(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))':
+  '@cloudflare/vite-plugin@1.37.3(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(workerd@1.20260520.1)(wrangler@4.93.1(@cloudflare/workers-types@4.20260520.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260520.1)
       miniflare: 4.20260520.0
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       wrangler: 4.93.1(@cloudflare/workers-types@4.20260520.1)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -11398,33 +11386,12 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
-  '@inquirer/confirm@6.0.13(@types/node@20.19.37)':
-    dependencies:
-      '@inquirer/core': 11.1.10(@types/node@20.19.37)
-      '@inquirer/type': 4.0.5(@types/node@20.19.37)
-    optionalDependencies:
-      '@types/node': 20.19.37
-    optional: true
-
   '@inquirer/confirm@6.0.13(@types/node@22.19.18)':
     dependencies:
       '@inquirer/core': 11.1.10(@types/node@22.19.18)
       '@inquirer/type': 4.0.5(@types/node@22.19.18)
     optionalDependencies:
       '@types/node': 22.19.18
-
-  '@inquirer/core@11.1.10(@types/node@20.19.37)':
-    dependencies:
-      '@inquirer/ansi': 2.0.5
-      '@inquirer/figures': 2.0.5
-      '@inquirer/type': 4.0.5(@types/node@20.19.37)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.2
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 20.19.37
-    optional: true
 
   '@inquirer/core@11.1.10(@types/node@22.19.18)':
     dependencies:
@@ -11439,11 +11406,6 @@ snapshots:
       '@types/node': 22.19.18
 
   '@inquirer/figures@2.0.5': {}
-
-  '@inquirer/type@4.0.5(@types/node@20.19.37)':
-    optionalDependencies:
-      '@types/node': 20.19.37
-    optional: true
 
   '@inquirer/type@4.0.5(@types/node@22.19.18)':
     optionalDependencies:
@@ -11471,7 +11433,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -11485,14 +11447,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -11518,14 +11480,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-mock: 29.7.0
 
   '@jest/environment@30.3.0':
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-mock: 30.3.0
 
   '@jest/expect-utils@29.7.0':
@@ -11547,7 +11509,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -11556,7 +11518,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.1.1
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -11574,7 +11536,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -11585,7 +11547,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -11664,7 +11626,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -11674,7 +11636,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -12230,7 +12192,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/chai@5.2.3':
     dependencies:
@@ -12240,17 +12202,17 @@ snapshots:
   '@types/compression@1.8.1':
     dependencies:
       '@types/express': 4.17.21
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/cookiejar@2.1.5': {}
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/debug@4.1.12':
     dependencies:
@@ -12282,7 +12244,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.43':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@types/qs': 6.9.14
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -12310,12 +12272,12 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/gunzip-maybe@1.4.3':
     dependencies:
@@ -12355,13 +12317,13 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
 
   '@types/jsdom@21.1.1':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@types/tough-cookie': 4.0.5
       parse5: 7.1.2
 
@@ -12393,21 +12355,9 @@ snapshots:
 
   '@types/morgan@1.9.10':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/ms@0.7.34': {}
-
-  '@types/node@20.11.30':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.19.37':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.14.0':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.19.18':
     dependencies:
@@ -12440,20 +12390,20 @@ snapshots:
 
   '@types/recursive-readdir@2.2.4':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/serve-static@1.15.5':
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/serve-static@2.2.0':
     dependencies:
@@ -12467,7 +12417,7 @@ snapshots:
   '@types/shelljs@0.8.16':
     dependencies:
       '@types/glob': 7.2.0
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/source-map-support@0.5.10':
     dependencies:
@@ -12483,7 +12433,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/supertest@2.0.16':
     dependencies:
@@ -12491,12 +12441,12 @@ snapshots:
 
   '@types/tar-fs@2.0.4':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
       '@types/tar-stream': 3.1.3
 
   '@types/tar-stream@3.1.3':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -12506,7 +12456,7 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
 
   '@types/yargs-parser@21.0.0': {}
 
@@ -12842,27 +12792,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/compiler@0.6.0(@types/node@22.14.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)':
-    dependencies:
-      '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
-      '@vanilla-extract/integration': 8.0.9(babel-plugin-macros@3.1.0)
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@vanilla-extract/compiler@0.6.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)':
     dependencies:
       '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
@@ -12938,26 +12867,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vanilla-extract/vite-plugin@5.2.1(@types/node@22.14.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)':
-    dependencies:
-      '@vanilla-extract/compiler': 0.6.0(@types/node@22.14.0)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      '@vanilla-extract/integration': 8.0.9(babel-plugin-macros@3.1.0)
-      vite: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@vanilla-extract/vite-plugin@5.2.1(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@vanilla-extract/compiler': 0.6.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
@@ -12998,18 +12907,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@vitejs/plugin-react@4.5.2(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
-    dependencies:
-      '@babel/core': 7.27.7
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.7)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.27.7)
-      '@rolldown/pluginutils': 1.0.0-beta.11
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-react@4.5.2(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.27.7
@@ -13022,7 +12919,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.5.2(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.5.2(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.27.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.27.7)
@@ -13030,16 +12927,16 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
-  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4)))(react@19.2.6)(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.5
       es-module-lexer: 2.0.0
@@ -13051,12 +12948,12 @@ snapshots:
       srvx: 0.11.13
       strip-literal: 3.1.0
       turbo-stream: 3.1.0
-      vite: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       react-server-dom-webpack: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.27.4))
 
-  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.5
       es-module-lexer: 2.0.0
@@ -13068,12 +12965,12 @@ snapshots:
       srvx: 0.11.13
       strip-literal: 3.1.0
       turbo-stream: 3.1.0
-      vite: 6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       react-server-dom-webpack: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0))
 
-  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.21(react-dom@19.2.6(react@19.2.6))(react-server-dom-webpack@19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0)))(react@19.2.6)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.5
       es-module-lexer: 2.0.0
@@ -13085,12 +12982,12 @@ snapshots:
       srvx: 0.11.13
       strip-literal: 3.1.0
       turbo-stream: 3.1.0
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       react-server-dom-webpack: 19.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(webpack@5.103.0(esbuild@0.28.0))
 
-  '@vitejs/plugin-rsc@0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.6(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.28.0)))(react@19.3.0-canary-d763f313-20251210)(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-rsc@0.5.21(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react-server-dom-webpack@19.2.6(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.28.0)))(react@19.3.0-canary-d763f313-20251210)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.5
       es-module-lexer: 2.0.0
@@ -13102,8 +12999,8 @@ snapshots:
       srvx: 0.11.13
       strip-literal: 3.1.0
       turbo-stream: 3.1.0
-      vite: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       react-server-dom-webpack: 19.2.6(react-dom@19.3.0-canary-d763f313-20251210(react@19.3.0-canary-d763f313-20251210))(react@19.3.0-canary-d763f313-20251210)(webpack@5.103.0(@swc/core@1.11.24)(esbuild@0.28.0))
 
@@ -13116,14 +13013,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(msw@2.14.6(@types/node@20.19.37)(typescript@5.4.5))(vite@7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.1(msw@2.14.6(@types/node@22.19.18)(typescript@5.4.5))(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.14.6(@types/node@20.19.37)(typescript@5.4.5)
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      msw: 2.14.6(@types/node@22.19.18)(typescript@5.4.5)
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -14533,7 +14430,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/eslint-parser': 7.24.1(@babel/core@7.29.0)(eslint@10.4.0(jiti@2.4.2))
@@ -14545,7 +14442,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.4.2)
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.18.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.29.0))(eslint@10.4.0(jiti@2.4.2))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@10.4.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 4.6.2(eslint@10.4.0(jiti@2.4.2))
@@ -14654,24 +14551,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5)
       eslint: 10.4.0(jiti@2.4.2)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5)
-      jest: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
+  eslint-plugin-jest@29.15.1(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)))(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/utils': 8.57.2(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5)
       eslint: 10.4.0(jiti@2.4.2)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5))(eslint@10.4.0(jiti@2.4.2))(typescript@5.4.5)
-      jest: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -15827,7 +15724,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-cli@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/test-result': 30.3.0
@@ -15835,7 +15732,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -15846,7 +15743,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -15872,7 +15769,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -15910,7 +15807,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 22.14.0
+      '@types/node': 22.19.18
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -15992,13 +15889,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-util: 29.7.0
 
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -16032,7 +15929,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -16061,7 +15958,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -16108,7 +16005,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -16117,7 +16014,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -16136,7 +16033,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -16151,18 +16048,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest@30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-cli: 30.3.0(@types/node@22.19.18)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -16901,32 +16798,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.6(@types/node@20.19.37)(typescript@5.4.5):
-    dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@20.19.37)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   msw@2.14.6(@types/node@22.19.18)(typescript@5.4.5):
     dependencies:
       '@inquirer/confirm': 6.0.13(@types/node@22.19.18)
@@ -16976,7 +16847,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-mocks-http@1.17.2(@types/express@4.17.21)(@types/node@20.11.30):
+  node-mocks-http@1.17.2(@types/express@4.17.21)(@types/node@22.19.18):
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
@@ -16990,7 +16861,7 @@ snapshots:
       type-is: 1.6.18
     optionalDependencies:
       '@types/express': 4.17.21
-      '@types/node': 20.11.30
+      '@types/node': 22.19.18
 
   node-releases@2.0.27: {}
 
@@ -18526,8 +18397,6 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
   undici@6.20.1: {}
@@ -18702,19 +18571,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-env-only@3.0.1(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      '@babel/core': 7.27.7
-      '@babel/generator': 7.27.5
-      '@babel/parser': 7.27.7
-      '@babel/traverse': 7.27.7
-      '@babel/types': 7.27.7
-      babel-dead-code-elimination: 1.0.10
-      micromatch: 4.0.5
-      vite: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
   vite-env-only@3.0.1(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.27.7
@@ -18727,48 +18583,6 @@ snapshots:
       vite: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
-
-  vite-node@3.2.4(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vite-node@3.2.4(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vite-node@3.2.4(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
@@ -18791,17 +18605,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.1
-      globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.4.5)
-    optionalDependencies:
-      vite: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.1
@@ -18813,23 +18616,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.25.0
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.15
-      rollup: 4.43.0
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 22.14.0
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
   vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.0
@@ -18840,57 +18626,6 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.19.18
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
-  vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.43.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.11.30
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
-  vite@7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.43.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.37
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
-  vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rollup: 4.43.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.14.0
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.32.0
@@ -18932,38 +18667,6 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vite@8.0.2(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.11
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.37
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
-  vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.11
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.14.0
-      esbuild: 0.27.4
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      terser: 5.44.1
-      tsx: 4.22.3
-      yaml: 2.9.0
-
   vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -18980,26 +18683,22 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.11.30)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
+  vitefu@1.1.2(vite@8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.2(@types/node@22.19.18)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitefu@1.1.2(vite@8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
-    optionalDependencies:
-      vite: 8.0.2(@types/node@22.14.0)(esbuild@0.27.4)(jiti@2.4.2)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
-
-  vitest@4.1.1(@types/node@20.19.37)(jsdom@29.1.1)(msw@2.14.6(@types/node@20.19.37)(typescript@5.4.5))(vite@7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.1(@types/node@22.19.18)(jsdom@29.1.1)(msw@2.14.6(@types/node@22.19.18)(typescript@5.4.5))(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(msw@2.14.6(@types/node@20.19.37)(typescript@5.4.5))(vite@7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.1(msw@2.14.6(@types/node@22.19.18)(typescript@5.4.5))(vite@7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -19016,10 +18715,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.1(@types/node@22.19.18)(jiti@2.4.2)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.37
+      '@types/node': 22.19.18
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,7 +8,7 @@
     "semver": "^7.8.0"
   },
   "devDependencies": {
-    "@types/node": "^22.18.0",
+    "@types/node": "^22.19.0",
     "@types/prompts": "^2.4.9",
     "@types/semver": "^7.7.1"
   },

--- a/tutorials/address-book/package.json
+++ b/tutorials/address-book/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@react-router/dev": "*",
-    "@types/node": "^20",
+    "@types/node": "^22.19.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
Update active packages and templates to use @types/node 22.19.x so the workspace matches the Node 22.12 runtime floor. Refresh the lockfile to collapse older Node 20 and 22.14 type resolutions.