### PR TITLE
fix: keep useNavigation() return type a discriminated union

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -94,6 +94,7 @@
 - codeape2
 - coolport
 - coryhouse
+- csamuel
 - ctnelson1997
 - cvbuelow
 - dadamssg

--- a/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
+++ b/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
@@ -1,0 +1,1 @@
+Fix `useNavigation()` return type so it stays a discriminated union

--- a/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
+++ b/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
@@ -1,1 +1,1 @@
-Fix `useNavigation()` return type so it stays a discriminated union
+Fix `useNavigation()` return type to preserve discriminated union across navigation states

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -24,7 +24,6 @@ import type {
   RelativeRoutingType,
   Router as DataRouter,
   RevalidationState,
-  Navigation,
   NavigationStates,
 } from "./router/router";
 import { IDLE_BLOCKER } from "./router/router";
@@ -1451,6 +1450,13 @@ export function useRouteId() {
   return useCurrentRouteId(DataRouterStateHook.UseRouteId);
 }
 
+type UseNavigationResult = {
+  [K in keyof NavigationStates]: Omit<
+    NavigationStates[K],
+    "matches" | "historyAction"
+  >;
+}[keyof NavigationStates];
+
 /**
  * Returns the current {@link Navigation}, defaulting to an "idle" navigation
  * when no navigation is in progress. You can use this to render pending UI
@@ -1473,9 +1479,9 @@ export function useRouteId() {
  * @mode data
  * @returns The current {@link Navigation} object
  */
-export function useNavigation(): Omit<Navigation, "matches" | "historyAction"> {
+export function useNavigation(): UseNavigationResult {
   let state = useDataRouterState(DataRouterStateHook.UseNavigation);
-  return React.useMemo<Omit<Navigation, "matches" | "historyAction">>(() => {
+  return React.useMemo<UseNavigationResult>(() => {
     let { matches, historyAction, ...rest } = state.navigation;
     return rest;
   }, [state.navigation]);

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1450,12 +1450,15 @@ export function useRouteId() {
   return useCurrentRouteId(DataRouterStateHook.UseRouteId);
 }
 
-type UseNavigationResult = {
-  [K in keyof NavigationStates]: Omit<
-    NavigationStates[K],
-    "matches" | "historyAction"
-  >;
-}[keyof NavigationStates];
+// Omit the fields from each navigation state individually to preserve the discriminated union
+type UseNavigationResult =
+  UseNavigationResultStates[keyof UseNavigationResultStates];
+
+type UseNavigationResultStates = {
+  Idle: Omit<NavigationStates["Idle"], "matches" | "historyAction">;
+  Loading: Omit<NavigationStates["Loading"], "matches" | "historyAction">;
+  Submitting: Omit<NavigationStates["Submitting"], "matches" | "historyAction">;
+};
 
 /**
  * Returns the current {@link Navigation}, defaulting to an "idle" navigation


### PR DESCRIPTION
## Summary

After upgrading a react-router app to `7.15.1`,  I noticed `useNavigation()`'s return type was updated to no longer be a discriminated union. This means narrowing on `navigation.state` no longer narrows `navigation.location`, so code that passed typecheck in `7.14.x` now fails with `'navigation.location' is possibly 'undefined'`). This PR restores the return type to be a discriminated union.

## Reproduction

[StackBlitz repro](https://stackblitz.com/~/github.com/csamuel/rr-usenavigation-repro) 

```ts
const navigation = useNavigation();
// 7.14.x: `state !== "idle"` narrowed `location` to `Location`.
// 7.15.1: TS18048, `navigation.location` is possibly `undefined`.
const isNavigating =
  navigation.state !== "idle" && navigation.location.pathname.length > 0;
```

## Root cause

[#15017](https://github.com/remix-run/react-router/pull/15017) added `matches`/`historyAction` to the `Navigation` union and stripped them off the public return type with `Omit<Navigation, "matches" | "historyAction">`.

`Navigation` is a discriminated union (`Idle | Loading | Submitting`, keyed on `state`). `Omit<T, K>` is `Pick<T, Exclude<keyof T, K>>`, which does not distribute over unions. It collapses every member into one object type where `location` is always `Location | undefined`. Once the union is collapsed, narrowing on `state` can't narrow `location`.

### The fix

Omit the fields from each navigation state individually instead of from the union as a whole, so the discriminant remains intact. This matches the existing `unstable_RouterStatePendingVariants`, which already does `Omit<NavigationStates["Loading"], "matches" | "historyAction">` per variant.

## Testing

`pnpm --filter react-router typecheck`, `lint`, and `build` pass, along with the existing `data-memory-router-test` and `unstable-useRouterState-test` suites. I also confirmed the regression directly: a type assertion that `useNavigation()` narrows `location` per `state` fails against the old `Omit<Navigation, ...>` return type and passes with this change.