### PR TITLE
Remove trailing slash data request flag

### DIFF
--- a/integration/error-data-request-test.ts
+++ b/integration/error-data-request-test.ts
@@ -108,7 +108,7 @@ test.describe("ErrorBoundary", () => {
 
   test("returns a 200 empty response on a data fetch to a path with no loaders", async () => {
     let { status, headers, data } =
-      await fixture.requestSingleFetchData("/_root.data");
+      await fixture.requestSingleFetchData("/_.data");
     expect(status).toBe(200);
     expect(headers.has("X-Remix-Response")).toBe(true);
     expect(data).toEqual({});
@@ -116,7 +116,7 @@ test.describe("ErrorBoundary", () => {
 
   test("returns a 405 on a data fetch POST to a path with no action", async () => {
     let { status, headers, data } = await fixture.requestSingleFetchData(
-      "/_root.data?index",
+      "/_.data?index",
       {
         method: "POST",
       },
@@ -127,11 +127,11 @@ test.describe("ErrorBoundary", () => {
       error: new ErrorResponseImpl(
         405,
         "Method Not Allowed",
-        'Error: You made a POST request to "/_root.data" but did not provide an `action` for route "routes/_index", so there is no way to handle the request.',
+        'Error: You made a POST request to "/_.data" but did not provide an `action` for route "routes/_index", so there is no way to handle the request.',
       ),
     });
     assertLoggedErrorInstance(
-      'You made a POST request to "/_root.data" but did not provide an `action` for route "routes/_index", so there is no way to handle the request.',
+      'You made a POST request to "/_.data" but did not provide an `action` for route "routes/_index", so there is no way to handle the request.',
     );
   });
 

--- a/integration/error-sanitization-test.ts
+++ b/integration/error-sanitization-test.ts
@@ -230,7 +230,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("returns data without errors", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data");
+      let { data } = await fixture.requestSingleFetchData("/_.data");
       expect(data).toEqual({
         "routes/_index": {
           data: "LOADER",
@@ -239,7 +239,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("sanitizes loader errors in data requests", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data?loader");
+      let { data } = await fixture.requestSingleFetchData("/_.data?loader");
       expect(data).toEqual({
         "routes/_index": {
           error: new Error("Unexpected Server Error"),
@@ -388,7 +388,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("returns data without errors", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data");
+      let { data } = await fixture.requestSingleFetchData("/_.data");
       expect(data).toEqual({
         "routes/_index": {
           data: "LOADER",
@@ -397,7 +397,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("does not sanitize loader errors in data requests", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data?loader");
+      let { data } = await fixture.requestSingleFetchData("/_.data?loader");
       expect(data).toEqual({
         "routes/_index": {
           error: new Error("Loader Error"),
@@ -634,7 +634,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("returns data without errors", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data");
+      let { data } = await fixture.requestSingleFetchData("/_.data");
       expect(data).toEqual({
         "routes/_index": {
           data: "LOADER",
@@ -643,7 +643,7 @@ test.describe("Error Sanitization", () => {
     });
 
     test("sanitizes loader errors in data requests", async () => {
-      let { data } = await fixture.requestSingleFetchData("/_root.data?loader");
+      let { data } = await fixture.requestSingleFetchData("/_.data?loader");
       expect(data).toEqual({
         "routes/_index": {
           error: new Error("Unexpected Server Error"),
@@ -651,7 +651,7 @@ test.describe("Error Sanitization", () => {
       });
       expect(errorLogs[0][0]).toEqual("App Specific Error Logging:");
       expect(errorLogs[1][0]).toEqual(
-        "  Request: GET test://test/_root.data?loader",
+        "  Request: GET test://test/_.data?loader",
       );
       expect(errorLogs[2][0]).toEqual("  Error: Loader Error");
       expect(errorLogs[3][0]).toMatch(" at ");

--- a/integration/http-test.ts
+++ b/integration/http-test.ts
@@ -59,7 +59,7 @@ test.describe("HTTP behavior", () => {
     expect(await response.text()).toBe("RESOURCE");
 
     let singleFetchResponse =
-      await appFixture.requestSingleFetchData("/_root.data");
+      await appFixture.requestSingleFetchData("/_.data");
     expect(response.status).toBe(202);
     expect(singleFetchResponse.data).toEqual({
       "routes/_index": { data: "INDEX" },
@@ -78,7 +78,7 @@ test.describe("HTTP behavior", () => {
     expect(response.body).toBe(null);
 
     let singleFetchResponse = await appFixture.requestSingleFetchData(
-      "/_root.data",
+      "/_.data",
       { method: "HEAD" },
     );
     expect(response.status).toBe(202);

--- a/integration/loader-test.ts
+++ b/integration/loader-test.ts
@@ -52,7 +52,7 @@ test.describe("loader", () => {
   });
 
   test("returns responses for single fetch routes", async () => {
-    let { data } = await fixture.requestSingleFetchData("/_root.data");
+    let { data } = await fixture.requestSingleFetchData("/_.data");
     expect(data).toEqual({
       root: { data: ROOT_DATA },
       "routes/_index": { data: INDEX_DATA },

--- a/integration/multiple-cookies-test.ts
+++ b/integration/multiple-cookies-test.ts
@@ -67,9 +67,7 @@ test.describe("pathless layout routes", () => {
     let app = new PlaywrightFixture(appFixture, page);
     await app.goto("/");
     // do this after the first request so that it doesnt appear in our next assertions
-    let responses = app.collectResponses(
-      (url) => url.pathname === "/_root.data",
-    );
+    let responses = app.collectResponses((url) => url.pathname === "/_.data");
     await page.click("button[type=submit]");
     await page.waitForSelector(`[data-testid="action-success"]`);
     let setCookies = await responses[0].headerValues("set-cookie");

--- a/integration/passthrough-requests-test.ts
+++ b/integration/passthrough-requests-test.ts
@@ -120,29 +120,29 @@ test.describe("pass through requests", () => {
     // Client-side navigation with query params
     await app.clickLink("/?a=1");
     expect(await page.locator("[data-loader-url]").textContent()).toBe(
-      "/_root.data?a=1",
+      "/_.data?a=1",
     );
     expect(await page.locator("[data-loader-path]").textContent()).toBe(
       "/?a=1",
     );
-    expect(requests).toEqual(["/_root.data?a=1"]);
+    expect(requests).toEqual(["/_.data?a=1"]);
     requests = [];
 
     // Client-side form submission with query params
     await app.clickElement('button[type="submit"]');
     expect(await page.locator("[data-action-url]").textContent()).toBe(
-      "/_root.data?index&a=1",
+      "/_.data?index&a=1",
     );
     expect(await page.locator("[data-action-path]").textContent()).toBe(
       "/?a=1",
     );
     expect(await page.locator("[data-loader-url]").textContent()).toBe(
-      "/_root.data?a=1",
+      "/_.data?a=1",
     );
     expect(await page.locator("[data-loader-path]").textContent()).toBe(
       "/?a=1",
     );
-    expect(requests).toEqual(["/_root.data?index&a=1", "/_root.data?a=1"]);
+    expect(requests).toEqual(["/_.data?index&a=1", "/_.data?a=1"]);
     requests = [];
 
     // Navigate to new page

--- a/integration/request-test.ts
+++ b/integration/request-test.ts
@@ -120,7 +120,7 @@ test("loader request on CSR GET requests", async ({ page }) => {
   loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
   expect(loaderData.method).toEqual("GET");
   expect(loaderData.url).toMatch(
-    /^http:\/\/localhost:\d+\/_root\.data\?type=csr$/,
+    /^http:\/\/localhost:\d+\/_.data\?type=csr$/,
   );
   expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
   expect(loaderData.body).toEqual(null);
@@ -168,14 +168,14 @@ test("action + loader requests on CSR POST requests", async ({ page }) => {
   let actionData = JSON.parse(await page.locator("#action-data").innerHTML());
   expect(actionData.method).toEqual("POST");
   expect(actionData.url).toMatch(
-    /^http:\/\/localhost:\d+\/_root\.data\?index$/,
+    /^http:\/\/localhost:\d+\/_.data\?index$/,
   );
   expect(actionData.headers.cookie).toEqual("cookie=nomnom");
   expect(actionData.body).toEqual({ type: "csr" });
 
   loaderData = JSON.parse(await page.locator("#loader-data").innerHTML());
   expect(loaderData.method).toEqual("GET");
-  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/_root\.data$/);
+  expect(loaderData.url).toMatch(/^http:\/\/localhost:\d+\/_.data$/);
   expect(loaderData.headers.cookie).toEqual("cookie=nomnom");
   expect(loaderData.body).toEqual(null);
 });

--- a/integration/single-fetch-test.ts
+++ b/integration/single-fetch-test.ts
@@ -205,7 +205,7 @@ test.describe("single-fetch", () => {
     let fixture = await createFixture({
       files,
     });
-    let res = await fixture.requestSingleFetchData("/_root.data");
+    let res = await fixture.requestSingleFetchData("/_.data");
     expect(res.data).toEqual({
       root: {
         data: {
@@ -1141,7 +1141,7 @@ test.describe("single-fetch", () => {
     expect(await page.locator("#data").innerText()).toBe(
       '[["root",{"count":3}],["routes/_index",null]]',
     );
-    expect(urls).toEqual(["/_root.data"]);
+    expect(urls).toEqual(["/_.data"]);
     urls.splice(0, urls.length);
 
     await app.clickLink("/page?optout");
@@ -1960,7 +1960,7 @@ test.describe("single-fetch", () => {
     await app.clickLink("/base/");
     await expect(page.getByText("Index")).toBeVisible();
 
-    expect(requests).toEqual(["/base/data.data", "/base/_root.data"]);
+    expect(requests).toEqual(["/base/data.data", "/base/_.data"]);
   });
 
   test("processes redirects when a basename is present", async ({ page }) => {
@@ -2497,8 +2497,8 @@ test.describe("single-fetch", () => {
 
     expect(await page.innerText("[data-submit]")).toEqual("no content!");
     expect(requests).toEqual([
-      ["POST", 204, "/_root.data?index"],
-      ["GET", 200, "/_root.data"],
+      ["POST", 204, "/_.data?index"],
+      ["GET", 200, "/_.data"],
     ]);
   });
 
@@ -2538,7 +2538,7 @@ test.describe("single-fetch", () => {
     expect(await documentRes.text()).toBe("");
 
     // Data requests
-    let dataRes = await fixture.requestSingleFetchData("/_root.data");
+    let dataRes = await fixture.requestSingleFetchData("/_.data");
     expect(dataRes.data).toEqual({
       root: {
         data: {
@@ -2551,7 +2551,7 @@ test.describe("single-fetch", () => {
         },
       },
     });
-    dataRes = await fixture.requestSingleFetchData("/_root.data", {
+    dataRes = await fixture.requestSingleFetchData("/_.data", {
       headers: {
         "If-None-Match": "1234",
       },
@@ -4566,111 +4566,12 @@ test.describe("single-fetch", () => {
     expect(await app.getHtml("h1")).toMatch("It worked!");
   });
 
-  test("always uses /{path}.data without future.v8_trailingSlashAwareDataRequests flag", async ({
+  test("uses {path}.data or {path}/_.data depending on trailing slash", async ({
     page,
   }) => {
     let fixture = await createFixture({
       files: {
         ...files,
-        "app/routes/_index.tsx": js`
-          import { Link } from "react-router";
-
-          export default function Index() {
-            return (
-              <div>
-                <h1>Home</h1>
-                <Link to="/about/">Go to About (with trailing slash)</Link>
-                <Link to="/about">Go to About (without trailing slash)</Link>
-              </div>
-            );
-          }
-        `,
-        "app/routes/about.tsx": js`
-          import { Link, useLoaderData } from "react-router";
-
-          export function loader({ request }) {
-            let pathname = new URL(request.url).pathname
-              .replace(/_\.data$/, "")
-              .replace(/\.data$/, "");
-            return {
-              pathname,
-              hasTrailingSlash: pathname.endsWith("/"),
-            };
-          }
-
-          export default function About() {
-            let { pathname, hasTrailingSlash } = useLoaderData();
-            return (
-              <div>
-                <h1>About</h1>
-                <p id="pathname">{pathname}</p>
-                <p id="trailing-slash">{String(hasTrailingSlash)}</p>
-                <Link to="/">Go back home</Link>
-              </div>
-            );
-          }
-        `,
-      },
-    });
-    let appFixture = await createAppFixture(fixture);
-    let app = new PlaywrightFixture(appFixture, page);
-
-    let requests: string[] = [];
-    page.on("request", (req) => {
-      let url = new URL(req.url());
-      if (url.pathname.endsWith(".data")) {
-        requests.push(url.pathname + url.search);
-      }
-    });
-
-    // Document load without trailing slash
-    await app.goto("/about");
-    await page.waitForSelector("#pathname");
-    expect(await page.locator("#pathname").innerText()).toEqual("/about");
-    expect(await page.locator("#trailing-slash").innerText()).toEqual("false");
-
-    // Client-side navigation without trailing slash
-    await app.goto("/");
-    await app.clickLink("/about");
-    await page.waitForSelector("#pathname");
-    expect(await page.locator("#pathname").innerText()).toEqual("/about");
-    expect(await page.locator("#trailing-slash").innerText()).toEqual("false");
-    expect(requests).toEqual(["/about.data"]);
-    requests = [];
-
-    // Document load with trailing slash
-    await app.goto("/about/");
-    await page.waitForSelector("#pathname");
-    expect(await page.locator("#pathname").innerText()).toEqual("/about/");
-    expect(await page.locator("#trailing-slash").innerText()).toEqual("true");
-
-    // Client-side navigation with trailing slash
-    await app.goto("/");
-    await app.clickLink("/about/");
-    await page.waitForSelector("#pathname");
-    expect(await page.locator("#pathname").innerText()).toEqual("/about");
-    expect(await page.locator("#trailing-slash").innerText()).toEqual("false");
-    expect(requests).toEqual(["/about.data"]);
-    requests = [];
-
-    // Client-side navigation back to /
-    await app.clickLink("/");
-    await page.waitForSelector("h1:has-text('Home')");
-    expect(requests).toEqual(["/_root.data"]);
-    requests = [];
-  });
-
-  test("uses {path}.data or {path}/_.data depending on trailing slash with future.v8_trailingSlashAwareDataRequests flag", async ({
-    page,
-  }) => {
-    let fixture = await createFixture({
-      files: {
-        ...files,
-        "react-router.config.ts": reactRouterConfig({
-          future: {
-            v8_trailingSlashAwareDataRequests: true,
-          },
-        }),
         "app/routes/_index.tsx": js`
           import { Link } from "react-router";
 

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -218,7 +218,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -273,7 +273,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -327,7 +327,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -383,7 +383,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "a.data",
         "a/index.html",
         "about.data",
@@ -484,7 +484,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -565,7 +565,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -615,7 +615,7 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "_root.data",
+        "_.data",
         "about.data",
         "about/index.html",
         "favicon.ico",
@@ -899,7 +899,7 @@ test.describe(`Prerendering`, () => {
 
     test("Ignores build-time headers at runtime", async () => {
       fixture = await createFixture({ files });
-      let res = await fixture.requestSingleFetchData("/_root.data", {
+      let res = await fixture.requestSingleFetchData("/_.data", {
         headers: {
           "X-React-Router-Prerender-Data": encodeURI(
             '[{"_1":2},"routes/_index",{"_3":4},"data","Hello World!"]',
@@ -1091,7 +1091,7 @@ test.describe(`Prerendering`, () => {
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
         "__spa-fallback.html",
-        "_root.data",
+        "_.data",
         "favicon.ico",
         "index.html",
       ]);

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -1090,8 +1090,8 @@ test.describe(`Prerendering`, () => {
 
       let clientDir = path.join(fixture.projectDir, "build", "client");
       expect(listAllFiles(clientDir).sort()).toEqual([
-        "__spa-fallback.html",
         "_.data",
+        "__spa-fallback.html",
         "favicon.ico",
         "index.html",
       ]);

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -220,10 +220,12 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
         "parent/child.data",
+        "parent/child/_.data",
         "parent/child/index.html",
         "parent/index.html",
       ]);
@@ -275,6 +277,7 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -329,6 +332,7 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -385,10 +389,13 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "a.data",
+        "a/_.data",
         "a/index.html",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "b.data",
+        "b/_.data",
         "b/index.html",
         "favicon.ico",
         "index.html",
@@ -486,6 +493,7 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "image.png",
@@ -567,6 +575,7 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -617,6 +626,7 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
+        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -220,12 +220,10 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
         "parent/child.data",
-        "parent/child/_.data",
         "parent/child/index.html",
         "parent/index.html",
       ]);
@@ -277,7 +275,6 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -332,7 +329,6 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -389,13 +385,10 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "a.data",
-        "a/_.data",
         "a/index.html",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "b.data",
-        "b/_.data",
         "b/index.html",
         "favicon.ico",
         "index.html",
@@ -493,7 +486,6 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "image.png",
@@ -575,7 +567,6 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",
@@ -626,7 +617,6 @@ test.describe(`Prerendering`, () => {
       expect(listAllFiles(clientDir).sort()).toEqual([
         "_.data",
         "about.data",
-        "about/_.data",
         "about/index.html",
         "favicon.ico",
         "index.html",

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -247,7 +247,6 @@ test.describe("Vite / presets", async () => {
       // Ensure future flags from presets are properly merged
       expect(buildEndArgsMeta.futureFlags).toEqual({
         unstable_optimizeDeps: true,
-        v8_trailingSlashAwareDataRequests: false,
       });
       expect(buildEndArgsMeta.splitRouteModules).toBe(true);
 

--- a/packages/react-router-dev/.changes/major.drop-trailing-slash-data-request-flag.md
+++ b/packages/react-router-dev/.changes/major.drop-trailing-slash-data-request-flag.md
@@ -1,0 +1,3 @@
+Remove the `future.v8_trailingSlashAwareDataRequests` flag
+
+Trailing slash-aware data request URLs are now the default behavior.

--- a/packages/react-router-dev/.changes/minor.stabilize-trailing-slash-data-requests.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-trailing-slash-data-requests.md
@@ -1,3 +1,0 @@
-Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests`
-
-- The unstable flag is no longer supported and will error during config resolution

--- a/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
+++ b/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
@@ -1,3 +1,3 @@
 Log future flag warnings for upcoming React Router v8 flags
 
-- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
+- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -90,7 +90,6 @@ type ValidateConfigFunction = (config: ReactRouterConfig) => string | void;
 
 interface FutureConfig {
   unstable_optimizeDeps: boolean;
-  v8_trailingSlashAwareDataRequests: boolean;
 }
 
 type SplitRouteModulesOption = boolean | "enforce";
@@ -709,7 +708,12 @@ async function resolveConfig({
     }
     if ("unstable_trailingSlashAwareDataRequests" in futureConfig) {
       return err(
-        "The `future.unstable_trailingSlashAwareDataRequests` flag has been stabilized as `future.v8_trailingSlashAwareDataRequests`",
+        "The `future.unstable_trailingSlashAwareDataRequests` flag has been removed because trailing slash-aware data requests are now the default behavior",
+      );
+    }
+    if ("v8_trailingSlashAwareDataRequests" in futureConfig) {
+      return err(
+        "The `future.v8_trailingSlashAwareDataRequests` flag has been removed because trailing slash-aware data requests are now the default behavior",
       );
     }
     if ("unstable_subResourceIntegrity" in futureConfig) {
@@ -722,8 +726,6 @@ async function resolveConfig({
   let future: FutureConfig = {
     unstable_optimizeDeps:
       userAndPresetConfigs.future?.unstable_optimizeDeps ?? false,
-    v8_trailingSlashAwareDataRequests:
-      userAndPresetConfigs.future?.v8_trailingSlashAwareDataRequests ?? false,
   };
 
   let allowedActionOrigins = userAndPresetConfigs.allowedActionOrigins ?? false;

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -706,12 +706,10 @@ async function resolveConfig({
         "The `future.v8_viteEnvironmentApi` flag has been removed because Vite Environment API usage is now always enabled",
       );
     }
-    if ("unstable_trailingSlashAwareDataRequests" in futureConfig) {
-      return err(
-        "The `future.unstable_trailingSlashAwareDataRequests` flag has been removed because trailing slash-aware data requests are now the default behavior",
-      );
-    }
-    if ("v8_trailingSlashAwareDataRequests" in futureConfig) {
+    if (
+      "unstable_trailingSlashAwareDataRequests" in futureConfig ||
+      "v8_trailingSlashAwareDataRequests" in futureConfig
+    ) {
       return err(
         "The `future.v8_trailingSlashAwareDataRequests` flag has been removed because trailing slash-aware data requests are now the default behavior",
       );

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3761,13 +3761,11 @@ function createDataRequest(
   onlyRoutes: string[] | null,
   isResourceRoute?: boolean,
 ): PrerenderRequest<PrerenderMetadata> {
-  let normalizedPath = `${reactRouterConfig.basename}${
-    prerenderPath === "/"
-      ? reactRouterConfig.future.v8_trailingSlashAwareDataRequests
-        ? "/_.data"
-        : "/_root.data"
-      : `${prerenderPath.replace(/\/$/, "")}.data`
-  }`.replace(/\/\/+/g, "/");
+  let dataRequestPath = prerenderPath.endsWith("/")
+    ? `${prerenderPath}_.data`
+    : `${prerenderPath}.data`;
+  let normalizedPath =
+    `${reactRouterConfig.basename}${dataRequestPath}`.replace(/\/\/+/g, "/");
   let url = new URL(`http://localhost${normalizedPath}`);
   if (onlyRoutes?.length) {
     url.searchParams.set("_routes", onlyRoutes.join(","));

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2529,6 +2529,17 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 requests.push(
                   createDataRequest(prerenderPath, reactRouterConfig, null),
                 );
+                if (prerenderPath !== "/" && !prerenderPath.endsWith("/")) {
+                  requests.push(
+                    createDataRequest(
+                      prerenderPath,
+                      reactRouterConfig,
+                      null,
+                      false,
+                      `${prerenderPath}/`,
+                    ),
+                  );
+                }
               } else {
                 requests.push(
                   createRouteRequest(prerenderPath, reactRouterConfig),
@@ -3760,10 +3771,11 @@ function createDataRequest(
   reactRouterConfig: ResolvedReactRouterConfig,
   onlyRoutes: string[] | null,
   isResourceRoute?: boolean,
+  dataPath: string = prerenderPath,
 ): PrerenderRequest<PrerenderMetadata> {
-  let dataRequestPath = prerenderPath.endsWith("/")
-    ? `${prerenderPath}_.data`
-    : `${prerenderPath}.data`;
+  let dataRequestPath = dataPath.endsWith("/")
+    ? `${dataPath}_.data`
+    : `${dataPath}.data`;
   let normalizedPath =
     `${reactRouterConfig.basename}${dataRequestPath}`.replace(/\/\/+/g, "/");
   let url = new URL(`http://localhost${normalizedPath}`);

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2529,17 +2529,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 requests.push(
                   createDataRequest(prerenderPath, reactRouterConfig, null),
                 );
-                if (prerenderPath !== "/" && !prerenderPath.endsWith("/")) {
-                  requests.push(
-                    createDataRequest(
-                      prerenderPath,
-                      reactRouterConfig,
-                      null,
-                      false,
-                      `${prerenderPath}/`,
-                    ),
-                  );
-                }
               } else {
                 requests.push(
                   createRouteRequest(prerenderPath, reactRouterConfig),
@@ -3771,11 +3760,10 @@ function createDataRequest(
   reactRouterConfig: ResolvedReactRouterConfig,
   onlyRoutes: string[] | null,
   isResourceRoute?: boolean,
-  dataPath: string = prerenderPath,
 ): PrerenderRequest<PrerenderMetadata> {
-  let dataRequestPath = dataPath.endsWith("/")
-    ? `${dataPath}_.data`
-    : `${dataPath}.data`;
+  let dataRequestPath = prerenderPath.endsWith("/")
+    ? `${prerenderPath}_.data`
+    : `${prerenderPath}.data`;
   let normalizedPath =
     `${reactRouterConfig.basename}${dataRequestPath}`.replace(/\/\/+/g, "/");
   let url = new URL(`http://localhost${normalizedPath}`);

--- a/packages/react-router/.changes/major.drop-trailing-slash-data-request-flag.md
+++ b/packages/react-router/.changes/major.drop-trailing-slash-data-request-flag.md
@@ -1,0 +1,3 @@
+Remove the `future.v8_trailingSlashAwareDataRequests` flag
+
+Trailing slash-aware data request URLs are now the default behavior.

--- a/packages/react-router/.changes/minor.stabilize-trailing-slash-data-requests.md
+++ b/packages/react-router/.changes/minor.stabilize-trailing-slash-data-requests.md
@@ -1,1 +1,0 @@
-Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests`

--- a/packages/react-router/__tests__/server-runtime/handle-error-test.ts
+++ b/packages/react-router/__tests__/server-runtime/handle-error-test.ts
@@ -107,7 +107,7 @@ describe("handleError", () => {
           throw error;
         },
       });
-      let request = new Request("http://example.com/_root.data");
+      let request = new Request("http://example.com/_.data");
       await handler(request);
       expect(handleErrorSpy).toHaveBeenCalledWith(error, {
         request,
@@ -118,7 +118,7 @@ describe("handleError", () => {
 
     it("provides router-thrown ErrorResponse", async () => {
       let { handler, handleErrorSpy } = getHandler({});
-      let request = new Request("http://example.com/_root.data", {
+      let request = new Request("http://example.com/_.data", {
         method: "post",
       });
       await handler(request);
@@ -127,7 +127,7 @@ describe("handleError", () => {
           405,
           "Method Not Allowed",
           new Error(
-            'You made a POST request to "/_root.data" but did not provide an `action` for route "root", so there is no way to handle the request.',
+            'You made a POST request to "/_.data" but did not provide an `action` for route "root", so there is no way to handle the request.',
           ),
           true,
         ),
@@ -148,7 +148,7 @@ describe("handleError", () => {
           );
         },
       });
-      let request = new Request("http://example.com/_root.data");
+      let request = new Request("http://example.com/_.data");
       await handler(request);
       expect(handleErrorSpy).not.toHaveBeenCalled();
     });

--- a/packages/react-router/__tests__/server-runtime/server-test.ts
+++ b/packages/react-router/__tests__/server-runtime/server-test.ts
@@ -56,15 +56,15 @@ describe("server", () => {
 
     let allowThrough = [
       ["GET", "/", "COMPONENT"],
-      ["GET", "/_root.data", "LOADER"],
+      ["GET", "/_.data", "LOADER"],
       ["POST", "/", "COMPONENT"],
-      ["POST", "/_root.data", "ACTION"],
+      ["POST", "/_.data", "ACTION"],
       ["PUT", "/", "COMPONENT"],
-      ["PUT", "/_root.data", "ACTION"],
+      ["PUT", "/_.data", "ACTION"],
       ["DELETE", "/", "COMPONENT"],
-      ["DELETE", "/_root.data", "ACTION"],
+      ["DELETE", "/_.data", "ACTION"],
       ["PATCH", "/", "COMPONENT"],
-      ["PATCH", "/_root.data", "ACTION"],
+      ["PATCH", "/_.data", "ACTION"],
     ];
     it.each(allowThrough)(
       `allows through %s request to %s`,
@@ -113,7 +113,7 @@ describe("server", () => {
       );
       let handler = createRequestHandler(build);
       let response = await handler(
-        new Request("http://localhost:3000/_root.data"),
+        new Request("http://localhost:3000/_.data"),
         new RouterContextProvider(new Map([[fooContext, "FOO"]])),
       );
 
@@ -139,7 +139,7 @@ describe("server", () => {
       );
       let handler = createRequestHandler(build);
       let response = await handler(
-        new Request("http://localhost:3000/_root.data"),
+        new Request("http://localhost:3000/_.data"),
         {
           foo: "FOO",
         },

--- a/packages/react-router/__tests__/server-runtime/utils.ts
+++ b/packages/react-router/__tests__/server-runtime/utils.ts
@@ -43,7 +43,6 @@ export function mockServerBuild(
   return {
     ssr: true,
     future: {
-      v8_trailingSlashAwareDataRequests: false,
       ...opts.future,
     },
     prerender: [],

--- a/packages/react-router/__tests__/utils/framework.ts
+++ b/packages/react-router/__tests__/utils/framework.ts
@@ -29,9 +29,7 @@ export function mockFrameworkContext(
       url: "",
       version: "",
     },
-    future: {
-      v8_trailingSlashAwareDataRequests: false,
-    },
+    future: {},
     ssr: true,
     isSpaMode: false,
     routeDiscovery: {

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -192,8 +192,6 @@ function createHydratedRouter({
       ssrInfo.manifest,
       ssrInfo.routeModules,
       ssrInfo.context.ssr,
-      ssrInfo.context.basename,
-      ssrInfo.context.future.v8_trailingSlashAwareDataRequests,
     ),
     patchRoutesOnNavigation: getPatchRoutesOnNavigationFunction(
       () => router,

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -366,7 +366,6 @@ export function createStaticRouter(
     },
     get future() {
       return {
-        v8_trailingSlashAwareDataRequests: false,
         ...opts?.future,
       };
     },

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -397,8 +397,6 @@ function RSCPrefetchPageLinksImpl({
   matches: DataRouteMatch[];
 }) {
   let location = useLocation();
-  let { future } = useFrameworkContext();
-  let { basename } = useDataRouterContext();
 
   let dataHrefs = React.useMemo(() => {
     if (page === location.pathname + location.search + location.hash) {
@@ -406,12 +404,7 @@ function RSCPrefetchPageLinksImpl({
       // since it would always trigger a prefetch of the existing loaders
       return [];
     }
-    let url = singleFetchUrl(
-      page,
-      basename,
-      future.v8_trailingSlashAwareDataRequests,
-      "rsc",
-    );
+    let url = singleFetchUrl(page, "rsc");
 
     let hasSomeRoutesWithShouldRevalidate = false;
     let targetRoutes: string[] = [];
@@ -428,13 +421,7 @@ function RSCPrefetchPageLinksImpl({
     }
 
     return [url.pathname + url.search];
-  }, [
-    basename,
-    future.v8_trailingSlashAwareDataRequests,
-    page,
-    location,
-    nextMatches,
-  ]);
+  }, [page, location, nextMatches]);
 
   return (
     <>
@@ -453,8 +440,7 @@ function PrefetchPageLinksImpl({
   matches: DataRouteMatch[];
 }) {
   let location = useLocation();
-  let { future, manifest, routeModules } = useFrameworkContext();
-  let { basename } = useDataRouterContext();
+  let { manifest, routeModules } = useFrameworkContext();
   let { loaderData, matches } = useDataRouterStateContext();
 
   let newMatchesForData = React.useMemo(
@@ -517,12 +503,7 @@ function PrefetchPageLinksImpl({
       return [];
     }
 
-    let url = singleFetchUrl(
-      page,
-      basename,
-      future.v8_trailingSlashAwareDataRequests,
-      "data",
-    );
+    let url = singleFetchUrl(page, "data");
     // When one or more routes have opted out, we add a _routes param to
     // limit the loaders to those that have a server loader and did not
     // opt out
@@ -538,8 +519,6 @@ function PrefetchPageLinksImpl({
 
     return [url.pathname + url.search];
   }, [
-    basename,
-    future.v8_trailingSlashAwareDataRequests,
     loaderData,
     location,
     manifest,

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -48,9 +48,7 @@ export interface EntryContext extends FrameworkContextObject {
   serverHandoffStream?: ReadableStream<Uint8Array>;
 }
 
-export interface FutureConfig {
-  v8_trailingSlashAwareDataRequests: boolean;
-}
+export type FutureConfig = Record<string, never>;
 
 export type CriticalCss = string | { rel: "stylesheet"; href: string };
 

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -44,7 +44,8 @@ interface StubRouteExtensions {
 }
 
 interface StubIndexRouteObject
-  extends Omit<
+  extends
+    Omit<
       IndexRouteObject,
       | "Component"
       | "HydrateFallback"
@@ -58,7 +59,8 @@ interface StubIndexRouteObject
     StubRouteExtensions {}
 
 interface StubNonIndexRouteObject
-  extends Omit<
+  extends
+    Omit<
       NonIndexRouteObject,
       | "Component"
       | "HydrateFallback"
@@ -124,10 +126,7 @@ export function createRoutesStub(
 
     if (routerRef.current == null || frameworkContextRef.current == null) {
       frameworkContextRef.current = {
-        future: {
-          v8_trailingSlashAwareDataRequests:
-            future?.v8_trailingSlashAwareDataRequests === true,
-        },
+        future: {},
         manifest: {
           routes: {},
           entry: { imports: [], module: "" },

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -17,8 +17,6 @@ import {
   isRouteErrorResponse,
   redirect,
   data,
-  stripBasename,
-  removeTrailingSlash,
 } from "../../router/utils";
 import { createRequestInit } from "./data";
 import type { AssetsManifest, EntryContext } from "./entry";
@@ -172,8 +170,6 @@ type ShouldAllowOptOutFunction = (match: DataRouteMatch) => boolean;
 
 export type FetchAndDecodeFunction = (
   args: DataStrategyFunctionArgs,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
   targetRoutes?: string[],
   shouldAllowOptOut?: ShouldAllowOptOutFunction,
 ) => Promise<{ status: number; data: DecodedSingleFetchResults }>;
@@ -183,8 +179,6 @@ export function getTurboStreamSingleFetchDataStrategy(
   manifest: AssetsManifest,
   routeModules: RouteModules,
   ssr: boolean,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
 ): DataStrategyFunction {
   let dataStrategy = getSingleFetchDataStrategyImpl(
     getRouter,
@@ -198,8 +192,6 @@ export function getTurboStreamSingleFetchDataStrategy(
     },
     fetchAndDecodeViaTurboStream,
     ssr,
-    basename,
-    trailingSlashAware,
   );
   return async (args) => args.runClientMiddleware(dataStrategy);
 }
@@ -209,8 +201,6 @@ export function getSingleFetchDataStrategyImpl(
   getRouteInfo: GetRouteInfoFunction,
   fetchAndDecode: FetchAndDecodeFunction,
   ssr: boolean,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
   shouldAllowOptOut: ShouldAllowOptOutFunction = () => true,
 ): DataStrategyFunction {
   return async (args) => {
@@ -219,12 +209,7 @@ export function getSingleFetchDataStrategyImpl(
 
     // Actions are simple and behave the same for navigations and fetchers
     if (request.method !== "GET") {
-      return singleFetchActionStrategy(
-        args,
-        fetchAndDecode,
-        basename,
-        trailingSlashAware,
-      );
+      return singleFetchActionStrategy(args, fetchAndDecode);
     }
 
     let foundRevalidatingServerLoader = matches.some((m) => {
@@ -264,23 +249,12 @@ export function getSingleFetchDataStrategyImpl(
       //   errored otherwise
       // - So it's safe to make the call knowing there will be a `.data` file on
       //   the other end
-      return nonSsrStrategy(
-        args,
-        getRouteInfo,
-        fetchAndDecode,
-        basename,
-        trailingSlashAware,
-      );
+      return nonSsrStrategy(args, getRouteInfo, fetchAndDecode);
     }
 
     // Fetcher loads are singular calls to one loader
     if (fetcherKey) {
-      return singleFetchLoaderFetcherStrategy(
-        args,
-        fetchAndDecode,
-        basename,
-        trailingSlashAware,
-      );
+      return singleFetchLoaderFetcherStrategy(args, fetchAndDecode);
     }
 
     // Navigational loads are more complex...
@@ -290,8 +264,6 @@ export function getSingleFetchDataStrategyImpl(
       getRouteInfo,
       fetchAndDecode,
       ssr,
-      basename,
-      trailingSlashAware,
       shouldAllowOptOut,
     );
   };
@@ -302,20 +274,15 @@ export function getSingleFetchDataStrategyImpl(
 async function singleFetchActionStrategy(
   args: DataStrategyFunctionArgs,
   fetchAndDecode: FetchAndDecodeFunction,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
 ) {
   let actionMatch = args.matches.find((m) => m.shouldCallHandler());
   invariant(actionMatch, "No action match found");
   let actionStatus: number | undefined = undefined;
   let result = await actionMatch.resolve(async (handler) => {
     let result = await handler(async () => {
-      let { data, status } = await fetchAndDecode(
-        args,
-        basename,
-        trailingSlashAware,
-        [actionMatch!.route.id],
-      );
+      let { data, status } = await fetchAndDecode(args, [
+        actionMatch!.route.id,
+      ]);
       actionStatus = status;
       return unwrapSingleFetchResult(data, actionMatch!.route.id);
     });
@@ -345,8 +312,6 @@ async function nonSsrStrategy(
   args: DataStrategyFunctionArgs,
   getRouteInfo: GetRouteInfoFunction,
   fetchAndDecode: FetchAndDecodeFunction,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
 ) {
   let matchesToLoad = args.matches.filter((m) => m.shouldCallHandler());
   let results: Record<string, DataStrategyResult> = {};
@@ -361,12 +326,7 @@ async function nonSsrStrategy(
           let routeId = m.route.id;
           let result = hasClientLoader
             ? await handler(async () => {
-                let { data } = await fetchAndDecode(
-                  args,
-                  basename,
-                  trailingSlashAware,
-                  [routeId],
-                );
+                let { data } = await fetchAndDecode(args, [routeId]);
                 return unwrapSingleFetchResult(data, routeId);
               })
             : await handler();
@@ -388,8 +348,6 @@ async function singleFetchLoaderNavigationStrategy(
   getRouteInfo: GetRouteInfoFunction,
   fetchAndDecode: FetchAndDecodeFunction,
   ssr: boolean,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
   shouldAllowOptOut: (match: DataRouteMatch) => boolean = () => true,
 ) {
   // Track which routes need a server load for use in a `_routes` param
@@ -436,12 +394,7 @@ async function singleFetchLoaderNavigationStrategy(
           }
           try {
             let result = await handler(async () => {
-              let { data } = await fetchAndDecode(
-                args,
-                basename,
-                trailingSlashAware,
-                [routeId],
-              );
+              let { data } = await fetchAndDecode(args, [routeId]);
               return unwrapSingleFetchResult(data, routeId);
             });
 
@@ -499,12 +452,7 @@ async function singleFetchLoaderNavigationStrategy(
         ? [...routesParams.keys()]
         : undefined;
     try {
-      let data = await fetchAndDecode(
-        args,
-        basename,
-        trailingSlashAware,
-        targetRoutes,
-      );
+      let data = await fetchAndDecode(args, targetRoutes);
       singleFetchDfd.resolve(data.data);
     } catch (e) {
       singleFetchDfd.reject(e);
@@ -578,17 +526,13 @@ async function bubbleMiddlewareErrors(
 async function singleFetchLoaderFetcherStrategy(
   args: DataStrategyFunctionArgs,
   fetchAndDecode: FetchAndDecodeFunction,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
 ) {
   let fetcherMatch = args.matches.find((m) => m.shouldCallHandler());
   invariant(fetcherMatch, "No fetcher match found");
   let routeId = fetcherMatch.route.id;
   let result = await fetcherMatch.resolve(async (handler) =>
     handler(async () => {
-      let { data } = await fetchAndDecode(args, basename, trailingSlashAware, [
-        routeId,
-      ]);
+      let { data } = await fetchAndDecode(args, [routeId]);
       return unwrapSingleFetchResult(data, routeId);
     }),
   );
@@ -613,8 +557,6 @@ export function stripIndexParam(url: URL) {
 
 export function singleFetchUrl(
   reqUrl: URL | string,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
   extension: "data" | "rsc",
 ) {
   let url =
@@ -629,22 +571,12 @@ export function singleFetchUrl(
         )
       : reqUrl;
 
-  if (trailingSlashAware) {
-    if (url.pathname.endsWith("/")) {
-      // Preserve trailing slash by using /_.data pattern
-      // e.g., /about/ -> /about/_.data
-      url.pathname = `${url.pathname}_.${extension}`;
-    } else {
-      url.pathname = `${url.pathname}.${extension}`;
-    }
+  if (url.pathname.endsWith("/")) {
+    // Preserve trailing slash by using /_.data pattern
+    // e.g., /about/ -> /about/_.data
+    url.pathname = `${url.pathname}_.${extension}`;
   } else {
-    if (url.pathname === "/") {
-      url.pathname = `_root.${extension}`;
-    } else if (basename && stripBasename(url.pathname, basename) === "/") {
-      url.pathname = `${removeTrailingSlash(basename)}/_root.${extension}`;
-    } else {
-      url.pathname = `${removeTrailingSlash(url.pathname)}.${extension}`;
-    }
+    url.pathname = `${url.pathname}.${extension}`;
   }
 
   return url;
@@ -652,12 +584,10 @@ export function singleFetchUrl(
 
 async function fetchAndDecodeViaTurboStream(
   args: DataStrategyFunctionArgs,
-  basename: string | undefined,
-  trailingSlashAware: boolean,
   targetRoutes?: string[],
 ): Promise<{ status: number; data: DecodedSingleFetchResults }> {
   let { request } = args;
-  let url = singleFetchUrl(request.url, basename, trailingSlashAware, "data");
+  let url = singleFetchUrl(request.url, "data");
   if (request.method === "GET") {
     url = stripIndexParam(url);
     if (targetRoutes) {

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -365,6 +365,9 @@ async function singleFetchLoaderNavigationStrategy(
   // We'll build up this results object as we loop through matches
   let results: Record<string, DataStrategyResult> = {};
 
+  let isInitialLoad =
+    !router.state.initialized && router.state.navigation.state === "idle";
+
   let resolvePromise = Promise.all(
     args.matches.map(async (m, i) =>
       m.resolve(async (handler) => {
@@ -418,6 +421,13 @@ async function singleFetchLoaderNavigationStrategy(
           });
           results[routeId] = { type: "data", result };
         } catch (e) {
+          if (isInitialLoad && e instanceof SingleFetchNoResultError) {
+            results[routeId] = {
+              type: "data",
+              result: router.state.loaderData[routeId],
+            };
+            return;
+          }
           results[routeId] = { type: "error", result: e };
         }
       }),
@@ -437,10 +447,11 @@ async function singleFetchLoaderNavigationStrategy(
   // One exception - if we are performing an HDR revalidation we have to call
   // the server in case a new loader has shown up that the manifest doesn't yet
   // know about
-  let isInitialLoad =
-    !router.state.initialized && router.state.navigation.state === "idle";
+  let missingHydrationData = [...routesParams].some(
+    (routeId) => !(routeId in router.state.loaderData),
+  );
   if (
-    (isInitialLoad || routesParams.size === 0) &&
+    ((isInitialLoad && !missingHydrationData) || routesParams.size === 0) &&
     !window.__reactRouterHdrActive
   ) {
     singleFetchDfd.resolve({ routes: {} });
@@ -508,7 +519,7 @@ async function bubbleMiddlewareErrors(
 
     if (middlewareError !== undefined) {
       Array.from(routesParams.values()).forEach((routeId) => {
-        if (results[routeId].result instanceof SingleFetchNoResultError) {
+        if (results[routeId]?.result instanceof SingleFetchNoResultError) {
           results[routeId].result = middlewareError;
         }
       });

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -365,9 +365,6 @@ async function singleFetchLoaderNavigationStrategy(
   // We'll build up this results object as we loop through matches
   let results: Record<string, DataStrategyResult> = {};
 
-  let isInitialLoad =
-    !router.state.initialized && router.state.navigation.state === "idle";
-
   let resolvePromise = Promise.all(
     args.matches.map(async (m, i) =>
       m.resolve(async (handler) => {
@@ -421,13 +418,6 @@ async function singleFetchLoaderNavigationStrategy(
           });
           results[routeId] = { type: "data", result };
         } catch (e) {
-          if (isInitialLoad && e instanceof SingleFetchNoResultError) {
-            results[routeId] = {
-              type: "data",
-              result: router.state.loaderData[routeId],
-            };
-            return;
-          }
           results[routeId] = { type: "error", result: e };
         }
       }),
@@ -447,11 +437,10 @@ async function singleFetchLoaderNavigationStrategy(
   // One exception - if we are performing an HDR revalidation we have to call
   // the server in case a new loader has shown up that the manifest doesn't yet
   // know about
-  let missingHydrationData = [...routesParams].some(
-    (routeId) => !(routeId in router.state.loaderData),
-  );
+  let isInitialLoad =
+    !router.state.initialized && router.state.navigation.state === "idle";
   if (
-    ((isInitialLoad && !missingHydrationData) || routesParams.size === 0) &&
+    (isInitialLoad || routesParams.size === 0) &&
     !window.__reactRouterHdrActive
   ) {
     singleFetchDfd.resolve({ routes: {} });
@@ -519,7 +508,7 @@ async function bubbleMiddlewareErrors(
 
     if (middlewareError !== undefined) {
       Array.from(routesParams.values()).forEach((routeId) => {
-        if (results[routeId]?.result instanceof SingleFetchNoResultError) {
+        if (results[routeId].result instanceof SingleFetchNoResultError) {
           results[routeId].result = middlewareError;
         }
       });

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -339,7 +339,6 @@ function createRouterFromPayload({
     dataStrategy: getRSCSingleFetchDataStrategy(
       () => globalVar.__reactRouterDataRouter,
       true,
-      payload.basename,
       createFromReadableStream,
       fetchImplementation,
     ),
@@ -440,7 +439,6 @@ const renderedRoutesContext = createContext<RSCRouteManifest[]>();
 export function getRSCSingleFetchDataStrategy(
   getRouter: () => DataRouter,
   ssr: boolean,
-  basename: string | undefined,
   createFromReadableStream: BrowserCreateFromReadableStreamFunction,
   fetchImplementation: (request: Request) => Promise<Response>,
 ): DataStrategyFunction {
@@ -471,9 +469,6 @@ export function getRSCSingleFetchDataStrategy(
     // pass map into fetchAndDecode so it can add payloads
     getFetchAndDecodeViaRSC(createFromReadableStream, fetchImplementation),
     ssr,
-    basename,
-    // .rsc requests are always trailing slash aware
-    true,
     // If the route has a component but we don't have an element, we need to hit
     // the server loader flow regardless of whether the client loader calls
     // `serverLoader` or not, otherwise we'll have nothing to render.
@@ -535,12 +530,10 @@ function getFetchAndDecodeViaRSC(
 ): FetchAndDecodeFunction {
   return async (
     args: DataStrategyFunctionArgs<unknown>,
-    basename: string | undefined,
-    trailingSlashAware: boolean,
     targetRoutes?: string[],
   ) => {
     let { request, context } = args;
-    let url = singleFetchUrl(request.url, basename, trailingSlashAware, "rsc");
+    let url = singleFetchUrl(request.url, "rsc");
     if (request.method === "GET") {
       url = stripIndexParam(url);
       if (targetRoutes) {
@@ -827,9 +820,7 @@ export function RSCHydratedRouter({
   }, [routeDiscovery, createFromReadableStream, fetchImplementation]);
 
   const frameworkContext: FrameworkContextObject = {
-    future: {
-      v8_trailingSlashAwareDataRequests: true, // always on for RSC
-    },
+    future: {},
     isSpaMode: false,
     ssr: true,
     criticalCss: "",

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -747,7 +747,7 @@ async function generateResourceResponse(
           return generateErrorResponse(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, basename),
     });
     return response;
   } catch (error) {
@@ -837,7 +837,7 @@ async function generateRenderResponse(
       ...(routeIdsToLoad
         ? { filterMatchesToLoad: (m) => routeIdsToLoad!.includes(m.route.id) }
         : {}),
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, basename),
       async generateMiddlewareResponse(query) {
         // If this is an RSC server action, process that and then call query as a
         // revalidation.  If this is a RR Form/Fetcher submission,

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -747,7 +747,7 @@ async function generateResourceResponse(
           return generateErrorResponse(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r, basename, null),
+      normalizePath: (r) => getNormalizedPath(r),
     });
     return response;
   } catch (error) {
@@ -837,7 +837,7 @@ async function generateRenderResponse(
       ...(routeIdsToLoad
         ? { filterMatchesToLoad: (m) => routeIdsToLoad!.includes(m.route.id) }
         : {}),
-      normalizePath: (r) => getNormalizedPath(r, basename, null),
+      normalizePath: (r) => getNormalizedPath(r),
       async generateMiddlewareResponse(query) {
         // If this is an RSC server action, process that and then call query as a
         // revalidation.  If this is a RR Form/Fetcher submission,

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -564,9 +564,7 @@ export function RSCStaticRouter({ getPayload }: RSCStaticRouterProps) {
   );
 
   const frameworkContext: FrameworkContextObject = {
-    future: {
-      v8_trailingSlashAwareDataRequests: true, // always on for RSC
-    },
+    future: {},
     isSpaMode: false,
     ssr: true,
     criticalCss: "",

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -104,11 +104,7 @@ function derive(build: ServerBuild, mode?: string) {
     loadContext = initialContext || new RouterContextProvider();
 
     let requestUrl = new URL(request.url);
-    let normalizedPathname = getNormalizedPath(
-      request,
-      build.basename,
-      build.future,
-    ).pathname;
+    let normalizedPathname = getNormalizedPath(request).pathname;
 
     let isSpaMode =
       getBuildTimeHeader(request, "X-React-Router-SPA-Mode") === "yes";
@@ -495,7 +491,7 @@ async function handleDocumentRequest(
           return new Response(null, { status: 500 });
         }
       },
-      normalizePath: (r) => getNormalizedPath(r, build.basename, build.future),
+      normalizePath: (r) => getNormalizedPath(r),
     });
 
     if (!isResponse(result)) {
@@ -671,7 +667,7 @@ async function handleResourceRequest(
           return handleQueryRouteError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r, build.basename, build.future),
+      normalizePath: (r) => getNormalizedPath(r),
     });
 
     return handleQueryRouteResult(result);

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -104,7 +104,10 @@ function derive(build: ServerBuild, mode?: string) {
     loadContext = initialContext || new RouterContextProvider();
 
     let requestUrl = new URL(request.url);
-    let normalizedPathname = getNormalizedPath(request).pathname;
+    let normalizedPathname = getNormalizedPath(
+      request,
+      build.basename,
+    ).pathname;
 
     let isSpaMode =
       getBuildTimeHeader(request, "X-React-Router-SPA-Mode") === "yes";
@@ -491,7 +494,7 @@ async function handleDocumentRequest(
           return new Response(null, { status: 500 });
         }
       },
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, build.basename),
     });
 
     if (!isResponse(result)) {
@@ -667,7 +670,7 @@ async function handleResourceRequest(
           return handleQueryRouteError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, build.basename),
     });
 
     return handleQueryRouteResult(result);

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -10,7 +10,6 @@ import {
   ErrorResponseImpl,
   RouterContextProvider,
   stripBasename,
-  removeTrailingSlash,
 } from "../router/utils";
 import {
   getStaticContextFromError,
@@ -147,8 +146,7 @@ function derive(build: ServerBuild, mode?: string) {
         isSpaMode = true;
       } else if (
         !build.prerender.includes(decodedPath) &&
-        !build.prerender.includes(decodedPath + "/") &&
-        !build.prerender.includes(removeTrailingSlash(decodedPath))
+        !build.prerender.includes(decodedPath + "/")
       ) {
         if (requestUrl.pathname.endsWith(".data")) {
           // 404 on non-pre-rendered `.data` requests

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -10,6 +10,7 @@ import {
   ErrorResponseImpl,
   RouterContextProvider,
   stripBasename,
+  removeTrailingSlash,
 } from "../router/utils";
 import {
   getStaticContextFromError,
@@ -146,7 +147,8 @@ function derive(build: ServerBuild, mode?: string) {
         isSpaMode = true;
       } else if (
         !build.prerender.includes(decodedPath) &&
-        !build.prerender.includes(decodedPath + "/")
+        !build.prerender.includes(decodedPath + "/") &&
+        !build.prerender.includes(removeTrailingSlash(decodedPath))
       ) {
         if (requestUrl.pathname.endsWith(".data")) {
           // 404 on non-pre-rendered `.data` requests

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -68,7 +68,7 @@ export async function singleFetchAction(
           return handleQueryError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, build.basename),
     });
 
     return handleQueryResult(result);
@@ -151,7 +151,7 @@ export async function singleFetchLoaders(
           return handleQueryError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r),
+      normalizePath: (r) => getNormalizedPath(r, build.basename),
     });
 
     return handleQueryResult(result);

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -68,7 +68,7 @@ export async function singleFetchAction(
           return handleQueryError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r, build.basename, build.future),
+      normalizePath: (r) => getNormalizedPath(r),
     });
 
     return handleQueryResult(result);
@@ -151,7 +151,7 @@ export async function singleFetchLoaders(
           return handleQueryError(error);
         }
       },
-      normalizePath: (r) => getNormalizedPath(r, build.basename, build.future),
+      normalizePath: (r) => getNormalizedPath(r),
     });
 
     return handleQueryResult(result);

--- a/packages/react-router/lib/server-runtime/urls.ts
+++ b/packages/react-router/lib/server-runtime/urls.ts
@@ -1,6 +1,12 @@
 import type { Path } from "../router/history";
+import { stripBasename } from "../router/utils";
 
-export function getNormalizedPath(request: Request): Path {
+export function getNormalizedPath(
+  request: Request,
+  basename: string | undefined,
+): Path {
+  basename = basename || "/";
+
   let url = new URL(request.url);
   let pathname = url.pathname;
 
@@ -10,6 +16,10 @@ export function getNormalizedPath(request: Request): Path {
     pathname = pathname.replace(/_\.data$/, "");
   } else {
     pathname = pathname.replace(/\.data$/, "");
+  }
+
+  if (stripBasename(pathname, basename) !== "/" && pathname.endsWith("/")) {
+    pathname = pathname.slice(0, -1);
   }
 
   // Strip _routes param

--- a/packages/react-router/lib/server-runtime/urls.ts
+++ b/packages/react-router/lib/server-runtime/urls.ts
@@ -1,35 +1,15 @@
-import type { FutureConfig } from "../dom/ssr/entry";
 import type { Path } from "../router/history";
-import { stripBasename } from "../router/utils";
 
-export function getNormalizedPath(
-  request: Request,
-  basename: string | undefined,
-  future: FutureConfig | null,
-): Path {
-  basename = basename || "/";
-
+export function getNormalizedPath(request: Request): Path {
   let url = new URL(request.url);
   let pathname = url.pathname;
 
   // Strip .data suffix
-  if (future?.v8_trailingSlashAwareDataRequests) {
-    if (pathname.endsWith("/_.data")) {
-      // Handle trailing slash URLs: /about/_.data -> /about/
-      pathname = pathname.replace(/_\.data$/, "");
-    } else {
-      pathname = pathname.replace(/\.data$/, "");
-    }
+  if (pathname.endsWith("/_.data")) {
+    // Handle trailing slash URLs: /about/_.data -> /about/
+    pathname = pathname.replace(/_\.data$/, "");
   } else {
-    if (stripBasename(pathname, basename) === "/_root.data") {
-      pathname = basename;
-    } else if (pathname.endsWith(".data")) {
-      pathname = pathname.replace(/\.data$/, "");
-    }
-
-    if (stripBasename(pathname, basename) !== "/" && pathname.endsWith("/")) {
-      pathname = pathname.slice(0, -1);
-    }
+    pathname = pathname.replace(/\.data$/, "");
   }
 
   // Strip _routes param


### PR DESCRIPTION
## Summary
- Remove `future.v8_trailingSlashAwareDataRequests`
- Make trailing slash-aware data request URLs the default behavior
- Remove dead false-flag codepaths and update tests/change files

## Testing
- `pnpm --filter @react-router/dev typecheck`
- `pnpm --filter react-router typecheck`
- `pnpm test packages/react-router/__tests__/server-runtime/server-test.ts packages/react-router/__tests__/server-runtime/handle-error-test.ts -- --runInBand`
- `git diff --check`