### PR TITLE
Release 7.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v7.16.0](#v7160)
   - [v7.15.1](#v7151)
   - [v7.15.0](#v7150)
     - [Stabilizations](#stabilizations)
@@ -172,6 +173,49 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v6.0.0](#v600)
 
 </details>
+
+## v7.16.0
+
+Date: 2026-05-28
+
+### Minor Changes
+
+- `react-router` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
+
+- `@react-router/dev` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
+
+  - The unstable flag is no longer supported and will error during config resolution
+
+- `@react-router/dev` - Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))
+
+  - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
+
+### Patch Changes
+
+- `react-router` - Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
+
+- `react-router` - Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))
+
+  - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.
+
+- `react-router` - Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))
+
+- `react-router` - Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />` ([#15082](https://github.com/remix-run/react-router/pull/15082))
+
+- `react-router-dom` - Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package ([#15075](https://github.com/remix-run/react-router/pull/15075))
+
+- `@react-router/express` - Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))
+
+  - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
+
+- `@react-router/node` - Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))
+
+  - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
+  - Reject (rather than hang) if the writable errors or closes mid-stream.
+
+- `@react-router/serve` - Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux. ([#14982](https://github.com/remix-run/react-router/pull/14982))
+
+**Full Changelog**: [`v7.15.1...v7.16.0`](https://github.com/remix-run/react-router/compare/react-router@7.15.1...react-router@7.16.0)
 
 ## v7.15.1
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v7.16.0
+
+### Patch Changes
+
+- _No changes_
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-router",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/architect`
 
+## v7.16.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/architect",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v7.16.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/cloudflare",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/.changes/minor.stabilize-trailing-slash-data-requests.md
+++ b/packages/react-router-dev/.changes/minor.stabilize-trailing-slash-data-requests.md
@@ -1,3 +1,0 @@
-Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests`
-
-- The unstable flag is no longer supported and will error during config resolution

--- a/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
+++ b/packages/react-router-dev/.changes/minor.v8-future-flag-warnings.md
@@ -1,3 +1,0 @@
-Log future flag warnings for upcoming React Router v8 flags
-
-- `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,24 @@
 # `@react-router/dev`
 
+## v7.16.0
+
+### Minor Changes
+
+- Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
+
+  - The unstable flag is no longer supported and will error during config resolution
+
+- Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))
+
+  - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)
+  - [`@react-router/serve@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/dev",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Dev tools and CLI for React Router",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-dom/.changes/patch.remove-staleinvalid-unpkg-field-packagejson-removed.md
+++ b/packages/react-router-dom/.changes/patch.remove-staleinvalid-unpkg-field-packagejson-removed.md
@@ -1,1 +1,0 @@
-Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package

--- a/packages/react-router-dom/CHANGELOG.md
+++ b/packages/react-router-dom/CHANGELOG.md
@@ -1,5 +1,13 @@
 # react-router-dom
 
+## v7.16.0
+
+### Patch Changes
+
+- Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package ([#15075](https://github.com/remix-run/react-router/pull/15075))
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Declarative routing for React web applications",
   "keywords": [
     "react",

--- a/packages/react-router-express/.changes/patch.closed-response-stream.md
+++ b/packages/react-router-express/.changes/patch.closed-response-stream.md
@@ -1,3 +1,0 @@
-Ignore writes after Express responses close
-
-- Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,16 @@
 # `@react-router/express`
 
+## v7.16.0
+
+### Patch Changes
+
+- Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))
+
+  - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/express",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v7.16.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/fs-routes",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/.changes/patch.writable-backpressure.md
+++ b/packages/react-router-node/.changes/patch.writable-backpressure.md
@@ -1,4 +1,0 @@
-Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable`
-
-- Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
-- Reject (rather than hang) if the writable errors or closes mid-stream.

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # `@react-router/node`
 
+## v7.16.0
+
+### Patch Changes
+
+- Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))
+
+  - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
+  - Reject (rather than hang) if the writable errors or closes mid-stream.
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/node",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v7.16.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/.changes/patch.windows-assets-directory-separators.md
+++ b/packages/react-router-serve/.changes/patch.windows-assets-directory-separators.md
@@ -1,1 +1,0 @@
-Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux.

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,15 @@
 # `@react-router/serve`
 
+## v7.16.0
+
+### Patch Changes
+
+- Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux. ([#14982](https://github.com/remix-run/react-router/pull/14982))
+- Updated dependencies:
+  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
+  - [`@react-router/express@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.16.0)
+  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/serve",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/minor.stabilize-trailing-slash-data-requests.md
+++ b/packages/react-router/.changes/minor.stabilize-trailing-slash-data-requests.md
@@ -1,1 +1,0 @@
-Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests`

--- a/packages/react-router/.changes/patch.disable-manifest-route.md
+++ b/packages/react-router/.changes/patch.disable-manifest-route.md
@@ -1,1 +1,0 @@
-Disable manifest path when lazy route dicovery is disabled

--- a/packages/react-router/.changes/patch.fix-browser-history-window-url-base.md
+++ b/packages/react-router/.changes/patch.fix-browser-history-window-url-base.md
@@ -1,3 +1,0 @@
-Fix browser URL creation to use the configured history window instead of the global window.
-
-- Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.

--- a/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
+++ b/packages/react-router/.changes/patch.fix-usenavigation-narrowing.md
@@ -1,1 +1,0 @@
-Fix `useNavigation()` return type to preserve discriminated union across navigation states

--- a/packages/react-router/.changes/patch.support-array-script-ld-json.md
+++ b/packages/react-router/.changes/patch.support-array-script-ld-json.md
@@ -1,1 +1,0 @@
-Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />`

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,23 @@
 # `react-router`
 
+## v7.16.0
+
+### Minor Changes
+
+- Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
+
+### Patch Changes
+
+- Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
+
+- Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))
+
+  - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.
+
+- Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))
+
+- Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />` ([#15082](https://github.com/remix-run/react-router/pull/15082))
+
 ## v7.15.1
 
 ### Patch Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `7.15.1` → `7.16.0` |
| react-router-dom | `7.15.1` → `7.16.0` |
| @react-router/architect | `7.15.1` → `7.16.0` |
| @react-router/cloudflare | `7.15.1` → `7.16.0` |
| @react-router/dev | `7.15.1` → `7.16.0` |
| @react-router/express | `7.15.1` → `7.16.0` |
| @react-router/fs-routes | `7.15.1` → `7.16.0` |
| @react-router/node | `7.15.1` → `7.16.0` |
| @react-router/remix-routes-option-adapter | `7.15.1` → `7.16.0` |
| @react-router/serve | `7.15.1` → `7.16.0` |
| create-react-router | `7.15.1` → `7.16.0` |

# Changelogs

## react-router v7.16.0

### Minor Changes

- Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))

### Patch Changes

- Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))

- Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))

  - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.

- Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))

- Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />` ([#15082](https://github.com/remix-run/react-router/pull/15082))


## react-router-dom v7.16.0

### Patch Changes

- Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package ([#15075](https://github.com/remix-run/react-router/pull/15075))
- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)


## @react-router/architect v7.16.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)


## @react-router/cloudflare v7.16.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)


## @react-router/dev v7.16.0

### Minor Changes

- Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))

  - The unstable flag is no longer supported and will error during config resolution

- Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))

  - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`

### Patch Changes

- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)
  - [`@react-router/serve@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.16.0)


## @react-router/express v7.16.0

### Patch Changes

- Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))

  - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)


## @react-router/fs-routes v7.16.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.16.0)


## @react-router/node v7.16.0

### Patch Changes

- Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))

  - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
  - Reject (rather than hang) if the writable errors or closes mid-stream.
- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)


## @react-router/remix-routes-option-adapter v7.16.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.16.0)


## @react-router/serve v7.16.0

### Patch Changes

- Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux. ([#14982](https://github.com/remix-run/react-router/pull/14982))
- Updated dependencies:
  - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
  - [`@react-router/express@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.16.0)
  - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)


## create-react-router v7.16.0

### Patch Changes

- _No changes_
