### PR TITLE
docs(how-to/data-strategy): fix broken links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -307,6 +307,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/docs/how-to/data-strategy.md
+++ b/docs/how-to/data-strategy.md
@@ -184,9 +184,9 @@ return results;
 
 <docs-info>This is an unlikely use-case now that React Router has built-in middleware, but if you wish to use a custom middleware you can do so with a `dataStrategy`.</docs-info>
 
-Let's define a middleware on each route via [`handle`](../../start/data/route-object#handle)
+Let's define a middleware on each route via [`handle`](../start/data/route-object#handle)
 and call middleware sequentially first, then call all
-[`loader`](../../start/data/route-object#loader)s in parallel - providing
+[`loader`](../start/data/route-object#loader)s in parallel - providing
 any data made available via the middleware:
 
 ```ts
@@ -258,7 +258,7 @@ let router = createBrowserRouter(routes, {
 
 ### Custom Handler
 
-It's also possible you don't even want to define a [`loader`](../../start/daoute-object#loader)
+It's also possible you don't even want to define a [`loader`](../start/data/route-object#loader)
 implementation at the route level. Maybe you want to just determine the
 routes and issue a single GraphQL request for all of your data. You can do
 that by setting your `route.loader=true` so it qualifies as "having a


### PR DESCRIPTION
The "Custom Middleware" and "Custom Handler" sections of the Data Strategy
guide link to `../../start/data/route-object`. From `docs/how-to/`, `../../`
resolves outside the `docs/` tree (to a non-existent `start/data/route-object`),
so these render as dead links on the docs site. One of them also had a typo in
the path: `daoute-object`.

This corrects all three inline links to `../start/data/route-object`, which
matches the `[loader]`/`[action]` reference-link definitions already used at the
bottom of the same file.

Docs-only change, branched from `main` per CONTRIBUTING. No change file needed
(no user-facing API impact).
