### PR TITLE
docs(community/api-development-strategy): fix broken links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -307,6 +307,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/docs/community/api-development-strategy.md
+++ b/docs/community/api-development-strategy.md
@@ -32,7 +32,7 @@ When you opt-in to an unstable flag you are becoming a contributor to the projec
 
 Because unstable flags are experimental and not guaranteed to stick around, we ship them in SemVer patch releases because they're not new _stable_/_documented_ APIs. When an unstable flag stabilizes into a Future Flag, that will be released in a SemVer minor release and will be properly documented and added to the [Future Flags Guide](../upgrading/future).
 
-To learn about current unstable flags, keep an eye on the [CHANGELOG](../start/changelog).
+To learn about current unstable flags, keep an eye on the [CHANGELOG](https://github.com/remix-run/react-router/blob/main/CHANGELOG.md).
 
 ### Example New Feature Flow
 


### PR DESCRIPTION
The "Unstable Flags" section of the API Development Strategy page links to
`../start/changelog`, but no such page exists in the docs tree, so it renders
as a dead link.

This points it at the repository `CHANGELOG.md` on GitHub, matching how every
other docs page references the changelog (e.g. the upgrading guides and the
data-router API docs).

Docs-only change, branched from `main` per CONTRIBUTING. No change file needed.
