### PR TITLE
docs: fix broken links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -307,6 +307,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/docs/explanation/code-splitting.md
+++ b/docs/explanation/code-splitting.md
@@ -58,4 +58,4 @@ export default function Component({ loaderData }) {
 
 After building for the browser, only the `Component` will still be in the bundle, so you can use server-only code in the other module exports.
 
-[route-module]: ../../start/framework/route-module
+[route-module]: ../start/framework/route-module

--- a/docs/explanation/index-query-param.md
+++ b/docs/explanation/index-query-param.md
@@ -80,7 +80,7 @@ function Component() {
 }
 ```
 
-[loader]: ../api/data-routers/loader
+[loader]: ../start/data/route-object#loader
 [form_element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 [form_component]: ../api/components/Form
-[action]: ../api/data-routers/action
+[action]: ../start/data/route-object#action

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -27,4 +27,4 @@ If you are implementing a [Content-Security-Policy (CSP)][csp] in your applicati
 [renderToReadableStream]: https://react.dev/reference/react-dom/server/renderToReadableStream
 [scripts]: ../api/components/Scripts
 [scrollrestoration]: ../api/components/ScrollRestoration
-[serverrouter]: ../api/components/ServerRouter
+[serverrouter]: ../api/framework-routers/ServerRouter

--- a/docs/start/framework/actions.md
+++ b/docs/start/framework/actions.md
@@ -172,4 +172,3 @@ See the [Using Fetchers][fetchers] guide for more information.
 Next: [Navigating](./navigating)
 
 [fetchers]: ../../how-to/fetchers
-[data]: ../../api/react-router/data

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -37,6 +37,5 @@ npx create-react-router@latest --template remix-run/react-router-templates/<temp
 
 Next: [Routing](./routing)
 
-[manual_usage]: ../how-to/manual-usage
 [default-template]: https://github.com/remix-run/react-router-templates/tree/main/default
 [react-router-templates]: https://github.com/remix-run/react-router-templates


### PR DESCRIPTION
Several relative-link reference definitions in the docs point at paths that
don't exist, so they render as dead links on the docs site:

- `explanation/code-splitting.md`: `[route-module]` used `../../start/framework/route-module`,
  which escapes the `docs/` tree (resolves to `<repo>/start/...`). Corrected to
  `../start/framework/route-module`, matching the same target already referenced from
  `hot-module-replacement.md` and `styling.md`.
- `explanation/index-query-param.md`: `[loader]` and `[action]` pointed at
  `../api/data-routers/loader` / `action`, which have no corresponding pages. Repointed
  to `../start/data/route-object#loader` / `#action`, the canonical targets used
  elsewhere in the docs.
- `how-to/security.md`: `[serverrouter]` pointed at `../api/components/ServerRouter`,
  but `ServerRouter` lives at `../api/framework-routers/ServerRouter`.
- `start/framework/installation.md` and `start/framework/actions.md`: removed two
  orphaned reference definitions (`[manual_usage]`, `[data]`) that were never used and
  pointed at non-existent pages.

Docs-only change, branched from `main` per CONTRIBUTING. No change file needed
(no user-facing API impact).
