### PR TITLE
docs: fix broken links

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -307,6 +307,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/docs/tutorials/address-book.md
+++ b/docs/tutorials/address-book.md
@@ -1939,7 +1939,7 @@ Now the star _immediately_ changes to the new state when you click it.
 That's it! Thanks for giving React Router a shot. We hope this tutorial gives you a solid start to build great user experiences. There's a lot more you can do, so make sure to check out all the [APIs][react-router-apis] 😀
 
 [http-localhost-5173]: http://localhost:5173
-[root-route]: ../explanation/special-files#roottsx
+[root-route]: ../api/framework-conventions/root.tsx
 [error-boundaries]: ../how-to/error-boundary
 [links]: ../start/framework/route-module#links
 [outlet-component]: https://api.reactrouter.com/v7/functions/react-router.Outlet
@@ -1949,7 +1949,7 @@ That's it! Thanks for giving React Router a shot. We hope this tutorial gives yo
 [client-loader]: ../start/framework/route-module#clientloader
 [spa]: ../how-to/spa
 [type-safety]: ../explanation/type-safety
-[react-router-config]: ../explanation/special-files#react-routerconfigts
+[react-router-config]: ../api/framework-conventions/react-router.config.ts
 [rendering-strategies]: ../start/framework/rendering
 [index-route]: ../start/framework/routing#index-routes
 [layout-route]: ../start/framework/routing#layout-routes

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -61,7 +61,7 @@ const router = createBrowserRouter(routes, {
 If you're using the `context` parameter in `loader` and `action` functions, you may need to update your code:
 
 - In Framework mode, if you're using `react-router-serve`, you should not need to make any updates. Otherwise, this only applies if you have a custom server with a `getLoadContext` function. Please see the docs on the middleware [`getLoadContext` changes](../how-to/middleware#changes-to-getloadcontextapploadcontext) and the instructions to [migrate to the new API](../how-to/middleware#migration-from-apploadcontext).
-- In Data mode, add the `Future` module augmentation described in the [middleware docs](../how-to/middleware#2-typescript-augment-future-for-loaderaction-context) so `context` is typed correctly.
+- In Data mode, add the `Future` module augmentation described in the [middleware docs](../how-to/middleware#1-typescript-augment-future-for-loaderaction-context) so `context` is typed correctly.
 
 ## `future.v8_splitRouteModules`
 


### PR DESCRIPTION
Two sets of internal links point at heading anchors that no longer exist:

- `upgrading/future.md` links to the middleware Data-mode setup section as
  `#2-typescript-augment-future-for-loaderaction-context`, but that heading is step 1
  under "Quick Start (Data Mode)" in `how-to/middleware.md`, so the correct anchor is
  `#1-typescript-augment-future-for-loaderaction-context`.
- `tutorials/address-book.md` links `[root-route]` and `[react-router-config]` to
  `../explanation/special-files#roottsx` and `#react-routerconfigts`. The Special Files
  page is now a stub whose content has moved to the framework-conventions API pages, so
  neither anchor exists. Repointed both to `../api/framework-conventions/root.tsx` and
  `../api/framework-conventions/react-router.config.ts`, matching the links the Special
  Files page itself now uses.

Docs-only change, branched from `main` per CONTRIBUTING. No change file needed.
