### PR TITLE
docs: clarify v8_viteEnvironmentApi custom server config

### DIFF
--- a/.agents/skills/fix-bug/SKILL.md
+++ b/.agents/skills/fix-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-bug
-description: Fix a reported bug in React Router from a GitHub issue. Use when the user provides a GitHub issue URL and asks to fix a bug, investigate an issue, or reproduce a problem. Handles the full workflow: fetching the issue, finding the reproduction, writing a failing test, and implementing the fix.
+description: "Fix a reported bug in React Router from a GitHub issue. Use when the user provides a GitHub issue URL and asks to fix a bug, investigate an issue, or reproduce a problem. Handles the full workflow: fetching the issue, finding the reproduction, writing a failing test, and implementing the fix."
 disable-model-invocation: true
 ---
 

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -117,7 +117,38 @@ export default {
 
 **Update your Code**
 
-No code changes are required unless you have custom Vite configuration that needs to be updated for the [Environment API][vite-environment]. Most users won't need to make any changes.
+Most users won't need to make any changes. However, if you have custom Vite configuration that previously relied on the `isSsrBuild` flag — such as a custom server build that sets `build.rollupOptions.input` — you'll need to move that configuration under the per-environment [Environment API][vite-environment] config instead.
+
+For example, a custom server build should move its SSR `rollupOptions` from the top-level `build` config into `environments.ssr.build`:
+
+```diff filename=vite.config.ts
+import { reactRouter } from "@react-router/dev/vite";
+import { defineConfig } from "vite";
+
+-export default defineConfig(({ isSsrBuild }) => ({
+-  build: {
+-    rollupOptions: isSsrBuild
+-      ? {
+-          input: "./server/app.ts",
+-        }
+-      : undefined,
+-  },
++export default defineConfig({
++  environments: {
++    ssr: {
++      build: {
++        rollupOptions: {
++          input: "./server/app.ts",
++        },
++      },
++    },
++  },
+   plugins: [reactRouter()],
+-}));
++});
+```
+
+See the [`node-custom-server` template][node-custom-server-template] for a complete example.
 
 ## `future.v8_passThroughRequests`
 
@@ -246,3 +277,4 @@ _No current unstable flags to document_
 [observability]: ../how-to/instrumentation
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [vite-environment]: https://vite.dev/guide/api-environment
+[node-custom-server-template]: https://github.com/remix-run/react-router-templates/blob/7c617a435510bc3add3a5395c07bc65328b65e9e/node-custom-server/vite.config.ts


### PR DESCRIPTION
## Summary

Updates the `future.v8_viteEnvironmentApi` section in `docs/upgrading/future.md` to document a `vite.config.ts` update that custom server builds need when enabling the flag.

## Changes

- Add a before/after diff to the `v8_viteEnvironmentApi` docs showing how to migrate a custom server build's `rollupOptions` to the Environment API config.
- Link to the `node-custom-server` template for a complete example.
- Minor: fix YAML quoting in the `fix-bug` skill description.

Closes #15110
