### PR TITLE
Publish React Router docs in package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ build.utils.d.ts
 worker-configuration.d.ts
 /.env
 /NOTES.md
+/packages/react-router/docs/
 
 # v7 reference docs
 /public

--- a/packages/react-router/.changes/minor.ship-docs-in-package.md
+++ b/packages/react-router/.changes/minor.ship-docs-in-package.md
@@ -1,0 +1,4 @@
+Ship a subset of the official documentation inside the `react-router` package
+
+- Markdown docs are now available via the `react-router/docs` and `react-router/docs/*` package export subpaths, letting AI coding agents and the React Router agent skills read official docs locally
+- Excludes auto-generated API docs (`api/`), `community/` content, and tutorials (`tutorials/`)

--- a/packages/react-router/.changes/minor.ship-docs-in-package.md
+++ b/packages/react-router/.changes/minor.ship-docs-in-package.md
@@ -1,4 +1,3 @@
 Ship a subset of the official documentation inside the `react-router` package
-
-- Markdown docs are now available via the `react-router/docs` and `react-router/docs/*` package export subpaths, letting AI coding agents and the React Router agent skills read official docs locally
+- Markdown docs are now available in `node_modules/react-router/docs`, letting AI coding agents and the React Router agent skills read official docs locally
 - Excludes auto-generated API docs (`api/`), `community/` content, and tutorials (`tutorials/`)

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -101,8 +101,6 @@
         "default": "./dist/development/index.js"
       }
     },
-    "./docs": "./dist/docs/index.md",
-    "./docs/*": "./dist/docs/*",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -105,17 +105,16 @@
   },
   "scripts": {
     "build": "wireit",
+    "prepublishOnly": "node ./scripts/copy-docs.mjs",
     "watch": "tsup --watch & tsup --config tsup.config.rsc.ts --watch",
     "typecheck": "tsc"
   },
   "wireit": {
     "build": {
-      "command": "premove dist && tsup && tsup --config tsup.config.rsc.ts && node ./scripts/copy-docs.mjs",
+      "command": "premove dist && tsup && tsup --config tsup.config.rsc.ts",
       "files": [
         "../../pnpm-workspace.yaml",
-        "../../docs/**",
         "lib/**",
-        "scripts/copy-docs.mjs",
         "*.ts",
         "tsconfig.json",
         "package.json"

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -101,6 +101,8 @@
         "default": "./dist/development/index.js"
       }
     },
+    "./docs": "./dist/docs/index.md",
+    "./docs/*": "./dist/docs/*",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -110,10 +112,12 @@
   },
   "wireit": {
     "build": {
-      "command": "premove dist && tsup && tsup --config tsup.config.rsc.ts",
+      "command": "premove dist && tsup && tsup --config tsup.config.rsc.ts && node ./scripts/copy-docs.mjs",
       "files": [
         "../../pnpm-workspace.yaml",
+        "../../docs/**",
         "lib/**",
+        "scripts/copy-docs.mjs",
         "*.ts",
         "tsconfig.json",
         "package.json"

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -157,6 +157,7 @@
   },
   "files": [
     "dist/",
+    "docs/",
     "CHANGELOG.md",
     "LICENSE.md",
     "README.md"

--- a/packages/react-router/scripts/copy-docs.mjs
+++ b/packages/react-router/scripts/copy-docs.mjs
@@ -1,0 +1,63 @@
+// Copies a subset of the repo's `docs/` into this package so it ships to npm and
+// is available via `react-router/docs/...` package exports for AI coding agents
+// and the React Router agent skills.
+//
+// This runs as part of the package build (see `wireit.build` in package.json).
+
+/* eslint-disable import/no-nodejs-modules -- This package build script runs in Node. */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const SOURCE_DOCS_DIR = path.resolve(PACKAGE_DIR, "../../docs");
+const TARGET_DOCS_DIR = path.resolve(PACKAGE_DIR, "dist/docs");
+
+const EXCLUDED_TOP_LEVEL_DIRS = new Set(["api", "community", "tutorials"]);
+const EXCLUDED_FILES = new Set(["elements.md", "prettier.config.js"]);
+
+function copyDocs(relativeDir = "") {
+  let copied = 0;
+  let sourceDir = path.join(SOURCE_DOCS_DIR, relativeDir);
+
+  for (let entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    let relativePath = relativeDir
+      ? `${relativeDir}/${entry.name}`
+      : entry.name;
+
+    if (entry.isDirectory()) {
+      if (relativeDir === "" && EXCLUDED_TOP_LEVEL_DIRS.has(entry.name)) {
+        continue;
+      }
+
+      copied += copyDocs(relativePath);
+      continue;
+    }
+
+    if (EXCLUDED_FILES.has(relativePath)) continue;
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+
+    let source = path.join(SOURCE_DOCS_DIR, relativePath);
+    let target = path.join(TARGET_DOCS_DIR, relativePath);
+
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.copyFileSync(source, target);
+    copied++;
+  }
+
+  return copied;
+}
+
+if (!fs.existsSync(SOURCE_DOCS_DIR)) {
+  throw new Error(`Could not find docs directory at ${SOURCE_DOCS_DIR}`);
+}
+
+fs.rmSync(TARGET_DOCS_DIR, { recursive: true, force: true });
+
+let copied = copyDocs();
+let relativeTargetDocsDir = path.relative(PACKAGE_DIR, TARGET_DOCS_DIR);
+
+console.log(`Copied ${copied} doc file(s) to ${relativeTargetDocsDir}/`);

--- a/packages/react-router/scripts/copy-docs.mjs
+++ b/packages/react-router/scripts/copy-docs.mjs
@@ -14,7 +14,7 @@ const PACKAGE_DIR = path.resolve(
   "..",
 );
 const SOURCE_DOCS_DIR = path.resolve(PACKAGE_DIR, "../../docs");
-const TARGET_DOCS_DIR = path.resolve(PACKAGE_DIR, "dist/docs");
+const TARGET_DOCS_DIR = path.resolve(PACKAGE_DIR, "docs");
 
 const EXCLUDED_TOP_LEVEL_DIRS = new Set(["api", "community", "tutorials"]);
 const EXCLUDED_FILES = new Set(["elements.md", "prettier.config.js"]);


### PR DESCRIPTION
## Summary

- copy a subset of root markdown docs into `react-router/dist/docs` during the package build
- expose docs through `react-router/docs` and `react-router/docs/*` package export subpaths
- exclude generated API docs, community docs, and tutorials from the published subset

## Validation

- `node_modules/.bin/prettier --check packages/react-router/package.json packages/react-router/scripts/copy-docs.mjs packages/react-router/.changes/minor.ship-docs-in-package.md`
- `pnpm exec eslint packages/react-router/scripts/copy-docs.mjs`
- `pnpm run --filter react-router build`
- `npm pack --dry-run --json` from `packages/react-router` confirmed 85 `dist/docs` files, no top-level docs, no api/community/tutorials docs
