### PR TITLE
test: fix duplicate "when" in vite-basename test description

### DIFF
--- a/integration/vite-basename-test.ts
+++ b/integration/vite-basename-test.ts
@@ -521,7 +521,7 @@ test.describe("Vite base + React Router basename", () => {
           await workflowBuild({ page, port, basename: "/notmybase/" });
         });
 
-        test("works when when base is an absolute external URL", async ({
+        test("works when base is an absolute external URL", async ({
           page,
         }) => {
           test.skip(


### PR DESCRIPTION
Removes a duplicate "when" in a test description in `integration/vite-basename-test.ts`.
