### PR TITLE
docs(dev): fix future flag warning link

### DIFF
--- a/.agents/skills/fix-bug/SKILL.md
+++ b/.agents/skills/fix-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-bug
-description: Fix a reported bug in React Router from a GitHub issue. Use when the user provides a GitHub issue URL and asks to fix a bug, investigate an issue, or reproduce a problem. Handles the full workflow: fetching the issue, finding the reproduction, writing a failing test, and implementing the fix.
+description: "Fix a reported bug in React Router from a GitHub issue. Use when the user provides a GitHub issue URL and asks to fix a bug, investigate an issue, or reproduce a problem. Handles the full workflow: fetching the issue, finding the reproduction, writing a failing test, and implementing the fix."
 disable-model-invocation: true
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,11 +183,9 @@ Date: 2026-05-28
 - `react-router` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
 
 - `@react-router/dev` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
-
   - The unstable flag is no longer supported and will error during config resolution
 
 - `@react-router/dev` - Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))
-
   - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
 
 ### Patch Changes
@@ -195,7 +193,6 @@ Date: 2026-05-28
 - `react-router` - Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
 
 - `react-router` - Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))
-
   - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.
 
 - `react-router` - Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))
@@ -205,11 +202,9 @@ Date: 2026-05-28
 - `react-router-dom` - Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package ([#15075](https://github.com/remix-run/react-router/pull/15075))
 
 - `@react-router/express` - Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))
-
   - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
 
 - `@react-router/node` - Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))
-
   - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
   - Reject (rather than hang) if the writable errors or closes mid-stream.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,37 +178,37 @@ We manage release notes in this file instead of the paginated Github Releases Pa
 
 Date: 2026-05-28
 
+### What's Changed
+
+#### Stabilized `future.v8_trailingSlashAwareDataRequests`
+
+We've stabilized this flag in preparation for the upcoming v8 release. Unless you are doing specific path-inspection on `.data` requests or have specific CDN/caching/pre-rendering logic around `.data` requests, this should largely be a zero-code-change adoptions. Please see the [docs](https://reactrouter.com/upgrading/future#futurev8_trailingslashawaredatarequests) for more info.
+
+#### Pre-v8 Future Flag Warnings
+
+In preparation for the upcoming v8 release, `7.16.0` begins logging console warnings during builds for future flags that you have not enabled yet. If you have all future flags enabled, the v8 upgrade should be mostly non-breaking (short of some underlying dependency minimum versions bumps - React 19, Node 22.12, Vite 7). You can suppress these warnings until you are ready top adopt flags by setting an explicit `false` in your `react-router.config.ts`.
+
 ### Minor Changes
 
 - `react-router` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
-
-- `@react-router/dev` - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
-  - The unstable flag is no longer supported and will error during config resolution
-
 - `@react-router/dev` - Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))
   - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
 
 ### Patch Changes
 
-- `react-router` - Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
-
-- `react-router` - Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))
+- `react-router` - Disable manifest path when lazy route discovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
+- `react-router` - Fix browser URL creation to use the configured history `window` instead of the global `window` ([#15066](https://github.com/remix-run/react-router/pull/15066))
   - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.
-
 - `react-router` - Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))
-
 - `react-router` - Widen `MetaDescriptor` `script:ld+json` type from `LdJsonObject` to `LdJsonObject | LdJsonObject[]` to permit multiple JSON-LD schemas in a single `<script type="application/ld+json">` tag emitted by `<Meta />` ([#15082](https://github.com/remix-run/react-router/pull/15082))
-
-- `react-router-dom` - Remove stale/invalid `unpkg` field from `package.json`. This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package ([#15075](https://github.com/remix-run/react-router/pull/15075))
-
+- `react-router-dom` - Remove stale/invalid `unpkg` field from `package.json` ([#15075](https://github.com/remix-run/react-router/pull/15075))
+  - This was removed from other packages with the release of v7 but missed in the `react-router-dom` re-export package
 - `@react-router/express` - Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))
-  - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
-
+  - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended
 - `@react-router/node` - Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))
-  - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
-  - Reject (rather than hang) if the writable errors or closes mid-stream.
-
-- `@react-router/serve` - Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux. ([#14982](https://github.com/remix-run/react-router/pull/14982))
+  - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer
+  - Reject (rather than hang) if the writable errors or closes mid-stream
+- `@react-router/serve` - Normalize `assetsBuildDirectory` path separators in `react-router-serve` so Windows-built server artifacts can serve `/assets/*` correctly when run on Linux ([#14982](https://github.com/remix-run/react-router/pull/14982))
 
 **Full Changelog**: [`v7.15.1...v7.16.0`](https://github.com/remix-run/react-router/compare/react-router@7.15.1...react-router@7.16.0)
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -501,3 +501,4 @@
 - zeroqs
 - zheng-chuang
 - zxTomw
+- sushichan044

--- a/contributors.yml
+++ b/contributors.yml
@@ -307,6 +307,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/docs/explanation/code-splitting.md
+++ b/docs/explanation/code-splitting.md
@@ -58,4 +58,4 @@ export default function Component({ loaderData }) {
 
 After building for the browser, only the `Component` will still be in the bundle, so you can use server-only code in the other module exports.
 
-[route-module]: ../../start/framework/route-module
+[route-module]: ../start/framework/route-module

--- a/docs/explanation/index-query-param.md
+++ b/docs/explanation/index-query-param.md
@@ -80,7 +80,7 @@ function Component() {
 }
 ```
 
-[loader]: ../api/data-routers/loader
+[loader]: ../start/data/route-object#loader
 [form_element]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 [form_component]: ../api/components/Form
-[action]: ../api/data-routers/action
+[action]: ../start/data/route-object#action

--- a/docs/how-to/data-strategy.md
+++ b/docs/how-to/data-strategy.md
@@ -184,9 +184,9 @@ return results;
 
 <docs-info>This is an unlikely use-case now that React Router has built-in middleware, but if you wish to use a custom middleware you can do so with a `dataStrategy`.</docs-info>
 
-Let's define a middleware on each route via [`handle`](../../start/data/route-object#handle)
+Let's define a middleware on each route via [`handle`](../start/data/route-object#handle)
 and call middleware sequentially first, then call all
-[`loader`](../../start/data/route-object#loader)s in parallel - providing
+[`loader`](../start/data/route-object#loader)s in parallel - providing
 any data made available via the middleware:
 
 ```ts
@@ -258,7 +258,7 @@ let router = createBrowserRouter(routes, {
 
 ### Custom Handler
 
-It's also possible you don't even want to define a [`loader`](../../start/daoute-object#loader)
+It's also possible you don't even want to define a [`loader`](../start/data/route-object#loader)
 implementation at the route level. Maybe you want to just determine the
 routes and issue a single GraphQL request for all of your data. You can do
 that by setting your `route.loader=true` so it qualifies as "having a

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -27,4 +27,4 @@ If you are implementing a [Content-Security-Policy (CSP)][csp] in your applicati
 [renderToReadableStream]: https://react.dev/reference/react-dom/server/renderToReadableStream
 [scripts]: ../api/components/Scripts
 [scrollrestoration]: ../api/components/ScrollRestoration
-[serverrouter]: ../api/components/ServerRouter
+[serverrouter]: ../api/framework-routers/ServerRouter

--- a/docs/start/framework/actions.md
+++ b/docs/start/framework/actions.md
@@ -172,4 +172,3 @@ See the [Using Fetchers][fetchers] guide for more information.
 Next: [Navigating](./navigating)
 
 [fetchers]: ../../how-to/fetchers
-[data]: ../../api/react-router/data

--- a/docs/start/framework/installation.md
+++ b/docs/start/framework/installation.md
@@ -37,6 +37,5 @@ npx create-react-router@latest --template remix-run/react-router-templates/<temp
 
 Next: [Routing](./routing)
 
-[manual_usage]: ../how-to/manual-usage
 [default-template]: https://github.com/remix-run/react-router-templates/tree/main/default
 [react-router-templates]: https://github.com/remix-run/react-router-templates

--- a/docs/tutorials/address-book.md
+++ b/docs/tutorials/address-book.md
@@ -1939,7 +1939,7 @@ Now the star _immediately_ changes to the new state when you click it.
 That's it! Thanks for giving React Router a shot. We hope this tutorial gives you a solid start to build great user experiences. There's a lot more you can do, so make sure to check out all the [APIs][react-router-apis] 😀
 
 [http-localhost-5173]: http://localhost:5173
-[root-route]: ../explanation/special-files#roottsx
+[root-route]: ../api/framework-conventions/root.tsx
 [error-boundaries]: ../how-to/error-boundary
 [links]: ../start/framework/route-module#links
 [outlet-component]: https://api.reactrouter.com/v7/functions/react-router.Outlet
@@ -1949,7 +1949,7 @@ That's it! Thanks for giving React Router a shot. We hope this tutorial gives yo
 [client-loader]: ../start/framework/route-module#clientloader
 [spa]: ../how-to/spa
 [type-safety]: ../explanation/type-safety
-[react-router-config]: ../explanation/special-files#react-routerconfigts
+[react-router-config]: ../api/framework-conventions/react-router.config.ts
 [rendering-strategies]: ../start/framework/rendering
 [index-route]: ../start/framework/routing#index-routes
 [layout-route]: ../start/framework/routing#layout-routes

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -61,7 +61,7 @@ const router = createBrowserRouter(routes, {
 If you're using the `context` parameter in `loader` and `action` functions, you may need to update your code:
 
 - In Framework mode, if you're using `react-router-serve`, you should not need to make any updates. Otherwise, this only applies if you have a custom server with a `getLoadContext` function. Please see the docs on the middleware [`getLoadContext` changes](../how-to/middleware#changes-to-getloadcontextapploadcontext) and the instructions to [migrate to the new API](../how-to/middleware#migration-from-apploadcontext).
-- In Data mode, add the `Future` module augmentation described in the [middleware docs](../how-to/middleware#2-typescript-augment-future-for-loaderaction-context) so `context` is typed correctly.
+- In Data mode, add the `Future` module augmentation described in the [middleware docs](../how-to/middleware#1-typescript-augment-future-for-loaderaction-context) so `context` is typed correctly.
 
 ## `future.v8_splitRouteModules`
 

--- a/docs/upgrading/future.md
+++ b/docs/upgrading/future.md
@@ -117,7 +117,38 @@ export default {
 
 **Update your Code**
 
-No code changes are required unless you have custom Vite configuration that needs to be updated for the [Environment API][vite-environment]. Most users won't need to make any changes.
+Most users won't need to make any changes. However, if you have custom Vite configuration that previously relied on the `isSsrBuild` flag — such as a custom server build that sets `build.rollupOptions.input` — you'll need to move that configuration under the per-environment [Environment API][vite-environment] config instead.
+
+For example, a custom server build should move its SSR `rollupOptions` from the top-level `build` config into `environments.ssr.build`:
+
+```diff filename=vite.config.ts
+import { reactRouter } from "@react-router/dev/vite";
+import { defineConfig } from "vite";
+
+-export default defineConfig(({ isSsrBuild }) => ({
+-  build: {
+-    rollupOptions: isSsrBuild
+-      ? {
+-          input: "./server/app.ts",
+-        }
+-      : undefined,
+-  },
++export default defineConfig({
++  environments: {
++    ssr: {
++      build: {
++        rollupOptions: {
++          input: "./server/app.ts",
++        },
++      },
++    },
++  },
+   plugins: [reactRouter()],
+-}));
++});
+```
+
+See the [`node-custom-server` template][node-custom-server-template] for a complete example.
 
 ## `future.v8_passThroughRequests`
 
@@ -246,3 +277,4 @@ _No current unstable flags to document_
 [observability]: ../how-to/instrumentation
 [Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [vite-environment]: https://vite.dev/guide/api-environment
+[node-custom-server-template]: https://github.com/remix-run/react-router-templates/blob/7c617a435510bc3add3a5395c07bc65328b65e9e/node-custom-server/vite.config.ts

--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -116,7 +116,7 @@ test.describe("cli", () => {
     // Filter out future flag warnings for the format:
     // ⚠️  Future Flag Warning: Route module splitting behavior is changing in React Router v8.
     //     You can use the `future.v8_splitRouteModules` flag to opt in early.
-    //     -> https://reactrouter.com/upgrading/future-flags#v8_splitRouteModules
+    //     -> https://reactrouter.com/upgrading/future#futurev8_splitroutemodules
     let filteredStdOut = stdout.toString().split("\n");
     while (filteredStdOut[0]?.includes("Future Flag Warning:")) {
       filteredStdOut.splice(0, 3);

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -5,11 +5,9 @@
 ### Minor Changes
 
 - Stabilize `future.unstable_trailingSlashAwareDataRequests` as `future.v8_trailingSlashAwareDataRequests` ([#15098](https://github.com/remix-run/react-router/pull/15098))
-
   - The unstable flag is no longer supported and will error during config resolution
 
 - Log future flag warnings for upcoming React Router v8 flags ([#15029](https://github.com/remix-run/react-router/pull/15029))
-
   - `v8_middleware`, `v8_splitRouteModules`, `v8_viteEnvironmentApi`, `v8_passThroughRequests`, `v8_trailingSlashAwareDataRequests`
 
 ### Patch Changes

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -767,7 +767,7 @@ function logFutureFlagWarning(flag: string, message: string): void {
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +
-        `     -> https://reactrouter.com/upgrading/future-flags#${flag}`,
+        `     -> https://reactrouter.com/upgrading/future#future${flag.toLowerCase()}`,
     ),
   );
 }

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Patch Changes
 
 - Ignore writes after Express responses close ([#15107](https://github.com/remix-run/react-router/pull/15107))
-
   - Avoid surfacing client disconnects as adapter errors when the response stream has already been destroyed or ended.
+
 - Updated dependencies:
   - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
   - [`@react-router/node@7.16.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.16.0)

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -5,9 +5,9 @@
 ### Patch Changes
 
 - Honor Node writable backpressure in `writeReadableStreamToWritable` and `writeAsyncIterableToWritable` ([#15071](https://github.com/remix-run/react-router/pull/15071))
-
   - Await `'drain'` when `writable.write()` returns `false` instead of letting chunks accumulate in the writable's internal buffer.
   - Reject (rather than hang) if the writable errors or closes mid-stream.
+
 - Updated dependencies:
   - [`react-router@7.16.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.16.0)
 

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Disable manifest path when lazy route dicovery is disabled ([#15068](https://github.com/remix-run/react-router/pull/15068))
 
 - Fix browser URL creation to use the configured history window instead of the global window. ([#15066](https://github.com/remix-run/react-router/pull/15066))
-
   - Pass the history/router window through to `createBrowserURLImpl` so custom window contexts keep the correct URL origin.
 
 - Fix `useNavigation()` return type to preserve discriminated union across navigation states ([#15095](https://github.com/remix-run/react-router/pull/15095))


### PR DESCRIPTION
~~Fixed the URLs in the warning displayed when the v8 feature flag is disabled,
as they did not match the hashes provided at https://reactrouter.com/upgrading/future.~~

I am very sorry, but I will need to close this PR for now due to a failure in the git operation.