### PR TITLE
docs(dev): fix future flag warning link

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -501,3 +501,4 @@
 - zeroqs
 - zheng-chuang
 - zxTomw
+- sushichan044

--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -116,7 +116,7 @@ test.describe("cli", () => {
     // Filter out future flag warnings for the format:
     // ⚠️  Future Flag Warning: Route module splitting behavior is changing in React Router v8.
     //     You can use the `future.v8_splitRouteModules` flag to opt in early.
-    //     -> https://reactrouter.com/upgrading/future-flags#v8_splitRouteModules
+    //     -> https://reactrouter.com/upgrading/future#futurev8_splitroutemodules
     let filteredStdOut = stdout.toString().split("\n");
     while (filteredStdOut[0]?.includes("Future Flag Warning:")) {
       filteredStdOut.splice(0, 3);

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -767,7 +767,7 @@ function logFutureFlagWarning(flag: string, message: string): void {
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +
-        `     -> https://reactrouter.com/upgrading/future-flags#${flag}`,
+        `     -> https://reactrouter.com/upgrading/future#future${flag.toLowerCase()}`,
     ),
   );
 }


### PR DESCRIPTION
Fixed the URLs in the warning displayed when the v8 feature flag is disabled,
as they did not match the hashes provided at https://reactrouter.com/upgrading/future.