### PR TITLE
fix(router): avoid restarting fetcher revalidations

### DIFF
--- a/packages/react-router/.changes/patch.fetcher-revalidation-navigation.md
+++ b/packages/react-router/.changes/patch.fetcher-revalidation-navigation.md
@@ -1,0 +1,1 @@
+Prevent GET navigations from restarting in-flight fetcher revalidations triggered by action submissions.

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -1946,7 +1946,7 @@ describe("fetchers", () => {
       });
     });
 
-    it("properly ignores aborted action revalidation fetchers when a navigation triggers revalidations", async () => {
+    it("does not restart in-flight action revalidation fetchers when a navigation triggers revalidations", async () => {
       let keyA = "a";
       let keyB = "b";
       let t = initializeTest();
@@ -1976,27 +1976,24 @@ describe("fetchers", () => {
         data: "FOO",
       });
 
-      // Interrupt revalidation with GEt navigation
-      // TODO: This shouldn't actually abort the revalidation but it does currently
-      // which then causes the invalid invariant error.  This test is to ensure
-      // the invariant doesn't throw, but we'll fix the unnecessary revalidation
-      // in https://github.com/remix-run/react-router/issues/14115
+      // Interrupt revalidation with GET navigation
       let C = await t.navigate("/baz", undefined, ["foo"]);
-      expect(B.loaders.foo.signal.aborted).toBe(true);
+      expect(B.loaders.foo.signal.aborted).toBe(false);
+      expect(C.loaders.foo.stub).not.toHaveBeenCalled();
       expect(t.fetchers[keyA]).toMatchObject({
         state: "loading",
         data: "FOO",
       });
 
-      // Complete the aborted fetcher revalidation calls
+      // Complete the fetcher action revalidation calls
       await B.loaders.root.resolve("NOPE");
       await B.loaders.index.resolve("NOPE");
-      await B.loaders.foo.resolve("NOPE");
+      await B.loaders.foo.resolve("FOO*");
 
       // Complete the navigation
       await C.loaders.root.resolve("ROOT*");
       await C.loaders.baz.resolve("BAZ");
-      await C.loaders.foo.resolve("FOO*");
+      expect(C.loaders.foo.stub).not.toHaveBeenCalled();
       expect(t.router.state).toMatchObject({
         navigation: IDLE_NAVIGATION,
         location: { pathname: "/baz" },

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1259,6 +1259,9 @@ export function createRouter(init: RouterInit): Router {
   // Most recent href/match for fetcher.load calls for fetchers
   let fetchLoadMatches = new Map<string, FetchLoadMatch>();
 
+  // Fetchers currently being revalidated from a prior loader/action pass
+  let revalidatingFetchersInFlight = new Set<string>();
+
   // Ref-count mounted fetchers so we know when it's ok to clean them up
   let activeFetchers = new Map<string, number>();
 
@@ -2385,6 +2388,7 @@ export function createRouter(init: RouterInit): Router {
       initialHydration === true,
       isRevalidationRequired,
       cancelledFetcherLoads,
+      revalidatingFetchersInFlight,
       fetchersQueuedForDeletion,
       fetchLoadMatches,
       fetchRedirectIds,
@@ -2451,6 +2455,7 @@ export function createRouter(init: RouterInit): Router {
         // Fetchers use an independent AbortController so that aborting a fetcher
         // (via deleteFetcher) does not abort the triggering navigation that
         // triggered the revalidation
+        revalidatingFetchersInFlight.add(rf.key);
         fetchControllers.set(rf.key, rf.controller);
       }
     });
@@ -2488,7 +2493,10 @@ export function createRouter(init: RouterInit): Router {
       );
     }
 
-    revalidatingFetchers.forEach((rf) => fetchControllers.delete(rf.key));
+    revalidatingFetchers.forEach((rf) => {
+      fetchControllers.delete(rf.key);
+      revalidatingFetchersInFlight.delete(rf.key);
+    });
 
     // If any loaders returned a redirect Response, start a new REPLACE navigation
     let redirect = findRedirect(loaderResults);
@@ -2858,6 +2866,7 @@ export function createRouter(init: RouterInit): Router {
       false,
       isRevalidationRequired,
       cancelledFetcherLoads,
+      revalidatingFetchersInFlight,
       fetchersQueuedForDeletion,
       fetchLoadMatches,
       fetchRedirectIds,
@@ -2892,6 +2901,7 @@ export function createRouter(init: RouterInit): Router {
         workingFetchers.set(staleKey, revalidatingFetcher);
         abortFetcher(staleKey);
         if (rf.controller) {
+          revalidatingFetchersInFlight.add(staleKey);
           fetchControllers.set(staleKey, rf.controller);
         }
       });
@@ -2926,7 +2936,10 @@ export function createRouter(init: RouterInit): Router {
 
     fetchReloadIds.delete(key);
     fetchControllers.delete(key);
-    revalidatingFetchers.forEach((r) => fetchControllers.delete(r.key));
+    revalidatingFetchers.forEach((r) => {
+      fetchControllers.delete(r.key);
+      revalidatingFetchersInFlight.delete(r.key);
+    });
 
     let fetcherIsMounted = state.fetchers.has(key);
 
@@ -3552,6 +3565,7 @@ export function createRouter(init: RouterInit): Router {
     if (controller) {
       controller.abort(reason);
       fetchControllers.delete(key);
+      revalidatingFetchersInFlight.delete(key);
     }
   }
 
@@ -5279,6 +5293,7 @@ function getMatchesToLoad(
   initialHydration: boolean,
   isRevalidationRequired: boolean,
   cancelledFetcherLoads: Set<string>,
+  revalidatingFetchersInFlight: Set<string>,
   fetchersQueuedForDeletion: Set<string>,
   fetchLoadMatches: Map<string, FetchLoadMatch>,
   fetchRedirectIds: Set<string>,
@@ -5479,6 +5494,15 @@ function getMatchesToLoad(
 
     if (fetchRedirectIds.has(key)) {
       // Never trigger a revalidation of an actively redirecting fetcher
+      return;
+    }
+
+    if (
+      revalidatingFetchersInFlight.has(key) &&
+      !cancelledFetcherLoads.has(key)
+    ) {
+      // Let in-flight fetcher revalidations complete instead of aborting and
+      // restarting the same fetcher load.
       return;
     }
 


### PR DESCRIPTION
Summary:
- Fix #14115
- Track in-flight fetcher revalidations so a subsequent GET navigation does not abort and restart the same fetcher load
- Update the fetcher interruption regression test and add a patch change file

Testing:
- pnpm test packages/react-router/__tests__/router/fetchers-test.ts
- pnpm test packages/react-router/__tests__/router
- pnpm prettier --check packages/react-router/lib/router/router.ts packages/react-router/__tests__/router/fetchers-test.ts packages/react-router/.changes/patch.fetcher-revalidation-navigation.md
- git diff --check
- pnpm run typecheck
- pnpm build