### PR TITLE
Don’t drop blocker state during revalidation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -308,6 +308,7 @@
 - mm-jpoole
 - mobregozo
 - modex98
+- morgan-coded
 - morleytatro
 - ms10596
 - mspiess

--- a/packages/react-router/.changes/patch.keep-blocker-state-through-revalidation.md
+++ b/packages/react-router/.changes/patch.keep-blocker-state-through-revalidation.md
@@ -1,0 +1,3 @@
+Keep a blocker's `blocked` state through a revalidation
+
+- `router.revalidate()` ran through `completeNavigation`, which reset all blockers to the idle state even though a revalidation does not pass through any blocker. A blocked navigation now keeps its `proceed`/`reset` handlers after a revalidation.

--- a/packages/react-router/__tests__/router/navigation-blocking-test.ts
+++ b/packages/react-router/__tests__/router/navigation-blocking-test.ts
@@ -112,6 +112,21 @@ describe("navigation blocking", () => {
           location: expect.any(Object),
         });
       });
+
+      it("keeps the 'blocked' blocker through a revalidation", async () => {
+        router.getBlocker("KEY", fn);
+        await router.navigate("/about");
+        expect(router.getBlocker("KEY", fn).state).toBe("blocked");
+
+        await router.revalidate();
+
+        expect(router.getBlocker("KEY", fn)).toEqual({
+          state: "blocked",
+          proceed: expect.any(Function),
+          reset: expect.any(Function),
+          location: expect.any(Object),
+        });
+      });
     });
 
     describe("proceeds from blocked state", () => {
@@ -146,6 +161,22 @@ describe("navigation blocking", () => {
         await router.navigate("/about");
         router.getBlocker("KEY", fn).proceed?.();
         await sleep(LOADER_LATENCY_MS);
+        expect(router.state.location.pathname).toBe("/about");
+      });
+
+      it("still completes a proceeding navigation interrupted by a revalidation", async () => {
+        router.getBlocker("KEY", fn);
+        await router.navigate("/about");
+        router.getBlocker("KEY", fn).proceed?.();
+        expect(router.getBlocker("KEY", fn).state).toBe("proceeding");
+        await router.revalidate();
+        await sleep(LOADER_LATENCY_MS);
+        expect(router.getBlocker("KEY", fn)).toEqual({
+          state: "unblocked",
+          proceed: undefined,
+          reset: undefined,
+          location: undefined,
+        });
         expect(router.state.location.pathname).toBe("/about");
       });
     });

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1539,9 +1539,11 @@ export function createRouter(init: RouterInit): Router {
       : state.loaderData;
 
     // On a successful navigation we can assume we got through all blockers
-    // so we can start fresh
+    // so we can start fresh.  Skip this on an uninterrupted revalidation
+    // (router.revalidate()), which lands here without going through any blocker
+    // and should leave a pending blocker's state intact.
     let blockers = state.blockers;
-    if (blockers.size > 0) {
+    if (!isUninterruptedRevalidation && blockers.size > 0) {
       blockers = new Map(blockers);
       blockers.forEach((_, k) => blockers.set(k, IDLE_BLOCKER));
     }


### PR DESCRIPTION
`router.revalidate()` could move a pending blocked navigation back to idle, so the blocker could get lost while the router was just revalidating.
I kept already-blocked blockers from being reset during uninterrupted revalidation.
Added the regression test and reran the router suite plus the blocker DOM tests.
Closes #13439