### PR TITLE
ci: restrict test workflow permissions to read-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "🧪 Test: (Node: ${{ matrix.node }})"

--- a/contributors.yml
+++ b/contributors.yml
@@ -43,6 +43,7 @@
 - Armanio
 - arnassavickas
 - aroyan
+- arpitjain099
 - Artur-
 - ashusnapx
 - avipatel97


### PR DESCRIPTION
This narrows the `GITHUB_TOKEN` for `.github/workflows/test.yml` to read-only.

- These jobs only check out the repo and run build/test steps, so `contents: read` covers them.
- Without an explicit block the token inherits the repo default, often write-enabled.
- Following the principle of least privilege from the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Behavior is unchanged.