### PR TITLE
fix: correct future flag warning docs URL

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -31,6 +31,7 @@
 - amtins
 - AnandShiva
 - Andarist
+- Antoliny0919
 - andreasottosson-polestar
 - andreiborza
 - andreiduca

--- a/packages/react-router-dev/.changes/patch.fixed-future-flag-warning-url-point.md
+++ b/packages/react-router-dev/.changes/patch.fixed-future-flag-warning-url-point.md
@@ -1,0 +1,1 @@
+Fixed future flag warning URL to point to the correct docs path

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -767,7 +767,7 @@ function logFutureFlagWarning(flag: string, message: string): void {
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +
-        `     -> https://reactrouter.com/upgrading/future-flags#${flag}`,
+        `     -> https://reactrouter.com/upgrading/future#future.${flag}`,
     ),
   );
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/remix-run/react-router/issues/15137

The URL in the future flag CLI warnings was pointing to an incorrect docs path.

## Change

updated the anchor format in `logFutureFlagWarning` from `future-flags#${flag}` to `future#future.${flag}`

### Before

Future Flag Warning: Route middleware support is changing in React Router v8.
     You can use the `future.v8_middleware` flag to opt in early.
     -> https://reactrouter.com/upgrading/future-flags#v8_middleware


### After

Future Flag Warning: Route middleware support is changing in React Router v8.
You can use the future.v8_middleware flag to opt in early.
-> https://reactrouter.com/upgrading/future#future.v8_middleware