### PR TITLE
Only log future flag warnings once

### DIFF
--- a/packages/react-router-dev/.changes/patch.log-future-flags-once.md
+++ b/packages/react-router-dev/.changes/patch.log-future-flags-once.md
@@ -1,0 +1,1 @@
+Fix future flag warning URLs and only log each future flag warning one time

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -21,7 +21,6 @@ import {
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
-import { warnOnce } from "./warnings";
 import { detectPackageManager } from "../cli/detectPackageManager";
 
 const excludedConfigPresetKeys = ["presets"] as const satisfies ReadonlyArray<
@@ -767,13 +766,8 @@ async function resolveConfig({
   return ok(reactRouterConfig);
 }
 
-function logFutureFlagWarning(
-  condition: boolean,
-  flag: string,
-  message: string,
-): void {
-  warnOnce(
-    condition,
+function logFutureFlagWarning(flag: string, message: string): void {
+  console.log(
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +
@@ -783,31 +777,36 @@ function logFutureFlagWarning(
 }
 
 export function logFutureFlagWarnings(future: Partial<FutureConfig>): void {
-  logFutureFlagWarning(
-    future.v8_middleware !== undefined,
-    "v8_middleware",
-    "Route middleware support is changing in React Router v8.",
-  );
-  logFutureFlagWarning(
-    future.v8_splitRouteModules !== undefined,
-    "v8_splitRouteModules",
-    "Route module splitting behavior is changing in React Router v8.",
-  );
-  logFutureFlagWarning(
-    future.v8_viteEnvironmentApi !== undefined,
-    "v8_viteEnvironmentApi",
-    "Vite Environment API usage is changing in React Router v8.",
-  );
-  logFutureFlagWarning(
-    future.v8_passThroughRequests !== undefined,
-    "v8_passThroughRequests",
-    "Request handling behavior is changing in React Router v8.",
-  );
-  logFutureFlagWarning(
-    future.v8_trailingSlashAwareDataRequests !== undefined,
-    "v8_trailingSlashAwareDataRequests",
-    "Data request URL formats are changing in React Router v8.",
-  );
+  if (future.v8_middleware === undefined) {
+    logFutureFlagWarning(
+      "v8_middleware",
+      "Route middleware support is changing in React Router v8.",
+    );
+  }
+  if (future.v8_splitRouteModules === undefined) {
+    logFutureFlagWarning(
+      "v8_splitRouteModules",
+      "Route module splitting behavior is changing in React Router v8.",
+    );
+  }
+  if (future.v8_viteEnvironmentApi === undefined) {
+    logFutureFlagWarning(
+      "v8_viteEnvironmentApi",
+      "Vite Environment API usage is changing in React Router v8.",
+    );
+  }
+  if (future.v8_passThroughRequests === undefined) {
+    logFutureFlagWarning(
+      "v8_passThroughRequests",
+      "Request handling behavior is changing in React Router v8.",
+    );
+  }
+  if (future.v8_trailingSlashAwareDataRequests === undefined) {
+    logFutureFlagWarning(
+      "v8_trailingSlashAwareDataRequests",
+      "Data request URL formats are changing in React Router v8.",
+    );
+  }
 }
 
 type ChokidarEventName = ChokidarEmitArgs[0];

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -21,6 +21,7 @@ import {
   validateRouteConfig,
   configRoutesToRouteManifest,
 } from "./routes";
+import { warnOnce } from "./warnings";
 import { detectPackageManager } from "../cli/detectPackageManager";
 
 const excludedConfigPresetKeys = ["presets"] as const satisfies ReadonlyArray<
@@ -435,12 +436,14 @@ async function resolveConfig({
   reactRouterConfigFile,
   skipRoutes,
   validateConfig,
+  shouldLogFutureFlagWarnings,
 }: {
   root: string;
   viteNodeContext: ViteNode.Context;
   reactRouterConfigFile?: string;
   skipRoutes?: boolean;
   validateConfig?: ValidateConfigFunction;
+  shouldLogFutureFlagWarnings?: boolean;
 }): Promise<ConfigResult> {
   let reactRouterUserConfig: ReactRouterConfig = {};
 
@@ -757,52 +760,54 @@ async function resolveConfig({
     await preset.reactRouterConfigResolved?.({ reactRouterConfig });
   }
 
-  logFutureFlagWarnings(userAndPresetConfigs.future || {});
+  if (shouldLogFutureFlagWarnings) {
+    logFutureFlagWarnings(userAndPresetConfigs.future || {});
+  }
 
   return ok(reactRouterConfig);
 }
 
-function logFutureFlagWarning(flag: string, message: string): void {
-  console.log(
+function logFutureFlagWarning(
+  condition: boolean,
+  flag: string,
+  message: string,
+): void {
+  warnOnce(
+    condition,
     colors.yellow(
       `  ⚠️  Future Flag Warning: ${message}\n` +
         `     You can use the \`future.${flag}\` flag to opt in early.\n` +
-        `     -> https://reactrouter.com/upgrading/future#future${flag.toLowerCase()}`,
+        `     -> https://reactrouter.com/7.16.0/upgrading/future#future${flag.toLowerCase()}`,
     ),
   );
 }
 
 export function logFutureFlagWarnings(future: Partial<FutureConfig>): void {
-  if (future.v8_middleware === undefined) {
-    logFutureFlagWarning(
-      "v8_middleware",
-      "Route middleware support is changing in React Router v8.",
-    );
-  }
-  if (future.v8_splitRouteModules === undefined) {
-    logFutureFlagWarning(
-      "v8_splitRouteModules",
-      "Route module splitting behavior is changing in React Router v8.",
-    );
-  }
-  if (future.v8_viteEnvironmentApi === undefined) {
-    logFutureFlagWarning(
-      "v8_viteEnvironmentApi",
-      "Vite Environment API usage is changing in React Router v8.",
-    );
-  }
-  if (future.v8_passThroughRequests === undefined) {
-    logFutureFlagWarning(
-      "v8_passThroughRequests",
-      "Request handling behavior is changing in React Router v8.",
-    );
-  }
-  if (future.v8_trailingSlashAwareDataRequests === undefined) {
-    logFutureFlagWarning(
-      "v8_trailingSlashAwareDataRequests",
-      "Data request URL formats are changing in React Router v8.",
-    );
-  }
+  logFutureFlagWarning(
+    future.v8_middleware !== undefined,
+    "v8_middleware",
+    "Route middleware support is changing in React Router v8.",
+  );
+  logFutureFlagWarning(
+    future.v8_splitRouteModules !== undefined,
+    "v8_splitRouteModules",
+    "Route module splitting behavior is changing in React Router v8.",
+  );
+  logFutureFlagWarning(
+    future.v8_viteEnvironmentApi !== undefined,
+    "v8_viteEnvironmentApi",
+    "Vite Environment API usage is changing in React Router v8.",
+  );
+  logFutureFlagWarning(
+    future.v8_passThroughRequests !== undefined,
+    "v8_passThroughRequests",
+    "Request handling behavior is changing in React Router v8.",
+  );
+  logFutureFlagWarning(
+    future.v8_trailingSlashAwareDataRequests !== undefined,
+    "v8_trailingSlashAwareDataRequests",
+    "Data request URL formats are changing in React Router v8.",
+  );
 }
 
 type ChokidarEventName = ChokidarEmitArgs[0];
@@ -829,12 +834,14 @@ export async function createConfigLoader({
   mode,
   skipRoutes,
   validateConfig,
+  shouldLogFutureFlagWarnings,
 }: {
   watch: boolean;
   rootDirectory?: string;
   mode: string;
   skipRoutes?: boolean;
   validateConfig?: ValidateConfigFunction;
+  shouldLogFutureFlagWarnings?: boolean;
 }): Promise<ConfigLoader> {
   root = Path.normalize(root ?? process.env.REACT_ROUTER_ROOT ?? process.cwd());
 
@@ -865,11 +872,18 @@ export async function createConfigLoader({
       reactRouterConfigFile,
       skipRoutes,
       validateConfig,
+      shouldLogFutureFlagWarnings,
     });
 
   let appDirectory: string;
 
-  let initialConfigResult = await getConfig();
+  let initialConfigResult = await resolveConfig({
+    root,
+    viteNodeContext,
+    reactRouterConfigFile,
+    skipRoutes,
+    validateConfig,
+  });
 
   if (!initialConfigResult.ok) {
     throw new Error(initialConfigResult.error);
@@ -1069,9 +1083,8 @@ export async function resolveEntryFiles({
     }
 
     // TODO(v8): Remove - only required for Node 20.18 and below
-    let { readPackageJSON, sortPackage, updatePackage } = await import(
-      "pkg-types"
-    );
+    let { readPackageJSON, sortPackage, updatePackage } =
+      await import("pkg-types");
     let packageJsonDirectory = Path.dirname(packageJsonPath);
     let pkgJson = await readPackageJSON(packageJsonDirectory);
     let deps = pkgJson.dependencies ?? {};

--- a/packages/react-router-dev/config/warnings.ts
+++ b/packages/react-router-dev/config/warnings.ts
@@ -1,0 +1,8 @@
+const alreadyWarned: { [message: string]: boolean } = {};
+
+export function warnOnce(condition: boolean, message: string): void {
+  if (!condition && !alreadyWarned[message]) {
+    alreadyWarned[message] = true;
+    console.warn(message);
+  }
+}

--- a/packages/react-router-dev/config/warnings.ts
+++ b/packages/react-router-dev/config/warnings.ts
@@ -1,8 +1,0 @@
-const alreadyWarned: { [message: string]: boolean } = {};
-
-export function warnOnce(condition: boolean, message: string): void {
-  if (!condition && !alreadyWarned[message]) {
-    alreadyWarned[message] = true;
-    console.warn(message);
-  }
-}

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1306,6 +1306,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           rootDirectory,
           mode,
           watch: viteCommand === "serve",
+          shouldLogFutureFlagWarnings:
+            viteCommand !== "build" || viteConfigEnv.isSsrBuild === true,
         });
 
         await updatePluginContext();


### PR DESCRIPTION
When we implemented this we grabbed the approach from v6->V7 but it loos like we changed the URL path since then.  The proper version-locked URLs are:

https://reactrouter.com/7.16.0/upgrading/future#futurev8_middleware

