### PR TITLE
docs: fix Headers.append() call to use two arguments

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -121,6 +121,7 @@
 - dokeet
 - doytch
 - Drishtantr
+- DucMinhNe
 - EdgeOneDev
 - edmundhung
 - edwin177

--- a/docs/how-to/headers.md
+++ b/docs/how-to/headers.md
@@ -110,7 +110,8 @@ The easiest way is to simply append to the parent headers. This avoids overwriti
 ```tsx
 export function headers({ parentHeaders }: HeadersArgs) {
   parentHeaders.append(
-    "Permissions-Policy: geolocation=()",
+    "Permissions-Policy",
+    "geolocation=()",
   );
   return parentHeaders;
 }


### PR DESCRIPTION
## Problem

The "Merging with parent headers → Appending" example in `docs/how-to/headers.md` calls `Headers.append()` with a **single** combined string:

```ts
parentHeaders.append(
  "Permissions-Policy: geolocation=()",
);
```

But the Web Fetch [`Headers.append(name, value)`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/append) API takes **two** arguments. Copy-pasting this throws at runtime:

```
TypeError: Headers.append: 2 arguments required, but only 1 found.
```

(reproduced on Node v22). The `.set("Cache-Control", "...")` example just below it in the same section already uses the correct two-argument form.

## Fix

Split into the two-argument call — docs-only, one example:

```ts
parentHeaders.append(
  "Permissions-Policy",
  "geolocation=()",
);
```
