### PR TITLE
Fix encoded backslash crash in static router

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -501,6 +501,7 @@
 - yuleicul
 - yuri-poliantsev
 - zeevick10
+- Zelys-DFKH
 - zeromask1337
 - zeroqs
 - zheng-chuang

--- a/packages/react-router/.changes/patch.fix-encoded-backslash-crash-in-splat-routes.md
+++ b/packages/react-router/.changes/patch.fix-encoded-backslash-crash-in-splat-routes.md
@@ -1,0 +1,5 @@
+Fix TypeError: Invalid URL crash when splat route receives encoded backslash
+
+Sending a request with an encoded backslash (`/%5C`) to a splat route caused a server crash with `TypeError: Invalid URL` inside `encodeLocation`. The server decodes `%5C` to a literal `\`, which `new URL()` rejects as an invalid URL path character.
+
+`encodeLocation` in `server.tsx` now pre-encodes backslashes before constructing the `URL` object, matching the existing pattern for trailing spaces.

--- a/packages/react-router/__tests__/dom/data-static-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-static-router-test.tsx
@@ -558,6 +558,27 @@ describe("A <StaticRouterProvider>", () => {
     );
   });
 
+  it("does not crash on encoded backslash in splat route path", async () => {
+    let routes = [{ path: "/*", element: <h1>splat</h1> }];
+    let { query } = createStaticHandler(routes);
+
+    let context = (await query(
+      new Request("http://localhost/%5C", {
+        signal: new AbortController().signal,
+      }),
+    )) as StaticHandlerContext;
+
+    let html = ReactDOMServer.renderToStaticMarkup(
+      <React.StrictMode>
+        <StaticRouterProvider
+          router={createStaticRouter(routes, context)}
+          context={context}
+        />
+      </React.StrictMode>,
+    );
+    expect(html).toContain("<h1>splat</h1>");
+  });
+
   it("does not encode user-specified <a href> values", async () => {
     let routes = [
       { path: "/", element: <Link to="/path/with space">👋</Link> },

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -514,6 +514,9 @@ function encodeLocation(to: To): Path {
   // pre-encode them since they might be part of a matching splat param from
   // an ancestor route
   href = href.replace(/ $/, "%20");
+  // Pre-encode backslashes; new URL() rejects paths containing literal `\`
+  // with ERR_INVALID_URL (e.g. from a /%5C request decoded by the server)
+  href = href.replace(/\\/g, "%5C");
   let encoded = ABSOLUTE_URL_REGEX.test(href)
     ? new URL(href)
     : new URL(href, "http://localhost");


### PR DESCRIPTION
Adds `.replace(/\\/g, "%5C")` in `encodeLocation` in `server.tsx`, right after the existing trailing-space pre-encode, to prevent `new URL()` from receiving a bare backslash.

Without this, a request with an encoded backslash (`/%5C`) to any splat route crashes the server. The server decodes `%5C` to `\` before route matching, so `useRoutesImpl` passes a pathname with a literal backslash to `navigator.encodeLocation`, which calls `new URL('/\\', 'http://localhost')`. Node rejects that with `ERR_INVALID_URL`.

Fixes #15140