### PR TITLE
fix: preserve non-Error deferred rejection reasons in streaming loaders

### DIFF
--- a/packages/react-router/.changes/patch.turbo-stream-non-error-deferred-rejection.md
+++ b/packages/react-router/.changes/patch.turbo-stream-non-error-deferred-rejection.md
@@ -1,0 +1,1 @@
+Fix deferred loader promises that reject with a non-Error value being replaced by a generic "An unknown error occurred" error. Plain objects, strings, and other non-Error rejection reasons thrown from a streaming loader now reach the ErrorBoundary intact on client navigation, matching the behavior of a full-page load.

--- a/packages/react-router/__tests__/server-runtime/data-test.ts
+++ b/packages/react-router/__tests__/server-runtime/data-test.ts
@@ -115,3 +115,46 @@ describe("turbo-stream error decoding", () => {
     expect(error.internal).toBe(false);
   });
 });
+
+describe("encodeViaTurboStream / decodeViaTurboStream roundtrip", () => {
+  it("preserves a non-Error object thrown from a deferred loader promise", async () => {
+    const rejection = { code: "NOT_FOUND", id: 42 };
+    const controller = new AbortController();
+
+    // Attach a no-op catch so Node does not raise an unhandled rejection before
+    // the encoder consumes the promise.
+    const deferred = Promise.reject(rejection);
+    deferred.catch(() => {});
+
+    const stream = encodeViaTurboStream(
+      { deferred },
+      controller.signal,
+      undefined,
+      ServerMode.Development,
+    );
+
+    const decoded = await decodeViaTurboStream(stream, global);
+    const value = decoded.value as { deferred: Promise<unknown> };
+    await expect(value.deferred).rejects.toEqual(rejection);
+    await decoded.done;
+  });
+
+  it("preserves a string thrown from a deferred loader promise", async () => {
+    const controller = new AbortController();
+
+    const deferred = Promise.reject("custom string error");
+    deferred.catch(() => {});
+
+    const stream = encodeViaTurboStream(
+      { deferred },
+      controller.signal,
+      undefined,
+      ServerMode.Development,
+    );
+
+    const decoded = await decodeViaTurboStream(stream, global);
+    const value = decoded.value as { deferred: Promise<unknown> };
+    await expect(value.deferred).rejects.toBe("custom string error");
+    await decoded.done;
+  });
+});

--- a/packages/react-router/__tests__/vendor/turbo-stream-test.ts
+++ b/packages/react-router/__tests__/vendor/turbo-stream-test.ts
@@ -321,6 +321,46 @@ test("should encode and decode object with rejected promise", async () => {
   return decoded.done;
 });
 
+test("should encode and decode rejected promise with plain object reason", async () => {
+  const reason = { code: "NOT_FOUND", id: 42 };
+  const input = Promise.reject(reason);
+  input.catch(() => {});
+  const decoded = await decode(encode(input));
+  expect(decoded.value).toBeInstanceOf(Promise);
+  await expect(decoded.value).rejects.toEqual(reason);
+  await decoded.done;
+});
+
+test("should encode and decode rejected promise with string reason", async () => {
+  const input = Promise.reject("something went wrong");
+  input.catch(() => {});
+  const decoded = await decode(encode(input));
+  expect(decoded.value).toBeInstanceOf(Promise);
+  await expect(decoded.value).rejects.toBe("something went wrong");
+  await decoded.done;
+});
+
+test("should encode and decode rejected promise with null reason", async () => {
+  const input = Promise.reject(null);
+  input.catch(() => {});
+  const decoded = await decode(encode(input));
+  expect(decoded.value).toBeInstanceOf(Promise);
+  await expect(decoded.value).rejects.toBeNull();
+  await decoded.done;
+});
+
+test("should encode and decode object with rejected promise with plain object reason", async () => {
+  const reason = { code: "NOT_FOUND" };
+  const prom = Promise.reject(reason);
+  prom.catch(() => {});
+  const input = { item: prom };
+  const decoded = await decode(encode(input));
+  const value = decoded.value as typeof input;
+  expect(value.item).toBeInstanceOf(Promise);
+  await expect(value.item).rejects.toEqual(reason);
+  return decoded.done;
+});
+
 test("should encode and decode set with promises as values", async () => {
   const prom = Promise.resolve("foo");
   const input = new Set([prom, prom]);

--- a/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
+++ b/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
@@ -244,14 +244,6 @@ export function encode(
                   },
                   (reason) => {
                     processingChain = processingChain.then(async () => {
-                      if (
-                        !reason ||
-                        typeof reason !== "object" ||
-                        !(reason instanceof Error)
-                      ) {
-                        reason = new Error("An unknown error occurred");
-                      }
-
                       const id = await flatten.call(encoder, reason);
                       if (Array.isArray(id)) {
                         controller.enqueue(


### PR DESCRIPTION
Fixes #12676

When a streaming loader returns a deferred promise that rejects with a non-Error value (a plain object, string, or any other non-Error), the ErrorBoundary on client navigation always received a generic "An unknown error occurred" instead of the original value. Full-page loads worked correctly.

The root cause is in `vendor/turbo-stream-v2/turbo-stream.ts`. The rejection handler for deferred promises checked `reason instanceof Error` and replaced anything else with `new Error("An unknown error occurred")` before calling `flatten`. That happened before the encoder's plugin chain ran, so the server-side plugins that serialize plain objects as `SingleFetchClassInstance` never saw the original reason.

The fix removes that guard. The `flatten` function already handles every type that can appear as a rejection reason: `null`, `undefined`, primitives, and objects (via plugins and postPlugins). Error instances continue to go through the `SanitizedError` plugin path unchanged.

Changes:
- `vendor/turbo-stream-v2/turbo-stream.ts`: remove the `instanceof Error` guard in the deferred rejection handler
- `__tests__/vendor/turbo-stream-test.ts`: add tests for rejected promises with plain object, string, and null reasons
- `__tests__/server-runtime/data-test.ts`: add end-to-end roundtrip tests through `encodeViaTurboStream` / `decodeViaTurboStream`
- `.changes/patch.turbo-stream-non-error-deferred-rejection.md`: change file