### PR TITLE
fix: preserve child compiler watch options

### DIFF
--- a/packages/react-router-dev/.changes/patch.preserve-child-compiler-watch.md
+++ b/packages/react-router-dev/.changes/patch.preserve-child-compiler-watch.md
@@ -1,0 +1,1 @@
+Preserve Vite `server.watch` options when creating the React Router child compiler in dev.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1551,7 +1551,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           cacheDir: "node_modules/.vite-child-compiler",
           mode: viteConfig.mode,
           server: {
-            watch: viteConfig.command === "build" ? null : undefined,
+            watch:
+              viteConfig.command === "build" ? null : viteConfig.server.watch,
             preTransformRequests: false,
             hmr: false,
           },


### PR DESCRIPTION
<!--
  Thanks for contributing! Please include a summary and the tests you ran.
-->

Fixes #15144.

## Summary

- Preserve the resolved Vite `server.watch` options when React Router creates its internal child compiler in dev.
- Keeps the existing build-mode `watch: null`, `preTransformRequests: false`, and `hmr: false` child compiler overrides intact.
- Adds a patch change file for `@react-router/dev`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter react-router build`
- `pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts packages/react-router-dev/.changes/patch.preserve-child-compiler-watch.md`
- `pnpm --filter @react-router/dev typecheck`
- `git diff --check`
