### PR TITLE
test: fix flaky HydrateFallback/dataStrategy test on Node 20

### DIFF
--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -541,14 +541,16 @@ function testDomRouter(
 
         // Resolve data strategy with only an error at the index route but nothing
         // for the root route
-        await dfd.resolve({
-          index: {
-            type: "error",
-            result: "INDEX ERROR",
-          },
+        // Wrap resolve in act() so React flushes all pending state updates
+        // triggered by the dataStrategy result before we assert.
+        await act(async () => {
+          await dfd.resolve({
+            index: {
+              type: "error",
+              result: "INDEX ERROR",
+            },
+          });
         });
-        await tick();
-        await tick();
 
         // The router stubs in an error for the root route to get out of
         // displaying the HydrateFallback


### PR DESCRIPTION
The test `clears the HydrateFallback when dataStrategy returns partial results during hydration` was failing on Node 20.19 but passing on Node 22. The test resolved a deferred promise and then called `await tick()` twice before asserting the DOM.

`tick()` is `setTimeout(r, 0)` — two macrotask yields. On Node 22, that happened to be enough time for the router to process the `dataStrategy` result and React to flush the state update. On Node 20.19, it wasn't.

The root cause is `IS_REACT_ACT_ENVIRONMENT = true` in the test setup. When a promise resolve triggers React state updates outside `act()`, the flush timing is non-deterministic across Node versions. Wrapping the resolve in `act(async () => { ... })` guarantees React flushes all pending updates before the assertion.

The other `tick()` patterns in this file are safe — they're always followed by `waitFor()`, which retries independently of timing. This was the only site where two bare ticks were the sole settlement mechanism before a direct `expect()`.