### PR TITLE
fix: correct exact-match detection for .server/.client dir boundaries

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -507,3 +507,4 @@
 - zeroqs
 - zheng-chuang
 - zxTomw
+- ErnestHysa

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -38,6 +38,23 @@ let tsconfig = (aliases: Record<string, string[]>) => `
   }
 `;
 
+test("Vite / exact-name .server directory is detected (regression for #14997)", async () => {
+  let cwd = await createProject({
+    "app/.server/utils.ts": serverOnlyModule,
+    "app/routes/_index.tsx": `
+      import { serverOnly as unused } from "../.server/utils";
+      export default () => <h1>no server-only usage in route exports</h1>;
+    `,
+  });
+  let { status } = build({ cwd });
+  expect(status).toBe(0);
+  let lines = grep(
+    path.join(cwd, "build/client"),
+    /SERVER_ONLY/,
+  );
+  expect(lines).toHaveLength(0);
+});
+
 test("Vite / dead-code elimination for server exports", async () => {
   let cwd = await createProject({
     "app/utils.server.ts": serverOnlyModule,

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2304,7 +2304,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         if (!resolved) return;
 
         let serverFileRE = /\.server(\.[cm]?[jt]sx?)?$/;
-        let serverDirRE = /\/\.server\//;
+        let serverDirRE = /\/(\.server)(\/|$)/;
         let isDotServer =
           serverFileRE.test(resolved!.id) || serverDirRE.test(resolved!.id);
         if (!isDotServer) return;
@@ -2359,7 +2359,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       async transform(code, id, options) {
         if (!options?.ssr) return;
         let clientFileRE = /\.client(\.[cm]?[jt]sx?)?$/;
-        let clientDirRE = /\/\.client\//;
+        let clientDirRE = /\/(\.client)(\/|$)/;
         if (clientFileRE.test(id) || clientDirRE.test(id)) {
           let exports = getExportNames(code);
           return {


### PR DESCRIPTION
Replaces https://github.com/remix-run/react-router/pull/15130

Closes: #14997