### PR TITLE
Add form submission regression test for %23-encoded dynamic route params

### DIFF
--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -3574,6 +3574,48 @@ function testDomRouter(
             "/foo/bar",
           );
         });
+
+        it("preserves encoded hash (%23) in form action and submission for param routes", async () => {
+          let actionPathname: string | null = null;
+          let router = createTestRouter(
+            [
+              {
+                path: "/",
+                children: [
+                  {
+                    path: ":slug",
+                    action: ({ request }) => {
+                      actionPathname = new URL(request.url).pathname;
+                      return "slug action";
+                    },
+                    Component: () => {
+                      let actionData = useActionData();
+                      return (
+                        <>
+                          <Form method="post">
+                            <button type="submit">Submit</button>
+                          </Form>
+                          {actionData && <p>{String(actionData)}</p>}
+                        </>
+                      );
+                    },
+                  },
+                ],
+              },
+            ],
+            { window: getWindow("/%23routeWithHashTag") },
+          );
+          let { container } = render(<RouterProvider router={router} />);
+
+          expect(container.querySelector("form")?.getAttribute("action")).toBe(
+            "/%23routeWithHashTag",
+          );
+
+          fireEvent.click(screen.getByText("Submit"));
+          await waitFor(() => screen.getByText("slug action"));
+
+          expect(actionPathname).toBe("/%23routeWithHashTag");
+        });
       });
 
       describe("splat routes", () => {


### PR DESCRIPTION
Adds a regression test for the form submission case from #12425 — the code path that had no coverage.

**The bug.** When a route contains a percent-encoded `#` (`%23`), `matchRoutes` decodes the pathname before matching, leaving a literal `#`. Before #14249 fixed this, that decoded pathname went straight to `encodeLocation`, so `new URL("/#slug")` split at the fragment delimiter and returned `.pathname = "/"`. Form actions on those routes resolved to `/` and submitted to the wrong handler.

The fix landed in #14249 (thanks @brophdawg11). Existing coverage tested the `<Link>` navigation case; this fills the gap for form submission, checking both the rendered `action` attribute and the URL the route's action handler actually receives.

Fixes #12425