### PR TITLE
Fix circular TypeScript type error when arrow function route components access `matches`

### DIFF
--- a/integration/typegen-test.ts
+++ b/integration/typegen-test.ts
@@ -869,6 +869,62 @@ test.describe("typegen", () => {
     });
   });
 
+  test("arrow function component and meta can access matches without circular type error (#12499)", async ({ edit, $ }) => {
+    await edit({
+      "app/routes.ts": tsx`
+        import { type RouteConfig, route } from "@react-router/dev/routes";
+
+        export default [
+          route("parent/:parentId", "routes/parent.tsx", [
+            route("child", "routes/child.tsx")
+          ])
+        ] satisfies RouteConfig;
+      `,
+      "app/routes/parent.tsx": tsx`
+        import { Outlet } from "react-router"
+
+        export function loader() {
+          return { parentValue: "hello" }
+        }
+
+        export default function ParentComponent() {
+          return <Outlet />
+        }
+      `,
+      "app/routes/child.tsx": tsx`
+        import type { Expect, Equal } from "../expect-type"
+        import type { Route } from "./+types/child"
+
+        export function loader() {
+          return { childValue: 42 }
+        }
+
+        // Arrow function meta — accessing matches must not cause a circular TS error (#12499)
+        export const meta = ({ matches }: Route.MetaArgs) => {
+          const parent = matches[1]
+          type TestParentLoaderData = Expect<Equal<typeof parent.loaderData, { parentValue: string }>>
+
+          const self = matches[2]
+          type TestSelfLoaderData = Expect<Equal<typeof self.loaderData, { childValue: number }>>
+          return []
+        }
+
+        // Arrow function Component — accessing matches must not cause a circular TS error (#12499)
+        const Component = ({ matches }: Route.ComponentProps) => {
+          const parent = matches[1]
+          type TestParentLoaderData = Expect<Equal<typeof parent.loaderData, { parentValue: string }>>
+
+          const self = matches[2]
+          type TestSelfLoaderData = Expect<Equal<typeof self.loaderData, { childValue: number }>>
+          return null
+        }
+
+        export default Component
+      `,
+    });
+    await $("pnpm typecheck");
+  });
+
   test("layout without pages", async ({ edit, $ }) => {
     await edit({
       "app/routes.ts": tsx`

--- a/packages/react-router-dev/.changes/patch.fix-arrow-function-matches-circular-type.md
+++ b/packages/react-router-dev/.changes/patch.fix-arrow-function-matches-circular-type.md
@@ -1,0 +1,3 @@
+Fix circular type error when arrow function route components access `matches`
+
+Typegen now emits `{ id, loaderData: Info["loaderData"] }` for the current route's entry in the `Matches` tuple instead of `{ id, module: typeof import("./self") }`. This avoids the `RouteModule` assignability check that caused a circular TypeScript type reference when the route's default export was an arrow function component.

--- a/packages/react-router-dev/typegen/generate.ts
+++ b/packages/react-router-dev/typegen/generate.ts
@@ -253,8 +253,33 @@ function getRouteAnnotations({
       Array.from(routeIds).map((routeId) => {
         const lineage = lineages.get(routeId)!;
         return t.tsTupleType(
-          lineage.map((route) =>
-            t.tsTypeLiteral([
+          lineage.map((route) => {
+            const isSelf = route.file === file;
+            if (isSelf) {
+              // Use Info["loaderData"] rather than `module: typeof import("./self")` to
+              // avoid a circular type reference when the default export is an arrow
+              // function.  The `RouteModule` assignability check evaluates `["default"]`,
+              // which for arrow functions requires resolving `Route.ComponentProps` —
+              // creating a cycle.  Pre-computed loaderData breaks the chain (#12499).
+              return t.tsTypeLiteral([
+                t.tsPropertySignature(
+                  t.identifier("id"),
+                  t.tsTypeAnnotation(
+                    t.tsLiteralType(t.stringLiteral(route.id)),
+                  ),
+                ),
+                t.tsPropertySignature(
+                  t.identifier("loaderData"),
+                  t.tsTypeAnnotation(
+                    t.tsIndexedAccessType(
+                      t.tsTypeReference(t.identifier("Info")),
+                      t.tsLiteralType(t.stringLiteral("loaderData")),
+                    ),
+                  ),
+                ),
+              ]);
+            }
+            return t.tsTypeLiteral([
               t.tsPropertySignature(
                 t.identifier("id"),
                 t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral(route.id))),
@@ -274,8 +299,8 @@ function getRouteAnnotations({
                   ),
                 ),
               ),
-            ]),
-          ),
+            ]);
+          }),
         );
       }),
     ),

--- a/packages/react-router/.changes/patch.fix-arrow-function-matches-circular-type.md
+++ b/packages/react-router/.changes/patch.fix-arrow-function-matches-circular-type.md
@@ -1,0 +1,7 @@
+Fix circular type error when arrow function route components access `matches`
+
+Accessing `matches` from `Route.ComponentProps` in an arrow function component caused a TypeScript circular type reference error while the equivalent function declaration worked fine.
+
+The issue was that the generated `Matches` tuple included `module: typeof import("./self")` for the current route's entry. TypeScript's `RouteModule` assignability check evaluates `["default"]` — which for arrow functions requires resolving the parameter type annotation, ultimately looping back to `Route.ComponentProps`. Function declarations avoid this because their type is known from the declaration without evaluating parameter types.
+
+The fix changes the type infrastructure to use a `MatchInfoWithLoaderData` alternative for the self-match entry, which carries `loaderData` directly and sidesteps the `RouteModule` check entirely.

--- a/packages/react-router/lib/types/route-module-annotations.ts
+++ b/packages/react-router/lib/types/route-module-annotations.ts
@@ -23,33 +23,55 @@ type Props = {
   actionData: unknown;
 };
 
-type RouteInfo = Props & {
-  module: RouteModule;
-  matches: Array<MatchInfo>;
-};
-
 type MatchInfo = {
   id: string;
   module: RouteModule;
 };
 
-type MetaMatch<T extends MatchInfo> = Pretty<{
+// Used for the current route's entry in the matches tuple instead of
+// `{ module: RouteModule }` to avoid a circular type reference when the
+// default export is an arrow function. The `RouteModule` assignability check
+// evaluates `["default"]`, which for arrow functions requires resolving
+// `Route.ComponentProps` — creating a cycle. Pre-computed `loaderData`
+// breaks the chain (see react-router#12499).
+type MatchInfoWithLoaderData = {
+  id: string;
+  module?: never; // ensures MatchData<T> discriminant is disjoint from MatchInfo
+  loaderData: unknown;
+};
+
+type AnyMatchInfo = MatchInfo | MatchInfoWithLoaderData;
+
+type RouteInfo = Props & {
+  module: RouteModule;
+  matches: Array<AnyMatchInfo>;
+};
+
+// prettier-ignore
+type MatchData<T extends AnyMatchInfo> =
+  T extends MatchInfo
+    ? GetLoaderData<T["module"]>
+    : T extends MatchInfoWithLoaderData
+      ? T["loaderData"]
+      : never;
+
+type MetaMatch<T extends AnyMatchInfo> = Pretty<{
   id: T["id"];
   params: Record<string, string | undefined>;
   pathname: string;
   meta: MetaDescriptor[];
   /** @deprecated Use `MetaMatch.loaderData` instead */
-  data: GetLoaderData<T["module"]>;
-  loaderData: GetLoaderData<T["module"]>;
+  data: MatchData<T>;
+  loaderData: MatchData<T>;
   handle?: unknown;
   error?: unknown;
 }>;
 
 // prettier-ignore
-type MetaMatches<T extends Array<MatchInfo>> =
-  T extends [infer F extends MatchInfo, ...infer R extends Array<MatchInfo>]
+type MetaMatches<T extends Array<AnyMatchInfo>> =
+  T extends [infer F extends AnyMatchInfo, ...infer R extends Array<AnyMatchInfo>]
     ? [MetaMatch<F>, ...MetaMatches<R>]
-    : Array<MetaMatch<MatchInfo> | undefined>;
+    : Array<MetaMatch<AnyMatchInfo> | undefined>;
 
 type HasErrorBoundary<T extends RouteInfo> = T["module"] extends {
   ErrorBoundary: Func;
@@ -139,21 +161,21 @@ type CreateHydrateFallbackProps<
       actionData?: T["actionData"];
     });
 
-type Match<T extends MatchInfo> = Pretty<{
+type Match<T extends AnyMatchInfo> = Pretty<{
   id: T["id"];
   params: Record<string, string | undefined>;
   pathname: string;
   /** @deprecated Use `Match.loaderData` instead */
-  data: GetLoaderData<T["module"]>;
-  loaderData: GetLoaderData<T["module"]>;
+  data: MatchData<T>;
+  loaderData: MatchData<T>;
   handle: unknown;
 }>;
 
 // prettier-ignore
-type Matches<T extends Array<MatchInfo>> =
-  T extends [infer F extends MatchInfo, ...infer R extends Array<MatchInfo>]
+type Matches<T extends Array<AnyMatchInfo>> =
+  T extends [infer F extends AnyMatchInfo, ...infer R extends Array<AnyMatchInfo>]
     ? [Match<F>, ...Matches<R>]
-    : Array<Match<MatchInfo> | undefined>;
+    : Array<Match<AnyMatchInfo> | undefined>;
 
 type CreateComponentProps<T extends RouteInfo, RSCEnabled extends boolean> = {
   /**


### PR DESCRIPTION
Fixes #12499 — TypeScript error when accessing `matches` in an arrow function route component.

## What

Arrow function route components that destructure `matches` from `Route.ComponentProps` get a TypeScript circular type error. The same annotation on a function declaration works fine.

## Why it fails

The generated `+types/*.ts` builds a `Matches` tuple where the current route's entry is `{ id, module: typeof import("./self") }`. When TypeScript resolves `ComponentProps["matches"]`, it verifies the `module` field is assignable to `RouteModule`. That check evaluates `["default"]` — the route component itself. For arrow functions, TypeScript needs to evaluate the parameter type annotation to determine the function's type, which requires resolving `Route.ComponentProps`, forming a cycle.

Function declarations skip it because TypeScript reads their signature from the declaration without evaluating parameter types.

## Fix

For the current route's entry in the `Matches` tuple, typegen now emits `{ id, loaderData: Info["loaderData"] }` instead of `{ id, module: typeof import("./self") }`. `Info["loaderData"]` is computed via `GetLoaderData`, which only accesses `["loader"]` and `["clientLoader"]`, not `["default"]`, so the cycle never forms.

This required adding `MatchInfoWithLoaderData` (with `module?: never` to keep the `MatchData<T>` discriminant disjoint from `MatchInfo`) and corresponding updates to `Match<T>`, `Matches<T>`, `MetaMatch<T>`, and `MetaMatches<T>` to accept `AnyMatchInfo = MatchInfo | MatchInfoWithLoaderData`. The loaderData type is identical to what the module path produced before; only the resolution path changes.

Closes #12499