### PR TITLE
Allow .server imports from Vitest setup files

### DIFF
--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { expect } from "@playwright/test";
+import { sync as spawnSync } from "cross-spawn";
 import stripAnsi from "strip-ansi";
 import dedent from "dedent";
 
@@ -37,6 +38,22 @@ let tsconfig = (aliases: Record<string, string[]>) => `
     }
   }
 `;
+
+let vitest = ({ cwd }: { cwd: string }) => {
+  let nodeBin = process.argv[0];
+  return spawnSync(
+    nodeBin,
+    [path.join(process.cwd(), "node_modules/vitest/vitest.mjs"), "run"],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        FORCE_COLOR: undefined,
+        NO_COLOR: "1",
+      },
+    },
+  );
+};
 
 test("Vite / dead-code elimination for server exports", async () => {
   let cwd = await createProject({
@@ -210,6 +227,101 @@ test.describe("Vite / non-route / server-only module referenced by client", () =
       ].forEach(expect(stderr).toMatch);
     });
   }
+});
+
+test("Vite / Vitest setup files can import server-only modules", async () => {
+  let cwd = await createProject({
+    "tsconfig.json": tsconfig({
+      "#app/*": ["app/*"],
+    }),
+    "vite.config.ts": dedent`
+      import { reactRouter } from "@react-router/dev/vite";
+      import { defineConfig } from "vite";
+      import tsconfigPaths from "vite-tsconfig-paths";
+
+      export default defineConfig({
+        plugins: [reactRouter(), tsconfigPaths()],
+        test: {
+          environment: "jsdom",
+          setupFiles: ["./tests/setup/setup-test-env.ts"],
+        },
+      });
+    `,
+    "app/utils/env.server.ts": serverOnlyModule,
+    "tests/setup/setup-test-env.ts": `
+      import { serverOnly } from "#app/utils/env.server.ts";
+
+      (globalThis as any).__serverOnlyFromSetup = serverOnly;
+    `,
+    "tests/example.test.ts": `
+      import { expect, test } from "vitest";
+
+      test("runs", () => {
+        expect(document.body).toBeDefined();
+        expect((globalThis as any).__serverOnlyFromSetup).toBe("SERVER_ONLY");
+      });
+    `,
+  });
+
+  let result = vitest({ cwd });
+  let stderr = stripAnsi(result.stderr.toString("utf8"));
+
+  expect(stderr).not.toContain("Server-only module referenced by client");
+  expect(result.status).toBe(0);
+});
+
+test("Vite / Vitest keeps server-only guard for client-reachable imports", async () => {
+  let cwd = await createProject({
+    "tsconfig.json": tsconfig({
+      "#app/*": ["app/*"],
+    }),
+    "vite.config.ts": dedent`
+      import { reactRouter } from "@react-router/dev/vite";
+      import { defineConfig } from "vite";
+      import tsconfigPaths from "vite-tsconfig-paths";
+
+      export default defineConfig({
+        plugins: [reactRouter(), tsconfigPaths()],
+        test: {
+          environment: "jsdom",
+          setupFiles: ["./tests/setup/setup-test-env.ts"],
+        },
+      });
+    `,
+    "app/utils/env.server.ts": serverOnlyModule,
+    "shared/helper.ts": `
+      import { serverOnly } from "../app/utils/env.server.ts";
+
+      export const helper = serverOnly;
+    `,
+    "tests/setup/setup-test-env.ts": `
+      import { serverOnly } from "#app/utils/env.server.ts";
+
+      (globalThis as any).__serverOnlyFromSetup = serverOnly;
+    `,
+    "app/routes/_index.tsx": `
+      import { helper } from "../../shared/helper";
+
+      export default function Index() {
+        return <div>{helper}</div>;
+      }
+    `,
+    "tests/example.test.ts": `
+      import { expect, test } from "vitest";
+      import Index from "#app/routes/_index";
+
+      test("imports route", () => {
+        expect(Index).toBeDefined();
+      });
+    `,
+  });
+
+  let result = vitest({ cwd });
+  let stderr = stripAnsi(result.stderr.toString("utf8"));
+
+  expect(stderr).toContain("Server-only module referenced by client");
+  expect(stderr).toContain("'../app/utils/env.server.ts' imported by");
+  expect(result.status).not.toBe(0);
 });
 
 test.describe("Vite / server-only escape hatch", async () => {

--- a/packages/react-router-dev/.changes/patch.allow-server-modules-in-vitest-setup.md
+++ b/packages/react-router-dev/.changes/patch.allow-server-modules-in-vitest-setup.md
@@ -1,0 +1,1 @@
+Allow configured Vitest setup files to import `.server` modules in test mode while keeping the `.server` guard active for client-reachable app imports.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -692,6 +692,12 @@ export let setReactRouterDevLoadContext = (
 };
 
 type ReactRouterVitePlugin = () => Vite.Plugin[];
+type VitestResolvedConfig = Vite.ResolvedConfig & {
+  test?: {
+    setupFiles?: string | string[];
+  };
+};
+
 /**
  * React Router [Vite plugin.](https://vitejs.dev/guide/using-plugins.html)
  */
@@ -2321,6 +2327,24 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         let importerShort = vite.normalizePath(
           path.relative(ctx.rootDirectory, importer),
         );
+        if (viteCommand === "serve" && viteConfigEnv.mode === "test") {
+          invariant(viteConfig);
+          let setupFiles = (viteConfig as VitestResolvedConfig).test
+            ?.setupFiles;
+          let setupFilePaths = (
+            Array.isArray(setupFiles)
+              ? setupFiles
+              : setupFiles
+                ? [setupFiles]
+                : []
+          ).map((setupFile) =>
+            vite.normalizePath(path.resolve(ctx.rootDirectory, setupFile)),
+          );
+          if (setupFilePaths.includes(vite.normalizePath(importer))) {
+            return;
+          }
+        }
+
         if (isRoute(ctx.reactRouterConfig, importer)) {
           let serverOnlyExports = SERVER_ONLY_ROUTE_EXPORTS.map(
             (xport) => `\`${xport}\``,


### PR DESCRIPTION
Problem I saw:
The `.server` import guard could reject a configured Vitest setup file outside `app/` when that setup file imported an app server module.
That setup file runs in Vite test mode, but the plugin still treated the import as client-reachable and raised `Server-only module referenced by client`.
What I changed:
I limited the exception to configured Vitest setup files while the dev plugin is running in serve/test mode.
This does not allow arbitrary test files to import `.server` modules. The guard still applies to route and client-reachable app imports, including imports that pass through helpers outside `app/`, and build-time `.server` checks stay active.
How I checked it:
I confirmed the focused setup-file test failed before the plugin change with `Server-only module referenced by client`.
Then I reran the final checks under Node 22.22.3:
@react-router/dev build
@react-router/dev typecheck
focused integration file, 23 tests
changed-file ESLint
Prettier check
changes validation
git diff --check
The integration coverage includes the setup-file allow case and a negative route-through-outside-helper case.
Closes #13216
