### PR TITLE
docs(deploying): add DeployHQ as a Git-based deployment option for Node templates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -135,6 +135,7 @@
 - ericschn
 - ErlendS
 - esadek
+- facundofarias
 - faergeek
 - fernandojbf
 - FilipJirsak

--- a/docs/start/framework/deploying.md
+++ b/docs/start/framework/deploying.md
@@ -94,3 +94,8 @@ Netlify maintains their own template for React Router. Checkout the [Netlify Gui
 ### EdgeOne Pages
 
 EdgeOne Pages maintains their own template for React Router. Checkout the [EdgeOne Pages Guide](https://pages.edgeone.ai/document/framework-react-router) for more information.
+
+### DeployHQ
+
+DeployHQ maintains their own guide for deploying React Router v7 to your own server. Checkout the [DeployHQ Guide](https://www.deployhq.com/guides/deploy-react-router-from-github) for more information.
+


### PR DESCRIPTION
Adds a one-line entry for DeployHQ under the "Templates" section of the deployment page, matching the existing format used for Vercel, Cloudflare Workers, Netlify, and EdgeOne Pages — a single H3 with a short description that links to an externally-maintained guide on the provider's own site.

The linked guide at https://www.deployhq.com/guides/deploy-react-router-from-github covers the BYO-server path for React Router v7's Node templates (default, `node-custom-server`, `node-postgres`): build runs in DeployHQ's managed environment, the compiled `build/` directory plus `package.json` ships to a Linux VPS over SSH, `npm ci --omit dev` installs production dependencies in place, and the Node process reloads under PM2 or systemd. This complements the existing managed-host rows above it and the Docker template options elsewhere in the page — it doesn't replace either.

### Scope

- One file changed: `docs/start/framework/deploying.md`
- One new H3 under "Templates", appended after `### EdgeOne Pages`
- Two short sentences matching the Netlify / EdgeOne shape exactly
- No images, no logos

### Notes

Drafted with AI assistance and reviewed by the contributor before opening.
