### PR TITLE
Use ServerRouter nonce when nonce prop is not specified

### DIFF
--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -13,15 +13,17 @@ This is by no means a comprehensive guide, but React Router provides features to
 
 ## `Content-Security-Policy`
 
-If you are implementing a [Content-Security-Policy (CSP)][csp] in your application, specifically one using the `unsafe-inline` directive, you will need to specify a [`nonce`][nonce] attribute on the inline `<script>` elements rendered in your HTML. This must be specified on any API that generates inline scripts, including:
+If you are implementing a [Content-Security-Policy (CSP)][csp] in your application, specifically one using the `unsafe-inline` directive, you will need to specify a [`nonce`][nonce] attribute on the inline `<script>` elements rendered in your HTML.
 
-- [`<Scripts nonce>`][scripts] (`root.tsx`)
-- [`<ScrollRestoration nonce>`][scrollrestoration] (`root.tsx`)
-- [`<ServerRouter nonce>`][serverrouter] (`entry.server.tsx`)
-- [`renderToPipeableStream(..., { nonce })`][renderToPipeableStream] (`entry.server.tsx`)
-- [`renderToReadableStream(..., { nonce })`][renderToReadableStream] (`entry.server.tsx`)
+Add a nonce to these two spots in [`entry.server.tsx`][entryserver]:
+
+- The [`<ServerRouter nonce>`][serverrouter] prop
+  - This will be proxied along through React Context and used for other Framework Mode components that output `nonce`-aware elements, including [`<Scripts>`][scripts], [`<ScrollRestoration>`][scrollrestoration]
+  - If those components specify their own `nonce` prop, it will override the `ServerRouter` value
+- The `nonce` options of [`renderToPipeableStream`][renderToPipeableStream]/[`renderToReadableStream`][renderToReadableStream]
 
 [csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
+[entryserver]: ../api/framework-conventions/entry.server.tsx
 [nonce]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
 [renderToPipeableStream]: https://react.dev/reference/react-dom/server/renderToPipeableStream
 [renderToReadableStream]: https://react.dev/reference/react-dom/server/renderToReadableStream

--- a/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
+++ b/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
@@ -1,1 +1,1 @@
-Use the `ServerRouter` nonce for default SSR fallback scripts so strict CSP pages can load them.
+Use the `ServerRouter` nonce for nonce-aware SSR components when they don't provide their own value so strict CSP pages can load them.

--- a/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
+++ b/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
@@ -1,0 +1,1 @@
+Use the `ServerRouter` nonce for default SSR fallback scripts so strict CSP pages can load them.

--- a/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
+++ b/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
@@ -233,6 +233,32 @@ describe(`ScrollRestoration`, () => {
       expect(script instanceof HTMLScriptElement).toBe(true);
     });
 
+    it("uses the FrameworkContext nonce when one is not provided", () => {
+      let router = createMemoryRouter([
+        {
+          id: "root",
+          path: "/",
+          element: (
+            <>
+              <Outlet />
+              <ScrollRestoration data-testid="scroll-script" />
+              <Scripts />
+            </>
+          ),
+        },
+      ]);
+
+      render(
+        <FrameworkContext.Provider
+          value={mockFrameworkContext({ nonce: "server-nonce" })}
+        >
+          <RouterProvider router={router} />
+        </FrameworkContext.Provider>,
+      );
+      let script = screen.getByTestId("scroll-script");
+      expect(script).toHaveAttribute("nonce", "server-nonce");
+    });
+
     it("should pass props to <script>", () => {
       let router = createMemoryRouter([
         {
@@ -259,6 +285,35 @@ describe(`ScrollRestoration`, () => {
       let script = screen.getByTestId("scroll-script");
       expect(script).toHaveAttribute("nonce", "hello");
       expect(script).toHaveAttribute("crossorigin", "anonymous");
+    });
+
+    it("prefers an explicit nonce over the FrameworkContext nonce", () => {
+      let router = createMemoryRouter([
+        {
+          id: "root",
+          path: "/",
+          element: (
+            <>
+              <Outlet />
+              <ScrollRestoration
+                data-testid="scroll-script"
+                nonce="explicit-nonce"
+              />
+              <Scripts />
+            </>
+          ),
+        },
+      ]);
+
+      render(
+        <FrameworkContext.Provider
+          value={mockFrameworkContext({ nonce: "server-nonce" })}
+        >
+          <RouterProvider router={router} />
+        </FrameworkContext.Provider>,
+      );
+      let script = screen.getByTestId("scroll-script");
+      expect(script).toHaveAttribute("nonce", "explicit-nonce");
     });
 
     it("should restore scroll position", () => {

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -291,6 +291,46 @@ describe("<HydratedRouter>", () => {
 });
 
 describe("<Links />", () => {
+  it("uses the FrameworkContext nonce when one is not provided", () => {
+    let context = mockFrameworkContext({
+      criticalCss: ".critical { color: red; }",
+      nonce: "server-nonce",
+    });
+
+    let { container } = render(
+      <DataRouterStateContext.Provider
+        value={{ matches: [], errors: null } as any}
+      >
+        <FrameworkContext.Provider value={context}>
+          <Links />
+        </FrameworkContext.Provider>
+      </DataRouterStateContext.Provider>,
+    );
+
+    let style = container.querySelector("style");
+    expect(style).toHaveAttribute("nonce", "server-nonce");
+  });
+
+  it("prefers an explicit nonce over the FrameworkContext nonce", () => {
+    let context = mockFrameworkContext({
+      criticalCss: ".critical { color: red; }",
+      nonce: "server-nonce",
+    });
+
+    let { container } = render(
+      <DataRouterStateContext.Provider
+        value={{ matches: [], errors: null } as any}
+      >
+        <FrameworkContext.Provider value={context}>
+          <Links nonce="explicit-nonce" />
+        </FrameworkContext.Provider>
+      </DataRouterStateContext.Provider>,
+    );
+
+    let style = container.querySelector("style");
+    expect(style).toHaveAttribute("nonce", "explicit-nonce");
+  });
+
   it("renders critical css with nonce", () => {
     let context = mockFrameworkContext({
       criticalCss: ".critical { color: red; }",
@@ -384,6 +424,60 @@ describe("<Links />", () => {
 
     let link = container.querySelector("link[href='/style.css']");
     expect(link).toHaveAttribute("nonce", "test-nonce");
+  });
+
+  it("propagates the FrameworkContext nonce to route links", () => {
+    let context = mockFrameworkContext({
+      nonce: "server-nonce",
+      routeModules: {
+        root: {
+          default: () => null,
+          links: () => [{ rel: "stylesheet", href: "/style.css" }],
+        },
+      },
+      manifest: {
+        routes: {
+          root: {
+            id: "root",
+            module: "root.js",
+            hasLoader: false,
+            hasAction: false,
+            hasErrorBoundary: false,
+            hasClientAction: false,
+            hasClientLoader: false,
+            hasClientMiddleware: false,
+            clientActionModule: undefined,
+            clientLoaderModule: undefined,
+            clientMiddlewareModule: undefined,
+            hydrateFallbackModule: undefined,
+          },
+        },
+        entry: { imports: [], module: "" },
+        url: "",
+        version: "",
+      },
+    });
+
+    let { container } = render(
+      <DataRouterStateContext.Provider
+        value={
+          {
+            matches: [
+              {
+                route: { id: "root" },
+              },
+            ],
+          } as any
+        }
+      >
+        <FrameworkContext.Provider value={context}>
+          <Links />
+        </FrameworkContext.Provider>
+      </DataRouterStateContext.Provider>,
+    );
+
+    let link = container.querySelector("link[href='/style.css']");
+    expect(link).toHaveAttribute("nonce", "server-nonce");
   });
 });
 

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -463,6 +463,62 @@ describe("<Scripts />", () => {
       ),
     ).toHaveAttribute("nonce", "test-nonce");
   });
+
+  it("propagates the ServerRouter nonce to default HydrateFallback scripts when a route has a clientLoader without a HydrateFallback", async () => {
+    let staticHandlerContext = await createStaticHandler([{ path: "/" }]).query(
+      new Request("http://localhost/"),
+    );
+
+    invariant(
+      !(staticHandlerContext instanceof Response),
+      "Expected a context",
+    );
+
+    let context = mockEntryContext({
+      manifest: {
+        routes: {
+          root: {
+            // No server loader and a hydrating clientLoader with no
+            // HydrateFallback => the default HydrateFallback is rendered on the
+            // server, emitting `<Scripts>` (and a dev console script) inline.
+            hasLoader: false,
+            hasClientLoader: true,
+            hasAction: false,
+            hasErrorBoundary: false,
+            id: "root",
+            module: "root.js",
+            path: "/",
+          },
+        },
+        entry: {
+          imports: [],
+          module: "entry.js",
+        },
+        url: "manifest.js",
+        version: "",
+      },
+      routeModules: {
+        root: {
+          default: () => <h1>Root</h1>,
+          clientLoader: Object.assign(() => null, { hydrate: true as const }),
+        },
+      },
+    });
+
+    let { container } = render(
+      <ServerRouter
+        context={context}
+        url="http://localhost/"
+        nonce="test-nonce"
+      />,
+    );
+
+    let scripts = container.ownerDocument.querySelectorAll("script");
+    expect(scripts.length).toBeGreaterThan(0);
+    scripts.forEach((script) => {
+      expect(script).toHaveAttribute("nonce", "test-nonce");
+    });
+  });
 });
 
 describe("usePrefetchBehavior", () => {

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2120,10 +2120,13 @@ export function ScrollRestoration({
     }
   }).toString();
 
+  if (props.nonce == null && remixContext?.nonce) {
+    props.nonce = remixContext.nonce;
+  }
+
   return (
     <script
       {...props}
-      nonce={props.nonce ?? remixContext?.nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `(${restoreScroll})(${escapeHtml(

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2044,7 +2044,10 @@ export type ScrollRestorationProps = ScriptsProps & {
  * }
  * ```
  *
- * This component renders an inline `<script>` to prevent scroll flashing. The `nonce` prop will be passed down to the script tag to allow CSP nonce usage.
+ * This component renders an inline `<script>` to prevent scroll flashing. The
+ * `nonce` prop will be passed down to the script tag to allow CSP nonce usage.
+ * If not provided in Framework Mode, it will default to any
+ * {@link ServerRouter | `<ServerRouter nonce>`} prop.
  *
  * ```tsx
  * <ScrollRestoration nonce={cspNonce} />
@@ -2120,6 +2123,7 @@ export function ScrollRestoration({
   return (
     <script
       {...props}
+      nonce={props.nonce ?? remixContext?.nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `(${restoreScroll})(${escapeHtml(

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -224,7 +224,8 @@ export interface LinksProps {
   /**
    * A [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce)
    * attribute to render on the [`<link>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)
-   * element
+   * element. If not provided in Framework Mode, it will default to any
+   * {@link ServerRouter | `<ServerRouter nonce>`} prop.
    */
   nonce?: string | undefined;
   /**
@@ -265,8 +266,13 @@ export interface LinksProps {
  * tags
  */
 export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
-  let { isSpaMode, manifest, routeModules, criticalCss } =
-    useFrameworkContext();
+  let {
+    isSpaMode,
+    manifest,
+    routeModules,
+    criticalCss,
+    nonce: contextNonce,
+  } = useFrameworkContext();
   let { errors, matches: routerMatches } = useDataRouterStateContext();
 
   let matches = getActiveMatches(routerMatches, errors, isSpaMode);
@@ -275,6 +281,10 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
     () => getKeyedLinksForMatches(matches, routeModules, manifest),
     [matches, routeModules, manifest],
   );
+
+  if (nonce == null && contextNonce) {
+    nonce = contextNonce;
+  }
 
   return (
     <>
@@ -344,6 +354,7 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
  */
 export function PrefetchPageLinks({ page, ...linkProps }: PageLinkDescriptor) {
   let rsc = useIsRSCRouterContext();
+  let { nonce: contextNonce } = useFrameworkContext();
   let { router } = useDataRouterContext();
   let matches = React.useMemo(
     () => matchRoutes(router.routes, page, router.basename),
@@ -352,6 +363,10 @@ export function PrefetchPageLinks({ page, ...linkProps }: PageLinkDescriptor) {
 
   if (!matches) {
     return null;
+  }
+
+  if (linkProps.nonce == null && contextNonce) {
+    linkProps = { ...linkProps, nonce: contextNonce };
   }
 
   if (rsc) {
@@ -785,7 +800,8 @@ export type ScriptsProps = Omit<
   /**
    * A [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce)
    * attribute to render on the [`<script>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)
-   * element
+   * element. If not provided in Framework Mode, it will default to any
+   * {@link ServerRouter | `<ServerRouter nonce>`} prop.
    */
   nonce?: string | undefined;
 };
@@ -831,19 +847,20 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
     renderMeta,
     routeDiscovery,
     ssr,
-    nonce,
+    nonce: contextNonce,
   } = useFrameworkContext();
-  // Fall back to the `nonce` provided via `FrameworkContext` (e.g. from
-  // `<ServerRouter nonce>`) when one isn't passed explicitly. This ensures the
-  // inline hydration scripts carry a nonce even when `<Scripts>` is rendered
-  // internally without props (such as in the default `HydrateFallback`).
-  if (scriptProps.nonce == null && nonce != null) {
-    scriptProps = { ...scriptProps, nonce };
-  }
   let { router, static: isStatic, staticContext } = useDataRouterContext();
   let { matches: routerMatches } = useDataRouterStateContext();
   let isRSCRouterContext = useIsRSCRouterContext();
   let enableFogOfWar = isFogOfWarEnabled(routeDiscovery, ssr);
+
+  // Fall back to the `nonce` provided via `FrameworkContext` (e.g. from
+  // `<ServerRouter nonce>`) when one isn't passed explicitly. This ensures the
+  // inline hydration scripts carry a nonce even when `<Scripts>` is rendered
+  // internally without props (such as in the default `HydrateFallback`).
+  if (scriptProps.nonce == null && contextNonce) {
+    scriptProps = { ...scriptProps, nonce: contextNonce };
+  }
 
   // Let <ServerRouter> know that we hydrated and we should render the single
   // fetch streaming scripts

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -831,7 +831,15 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
     renderMeta,
     routeDiscovery,
     ssr,
+    nonce,
   } = useFrameworkContext();
+  // Fall back to the `nonce` provided via `FrameworkContext` (e.g. from
+  // `<ServerRouter nonce>`) when one isn't passed explicitly. This ensures the
+  // inline hydration scripts carry a nonce even when `<Scripts>` is rendered
+  // internally without props (such as in the default `HydrateFallback`).
+  if (scriptProps.nonce == null && nonce != null) {
+    scriptProps = { ...scriptProps, nonce };
+  }
   let { router, static: isStatic, staticContext } = useDataRouterContext();
   let { matches: routerMatches } = useDataRouterStateContext();
   let isRSCRouterContext = useIsRSCRouterContext();

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -24,6 +24,7 @@ export interface FrameworkContextObject {
   ssr: boolean;
   isSpaMode: boolean;
   routeDiscovery: ServerBuild["routeDiscovery"];
+  nonce?: string;
   serializeError?(error: Error): SerializedError;
   renderMeta?: {
     didRenderScripts?: boolean;

--- a/packages/react-router/lib/dom/ssr/errorBoundaries.tsx
+++ b/packages/react-router/lib/dom/ssr/errorBoundaries.tsx
@@ -77,9 +77,9 @@ export function RemixRootDefaultErrorBoundary({
   error: unknown;
   isOutsideRemixApp?: boolean;
 }) {
-  console.error(error);
-
   let { nonce } = useFrameworkContext();
+
+  console.error(error);
 
   let heyDeveloper = (
     <script

--- a/packages/react-router/lib/dom/ssr/errorBoundaries.tsx
+++ b/packages/react-router/lib/dom/ssr/errorBoundaries.tsx
@@ -79,8 +79,11 @@ export function RemixRootDefaultErrorBoundary({
 }) {
   console.error(error);
 
+  let { nonce } = useFrameworkContext();
+
   let heyDeveloper = (
     <script
+      nonce={nonce}
       dangerouslySetInnerHTML={{
         __html: `
         console.log(

--- a/packages/react-router/lib/dom/ssr/fallback.tsx
+++ b/packages/react-router/lib/dom/ssr/fallback.tsx
@@ -10,6 +10,7 @@ import { ENABLE_DEV_WARNINGS } from "../../context";
 // `clientLoader` functions
 export function RemixRootDefaultHydrateFallback() {
   let { nonce } = useFrameworkContext();
+
   return (
     <BoundaryShell title="Loading..." renderScripts>
       {ENABLE_DEV_WARNINGS ? (

--- a/packages/react-router/lib/dom/ssr/fallback.tsx
+++ b/packages/react-router/lib/dom/ssr/fallback.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { BoundaryShell } from "./errorBoundaries";
+import { useFrameworkContext } from "./components";
 import { ENABLE_DEV_WARNINGS } from "../../context";
 
 // If the user sets `clientLoader.hydrate=true` somewhere but does not
@@ -8,10 +9,12 @@ import { ENABLE_DEV_WARNINGS } from "../../context";
 // least include `<Scripts>` in the SSR so we can hydrate the app and call the
 // `clientLoader` functions
 export function RemixRootDefaultHydrateFallback() {
+  let { nonce } = useFrameworkContext();
   return (
     <BoundaryShell title="Loading..." renderScripts>
       {ENABLE_DEV_WARNINGS ? (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `
               console.log(

--- a/packages/react-router/lib/dom/ssr/server.tsx
+++ b/packages/react-router/lib/dom/ssr/server.tsx
@@ -23,7 +23,10 @@ export interface ServerRouterProps {
   url: string | URL;
   /**
    * An optional `nonce` for [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP)
-   * compliance, used to allow inline scripts to run safely.
+   * compliance. This is applied to inline scripts rendered by React Router and
+   * used as the default for nonce-aware components such as {@link Links | `<Links>`},
+   * {@link Scripts | `<Scripts>`}, and {@link ScrollRestoration | `<ScrollRestoration>`}
+   * when they do not provide their own `nonce`.
    */
   nonce?: string;
 }

--- a/packages/react-router/lib/dom/ssr/server.tsx
+++ b/packages/react-router/lib/dom/ssr/server.tsx
@@ -106,6 +106,7 @@ export function ServerRouter({
           ssr: context.ssr,
           isSpaMode: context.isSpaMode,
           routeDiscovery: context.routeDiscovery,
+          nonce,
           serializeError: context.serializeError,
           renderMeta: context.renderMeta,
         }}

--- a/packages/react-router/lib/router/links.ts
+++ b/packages/react-router/lib/router/links.ts
@@ -186,7 +186,9 @@ export interface PageLinkDescriptor
   /**
    * A [`nonce`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/nonce)
    * attribute to render on the [`<link>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)
-   * element
+   * element. If not provided in Framework Mode, it will default to any
+   * {@link ServerRouter | `<ServerRouter nonce>`} prop.
+
    */
   nonce?: string | undefined;
   /**


### PR DESCRIPTION
When a route has a hydrating `clientLoader` but no custom `HydrateFallback`, React Router can emit default inline scripts during SSR. Those scripts were not using the `<ServerRouter nonce>` value, so strict CSP pages could block them on load.

This carries the server nonce through the framework context and uses it for the default fallback/error scripts and `<Scripts>` when no explicit nonce prop is provided. I checked it with the focused `<Scripts>` SSR component test, changed-file ESLint, and `git diff --check`.

Closes #15142
