### PR TITLE
fix(prerender): avoid Suspense fallback flash in prerendered HTML

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -508,3 +508,4 @@
 - zeroqs
 - zheng-chuang
 - zxTomw
+- medsabbar

--- a/integration/helpers/cloudflare-dev-proxy-template/app/entry.server.tsx
+++ b/integration/helpers/cloudflare-dev-proxy-template/app/entry.server.tsx
@@ -23,7 +23,10 @@ export default async function handleRequest(
   );
 
   const userAgent = request.headers.get("user-agent");
-  if (userAgent && isbot(userAgent)) {
+  if (
+    (userAgent && isbot(userAgent)) ||
+    routerContext.isPrerender
+  ) {
     await body.allReady;
   }
 

--- a/integration/helpers/vite-plugin-cloudflare-template/app/entry.server.tsx
+++ b/integration/helpers/vite-plugin-cloudflare-template/app/entry.server.tsx
@@ -31,7 +31,11 @@ export default async function handleRequest(
 
   // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
   // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-  if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+  if (
+    (userAgent && isbot(userAgent)) ||
+    routerContext.isSpaMode ||
+    routerContext.isPrerender
+  ) {
     await body.allReady;
   }
 

--- a/packages/react-router-dev/.changes/patch.prerender-avoid-suspense-fallback-flash.md
+++ b/packages/react-router-dev/.changes/patch.prerender-avoid-suspense-fallback-flash.md
@@ -1,0 +1,5 @@
+Use `onAllReady` for prerender requests to avoid Suspense fallback flash
+
+Prerendered HTML previously contained React's streaming Suspense markup (fallback content + `$RC` swap script) because the prerender request went through the streaming SSR path. This caused a visible flash of the fallback on initial paint, even when nothing actually suspended during prerendering.
+
+The fix adds a prerender signal header so entry.server templates can use `onAllReady` during prerendering, producing complete HTML without streaming artifacts.

--- a/packages/react-router-dev/config/defaults/entry.server.node.tsx
+++ b/packages/react-router-dev/config/defaults/entry.server.node.tsx
@@ -33,7 +33,9 @@ export default function handleRequest(
     // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
     // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
     let readyOption: keyof RenderToPipeableStreamOptions =
-      (userAgent && isbot(userAgent)) || routerContext.isSpaMode
+      (userAgent && isbot(userAgent)) ||
+      routerContext.isSpaMode ||
+      routerContext.isPrerender
         ? "onAllReady"
         : "onShellReady";
 

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -3257,13 +3257,14 @@ async function handlePrerender(
         clientBuildDirectory,
         reactRouterConfig,
         viteConfig,
-        data
-          ? {
-              headers: {
-                "X-React-Router-Prerender-Data": encodeURI(data),
-              },
-            }
-          : undefined,
+        {
+          headers: {
+            "X-React-Router-Prerender": "yes",
+            ...(data
+              ? { "X-React-Router-Prerender-Data": encodeURI(data) }
+              : {}),
+          },
+        },
       );
     }
   };
@@ -4326,6 +4327,10 @@ function createRouteRequest(
       headers.set("X-React-Router-Prerender-Data", encodedData);
     }
   }
+
+  // Signal to entry.server that this is a prerender request so it can use
+  // onAllReady and avoid shipping Suspense fallback + $RC swap scripts
+  headers.set("X-React-Router-Prerender", "yes");
 
   return {
     request: new Request(`http://localhost${normalizedPath}`, { headers }),

--- a/packages/react-router/.changes/patch.add-isPrerender-to-entry-context.md
+++ b/packages/react-router/.changes/patch.add-isPrerender-to-entry-context.md
@@ -1,0 +1,3 @@
+Expose `isPrerender` on `EntryContext` to support fallback-free prerendered HTML
+
+Adds `isPrerender: boolean` to the `EntryContext` interface so entry.server templates can detect prerender requests and use `onAllReady` (or `await body.allReady`) to avoid shipping Suspense fallback + `$RC` swap scripts in prerendered HTML.

--- a/packages/react-router/__tests__/prerender-test.ts
+++ b/packages/react-router/__tests__/prerender-test.ts
@@ -1,0 +1,13 @@
+import { mockEntryContext } from "./utils/framework";
+
+describe("prerender", () => {
+  it("mockEntryContext defaults isPrerender to false", () => {
+    let ctx = mockEntryContext();
+    expect(ctx.isPrerender).toBe(false);
+  });
+
+  it("mockEntryContext accepts isPrerender override", () => {
+    let ctx = mockEntryContext({ isPrerender: true });
+    expect(ctx.isPrerender).toBe(true);
+  });
+});

--- a/packages/react-router/__tests__/utils/framework.ts
+++ b/packages/react-router/__tests__/utils/framework.ts
@@ -65,6 +65,7 @@ export function mockEntryContext(
       loaderHeaders: {},
     },
     serverHandoffStream: undefined,
+    isPrerender: false,
     ...overrides,
   };
 }

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -46,6 +46,7 @@ export interface EntryContext extends FrameworkContextObject {
   branches: RouteBranch<DataRouteObject>[];
   staticHandlerContext: StaticHandlerContext;
   serverHandoffStream?: ReadableStream<Uint8Array>;
+  isPrerender: boolean;
 }
 
 export interface FutureConfig {

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -121,6 +121,8 @@ function derive(build: ServerBuild, mode?: string) {
 
     let isSpaMode =
       getBuildTimeHeader(request, "X-React-Router-SPA-Mode") === "yes";
+    let isPrerender =
+      getBuildTimeHeader(request, "X-React-Router-Prerender") === "yes";
 
     // When runtime SSR is disabled, make our dev server behave like the deployed
     // pre-rendered site would
@@ -293,6 +295,7 @@ function derive(build: ServerBuild, mode?: string) {
         loadContext,
         handleError,
         isSpaMode,
+        isPrerender,
         criticalCss,
       );
     }
@@ -481,6 +484,7 @@ async function handleDocumentRequest(
   loadContext: AppLoadContext | RouterContextProvider,
   handleError: (err: unknown) => void,
   isSpaMode: boolean,
+  isPrerender: boolean,
   criticalCss?: CriticalCss,
 ) {
   try {
@@ -504,7 +508,7 @@ async function handleDocumentRequest(
             try {
               let innerResult = await query(request);
               if (!isResponse(innerResult)) {
-                innerResult = await renderHtml(innerResult, isSpaMode);
+                innerResult = await renderHtml(innerResult, isSpaMode, isPrerender);
               }
               return innerResult;
             } catch (error: unknown) {
@@ -517,7 +521,7 @@ async function handleDocumentRequest(
     });
 
     if (!isResponse(result)) {
-      result = await renderHtml(result, isSpaMode);
+      result = await renderHtml(result, isSpaMode, isPrerender);
     }
     return result;
   } catch (error: unknown) {
@@ -525,7 +529,7 @@ async function handleDocumentRequest(
     return new Response(null, { status: 500 });
   }
 
-  async function renderHtml(context: StaticHandlerContext, isSpaMode: boolean) {
+  async function renderHtml(context: StaticHandlerContext, isSpaMode: boolean, isPrerender: boolean) {
     let headers = getDocumentHeaders(context, build);
 
     // Skip response body for unsupported status codes
@@ -580,6 +584,7 @@ async function handleDocumentRequest(
       ssr: build.ssr,
       routeDiscovery: build.routeDiscovery,
       isSpaMode,
+      isPrerender,
       serializeError: (err) => serializeError(err, serverMode),
     };
 

--- a/playground/vite-plugin-cloudflare/app/entry.server.tsx
+++ b/playground/vite-plugin-cloudflare/app/entry.server.tsx
@@ -31,7 +31,11 @@ export default async function handleRequest(
 
   // Ensure requests from bots and SPA Mode renders wait for all content to load before responding
   // https://react.dev/reference/react-dom/server/renderToPipeableStream#waiting-for-all-content-to-load-for-crawlers-and-static-generation
-  if ((userAgent && isbot(userAgent)) || routerContext.isSpaMode) {
+  if (
+    (userAgent && isbot(userAgent)) ||
+    routerContext.isSpaMode ||
+    routerContext.isPrerender
+  ) {
     await body.allReady;
   }
 


### PR DESCRIPTION
When prerendering routes with a `<Suspense>` boundary wrapping `<Outlet>`,
the prerendered HTML includes React's streaming Suspense markup, causing
a visible fallback flash on initial paint even when nothing suspended.

The fix signals prerender requests via an `X-React-Router-Prerender` header
and exposes `isPrerender` on `EntryContext` so entry.server templates can
use `onAllReady`, producing complete HTML without streaming artifacts.

Fixes #15025