### PR TITLE
fix encoded backslashes in splat matches (fix #15140)

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -182,6 +182,7 @@
 - ianduvall
 - ianflynnwork
 - IbraRouisDev
+- ifer47
 - igniscyan
 - imjordanxd
 - infoxicator

--- a/packages/react-router/.changes/patch.encode-backslash-splats.md
+++ b/packages/react-router/.changes/patch.encode-backslash-splats.md
@@ -1,0 +1,1 @@
+Prevent encoded backslashes in splat route matches from throwing during SSR.

--- a/packages/react-router/__tests__/dom/data-static-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-static-router-test.tsx
@@ -23,6 +23,30 @@ beforeEach(() => {
 });
 
 describe("A <StaticRouterProvider>", () => {
+  it("handles encoded backslashes in splat routes", async () => {
+    let routes = [
+      {
+        path: "*",
+        element: <h1>Splat</h1>,
+      },
+    ];
+    let { query } = createStaticHandler(routes);
+
+    let context = (await query(
+      new Request("http://localhost/%5C", {
+        signal: new AbortController().signal,
+      }),
+    )) as StaticHandlerContext;
+
+    let html = ReactDOMServer.renderToStaticMarkup(
+      <StaticRouterProvider
+        router={createStaticRouter(routes, context)}
+        context={context}
+      />,
+    );
+    expect(html).toMatch("<h1>Splat</h1>");
+  });
+
   it("renders an initialized router", async () => {
     let hooksData1: {
       location: ReturnType<typeof useLocation>;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -756,6 +756,18 @@ export function useRoutes(
   return useRoutesImpl(routes, locationArg);
 }
 
+function safelyEncodePathname(pathname: string) {
+  // Re-encode pathnames that were decoded inside matchRoutes.
+  // Pre-encode `%`, `?`, `#`, and `\` ahead of `encodeLocation` because it uses
+  // `new URL()` internally and we need to prevent it from treating them as
+  // separators or invalid URL syntax.
+  return pathname
+    .replace(/%/g, "%25")
+    .replace(/\?/g, "%3F")
+    .replace(/#/g, "%23")
+    .replace(/\\/g, "%5C");
+}
+
 // Internal implementation with accept optional param for RouterProvider usage
 export function useRoutesImpl(
   routes: RouteObject[],
@@ -897,17 +909,9 @@ export function useRoutesImpl(
           params: Object.assign({}, parentParams, match.params),
           pathname: joinPaths([
             parentPathnameBase,
-            // Re-encode pathnames that were decoded inside matchRoutes.
-            // Pre-encode `%`, `?` and `#` ahead of `encodeLocation` because it uses
-            // `new URL()` internally and we need to prevent it from treating
-            // them as separators
             navigator.encodeLocation
-              ? navigator.encodeLocation(
-                  match.pathname
-                    .replace(/%/g, "%25")
-                    .replace(/\?/g, "%3F")
-                    .replace(/#/g, "%23"),
-                ).pathname
+              ? navigator.encodeLocation(safelyEncodePathname(match.pathname))
+                  .pathname
               : match.pathname,
           ]),
           pathnameBase:
@@ -915,16 +919,9 @@ export function useRoutesImpl(
               ? parentPathnameBase
               : joinPaths([
                   parentPathnameBase,
-                  // Re-encode pathnames that were decoded inside matchRoutes
-                  // Pre-encode `%`, `?` and `#` ahead of `encodeLocation` because it uses
-                  // `new URL()` internally and we need to prevent it from treating
-                  // them as separators
                   navigator.encodeLocation
                     ? navigator.encodeLocation(
-                        match.pathnameBase
-                          .replace(/%/g, "%25")
-                          .replace(/\?/g, "%3F")
-                          .replace(/#/g, "%23"),
+                        safelyEncodePathname(match.pathnameBase),
                       ).pathname
                     : match.pathnameBase,
                 ]),


### PR DESCRIPTION
## What changed?

This prevents SSR rendering from throwing when a splat route match contains an encoded backslash, such as `/%5C`.

`matchRoutes` decodes matched pathnames before `useRoutesImpl` re-encodes them through `navigator.encodeLocation`. Since `encodeLocation` uses `new URL()` internally, a decoded `\` can become invalid URL syntax. This pre-encodes backslashes alongside the existing `%`, `?`, and `#` handling before calling `encodeLocation`.

## Test

- `pnpm build`
- `pnpm exec jest packages/react-router/__tests__/dom/data-static-router-test.tsx packages/react-router/__tests__/dom/special-characters-test.tsx --runInBand`
- `pnpm --filter react-router typecheck`
- `pnpm run changes:validate`
- `pnpm exec eslint packages/react-router/lib/hooks.tsx packages/react-router/__tests__/dom/data-static-router-test.tsx`