### PR TITLE
Migrate changeset for `server.watch` in child compiler

### DIFF
--- a/.changeset/wet-walls-camp.md
+++ b/.changeset/wet-walls-camp.md
@@ -1,5 +1,0 @@
----
-"@react-router/dev": patch
----
-
-Copy `server.watch` config options from `vite.config.(ts|js)` file to child vite server in development mode.

--- a/packages/react-router-dev/.changes/patch.copy-server-watch-config.md
+++ b/packages/react-router-dev/.changes/patch.copy-server-watch-config.md
@@ -1,0 +1,1 @@
+Pass Vite `server.watch` config to child compiler in development mode.


### PR DESCRIPTION
This is a follow up to https://github.com/remix-run/react-router/pull/14298, migrating from Changesets to our new `.changes` system.