### PR TITLE
fix: encode backslashes in static splat paths

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -361,6 +361,7 @@
 - promet99
 - proshunsuke
 - pruszel
+- pupuking723
 - pwdcd
 - pyitphyoaung
 - qu0b

--- a/packages/react-router/.changes/patch.fix-splat-encoded-backslash.md
+++ b/packages/react-router/.changes/patch.fix-splat-encoded-backslash.md
@@ -1,0 +1,1 @@
+Fix server rendering for splat pathnames containing decoded backslashes.

--- a/packages/react-router/__tests__/dom/static-location-test.tsx
+++ b/packages/react-router/__tests__/dom/static-location-test.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server.edge";
-import { Routes, Route, StaticRouter, useLocation } from "../../index";
+import {
+  Routes,
+  Route,
+  StaticRouter,
+  useLocation,
+  useParams,
+} from "../../index";
 
 describe("A <StaticRouter>", () => {
   describe("with a string location prop", () => {
@@ -30,6 +36,24 @@ describe("A <StaticRouter>", () => {
   });
 
   describe("with an object location prop", () => {
+    it("handles decoded backslashes in splat route pathnames", () => {
+      let params!: ReturnType<typeof useParams>;
+      function ParamsChecker() {
+        params = useParams();
+        return null;
+      }
+
+      ReactDOMServer.renderToStaticMarkup(
+        <StaticRouter location={{ pathname: "/\\" }}>
+          <Routes>
+            <Route path="*" element={<ParamsChecker />} />
+          </Routes>
+        </StaticRouter>,
+      );
+
+      expect(params).toEqual({ "*": "\\" });
+    });
+
     it("adds missing properties", () => {
       let location!: ReturnType<typeof useLocation>;
       function LocationChecker() {

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -514,6 +514,13 @@ function encodeLocation(to: To): Path {
   // pre-encode them since they might be part of a matching splat param from
   // an ancestor route
   href = href.replace(/ $/, "%20");
+  if (!ABSOLUTE_URL_REGEX.test(href)) {
+    let path = parsePath(href);
+    if (path.pathname) {
+      path.pathname = path.pathname.replace(/\\/g, "%5C");
+      href = createPath(path);
+    }
+  }
   let encoded = ABSOLUTE_URL_REGEX.test(href)
     ? new URL(href)
     : new URL(href, "http://localhost");


### PR DESCRIPTION
Fixes #15140

## Summary

`StaticRouter`'s `encodeLocation()` uses `new URL()` to mirror browser pathname encoding. When a splat route match contains a decoded backslash, `useRoutesImpl()` passes a pathname like `/\` into `encodeLocation()`, and the URL constructor throws `Invalid URL`.

This PR pre-encodes backslashes in relative pathnames before calling `new URL()`, while leaving search/hash handling untouched. It also adds a regression test for a decoded backslash in a static splat route pathname.

## Verification

- `pnpm exec jest packages/react-router/__tests__/dom/static-location-test.tsx --runInBand`
- `pnpm exec jest packages/react-router/__tests__/dom/static-location-test.tsx -t "handles decoded backslashes" --runInBand` fails with `Invalid URL: /\` when the fix is temporarily reverted
- `pnpm exec eslint packages/react-router/lib/dom/server.tsx packages/react-router/__tests__/dom/static-location-test.tsx`
- `pnpm exec prettier --ignore-path .prettierignore --check packages/react-router/lib/dom/server.tsx packages/react-router/__tests__/dom/static-location-test.tsx packages/react-router/.changes/patch.fix-splat-encoded-backslash.md`
- `pnpm --filter react-router build`
- `pnpm --filter react-router typecheck`
- `node --experimental-strip-types ./scripts/changes/validate.ts`
- `git diff --check`

Note: this machine has Node.js v22.17.0, while the `scripts` package asks for `^22.18`. `pnpm changes:validate` failed because it runs a `.ts` script directly in this Node version, so I ran the same script with `node --experimental-strip-types` and it reported all change files are valid.
