### PR TITLE
Release v7.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v7.18.0](#v7180)
   - [v7.17.0](#v7170)
   - [v7.16.0](#v7160)
     - [Stabilized `future.v8_trailingSlashAwareDataRequests`](#stabilized-futurev8_trailingslashawaredatarequests)
@@ -176,6 +177,47 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v6.0.0](#v600)
 
 </details>
+
+## v7.18.0
+
+Date: 2026-06-15
+
+### Minor Changes
+
+- `@react-router/architect` - Add a `useRequestContextDomainName` option to `createRequestHandler` to derive request URL hosts from the API Gateway request context. ([#15185](https://github.com/remix-run/react-router/pull/15185))
+
+### Patch Changes
+
+- `react-router` - Fix server handler prerender responses when using `ssr: false` and `future.v8_trailingSlashAwareDataRequests: true`. Avoids false positive "SPA Mode" detection when serving prerendered paths ([#15173](https://github.com/remix-run/react-router/pull/15173))
+
+- `react-router` - Use the `ServerRouter` nonce for nonce-aware SSR components when they don't provide their own value so strict CSP pages can load them. ([#15170](https://github.com/remix-run/react-router/pull/15170))
+
+- `react-router` - Use `turbo-stream` to serialize and deserialize Framework Mode hydration errors ([#15175](https://github.com/remix-run/react-router/pull/15175))
+
+- `react-router` - Precompute route branch matchers to avoid recompiling route path regexes during matching ([#15186](https://github.com/remix-run/react-router/pull/15186))
+
+- `react-router` - Use the constructed request URL host when validating action request origins. ([#15185](https://github.com/remix-run/react-router/pull/15185))
+
+- `react-router` - Remove the un-documented custom error serialization logic from Data Mode SSR built-in hydration flows ([#15175](https://github.com/remix-run/react-router/pull/15175))
+
+- `react-router` - Validate protocols in RSC render redirects ([#15177](https://github.com/remix-run/react-router/pull/15177))
+
+- `react-router` - Consolidate url normalization logic and better handle mixed slashes ([#15176](https://github.com/remix-run/react-router/pull/15176))
+
+- `@react-router/dev` - Pass Vite `server.watch` config to child compiler in development mode. ([#15178](https://github.com/remix-run/react-router/pull/15178))
+
+- `@react-router/dev` - Ignore external Vite server environments in Framework Mode build hooks ([#14883](https://github.com/remix-run/react-router/pull/14883))
+
+  When `future.v8_viteEnvironmentApi` is enabled, React Router previously treated any non-client Vite environment as its own server build. This caused issues with integrations like Nitro, where plugins can register additional environments.
+
+  Framework Mode build hooks now ignore external server environments and only process the app's own server build.
+
+- `@react-router/express` - Adjust express adapter host computation ([#15185](https://github.com/remix-run/react-router/pull/15185))
+
+  - read port from `x-forwarded-host` based on `trust proxy` setting
+  - handle invalid hostname characters
+
+**Full Changelog**: [`v7.17.0...v7.18.0`](https://github.com/remix-run/react-router/compare/react-router@7.17.0...react-router@7.18.0)
 
 ## v7.17.0
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v7.18.0
+
+### Patch Changes
+
+- _No changes_
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-router",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/.changes/minor.request-context-domain-name.md
+++ b/packages/react-router-architect/.changes/minor.request-context-domain-name.md
@@ -1,1 +1,0 @@
-Add a `useRequestContextDomainName` option to `createRequestHandler` to derive request URL hosts from the API Gateway request context.

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,17 @@
 # `@react-router/architect`
 
+## v7.18.0
+
+### Minor Changes
+
+- Add a `useRequestContextDomainName` option to `createRequestHandler` to derive request URL hosts from the API Gateway request context. ([#15185](https://github.com/remix-run/react-router/pull/15185))
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/architect",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/cloudflare",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/.changes/patch.copy-server-watch-config.md
+++ b/packages/react-router-dev/.changes/patch.copy-server-watch-config.md
@@ -1,1 +1,0 @@
-Pass Vite `server.watch` config to child compiler in development mode.

--- a/packages/react-router-dev/.changes/patch.ignore-external-server-environments-in-framework-mode-build-hooks.md
+++ b/packages/react-router-dev/.changes/patch.ignore-external-server-environments-in-framework-mode-build-hooks.md
@@ -1,5 +1,0 @@
-Ignore external Vite server environments in Framework Mode build hooks
-
-When `future.v8_viteEnvironmentApi` is enabled, React Router previously treated any non-client Vite environment as its own server build. This caused issues with integrations like Nitro, where plugins can register additional environments.
-
-Framework Mode build hooks now ignore external server environments and only process the app's own server build.

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,21 @@
 # `@react-router/dev`
 
+## v7.18.0
+
+### Patch Changes
+
+- Pass Vite `server.watch` config to child compiler in development mode. ([#15178](https://github.com/remix-run/react-router/pull/15178))
+
+- Ignore external Vite server environments in Framework Mode build hooks ([#14883](https://github.com/remix-run/react-router/pull/14883))
+
+  When `future.v8_viteEnvironmentApi` is enabled, React Router previously treated any non-client Vite environment as its own server build. This caused issues with integrations like Nitro, where plugins can register additional environments.
+
+  Framework Mode build hooks now ignore external server environments and only process the app's own server build.
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)
+  - [`@react-router/serve@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/dev",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Dev tools and CLI for React Router",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-dom/CHANGELOG.md
+++ b/packages/react-router-dom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # react-router-dom
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Declarative routing for React web applications",
   "keywords": [
     "react",

--- a/packages/react-router-express/.changes/patch.request-host-hardening.md
+++ b/packages/react-router-express/.changes/patch.request-host-hardening.md
@@ -1,4 +1,0 @@
-Adjust express adapter host computation
-
-- read port from `x-forwarded-host` based on `trust proxy` setting
-- handle invalid hostname characters

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,17 @@
 # `@react-router/express`
 
+## v7.18.0
+
+### Patch Changes
+
+- Adjust express adapter host computation ([#15185](https://github.com/remix-run/react-router/pull/15185))
+
+  - read port from `x-forwarded-host` based on `trust proxy` setting
+  - handle invalid hostname characters
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/express",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/fs-routes",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/node`
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/node",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/serve`
 
+## v7.18.0
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
+  - [`@react-router/express@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.18.0)
+  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)
+
 ## v7.17.0
 
 ### Patch Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/serve",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/patch.fix-bug-prerender.md
+++ b/packages/react-router/.changes/patch.fix-bug-prerender.md
@@ -1,1 +1,0 @@
-Fix server handler prerender responses when using `ssr: false` and `future.v8_trailingSlashAwareDataRequests: true`. Avoids false positive "SPA Mode" detection when serving prerendered paths

--- a/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
+++ b/packages/react-router/.changes/patch.fix-nonce-default-hydrate-fallback-scripts.md
@@ -1,1 +1,0 @@
-Use the `ServerRouter` nonce for nonce-aware SSR components when they don't provide their own value so strict CSP pages can load them.

--- a/packages/react-router/.changes/patch.framework-errors-turbo-stream.md
+++ b/packages/react-router/.changes/patch.framework-errors-turbo-stream.md
@@ -1,1 +1,0 @@
-Use `turbo-stream` to serialize and deserialize Framework Mode hydration errors

--- a/packages/react-router/.changes/patch.precompute-route-branch-matchers.md
+++ b/packages/react-router/.changes/patch.precompute-route-branch-matchers.md
@@ -1,1 +1,0 @@
-Precompute route branch matchers to avoid recompiling route path regexes during matching

--- a/packages/react-router/.changes/patch.request-url-csrf-host.md
+++ b/packages/react-router/.changes/patch.request-url-csrf-host.md
@@ -1,1 +1,0 @@
-Use the constructed request URL host when validating action request origins.

--- a/packages/react-router/.changes/patch.restrict-data-error-deserialization.md
+++ b/packages/react-router/.changes/patch.restrict-data-error-deserialization.md
@@ -1,1 +1,0 @@
-Remove the un-documented custom error serialization logic from Data Mode SSR built-in hydration flows

--- a/packages/react-router/.changes/patch.rsc-redirect-protocols.md
+++ b/packages/react-router/.changes/patch.rsc-redirect-protocols.md
@@ -1,1 +1,0 @@
-Validate protocols in RSC render redirects

--- a/packages/react-router/.changes/patch.url-consolidation.md
+++ b/packages/react-router/.changes/patch.url-consolidation.md
@@ -1,1 +1,0 @@
-Consolidate url normalization logic and better handle mixed slashes

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,18 @@
 # `react-router`
 
+## v7.18.0
+
+### Patch Changes
+
+- Fix server handler prerender responses when using `ssr: false` and `future.v8_trailingSlashAwareDataRequests: true`. Avoids false positive "SPA Mode" detection when serving prerendered paths ([#15173](https://github.com/remix-run/react-router/pull/15173))
+- Use the `ServerRouter` nonce for nonce-aware SSR components when they don't provide their own value so strict CSP pages can load them. ([#15170](https://github.com/remix-run/react-router/pull/15170))
+- Use `turbo-stream` to serialize and deserialize Framework Mode hydration errors ([#15175](https://github.com/remix-run/react-router/pull/15175))
+- Precompute route branch matchers to avoid recompiling route path regexes during matching ([#15186](https://github.com/remix-run/react-router/pull/15186))
+- Use the constructed request URL host when validating action request origins. ([#15185](https://github.com/remix-run/react-router/pull/15185))
+- Remove the un-documented custom error serialization logic from Data Mode SSR built-in hydration flows ([#15175](https://github.com/remix-run/react-router/pull/15175))
+- Validate protocols in RSC render redirects ([#15177](https://github.com/remix-run/react-router/pull/15177))
+- Consolidate url normalization logic and better handle mixed slashes ([#15176](https://github.com/remix-run/react-router/pull/15176))
+
 ## v7.17.0
 
 ### Minor Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "7.17.0",
+  "version": "7.18.0",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `7.17.0` → `7.18.0` |
| react-router-dom | `7.17.0` → `7.18.0` |
| @react-router/architect | `7.17.0` → `7.18.0` |
| @react-router/cloudflare | `7.17.0` → `7.18.0` |
| @react-router/dev | `7.17.0` → `7.18.0` |
| @react-router/express | `7.17.0` → `7.18.0` |
| @react-router/fs-routes | `7.17.0` → `7.18.0` |
| @react-router/node | `7.17.0` → `7.18.0` |
| @react-router/remix-routes-option-adapter | `7.17.0` → `7.18.0` |
| @react-router/serve | `7.17.0` → `7.18.0` |
| create-react-router | `7.17.0` → `7.18.0` |

# Changelogs

## react-router v7.18.0

### Patch Changes

- Fix server handler prerender responses when using `ssr: false` and `future.v8_trailingSlashAwareDataRequests: true`. Avoids false positive "SPA Mode" detection when serving prerendered paths ([#15173](https://github.com/remix-run/react-router/pull/15173))
- Use the `ServerRouter` nonce for nonce-aware SSR components when they don't provide their own value so strict CSP pages can load them. ([#15170](https://github.com/remix-run/react-router/pull/15170))
- Use `turbo-stream` to serialize and deserialize Framework Mode hydration errors ([#15175](https://github.com/remix-run/react-router/pull/15175))
- Precompute route branch matchers to avoid recompiling route path regexes during matching ([#15186](https://github.com/remix-run/react-router/pull/15186))
- Use the constructed request URL host when validating action request origins. ([#15185](https://github.com/remix-run/react-router/pull/15185))
- Remove the un-documented custom error serialization logic from Data Mode SSR built-in hydration flows ([#15175](https://github.com/remix-run/react-router/pull/15175))
- Validate protocols in RSC render redirects ([#15177](https://github.com/remix-run/react-router/pull/15177))
- Consolidate url normalization logic and better handle mixed slashes ([#15176](https://github.com/remix-run/react-router/pull/15176))


## react-router-dom v7.18.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)


## @react-router/architect v7.18.0

### Minor Changes

- Add a `useRequestContextDomainName` option to `createRequestHandler` to derive request URL hosts from the API Gateway request context. ([#15185](https://github.com/remix-run/react-router/pull/15185))

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)


## @react-router/cloudflare v7.18.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)


## @react-router/dev v7.18.0

### Patch Changes

- Pass Vite `server.watch` config to child compiler in development mode. ([#15178](https://github.com/remix-run/react-router/pull/15178))

- Ignore external Vite server environments in Framework Mode build hooks ([#14883](https://github.com/remix-run/react-router/pull/14883))

  When `future.v8_viteEnvironmentApi` is enabled, React Router previously treated any non-client Vite environment as its own server build. This caused issues with integrations like Nitro, where plugins can register additional environments.

  Framework Mode build hooks now ignore external server environments and only process the app's own server build.
- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)
  - [`@react-router/serve@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.18.0)


## @react-router/express v7.18.0

### Patch Changes

- Adjust express adapter host computation ([#15185](https://github.com/remix-run/react-router/pull/15185))

  - read port from `x-forwarded-host` based on `trust proxy` setting
  - handle invalid hostname characters
- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)


## @react-router/fs-routes v7.18.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.0)


## @react-router/node v7.18.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)


## @react-router/remix-routes-option-adapter v7.18.0

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.0)


## @react-router/serve v7.18.0

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.0`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.0)
  - [`@react-router/express@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.18.0)
  - [`@react-router/node@7.18.0`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.0)


## create-react-router v7.18.0

### Patch Changes

- _No changes_
