### PR TITLE
Support v7 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 #
 # Specific jobs only run on the proper trigger:
 #
-# - Change file driven stable releases (push to main/hotfix branches)
+# - Change file driven stable releases (push to main/hotfix/v7 branches)
 # - Experimental releases (from a workflow_dispatch trigger)
 
 name: 🚢 Release/Publish
@@ -14,6 +14,7 @@ on:
     branches:
       - "main"
       - "hotfix"
+      - "v7"
   workflow_dispatch:
     inputs:
       branch:
@@ -127,13 +128,15 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm and create releases
-        run: pnpm changes:publish
+        run: pnpm changes:publish -- --branch=${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   comment:
     name: 📝 Comment on released issues/pull requests
     needs: publish
+    # Only comment on issues/PRs for latest releases from main.
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     permissions:
       issues: write # enable commenting on released issues

--- a/scripts/changes/pr.ts
+++ b/scripts/changes/pr.ts
@@ -30,8 +30,11 @@ let args = process.argv.slice(2);
 let preview = args.includes("--preview");
 
 let baseBranch = logAndExec("git rev-parse --abbrev-ref HEAD", true).trim();
-if (!preview && !["main", "hotfix"].includes(baseBranch)) {
-  throw new Error("Error: script must be run from the main or hotfix branch");
+let releaseBranches = ["main", "hotfix", "v7"];
+if (!preview && !releaseBranches.includes(baseBranch)) {
+  throw new Error(
+    `Error: script must be run from one of these release branches: ${releaseBranches.join(", ")}`,
+  );
 }
 
 let prLabels = ["pkg:react-router"];

--- a/scripts/changes/publish.ts
+++ b/scripts/changes/publish.ts
@@ -9,9 +9,10 @@
  * This script is designed for CI use. For previewing releases, use `pnpm changes:preview`.
  *
  * Usage:
- *   node scripts/publish.ts [--skip-ci-check] [--dry-run]
+ *   node scripts/publish.ts --branch=<branch> [--skip-ci-check] [--dry-run]
  *
  * Options:
+ *   --branch        Required. Branch this release is publishing from.
  *   --skip-ci-check  Bypass the CI environment check
  *   --dry-run        Show what would be published without actually publishing.
  *                    Queries npm to determine unpublished packages and previews
@@ -20,6 +21,7 @@
 import * as cp from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { parseArgs } from "node:util";
 
 import { tagExists } from "../utils/git.ts";
 import { createRelease } from "../utils/github.ts";
@@ -33,9 +35,26 @@ import { readJson, fileExists } from "../utils/fs.ts";
 
 let rootDir = getRootDir();
 
-let args = process.argv.slice(2);
-let skipCiCheck = args.includes("--skip-ci-check");
-let dryRun = args.includes("--dry-run");
+let { values } = parseArgs({
+  strict: true,
+  options: {
+    branch: {
+      type: "string",
+      required: true,
+    },
+    "skip-ci-check": {
+      type: "boolean",
+    },
+    "dry-run": {
+      type: "boolean",
+    },
+  },
+});
+
+let skipCiCheck = values["skip-ci-check"];
+let dryRun = values["dry-run"];
+let branch = values.branch;
+let isLatest = branch === "main";
 
 interface PublishedPackage {
   packageName: string;
@@ -147,7 +166,11 @@ async function getUnpublishedPackages(): Promise<PublishedPackage[]> {
 }
 
 function getGithubReleaseBody(version: string) {
-  return `See the changelog for release notes: https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v${version.replace(/\./g, "")}`;
+  let href = `/blob/${branch}/CHANGELOG.md#v${version.replace(/\./g, "")}`;
+  return (
+    "See the changelog for release notes: " +
+    `https://github.com/remix-run/react-router${href}`
+  );
 }
 
 async function main() {
@@ -277,6 +300,7 @@ async function main() {
       pkg.packageName,
       pkg.version,
       getGithubReleaseBody(pkg.version),
+      { makeLatest: isLatest },
     );
     if (result.status === "created") {
       console.log(`  ✓ ${pkg.packageName} v${pkg.version}`);

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -52,6 +52,7 @@ export async function createRelease(
   packageName: string,
   version: string,
   body: string,
+  options: { makeLatest?: boolean } = {},
 ): Promise<CreateReleaseResult> {
   let tagName = getGitTag(packageName, version);
   let releaseName = `v${version}`;
@@ -71,6 +72,7 @@ export async function createRelease(
       tag_name: tagName,
       name: releaseName,
       body,
+      ...(options.makeLatest === false ? { make_latest: "false" } : {}),
     });
 
     return { status: "created", url: response.data.html_url };


### PR DESCRIPTION
## Summary
- run the stable release workflow for pushes to the v7 branch
- pass the source branch into the publish script so v7 release links point at the v7 changelog
- prevent non-main GitHub releases from being marked latest and skip release comments outside main

## Testing
- pnpm exec prettier --check .github/workflows/release.yml scripts/changes/publish.ts scripts/utils/github.ts
- node --experimental-strip-types --check scripts/changes/publish.ts
- node --experimental-strip-types --check scripts/utils/github.ts
- node --experimental-strip-types scripts/changes/publish.ts --dry-run --branch=v7