### PR TITLE
docs: fix 13 broken api.reactrouter.com/v7/functions/ reference links

### DIFF
--- a/docs/api/components/Form.md
+++ b/docs/api/components/Form.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.Form.html)
+[Reference Documentation ↗](https://reactrouter.com/api/components/Form)
 
 A progressively enhanced HTML [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
 that submits data to actions via [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch),

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.Link.html)
+[Reference Documentation ↗](https://reactrouter.com/api/components/Link)
 
 A progressively enhanced [`<a href>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
 wrapper to enable navigation with client-side routing.

--- a/docs/api/components/NavLink.md
+++ b/docs/api/components/NavLink.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.NavLink.html)
+[Reference Documentation ↗](https://reactrouter.com/api/components/NavLink)
 
 Wraps [`<Link>`](../components/Link) with additional props for styling active and
 pending states.

--- a/docs/api/utils/IsCookieFunction.md
+++ b/docs/api/utils/IsCookieFunction.md
@@ -8,4 +8,4 @@ title: IsCookieFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.IsCookieFunction.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/IsCookieFunction)

--- a/docs/api/utils/IsSessionFunction.md
+++ b/docs/api/utils/IsSessionFunction.md
@@ -8,4 +8,4 @@ title: IsSessionFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.IsSessionFunction.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/IsSessionFunction)

--- a/docs/api/utils/createRequestHandler.md
+++ b/docs/api/utils/createRequestHandler.md
@@ -9,4 +9,4 @@ hidden: true
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.createRequestHandler.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/createRequestHandler)

--- a/docs/api/utils/createRoutesFromElements.md
+++ b/docs/api/utils/createRoutesFromElements.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/co
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.createRoutesFromElements.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/createRoutesFromElements)
 
 Create route objects from JSX elements instead of arrays of objects.
 

--- a/docs/api/utils/createSession.md
+++ b/docs/api/utils/createSession.md
@@ -9,7 +9,7 @@ hidden: true
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.createSession.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/createSession)
 
 Creates a new Session object.
 

--- a/docs/api/utils/isCookie.md
+++ b/docs/api/utils/isCookie.md
@@ -8,6 +8,6 @@ title: isCookie
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.isCookie.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/isCookie)
 
 Returns true if an object is a Remix cookie container.

--- a/docs/api/utils/isSession.md
+++ b/docs/api/utils/isSession.md
@@ -8,6 +8,6 @@ title: isSession
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.isSession.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/isSession)
 
 Returns true if an object is a React Router session.

--- a/docs/api/utils/redirect.md
+++ b/docs/api/utils/redirect.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.redirect.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/redirect)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 Sets the status code and the [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location)

--- a/docs/api/utils/redirectDocument.md
+++ b/docs/api/utils/redirectDocument.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.redirectDocument.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/redirectDocument)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will force a document reload to the new location. Sets the status code

--- a/docs/api/utils/replace.md
+++ b/docs/api/utils/replace.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.replace.html)
+[Reference Documentation ↗](https://reactrouter.com/api/utils/replace)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will perform a [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)


### PR DESCRIPTION
## Summary

The 13 reference docs in `docs/api/components/` and `docs/api/utils/` that link to `https://api.reactrouter.com/v7/functions/react-router.<Name>.html` are all 404 — the `functions/` subpath of the v7 API docs has been removed in favor of the new docs at `reactrouter.com/api/`.

## Fix

Replaced the old URL pattern with the new docs format:

- Components: `https://api.reactrouter.com/v7/functions/react-router.Form.html` → `https://reactrouter.com/api/components/Form`
- Utils: `https://api.reactrouter.com/v7/functions/react-router.createSession.html` → `https://reactrouter.com/api/utils/createSession`

The category is determined by the export type: components go in `/api/components/`, utils/hooks in their respective subdirectories.

## Files changed

- `docs/api/components/Form.md`
- `docs/api/components/Link.md`
- `docs/api/components/NavLink.md`
- `docs/api/utils/IsCookieFunction.md`
- `docs/api/utils/IsSessionFunction.md`
- `docs/api/utils/createRequestHandler.md`
- `docs/api/utils/createRoutesFromElements.md`
- `docs/api/utils/createSession.md`
- `docs/api/utils/isCookie.md`
- `docs/api/utils/isSession.md`
- `docs/api/utils/redirect.md`
- `docs/api/utils/redirectDocument.md`
- `docs/api/utils/replace.md`

## Verification

- All 13 old URLs confirmed 404 via HEAD.
- All 13 new URLs confirmed 200 via HEAD.
- The `interfaces/` and `types/` subpaths of `api.reactrouter.com/v7/` still work and are not changed in this PR.