### PR TITLE
Use version-7 npm tag for v7 publishes

### DIFF
--- a/scripts/changes/publish.ts
+++ b/scripts/changes/publish.ts
@@ -198,13 +198,14 @@ async function main() {
 
   let args = `--access public --no-git-checks --report-summary`;
   let publishCommands = isV7
-    ? // Publish v7 releases with the `version-7` tag, except `react-router-dom`
-      // which was dropped in v8 so it continues to get the `latest` tag
+    ? // Two-phase publish:
+      //  - everything except `react-router-dom` as `version-7`
+      //  - `react-router-dom` as `latest` because it was dropped in v8
       [
         `pnpm publish --recursive --filter "./packages/*" --filter "!react-router-dom" --tag version-7 ${args}`,
         `pnpm publish --recursive --filter react-router-dom ${args}`,
       ]
-    : // Publish all as latest
+    : // Single-phase publish: everything as latest
       [`pnpm publish --recursive --filter "./packages/*" ${args}`];
 
   // In dry run mode, query npm to determine what would be published

--- a/scripts/changes/publish.ts
+++ b/scripts/changes/publish.ts
@@ -60,6 +60,7 @@ if (!branch) {
 }
 
 let isLatest = branch === "main";
+let isV7 = branch === "v7";
 
 interface PublishedPackage {
   packageName: string;
@@ -195,16 +196,25 @@ async function main() {
   // Publish packages to npm
   console.log("Publishing packages to npm...\n");
 
-  // Single-phase publish: everything as latest
-  let publishCommand =
-    'pnpm publish --recursive --filter "./packages/*" --access public --no-git-checks --report-summary';
+  let args = `--access public --no-git-checks --report-summary`;
+  let publishCommands = isV7
+    ? // Publish v7 releases with the `version-7` tag, except `react-router-dom`
+      // which was dropped in v8 so it continues to get the `latest` tag
+      [
+        `pnpm publish --recursive --filter "./packages/*" --filter "!react-router-dom" --tag version-7 ${args}`,
+        `pnpm publish --recursive --filter react-router-dom ${args}`,
+      ]
+    : // Publish all as latest
+      [`pnpm publish --recursive --filter "./packages/*" ${args}`];
 
   // In dry run mode, query npm to determine what would be published
   // and preview the GitHub releases. This is designed to be run against
   // the contents of the "Release" PR / `pnpm changes:version` output.
   if (dryRun) {
     console.log("Would run:");
-    console.log(`  $ ${publishCommand}`);
+    for (let publishCommand of publishCommands) {
+      console.log(`  $ ${publishCommand}`);
+    }
     console.log();
 
     console.log("Checking npm for unpublished versions...\n");
@@ -251,8 +261,10 @@ async function main() {
   }
 
   // Publish to npm
-  logAndExec(publishCommand);
-  let published = readPublishSummary();
+  let published = publishCommands.flatMap((publishCommand) => {
+    logAndExec(publishCommand);
+    return readPublishSummary();
+  });
 
   if (published.length === 0) {
     console.log("\nNo packages were published.");

--- a/scripts/changes/publish.ts
+++ b/scripts/changes/publish.ts
@@ -59,8 +59,8 @@ if (!branch) {
   throw new Error("--branch is required");
 }
 
-let isLatest = branch === "main";
-let isV7 = branch === "v7";
+let shouldTagGithubReleaseAsLatest = branch === "main";
+let shouldUseVersion7NpmTag = branch === "v7";
 
 interface PublishedPackage {
   packageName: string;
@@ -197,7 +197,7 @@ async function main() {
   console.log("Publishing packages to npm...\n");
 
   let args = `--access public --no-git-checks --report-summary`;
-  let publishCommands = isV7
+  let publishCommands = shouldUseVersion7NpmTag
     ? // Two-phase publish:
       //  - everything except `react-router-dom` as `version-7`
       //  - `react-router-dom` as `latest` because it was dropped in v8
@@ -318,7 +318,7 @@ async function main() {
       pkg.packageName,
       pkg.version,
       getGithubReleaseBody(pkg.version),
-      { makeLatest: isLatest },
+      { makeLatest: shouldTagGithubReleaseAsLatest },
     );
     if (result.status === "created") {
       console.log(`  ✓ ${pkg.packageName} v${pkg.version}`);


### PR DESCRIPTION
## Summary
- publish v7 branch packages with the version-7 npm tag
- keep react-router-dom publishing with npm's implicit latest tag because it is not carried forward to v8
- keep main publishes on npm's implicit latest behavior

## Testing
- pnpm exec prettier --check scripts/changes/publish.ts
- node --experimental-strip-types scripts/changes/publish.ts --dry-run --branch=v7
- node --experimental-strip-types scripts/changes/publish.ts --dry-run --branch=main