### PR TITLE
Remove AppLoadContext

### DIFF
--- a/docs/api/other-api/adapter.md
+++ b/docs/api/other-api/adapter.md
@@ -144,16 +144,16 @@ export const handler = createRequestHandler({
 Here's an example with Cloudflare:
 
 ```ts
-import { createRequestHandler } from "react-router";
+import {
+  RouterContextProvider,
+  createContext,
+  createRequestHandler,
+} from "react-router";
 
-declare module "react-router" {
-  export interface AppLoadContext {
-    cloudflare: {
-      env: Env;
-      ctx: ExecutionContext;
-    };
-  }
-}
+const cloudflareContext = createContext<{
+  env: Env;
+  ctx: ExecutionContext;
+}>();
 
 const requestHandler = createRequestHandler(
   () => import("virtual:react-router/server-build"),
@@ -162,9 +162,9 @@ const requestHandler = createRequestHandler(
 
 export default {
   async fetch(request, env, ctx) {
-    return requestHandler(request, {
-      cloudflare: { env, ctx },
-    });
+    let routerContext = new RouterContextProvider();
+    routerContext.set(cloudflareContext, { env, ctx });
+    return requestHandler(request, routerContext);
   },
 } satisfies ExportedHandler<Env>;
 ```

--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -335,7 +335,7 @@ Client middleware is simpler because since we are already on the client and are 
 
 ### Context API
 
-The new context system provides type safety and prevents naming conflicts and allows you to provide data to nested middlewares and `action`/`loader` functions. In Framework Mode, this replaces the previous `AppLoadContext` API.
+The context system provides type safety, prevents naming conflicts, and allows you to provide data to nested middlewares and `action`/`loader` functions.
 
 ```ts
 // ✅ Type-safe

--- a/docs/how-to/route-module-type-safety.md
+++ b/docs/how-to/route-module-type-safety.md
@@ -50,22 +50,7 @@ If you want to run type checking as its own command — for example, as part of 
 }
 ```
 
-## 4. Typing `AppLoadContext`
-
-## Extending app `Context` types
-
-To define your app's `context` type, add the following in a `.ts` or `.d.ts` file within your project:
-
-```typescript
-import "react-router";
-declare module "react-router" {
-  interface AppLoadContext {
-    // add context properties here
-  }
-}
-```
-
-## 5. Type-only auto-imports (optional)
+## 4. Type-only auto-imports (optional)
 
 When auto-importing the `Route` type helper, TypeScript will generate:
 

--- a/integration/helpers/vite-plugin-cloudflare-template/app/entry.server.tsx
+++ b/integration/helpers/vite-plugin-cloudflare-template/app/entry.server.tsx
@@ -1,4 +1,4 @@
-import type { AppLoadContext, EntryContext } from "react-router";
+import type { EntryContext, RouterContextProvider } from "react-router";
 import { ServerRouter } from "react-router";
 import { isbot } from "isbot";
 import { renderToReadableStream } from "react-dom/server";
@@ -8,7 +8,7 @@ export default async function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
-  _loadContext: AppLoadContext,
+  _loadContext: RouterContextProvider,
 ) {
   let shellRendered = false;
   const userAgent = request.headers.get("user-agent");

--- a/integration/middleware-test.ts
+++ b/integration/middleware-test.ts
@@ -1986,7 +1986,7 @@ test.describe("Middleware", () => {
             "app/entry.server.tsx": js`
               import { PassThrough } from "node:stream";
 
-              import type { AppLoadContext, EntryContext } from "react-router";
+              import type { EntryContext } from "react-router";
               import { createReadableStreamFromReadable } from "@react-router/node";
               import { ServerRouter } from "react-router";
               import type { RenderToPipeableStreamOptions } from "react-dom/server";

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -377,7 +377,7 @@ test.describe("SPA Mode", () => {
                 import * as path from "node:path";
                 import { PassThrough } from "node:stream";
 
-                import type { AppLoadContext, EntryContext } from "react-router";
+                import type { EntryContext, RouterContextProvider } from "react-router";
                 import { createReadableStreamFromReadable } from "@react-router/node";
                 import { ServerRouter } from "react-router";
                 import { renderToPipeableStream } from "react-dom/server";
@@ -387,7 +387,7 @@ test.describe("SPA Mode", () => {
                   responseStatusCode: number,
                   responseHeaders: Headers,
                   remixContext: EntryContext,
-                  loadContext: AppLoadContext
+                  loadContext: RouterContextProvider
                 ) {
                   return handleBotRequest(
                     request,

--- a/packages/react-router-dev/config/defaults/entry.server.node.tsx
+++ b/packages/react-router-dev/config/defaults/entry.server.node.tsx
@@ -1,6 +1,6 @@
 import { PassThrough } from "node:stream";
 
-import type { AppLoadContext, EntryContext } from "react-router";
+import type { EntryContext, RouterContextProvider } from "react-router";
 import { createReadableStreamFromReadable } from "@react-router/node";
 import { ServerRouter } from "react-router";
 import { isbot } from "isbot";
@@ -14,9 +14,7 @@ export default function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   routerContext: EntryContext,
-  loadContext: AppLoadContext,
-  // If you have middleware enabled:
-  // loadContext: RouterContextProvider
+  loadContext: RouterContextProvider,
 ) {
   // https://httpwg.org/specs/rfc9110.html#HEAD
   if (request.method.toUpperCase() === "HEAD") {

--- a/packages/react-router/.changes/patch.remove-app-load-context.md
+++ b/packages/react-router/.changes/patch.remove-app-load-context.md
@@ -1,0 +1,1 @@
+Remove the obsolete `AppLoadContext` type export accidentally left over from v7 now that middleware is always enabled and server request context is provided through `RouterContextProvider`.

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -277,8 +277,6 @@ export type {
   CookieSignatureOptions,
 } from "./lib/server-runtime/cookies";
 
-export type { AppLoadContext } from "./lib/server-runtime/data";
-
 export type {
   PageLinkDescriptor,
   HtmlLinkDescriptor,

--- a/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
+++ b/packages/react-router/lib/dom/ssr/routes-test-stub.tsx
@@ -166,7 +166,7 @@ export function createRoutesStub(
 
 function processRoutes(
   routes: StubRouteObject[],
-  context: unknown,
+  context: RouterContextProvider,
   manifest: AssetsManifest,
   routeModules: RouteModules,
   parentId?: string,
@@ -192,27 +192,16 @@ function processRoutes(
         ? withErrorBoundaryProps(route.ErrorBoundary)
         : undefined,
       action: route.action
-        ? (args: ActionFunctionArgs) =>
-            route.action!({
-              ...args,
-              context: context as Readonly<RouterContextProvider>,
-            })
+        ? (args: ActionFunctionArgs) => route.action!({ ...args, context })
         : undefined,
       loader: route.loader
-        ? (args: LoaderFunctionArgs) =>
-            route.loader!({
-              ...args,
-              context: context as Readonly<RouterContextProvider>,
-            })
+        ? (args: LoaderFunctionArgs) => route.loader!({ ...args, context })
         : undefined,
       middleware: route.middleware
         ? route.middleware.map(
             (mw) =>
               (...args: Parameters<MiddlewareFunction>) =>
-                mw(
-                  { ...args[0], context: context as RouterContextProvider },
-                  args[1],
-                ),
+                mw({ ...args[0], context }, args[1]),
           )
         : undefined,
       handle: route.handle,

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -4226,9 +4226,7 @@ export function createStaticHandler(
             pattern: getRoutePattern(matches),
             matches,
             params: matches[0].params,
-            // If we're calling middleware then it must be enabled so we can cast
-            // this to the proper type knowing it's not an `AppLoadContext`
-            context: requestContext as RouterContextProvider,
+            context: requestContext,
           },
           async () => {
             let res = await generateMiddlewareResponse(
@@ -4471,9 +4469,7 @@ export function createStaticHandler(
           pattern: getRoutePattern(matches),
           matches,
           params: matches[0].params,
-          // If we're calling middleware then it must be enabled so we can cast
-          // this to the proper type knowing it's not an `AppLoadContext`
-          context: requestContext as RouterContextProvider,
+          context: requestContext,
         },
         async () => {
           let res = await generateMiddlewareResponse(

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -488,11 +488,7 @@ export function getRSCSingleFetchDataStrategy(
       // requests returning multiple server payloads (due to clientLoaders, fine
       // grained revalidation, etc.).  This lets us stitch them all together and
       // patch them all at the end
-      // This cast should be fine since this is always run client side and
-      // `context` is always of this type on the client -- unlike on the server
-      // in framework mode when it could be `AppLoadContext`
-      let context = args.context as RouterContextProvider;
-      context.set(renderedRoutesContext, []);
+      args.context.set(renderedRoutesContext, []);
       let results = await dataStrategy(args);
       // patch into router from all payloads in map
       // TODO: Confirm that it's correct for us to have multiple rendered routes
@@ -500,7 +496,7 @@ export function getRSCSingleFetchDataStrategy(
       // where we're calling `fetchAndDecode` multiple times. This may be a
       // sign of a logical error in how we're handling client loader routes.
       const renderedRoutesById = new Map<string, RSCRouteManifest[]>();
-      for (const route of context.get(renderedRoutesContext)) {
+      for (const route of args.context.get(renderedRoutesContext)) {
         if (!renderedRoutesById.has(route.id)) {
           renderedRoutesById.set(route.id, []);
         }
@@ -531,10 +527,7 @@ function getFetchAndDecodeViaRSC(
   createFromReadableStream: BrowserCreateFromReadableStreamFunction,
   fetchImplementation: (request: Request) => Promise<Response>,
 ): FetchAndDecodeFunction {
-  return async (
-    args: DataStrategyFunctionArgs<unknown>,
-    targetRoutes?: string[],
-  ) => {
+  return async (args: DataStrategyFunctionArgs, targetRoutes?: string[]) => {
     let { request, context } = args;
     let url = singleFetchUrl(request.url, "rsc");
     if (request.method === "GET") {
@@ -584,13 +577,8 @@ function getFetchAndDecodeViaRSC(
       }
 
       // Track routes rendered per-single-fetch call so we can gather them up
-      // and patch them in together at the end.  This cast should be fine since
-      // this is always run client side and `context` is always of this type on
-      // the client -- unlike on the server in framework mode when it could be
-      // `AppLoadContext`
-      (context as RouterContextProvider)
-        .get(renderedRoutesContext)
-        .push(...payload.matches);
+      // and patch them in together at the end.
+      context.get(renderedRoutesContext).push(...payload.matches);
 
       let results: DecodedSingleFetchResults = { routes: {} };
       const dataKey = isMutationMethod(request.method)

--- a/packages/react-router/lib/server-runtime/data.ts
+++ b/packages/react-router/lib/server-runtime/data.ts
@@ -6,16 +6,6 @@ import type {
 } from "../router/utils";
 import { isDataWithResponseInit, isRedirectStatusCode } from "../router/router";
 
-/**
- * An object of unknown type for route loaders and actions provided by the
- * server's `getLoadContext()` function.  This is defined as an empty interface
- * specifically so apps can leverage declaration merging to augment this type
- * globally: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
- */
-export interface AppLoadContext {
-  [key: string]: unknown;
-}
-
 // Need to use RR's version here to permit the optional context even
 // though we know it'll always be provided in remix
 export async function callRouteHandler(


### PR DESCRIPTION
## Summary
- remove the obsolete AppLoadContext type export now that middleware always uses RouterContextProvider
- update framework/server templates, test stubs, and docs to reference RouterContextProvider/context APIs
- add a patch change file

## Testing
- pnpm run typecheck