### PR TITLE
Release v8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v8.0.1](#v801)
   - [v8.0.0](#v800)
     - [Baseline Support](#baseline-support)
     - [Adopted Future Flag Behavior](#adopted-future-flag-behavior)
@@ -102,6 +103,16 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v7.0.0](#v700)
 
 </details>
+
+## v8.0.1
+
+Date: 2026-06-18
+
+### Patch Changes
+
+- `react-router` - Remove the obsolete `AppLoadContext` type export accidentally left over from v7 now that middleware is always enabled and server request context is provided through `RouterContextProvider`. ([#15207](https://github.com/remix-run/react-router/pull/15207))
+
+**Full Changelog**: [`v8.0.0...v8.0.1`](https://github.com/remix-run/react-router/compare/react-router@8.0.0...react-router@8.0.1)
 
 ## v8.0.0
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v8.0.1
+
+### Patch Changes
+
+- _No changes_
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-react-router",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/architect`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/architect",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/cloudflare",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/dev`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)
+  - [`@react-router/serve@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/dev",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Dev tools and CLI for React Router",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/express`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/express",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/fs-routes",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/node`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/node",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/serve`
 
+## v8.0.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
+  - [`@react-router/express@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@8.0.1)
+  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/serve",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/patch.remove-app-load-context.md
+++ b/packages/react-router/.changes/patch.remove-app-load-context.md
@@ -1,1 +1,0 @@
-Remove the obsolete `AppLoadContext` type export accidentally left over from v7 now that middleware is always enabled and server request context is provided through `RouterContextProvider`.

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `react-router`
 
+## v8.0.1
+
+### Patch Changes
+
+- Remove the obsolete `AppLoadContext` type export accidentally left over from v7 now that middleware is always enabled and server request context is provided through `RouterContextProvider`. ([#15207](https://github.com/remix-run/react-router/pull/15207))
+
 ## v8.0.0
 
 ### Major Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-router",
   "type": "module",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `8.0.0` → `8.0.1` |
| @react-router/architect | `8.0.0` → `8.0.1` |
| @react-router/cloudflare | `8.0.0` → `8.0.1` |
| @react-router/dev | `8.0.0` → `8.0.1` |
| @react-router/express | `8.0.0` → `8.0.1` |
| @react-router/fs-routes | `8.0.0` → `8.0.1` |
| @react-router/node | `8.0.0` → `8.0.1` |
| @react-router/remix-routes-option-adapter | `8.0.0` → `8.0.1` |
| @react-router/serve | `8.0.0` → `8.0.1` |
| create-react-router | `8.0.0` → `8.0.1` |

# Changelogs

## react-router v8.0.1

### Patch Changes

- Remove the obsolete `AppLoadContext` type export accidentally left over from v7 now that middleware is always enabled and server request context is provided through `RouterContextProvider`. ([#15207](https://github.com/remix-run/react-router/pull/15207))


## @react-router/architect v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)


## @react-router/cloudflare v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)


## @react-router/dev v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)
  - [`@react-router/serve@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@8.0.1)


## @react-router/express v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)


## @react-router/fs-routes v8.0.1

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.0.1)


## @react-router/node v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)


## @react-router/remix-routes-option-adapter v8.0.1

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.0.1)


## @react-router/serve v8.0.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.0.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.0.1)
  - [`@react-router/express@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@8.0.1)
  - [`@react-router/node@8.0.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.0.1)


## create-react-router v8.0.1

### Patch Changes

- _No changes_
