### PR TITLE
Run buildEnd after prerendering

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -295,6 +295,51 @@ test.describe(`Prerendering`, () => {
       expect(html).toMatch('<p data-loader-data="true">About Loader Data</p>');
     });
 
+    test("Runs buildEnd after prerendering is complete", async () => {
+      let cwd = await createProject({
+        ...files,
+        "react-router.config.ts": js`
+          import fs from "node:fs";
+          import path from "node:path";
+
+          export default {
+            prerender: ["/about"],
+            async buildEnd({ reactRouterConfig }) {
+              let clientBuildDirectory = path.join(
+                reactRouterConfig.buildDirectory,
+                "client"
+              );
+
+              fs.writeFileSync(
+                "BUILD_END_META.json",
+                JSON.stringify({
+                  htmlExists: fs.existsSync(
+                    path.join(clientBuildDirectory, "about", "index.html")
+                  ),
+                  dataExists: fs.existsSync(
+                    path.join(clientBuildDirectory, "about.data")
+                  ),
+                })
+              );
+            },
+          };
+        `,
+      });
+
+      let result = build({ cwd });
+      expect(result.stderr.toString()).toBeFalsy();
+      expect(result.status).toBe(0);
+
+      await expect(
+        fs.promises.readFile(path.join(cwd, "BUILD_END_META.json"), "utf8"),
+      ).resolves.toEqual(
+        JSON.stringify({
+          htmlExists: true,
+          dataExists: true,
+        }),
+      );
+    });
+
     test("Prerenders a static array of routes with server bundles", async () => {
       fixture = await createFixture({
         prerender: true,

--- a/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
+++ b/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
@@ -1,0 +1,3 @@
+Run the `react-router.config.ts` `buildEnd` hook after prerendering is complete.
+
+- Ensures adapters and presets can inspect final prerendered build output from `buildEnd`.

--- a/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
+++ b/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
@@ -1,3 +1,1 @@
-Run the `react-router.config.ts` `buildEnd` hook after prerendering is complete.
-
-- Ensures adapters and presets can inspect final prerendered build output from `buildEnd`.
+Fix a regression with the new prerendering plugin where the `react-router.config.ts` `buildEnd` hook would run before prerendering was completed

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1358,33 +1358,18 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
               invariant(viteConfig);
               viteConfig.logger.info("Using Vite Environment API");
 
-              try {
-                let { reactRouterConfig } = ctx;
+              await cleanBuildDirectory(viteConfig, ctx);
 
-                await cleanBuildDirectory(viteConfig, ctx);
+              await builder.build(builder.environments.client);
 
-                await builder.build(builder.environments.client);
+              let serverEnvironments = getServerEnvironmentValues(
+                ctx,
+                builder.environments,
+              );
 
-                let serverEnvironments = getServerEnvironmentValues(
-                  ctx,
-                  builder.environments,
-                );
+              await Promise.all(serverEnvironments.map(builder.build));
 
-                await Promise.all(serverEnvironments.map(builder.build));
-
-                await cleanViteManifests(environments, ctx);
-
-                let { buildManifest } = ctx;
-                invariant(buildManifest, "Expected build manifest");
-
-                await reactRouterConfig.buildEnd?.({
-                  buildManifest,
-                  reactRouterConfig,
-                  viteConfig,
-                });
-              } finally {
-                await closePluginResources();
-              }
+              await cleanViteManifests(environments, ctx);
             },
           },
         };
@@ -2746,6 +2731,36 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }
       },
     }),
+    {
+      name: "react-router-build-end",
+      sharedDuringBuild: true,
+      config: {
+        order: "post",
+        handler({ builder: { buildApp } = {} }) {
+          return {
+            builder: {
+              async buildApp(builder) {
+                try {
+                  await buildApp?.(builder);
+
+                  invariant(viteConfig);
+                  let { buildManifest, reactRouterConfig } = ctx;
+                  invariant(buildManifest, "Expected build manifest");
+
+                  await reactRouterConfig.buildEnd?.({
+                    buildManifest,
+                    reactRouterConfig,
+                    viteConfig,
+                  });
+                } finally {
+                  await closePluginResources();
+                }
+              },
+            },
+          };
+        },
+      },
+    },
     validatePluginOrder(),
     warnOnClientSourceMaps(),
   ];


### PR DESCRIPTION
## Summary
- move the React Router config buildEnd hook to run after the prerender plugin completes
- keep buildEnd args unchanged and close plugin resources from the final build wrapper
- add a prerender regression test that verifies buildEnd can see generated HTML/data files

Closes #15206

## Testing
- pnpm test:integration:run integration/vite-prerender-test.ts --project chromium -g "Runs buildEnd after prerendering is complete"
- pnpm test:integration:run integration/vite-presets-test.ts --project chromium