### PR TITLE
[v7] Run buildEnd after preview prerendering

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -120,7 +120,7 @@ for (let previewServerPrerendering of [false, true]) {
     }
   `,
     "app/routes/about.tsx": js`
-    import { useActionData, useLoaderData } from "react-router";
+    import { useLoaderData } from "react-router";
 
     export function meta({ data }) {
       return [{
@@ -306,6 +306,59 @@ for (let previewServerPrerendering of [false, true]) {
         expect(html).toMatch('<h2 data-route="true">About</h2>');
         expect(html).toMatch(
           '<p data-loader-data="true">About Loader Data</p>',
+        );
+      });
+
+      test("Runs buildEnd after prerendering is complete", async () => {
+        test.skip(!previewServerPrerendering);
+
+        let cwd = await createProject(
+          {
+            ...files,
+            "react-router.config.ts": js`
+            import fs from "node:fs";
+            import path from "node:path";
+
+            export default {
+              prerender: ["/about"],
+              future: {
+                unstable_previewServerPrerendering: true,
+              },
+              async buildEnd({ reactRouterConfig }) {
+                let clientBuildDirectory = path.join(
+                  reactRouterConfig.buildDirectory,
+                  "client"
+                );
+
+                fs.writeFileSync(
+                  "BUILD_END_META.json",
+                  JSON.stringify({
+                    htmlExists: fs.existsSync(
+                      path.join(clientBuildDirectory, "about", "index.html")
+                    ),
+                    dataExists: fs.existsSync(
+                      path.join(clientBuildDirectory, "about.data")
+                    ),
+                  })
+                );
+              },
+            };
+          `,
+          },
+          "vite-6-template",
+        );
+
+        let result = build({ cwd });
+        expect(result.stderr.toString()).toBeFalsy();
+        expect(result.status).toBe(0);
+
+        await expect(
+          fs.promises.readFile(path.join(cwd, "BUILD_END_META.json"), "utf8"),
+        ).resolves.toEqual(
+          JSON.stringify({
+            htmlExists: true,
+            dataExists: true,
+          }),
         );
       });
 

--- a/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
+++ b/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
@@ -1,1 +1,1 @@
-Fix a regression with the new prerendering plugin where the `react-router.config.ts` `buildEnd` hook would run before prerendering was completed
+Fix a regression with the new `future._unstable_previewServerPrerendering` prerendering plugin where the `react-router.config.ts` `buildEnd` hook would run before prerendering was completed

--- a/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
+++ b/packages/react-router-dev/.changes/patch.build-end-after-prerender.md
@@ -1,0 +1,1 @@
+Fix a regression with the new prerendering plugin where the `react-router.config.ts` `buildEnd` hook would run before prerendering was completed

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -716,6 +716,15 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
   // change or route file addition/removal.
   let ctx: ReactRouterPluginContext;
 
+  let closePluginResources = async () => {
+    await viteChildCompiler?.close();
+    viteChildCompiler = null;
+    await reactRouterConfigLoader.close();
+
+    let typegenWatcher = await typegenWatcherPromise;
+    await typegenWatcher?.close();
+  };
+
   /** Mutates `ctx` as a side effect */
   let updatePluginContext = async (): Promise<void> => {
     let reactRouterConfig: ResolvedReactRouterConfig;
@@ -1429,8 +1438,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                       "Using Vite Environment API (experimental)",
                     );
 
-                    let { reactRouterConfig } = ctx;
-
                     await cleanBuildDirectory(viteConfig, ctx);
 
                     await builder.build(builder.environments.client);
@@ -1443,15 +1450,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                     await Promise.all(serverEnvironments.map(builder.build));
 
                     await cleanViteManifests(environments, ctx);
-
-                    let { buildManifest } = ctx;
-                    invariant(buildManifest, "Expected build manifest");
-
-                    await reactRouterConfig.buildEnd?.({
-                      buildManifest,
-                      reactRouterConfig,
-                      viteConfig,
-                    });
                   },
                 },
               }
@@ -2052,11 +2050,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         },
       },
       async buildEnd() {
-        await viteChildCompiler?.close();
-        await reactRouterConfigLoader.close();
+        if (
+          viteConfig?.command === "build" &&
+          ctx.reactRouterConfig.future.v8_viteEnvironmentApi
+        ) {
+          return;
+        }
 
-        let typegenWatcher = await typegenWatcherPromise;
-        await typegenWatcher?.close();
+        await closePluginResources();
       },
     },
     {
@@ -2889,6 +2890,42 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }
       },
     }),
+    {
+      name: "react-router-build-end",
+      sharedDuringBuild: true,
+      config: {
+        order: "post",
+        handler({ builder: { buildApp } = {} }) {
+          return {
+            builder: {
+              async buildApp(builder) {
+                try {
+                  await buildApp?.(builder);
+
+                  if (!ctx.reactRouterConfig.future.v8_viteEnvironmentApi) {
+                    return;
+                  }
+
+                  invariant(viteConfig);
+                  let { buildManifest, reactRouterConfig } = ctx;
+                  invariant(buildManifest, "Expected build manifest");
+
+                  await reactRouterConfig.buildEnd?.({
+                    buildManifest,
+                    reactRouterConfig,
+                    viteConfig,
+                  });
+                } finally {
+                  if (ctx?.reactRouterConfig.future.v8_viteEnvironmentApi) {
+                    await closePluginResources();
+                  }
+                }
+              },
+            },
+          };
+        },
+      },
+    },
     validatePluginOrder(),
     warnOnClientSourceMaps(),
   ];

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -725,6 +725,22 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     await typegenWatcher?.close();
   };
 
+  let isEnvironmentApiBuild = () =>
+    viteConfig?.command === "build" &&
+    ctx?.reactRouterConfig.future.v8_viteEnvironmentApi;
+
+  let runReactRouterConfigBuildEnd = async () => {
+    invariant(viteConfig);
+    let { buildManifest, reactRouterConfig } = ctx;
+    invariant(buildManifest, "Expected build manifest");
+
+    await reactRouterConfig.buildEnd?.({
+      buildManifest,
+      reactRouterConfig,
+      viteConfig,
+    });
+  };
+
   /** Mutates `ctx` as a side effect */
   let updatePluginContext = async (): Promise<void> => {
     let reactRouterConfig: ResolvedReactRouterConfig;
@@ -2050,10 +2066,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         },
       },
       async buildEnd() {
-        if (
-          viteConfig?.command === "build" &&
-          ctx.reactRouterConfig.future.v8_viteEnvironmentApi
-        ) {
+        if (isEnvironmentApiBuild()) {
           return;
         }
 
@@ -2890,8 +2903,12 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         }
       },
     }),
+    // In v7, prerendering only runs in a separate plugin when the Vite
+    // Environment API is enabled. Defer the user config `buildEnd` hook to
+    // this post-builder wrapper so that it runs after that plugin finalizes
+    // prerendered files; legacy builds keep their existing lifecycle.
     {
-      name: "react-router-build-end",
+      name: "react-router-environment-api-build-end",
       sharedDuringBuild: true,
       config: {
         order: "post",
@@ -2902,21 +2919,13 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 try {
                   await buildApp?.(builder);
 
-                  if (!ctx.reactRouterConfig.future.v8_viteEnvironmentApi) {
+                  if (!isEnvironmentApiBuild()) {
                     return;
                   }
 
-                  invariant(viteConfig);
-                  let { buildManifest, reactRouterConfig } = ctx;
-                  invariant(buildManifest, "Expected build manifest");
-
-                  await reactRouterConfig.buildEnd?.({
-                    buildManifest,
-                    reactRouterConfig,
-                    viteConfig,
-                  });
+                  await runReactRouterConfigBuildEnd();
                 } finally {
-                  if (ctx?.reactRouterConfig.future.v8_viteEnvironmentApi) {
+                  if (isEnvironmentApiBuild()) {
                     await closePluginResources();
                   }
                 }


### PR DESCRIPTION
## Summary
- Backport #15211 so the future-flagged prerender plugin runs buildEnd after prerender output is written
- Keep legacy prerender cleanup behavior unchanged outside the Vite Environment API path
- Add focused integration coverage for unstable_previewServerPrerendering

## Testing
- pnpm run --filter @react-router/dev build
- pnpm test:integration:run integration/vite-prerender-test.ts --project chromium -g "Runs buildEnd after prerendering is complete"