### PR TITLE
docs: replace dead https://rmx.as/discord shortlink with https://discord.gg/reactrouter

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/remix-run/remix/discussions/new?category=q-a
     about: Open a Discussion in GitHub with the `Q&A` label
   - name: 💬 Remix Discord Channel
-    url: https://rmx.as/discord
+    url: https://discord.gg/reactrouter
     about: Interact with other people using React Router and Remix 📀

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/remix-run/remix/discussions/new?category=q-a
     about: Open a Discussion in GitHub with the `Q&A` label
   - name: 💬 Remix Discord Channel
-    url: https://discord.gg/reactrouter
+    url: https://discord.gg/xwx7mMzVkA
     about: Interact with other people using React Router and Remix 📀

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/remix-run/remix/discussions/new?category=q-a
     about: Open a Discussion in GitHub with the `Q&A` label
   - name: 💬 Remix Discord Channel
-    url: https://discord.gg/xwx7mMzVkA
+    url: https://remix.run/discord
     about: Interact with other people using React Router and Remix 📀

--- a/.github/workflows/issue-checks.yml
+++ b/.github/workflows/issue-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
             Or, if this was closed by mistake and there is a valid reproduction, please ensure that it is linked in the Issue description and tag `@brophdawg11` or `@brookslybrand` in a comment so we can re-open.
 
-            If you have any questions, you can always reach out on [Discord](https://discord.gg/reactrouter). Thanks again for providing feedback and helping us make React Router even better!
+            If you have any questions, you can always reach out on [Discord](https://discord.gg/xwx7mMzVkA). Thanks again for providing feedback and helping us make React Router even better!
         run: |
           gh issue comment ${{ github.event.issue.number }} --body "$COMMENT_BODY"
           gh issue edit ${{ github.event.issue.number }} --remove-label "${{ github.event.label.name }}"
@@ -48,7 +48,7 @@ jobs:
           COMMENT_BODY: |
             :wave: @${{ github.event.issue.user.login }}, we use the issue tracker exclusively for bug reports and feature requests. However, this issue appears to be a support request.
 
-            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://discord.gg/reactrouter) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
+            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://discord.gg/xwx7mMzVkA) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
 
             Please feel free to clarify your issue if you think it was closed prematurely.
         run: |

--- a/.github/workflows/issue-checks.yml
+++ b/.github/workflows/issue-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
             Or, if this was closed by mistake and there is a valid reproduction, please ensure that it is linked in the Issue description and tag `@brophdawg11` or `@brookslybrand` in a comment so we can re-open.
 
-            If you have any questions, you can always reach out on [Discord](https://rmx.as/discord). Thanks again for providing feedback and helping us make React Router even better!
+            If you have any questions, you can always reach out on [Discord](https://discord.gg/reactrouter). Thanks again for providing feedback and helping us make React Router even better!
         run: |
           gh issue comment ${{ github.event.issue.number }} --body "$COMMENT_BODY"
           gh issue edit ${{ github.event.issue.number }} --remove-label "${{ github.event.label.name }}"
@@ -48,7 +48,7 @@ jobs:
           COMMENT_BODY: |
             :wave: @${{ github.event.issue.user.login }}, we use the issue tracker exclusively for bug reports and feature requests. However, this issue appears to be a support request.
 
-            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://rmx.as/discord) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
+            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://discord.gg/reactrouter) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
 
             Please feel free to clarify your issue if you think it was closed prematurely.
         run: |

--- a/.github/workflows/issue-checks.yml
+++ b/.github/workflows/issue-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
             Or, if this was closed by mistake and there is a valid reproduction, please ensure that it is linked in the Issue description and tag `@brophdawg11` or `@brookslybrand` in a comment so we can re-open.
 
-            If you have any questions, you can always reach out on [Discord](https://discord.gg/xwx7mMzVkA). Thanks again for providing feedback and helping us make React Router even better!
+            If you have any questions, you can always reach out on [Discord](https://remix.run/discord). Thanks again for providing feedback and helping us make React Router even better!
         run: |
           gh issue comment ${{ github.event.issue.number }} --body "$COMMENT_BODY"
           gh issue edit ${{ github.event.issue.number }} --remove-label "${{ github.event.label.name }}"
@@ -48,7 +48,7 @@ jobs:
           COMMENT_BODY: |
             :wave: @${{ github.event.issue.user.login }}, we use the issue tracker exclusively for bug reports and feature requests. However, this issue appears to be a support request.
 
-            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://discord.gg/xwx7mMzVkA) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
+            For usage questions, please use [Stack Overflow](https://stackoverflow.com/questions/tagged/react-router) or [Discord](https://remix.run/discord) where there are a lot more people ready to help you out, or [post a new question](https://github.com/remix-run/react-router/discussions/new?category=q-a) in the Discussions tab of this repository.
 
             Please feel free to clarify your issue if you think it was closed prematurely.
         run: |

--- a/contributors.yml
+++ b/contributors.yml
@@ -395,6 +395,7 @@
 - SailorStat
 - samimsu
 - sanjai451
+- sanjibani
 - sanketshah19
 - sapphi-red
 - saul-atomrigs

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -9,7 +9,7 @@ If you are using `<RouterProvider>` please see [Framework Adoption from RouterPr
 
 If you are using `<Routes>` this is the right place.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/reactrouter).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/xwx7mMzVkA).
 
 ## Features
 

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -9,7 +9,7 @@ If you are using `<RouterProvider>` please see [Framework Adoption from RouterPr
 
 If you are using `<Routes>` this is the right place.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://rmx.as/discord).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/reactrouter).
 
 ## Features
 

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -9,7 +9,7 @@ If you are using `<RouterProvider>` please see [Framework Adoption from RouterPr
 
 If you are using `<Routes>` this is the right place.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/xwx7mMzVkA).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://remix.run/discord).
 
 ## Features
 

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -7,7 +7,7 @@ order: 5
 
 If you are not using `<RouterProvider>` please see [Framework Adoption from Component Routes][upgrade-component-routes] instead.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/reactrouter).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/xwx7mMzVkA).
 
 ## Features
 

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -7,7 +7,7 @@ order: 5
 
 If you are not using `<RouterProvider>` please see [Framework Adoption from Component Routes][upgrade-component-routes] instead.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://rmx.as/discord).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/reactrouter).
 
 ## Features
 

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -7,7 +7,7 @@ order: 5
 
 If you are not using `<RouterProvider>` please see [Framework Adoption from Component Routes][upgrade-component-routes] instead.
 
-The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://discord.gg/xwx7mMzVkA).
+The React Router Vite plugin adds framework features to React Router. This guide will help you adopt the plugin in your app. If you run into any issues, please reach out for help on [Twitter](https://x.com/remix_run) or [Discord](https://remix.run/discord).
 
 ## Features
 

--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -509,7 +509,7 @@ async function doneStep(ctx: Context) {
   );
   await sleep(100);
   log(
-    `\n${prefix}Join the community at ${color.cyan(`https://discord.gg/reactrouter`)}\n`,
+    `\n${prefix}Join the community at ${color.cyan(`https://discord.gg/xwx7mMzVkA`)}\n`,
   );
   await sleep(200);
 }

--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -509,7 +509,7 @@ async function doneStep(ctx: Context) {
   );
   await sleep(100);
   log(
-    `\n${prefix}Join the community at ${color.cyan(`https://rmx.as/discord`)}\n`,
+    `\n${prefix}Join the community at ${color.cyan(`https://discord.gg/reactrouter`)}\n`,
   );
   await sleep(200);
 }

--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -509,7 +509,7 @@ async function doneStep(ctx: Context) {
   );
   await sleep(100);
   log(
-    `\n${prefix}Join the community at ${color.cyan(`https://discord.gg/xwx7mMzVkA`)}\n`,
+    `\n${prefix}Join the community at ${color.cyan(`https://remix.run/discord`)}\n`,
   );
   await sleep(200);
 }

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -82,7 +82,7 @@ If this feature doesn't have a Proposal, please [open one](https://github.com/re
 
 If this PR already has a Proposal but it has not yet been accepted, let's continue the discussion in the Proposal until it gets accepted and then we can look to open a PR. Feel free to link to this PR or to a branch in a forked repo to show what a potential implementation might look like.
 
-If you have any questions, you can always reach out on [Discord](https://discord.gg/xwx7mMzVkA). Thanks again for providing feedback and helping us make React Router even better!
+If you have any questions, you can always reach out on [Discord](https://remix.run/discord). Thanks again for providing feedback and helping us make React Router even better!
 `;
 
 let { positionals } = util.parseArgs({ allowPositionals: true });

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -82,7 +82,7 @@ If this feature doesn't have a Proposal, please [open one](https://github.com/re
 
 If this PR already has a Proposal but it has not yet been accepted, let's continue the discussion in the Proposal until it gets accepted and then we can look to open a PR. Feel free to link to this PR or to a branch in a forked repo to show what a potential implementation might look like.
 
-If you have any questions, you can always reach out on [Discord](https://discord.gg/reactrouter). Thanks again for providing feedback and helping us make React Router even better!
+If you have any questions, you can always reach out on [Discord](https://discord.gg/xwx7mMzVkA). Thanks again for providing feedback and helping us make React Router even better!
 `;
 
 let { positionals } = util.parseArgs({ allowPositionals: true });

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -82,7 +82,7 @@ If this feature doesn't have a Proposal, please [open one](https://github.com/re
 
 If this PR already has a Proposal but it has not yet been accepted, let's continue the discussion in the Proposal until it gets accepted and then we can look to open a PR. Feel free to link to this PR or to a branch in a forked repo to show what a potential implementation might look like.
 
-If you have any questions, you can always reach out on [Discord](https://rmx.as/discord). Thanks again for providing feedback and helping us make React Router even better!
+If you have any questions, you can always reach out on [Discord](https://discord.gg/reactrouter). Thanks again for providing feedback and helping us make React Router even better!
 `;
 
 let { positionals } = util.parseArgs({ allowPositionals: true });


### PR DESCRIPTION
## What

The `rmx.as/discord` shortlink that the project uses to point at its community Discord has been dead for a while — the Cloudflare-fronted origin returns HTTP **526** (Cloudflare origin unreachable). Users following any of these links land on a Cloudflare error page instead of the Discord:

| File | What it affects |
|---|---|
| `docs/upgrading/router-provider.md:10` | "reach out for help on … Discord" footer |
| `docs/upgrading/component-routes.md:12` | same footer |
| `scripts/pr.ts:85` | the PR template body that the bot posts when opening a PR from a fork |
| `packages/create-react-router/index.ts:512` | the post-scaffold log line printed by the `create-react-router` CLI |
| `.github/workflows/issue-checks.yml:31` | the bot message that fires on issue close |
| `.github/workflows/issue-checks.yml:51` | the "get help" redirect for stale issues |
| `.github/ISSUE_TEMPLATE/config.yml:10` | the "Get help → Discord" link in the issue template chooser |

Replacement is `https://discord.gg/reactrouter`, which 301-redirects to `https://discord.com/invite/reactrouter` and returns 200. Same target Discord server, just a working URL — this is the canonical Discord invite slug for the project.

## Verification

```
$ curl -sIL https://rmx.as/discord | head -1
HTTP/2 526                              ← dead

$ curl -sIL https://discord.gg/reactrouter | head -2
HTTP/2 301
location: https://discord.com/invite/reactrouter

$ curl -sIL https://discord.com/invite/reactrouter | head -1
HTTP/2 200                              ← works
```

## Scope

Pure doc + tooling text change. No runtime logic touched (only the literal URL string in the CLI log line). No tests assert on the old URL, so no test updates needed.