### PR TITLE
docs(decisions/0001): fix retired deno.land/manual/node/cdns link

### DIFF
--- a/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
+++ b/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
@@ -12,7 +12,7 @@ Deno has three ways to manage dependencies:
 2. [deps.ts](https://deno.land/manual/examples/manage_dependencies)
 3. [Import maps](https://deno.land/manual/linking_to_external_code/import_maps)
 
-Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://deno.land/manual/node/cdns#deno-friendly-cdns) like https://esm.sh.
+Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://docs.deno.com/runtime/manual/node/) like https://esm.sh. (The original deno.land/manual/node/cdns#deno-friendly-cdns anchor was retired when deno.land was deprecated in favor of docs.deno.com.)
 
 Remix has some requirements around dependencies:
 


### PR DESCRIPTION
Replaces `https://deno.land/manual/node/cdns#deno-friendly-cdns` (404 — deno.land was deprecated in favor of docs.deno.com) with `https://docs.deno.com/runtime/manual/node/` (200 — canonical docs.deno.com location for the Node/CDN integration docs; the specific `/cdns` subpath doesn't exist on the new site, so the link points to the parent `/node` page).