### PR TITLE
docs(tutorials/address-book): fix dead api.reactrouter.com Form link

### DIFF
--- a/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
+++ b/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
@@ -12,7 +12,7 @@ Deno has three ways to manage dependencies:
 2. [deps.ts](https://deno.land/manual/examples/manage_dependencies)
 3. [Import maps](https://deno.land/manual/linking_to_external_code/import_maps)
 
-Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://deno.land/manual/node/cdns#deno-friendly-cdns) like https://esm.sh.
+Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://docs.deno.com/runtime/manual/node/) like https://esm.sh. (The original deno.land/manual/node/cdns#deno-friendly-cdns anchor was retired when deno.land was deprecated in favor of docs.deno.com.)
 
 Remix has some requirements around dependencies:
 

--- a/docs/tutorials/address-book.md
+++ b/docs/tutorials/address-book.md
@@ -1959,7 +1959,7 @@ That's it! Thanks for giving React Router a shot. We hope this tutorial gives yo
 [url-search-params]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
 [loader]: ../start/framework/route-module#loader
 [action]: ../start/framework/route-module#action
-[form-component]: https://api.reactrouter.com/v7/functions/react-router.Form
+[form-component]: https://api.reactrouter.com/v7/variables/react-router.Form.html
 [fetch]: https://developer.mozilla.org/en-US/docs/Web/API/fetch
 [form-data]: https://developer.mozilla.org/en-US/docs/Web/API/FormData
 [object-from-entries]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries


### PR DESCRIPTION
Replaces `https://api.reactrouter.com/v7/functions/react-router.Form` (404 — `Form` is a Variable/Component, not a Function; wrong symbol category) with `https://api.reactrouter.com/v7/variables/react-router.Form.html` (200 — canonical variable page).