### PR TITLE
docs(api/{components,utils}): fix 7 dead api.reactrouter.com v8 component links

### DIFF
--- a/docs/api/components/Form.md
+++ b/docs/api/components/Form.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.Form.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.Form.html)
 
 A progressively enhanced HTML [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
 that submits data to actions via [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch),

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.Link.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.Link.html)
 
 A progressively enhanced [`<a href>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
 wrapper to enable navigation with client-side routing.

--- a/docs/api/components/NavLink.md
+++ b/docs/api/components/NavLink.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.NavLink.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.NavLink.html)
 
 Wraps [`<Link>`](../components/Link) with additional props for styling active and
 pending states.

--- a/docs/api/utils/createRoutesFromElements.md
+++ b/docs/api/utils/createRoutesFromElements.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/co
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.createRoutesFromElements.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.createRoutesFromElements.html)
 
 Create route objects from JSX elements instead of arrays of objects.
 

--- a/docs/api/utils/redirect.md
+++ b/docs/api/utils/redirect.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.redirect.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.redirect.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 Sets the status code and the [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location)

--- a/docs/api/utils/redirectDocument.md
+++ b/docs/api/utils/redirectDocument.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.redirectDocument.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.redirectDocument.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will force a document reload to the new location. Sets the status code

--- a/docs/api/utils/replace.md
+++ b/docs/api/utils/replace.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.replace.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.replace.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will perform a [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)


### PR DESCRIPTION
Replaces 7 `https://api.reactrouter.com/v8/functions/react-router.<sym>.html` URLs (404 — these symbols are categorized as Variables, not Functions) with `https://api.reactrouter.com/v8/variables/react-router.<sym>.html` (200).

Affects: Form.md, Link.md, NavLink.md, createRoutesFromElements.md, redirect.md, redirectDocument.md, replace.md.