### PR TITLE
docs(api/utils): fix 6 dead api.reactrouter.com v7 utility links

### DIFF
--- a/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
+++ b/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
@@ -12,7 +12,7 @@ Deno has three ways to manage dependencies:
 2. [deps.ts](https://deno.land/manual/examples/manage_dependencies)
 3. [Import maps](https://deno.land/manual/linking_to_external_code/import_maps)
 
-Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://deno.land/manual/node/cdns#deno-friendly-cdns) like https://esm.sh.
+Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://docs.deno.com/runtime/manual/node/) like https://esm.sh. (The original deno.land/manual/node/cdns#deno-friendly-cdns anchor was retired when deno.land was deprecated in favor of docs.deno.com.)
 
 Remix has some requirements around dependencies:
 

--- a/docs/api/utils/IsCookieFunction.md
+++ b/docs/api/utils/IsCookieFunction.md
@@ -8,4 +8,4 @@ title: IsCookieFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.IsCookieFunction.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/types/react-router.IsCookieFunction.html)

--- a/docs/api/utils/IsSessionFunction.md
+++ b/docs/api/utils/IsSessionFunction.md
@@ -8,4 +8,4 @@ title: IsSessionFunction
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.IsSessionFunction.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/types/react-router.IsSessionFunction.html)

--- a/docs/api/utils/createRequestHandler.md
+++ b/docs/api/utils/createRequestHandler.md
@@ -9,4 +9,4 @@ hidden: true
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.createRequestHandler.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/variables/react-router.createRequestHandler.html)

--- a/docs/api/utils/createSession.md
+++ b/docs/api/utils/createSession.md
@@ -9,7 +9,7 @@ hidden: true
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.createSession.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/variables/react-router.createSession.html)
 
 Creates a new Session object.
 

--- a/docs/api/utils/isCookie.md
+++ b/docs/api/utils/isCookie.md
@@ -8,6 +8,6 @@ title: isCookie
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.isCookie.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/variables/react-router.isCookie.html)
 
 Returns true if an object is a Remix cookie container.

--- a/docs/api/utils/isSession.md
+++ b/docs/api/utils/isSession.md
@@ -8,6 +8,6 @@ title: isSession
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v7/functions/react-router.isSession.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v7/variables/react-router.isSession.html)
 
 Returns true if an object is a React Router session.


### PR DESCRIPTION
Replaces 6 `https://api.reactrouter.com/v7/functions/react-router.<sym>.html` URLs (404 — wrong symbol category) with the correct categories:
- `IsCookieFunction` / `IsSessionFunction` → `/types/react-router.<sym>.html`
- `createRequestHandler` / `createSession` / `isCookie` / `isSession` → `/variables/react-router.<sym>.html`