### PR TITLE
Fix reference docs links for variable exports

### DIFF
--- a/docs/api/components/Form.md
+++ b/docs/api/components/Form.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.Form.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.Form.html)
 
 A progressively enhanced HTML [`<form>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
 that submits data to actions via [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/fetch),

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.Link.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.Link.html)
 
 A progressively enhanced [`<a href>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
 wrapper to enable navigation with client-side routing.

--- a/docs/api/components/NavLink.md
+++ b/docs/api/components/NavLink.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.NavLink.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.NavLink.html)
 
 Wraps [`<Link>`](../components/Link) with additional props for styling active and
 pending states.

--- a/docs/api/utils/createRoutesFromElements.md
+++ b/docs/api/utils/createRoutesFromElements.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/co
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.createRoutesFromElements.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.createRoutesFromElements.html)
 
 Create route objects from JSX elements instead of arrays of objects.
 

--- a/docs/api/utils/redirect.md
+++ b/docs/api/utils/redirect.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.redirect.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.redirect.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 Sets the status code and the [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location)

--- a/docs/api/utils/redirectDocument.md
+++ b/docs/api/utils/redirectDocument.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.redirectDocument.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.redirectDocument.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will force a document reload to the new location. Sets the status code

--- a/docs/api/utils/replace.md
+++ b/docs/api/utils/replace.md
@@ -20,7 +20,7 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ro
 
 ## Summary
 
-[Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.replace.html)
+[Reference Documentation ↗](https://api.reactrouter.com/v8/variables/react-router.replace.html)
 
 A redirect [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
 that will perform a [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState)

--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -287,18 +287,6 @@ function processTypedocModule(
                   ? "variables"
                   : undefined;
 
-    // Assigning an arrow function to a variable will be a "variable" here but
-    // typedoc will classify it as a "function".  We can identify these if they
-    // define `@params` or `@returns` tags in their JSDoc.
-    if (
-      type === "variables" &&
-      subChild.comment?.blockTags?.some(
-        (tag) => tag.tag === "@param" || tag.tag === "@returns",
-      )
-    ) {
-      type = "functions";
-    }
-
     if (!type) {
       warn(
         `Skipping ${apiName} because it is not a function, class, enum, interface, or type`,


### PR DESCRIPTION
## Summary

- Stop rewriting TypeDoc variable reflections into function reference URLs
- Regenerate affected API docs links for Form, Link, NavLink, createRoutesFromElements, redirect, redirectDocument, and replace

Replaces [remix-run/react-router#15222](https://github.com/remix-run/react-router/pull/15222)

## Testing

- pnpm exec typedoc --entryPoints packages/react-router --entryPointStrategy packages --json public/dev/api.json --out public/dev --name "React Router API Reference" --includeVersion false
- node scripts/docs.ts --api Form,Link,NavLink,createRoutesFromElements,redirect,redirectDocument,replace --write
- git diff --check