### PR TITLE
Fix release PR comment skip

### DIFF
--- a/scripts/release-comments.ts
+++ b/scripts/release-comments.ts
@@ -271,7 +271,7 @@ async function findMergedPRs(
 
       if (!pr) return;
 
-      if (pr.title.includes(`Release ${tag.clean}`)) {
+      if (pr.title.includes(`Release v${tag.clean}`)) {
         debug(`skipping release PR ${pr.number}`);
         return;
       }


### PR DESCRIPTION
## Summary
- Match release PR titles with the v-prefixed version when skipping release comments

## Testing
- node --check scripts/release-comments.ts
- pnpm exec prettier --check scripts/release-comments.ts