### PR TITLE
fix: warning with vite@8.1.0

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -47,6 +47,7 @@
 - Artur-
 - ashusnapx
 - avipatel97
+- AviVahl
 - awreese
 - aymanemadidi
 - ayushmanchhabra

--- a/packages/react-router-dev/.changes/patch.fix-envfile-warning-appeared-vite810.md
+++ b/packages/react-router-dev/.changes/patch.fix-envfile-warning-appeared-vite810.md
@@ -1,0 +1,1 @@
+Fix an "envFile" warning that appeared when using vite@8.1.0

--- a/packages/react-router-dev/.changes/patch.fix-envfile-warning-appeared-vite810.md
+++ b/packages/react-router-dev/.changes/patch.fix-envfile-warning-appeared-vite810.md
@@ -1,1 +1,1 @@
-Fix an "envFile" warning that appeared when using vite@8.1.0
+Replace the deprecated `envFile:false` Vite config with `envDir:false` to eliminate a deprecation warning when using vite@8.1.0+

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1455,7 +1455,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             hmr: false,
           },
           configFile: false,
-          envFile: false,
+          envDir: false,
           plugins: [
             childCompilerPlugins
               // Exclude this plugin from the child compiler to prevent an

--- a/packages/react-router-dev/vite/vite-runner.ts
+++ b/packages/react-router-dev/vite/vite-runner.ts
@@ -46,7 +46,7 @@ export async function createContext({
       postcss: {},
     },
     configFile: false,
-    envFile: false,
+    envDir: false,
     plugins: [],
     environments: {
       __config_loader: {


### PR DESCRIPTION
fixes https://github.com/remix-run/react-router/issues/15229

the new vite version started warning about this deprecated option being used.

envDir was added in vite@6.3.0, so react-router is safe to use it.

refs:
https://github.com/vitejs/vite/blob/v8.1.0/packages/vite/CHANGELOG.md
https://github.com/vitejs/vite/pull/22555