### PR TITLE
fix(dev): avoid Vite 8 envFile deprecation

### DIFF
--- a/packages/react-router-dev/.changes/patch.vite-8-envdir.md
+++ b/packages/react-router-dev/.changes/patch.vite-8-envdir.md
@@ -1,0 +1,1 @@
+Use `envDir: false` instead of the deprecated `envFile: false` option for internal Vite servers when running with Vite 8.

--- a/packages/react-router-dev/vite/env-test.ts
+++ b/packages/react-router-dev/vite/env-test.ts
@@ -1,0 +1,19 @@
+import { disableViteEnvFileLoading } from "./env";
+
+describe("disableViteEnvFileLoading", () => {
+  test("uses envFile on Vite 7", () => {
+    expect(
+      disableViteEnvFileLoading({
+        version: "7.2.0",
+      } as Parameters<typeof disableViteEnvFileLoading>[0]),
+    ).toEqual({ envFile: false });
+  });
+
+  test("uses envDir on Vite 8", () => {
+    expect(
+      disableViteEnvFileLoading({
+        version: "8.1.0",
+      } as Parameters<typeof disableViteEnvFileLoading>[0]),
+    ).toEqual({ envDir: false });
+  });
+});

--- a/packages/react-router-dev/vite/env.ts
+++ b/packages/react-router-dev/vite/env.ts
@@ -1,0 +1,13 @@
+type ViteModule = typeof import("vite");
+
+type DisableViteEnvFileLoadingConfig = {
+  envDir?: false;
+  envFile?: false;
+};
+
+export function disableViteEnvFileLoading(
+  vite: ViteModule,
+): DisableViteEnvFileLoadingConfig {
+  let viteMajor = Number(vite.version.split(".")[0]);
+  return viteMajor >= 8 ? { envDir: false } : { envFile: false };
+}

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -59,6 +59,7 @@ import * as VirtualModule from "./virtual-module";
 import { resolveFileUrl } from "./resolve-file-url";
 import { resolveRelativeRouteFilePath } from "./resolve-relative-route-file-path";
 import { combineURLs } from "./combine-urls";
+import { disableViteEnvFileLoading } from "./env";
 import { removeExports } from "./remove-exports";
 import { ssrExternals } from "./ssr-externals";
 import {
@@ -1455,7 +1456,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             hmr: false,
           },
           configFile: false,
-          envFile: false,
+          ...disableViteEnvFileLoading(vite),
           plugins: [
             childCompilerPlugins
               // Exclude this plugin from the child compiler to prevent an

--- a/packages/react-router-dev/vite/vite-runner.ts
+++ b/packages/react-router-dev/vite/vite-runner.ts
@@ -1,5 +1,6 @@
 import type * as Vite from "vite";
 
+import { disableViteEnvFileLoading } from "./env";
 import { preloadVite, getVite } from "./vite";
 import { ssrExternals } from "./ssr-externals";
 
@@ -46,7 +47,7 @@ export async function createContext({
       postcss: {},
     },
     configFile: false,
-    envFile: false,
+    ...disableViteEnvFileLoading(vite),
     plugins: [],
     environments: {
       __config_loader: {


### PR DESCRIPTION
Closes #15229.\n\n## Summary\n- use `envDir: false` instead of deprecated `envFile: false` for internal Vite servers when running with Vite 8+\n- keep `envFile: false` for Vite 7 compatibility\n- add focused coverage for the version-dependent config helper\n- add a patch change file for `@react-router/dev`\n\n## Testing\n- `node --experimental-vm-modules --no-warnings=ExperimentalWarning ./node_modules/jest/bin/jest.js packages/react-router-dev/vite/env-test.ts`\n- `./node_modules/.bin/eslint packages/react-router-dev/vite/env.ts packages/react-router-dev/vite/env-test.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/vite-runner.ts`\n- `./node_modules/.bin/prettier --check packages/react-router-dev/vite/env.ts packages/react-router-dev/vite/env-test.ts packages/react-router-dev/vite/plugin.ts packages/react-router-dev/vite/vite-runner.ts packages/react-router-dev/.changes/patch.vite-8-envdir.md`\n- `git diff --check`\n\nNote: direct package typecheck did not complete cleanly in this local checkout because of existing local toolchain/baseline issues unrelated to this change (unsupported `noUncheckedSideEffectImports` with the installed TypeScript, missing local `tsdown`, and existing framework/RSC type errors).