### PR TITLE
Fix SSR handling for encoded backslash splats

### DIFF
--- a/packages/react-router/.changes/patch.ssr-encoded-backslash-splat.md
+++ b/packages/react-router/.changes/patch.ssr-encoded-backslash-splat.md
@@ -1,0 +1,5 @@
+---
+"react-router": patch
+---
+
+Fix SSR handling for encoded backslashes in splat route params

--- a/packages/react-router/__tests__/dom/data-static-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-static-router-test.tsx
@@ -12,6 +12,7 @@ import {
   useLoaderData,
   useLocation,
   useMatches,
+  useParams,
   createStaticHandler,
   createStaticRouter,
   StaticRouterProvider,
@@ -23,6 +24,39 @@ beforeEach(() => {
 });
 
 describe("A <StaticRouterProvider>", () => {
+  it("handles encoded backslashes in splat params", async () => {
+    let params!: ReturnType<typeof useParams>;
+
+    function ParamsChecker() {
+      params = useParams();
+      return <h1>Splat Route</h1>;
+    }
+
+    let routes = [
+      {
+        path: "*",
+        element: <ParamsChecker />,
+      },
+    ];
+    let { query } = createStaticHandler(routes);
+
+    let context = (await query(
+      new Request("http://localhost/%5C", {
+        signal: new AbortController().signal,
+      }),
+    )) as StaticHandlerContext;
+
+    let html = ReactDOMServer.renderToStaticMarkup(
+      <StaticRouterProvider
+        router={createStaticRouter(routes, context)}
+        context={context}
+      />,
+    );
+
+    expect(html).toMatch("<h1>Splat Route</h1>");
+    expect(params).toEqual({ "*": "\\" });
+  });
+
   it("renders an initialized router", async () => {
     let hooksData1: {
       location: ReturnType<typeof useLocation>;

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -461,6 +461,9 @@ function encodeLocation(to: To): Path {
   // pre-encode them since they might be part of a matching splat param from
   // an ancestor route
   href = href.replace(/ $/, "%20");
+  // Backslashes can come from decoded splat params and need to be encoded
+  // before passing them through the URL constructor.
+  href = href.replace(/^[^?#]*/, (path) => path.replace(/\\/g, "%5C"));
   let encoded = ABSOLUTE_URL_REGEX.test(href)
     ? new URL(href)
     : new URL(href, "http://localhost");


### PR DESCRIPTION
## Summary

Fixes #15140.

- percent-encode backslashes in server-side `encodeLocation` path input before passing it to `new URL()`
- add an SSR regression test for a root splat matching `/%5C`
- add the required patch change file

## Verification

- `CI=true pnpm install --frozen-lockfile`
- `node --experimental-vm-modules --no-warnings=ExperimentalWarning ./node_modules/jest/bin/jest.js --config packages/react-router/jest.config.js packages/react-router/__tests__/dom/data-static-router-test.tsx --runInBand`
- `./node_modules/.bin/eslint packages/react-router/lib/dom/server.tsx packages/react-router/__tests__/dom/data-static-router-test.tsx`
- `./node_modules/.bin/prettier --check packages/react-router/lib/dom/server.tsx packages/react-router/__tests__/dom/data-static-router-test.tsx packages/react-router/.changes/patch.ssr-encoded-backslash-splat.md`
- `git diff --check`

Before starting, I checked that #15140 was open, unassigned, had no comments, and that there were no open PRs matching the issue number or encoded-backslash/encodeLocation terms.