### PR TITLE
docs(tutorials): fix dead Node.js debugging link in quickstart

### DIFF
--- a/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
+++ b/decisions/0001-use-npm-to-manage-npm-dependencies-for-deno-projects.md
@@ -12,7 +12,7 @@ Deno has three ways to manage dependencies:
 2. [deps.ts](https://deno.land/manual/examples/manage_dependencies)
 3. [Import maps](https://deno.land/manual/linking_to_external_code/import_maps)
 
-Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://deno.land/manual/node/cdns#deno-friendly-cdns) like https://esm.sh.
+Additionally, NPM packages can be accessed as Deno modules via [Deno-friendly CDNs](https://docs.deno.com/runtime/manual/node/) like https://esm.sh. (The original deno.land/manual/node/cdns#deno-friendly-cdns anchor was retired when deno.land was deprecated in favor of docs.deno.com.)
 
 Remix has some requirements around dependencies:
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -289,7 +289,7 @@ What's next?
 
 [templates]: ../start/framework/deploying#templates
 [spa]: ../how-to/spa
-[inspect]: https://nodejs.org/en/docs/guides/debugging-getting-started/
+[inspect]: https://nodejs.org/en/learn/getting-started/debugging
 [vite-config]: https://vite.dev/config
 [routing]: ../start/framework/routing
 [http-localhost-3000]: http://localhost:3000


### PR DESCRIPTION
The \`/en/docs/guides/debugging-getting-started/\` page returns 404 after the Node.js docs moved from \`/docs/\` to \`/learn/\`. The equivalent \`/en/learn/getting-started/debugging\` page is the canonical replacement.