### PR TITLE
Remove small runtime CLI dependencies

### DIFF
--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -1,6 +1,15 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { expect, test } from "@playwright/test";
 import dedent from "dedent";
@@ -8,11 +17,43 @@ import semver from "semver";
 
 import { createProject } from "./helpers/vite";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDirectory = path.resolve(__dirname, "..");
 const nodeBin = process.argv[0];
 const reactRouterBin = "node_modules/@react-router/dev/dist/cli/index.js";
+const reactRouterPackageBin = path.join(
+  rootDirectory,
+  "packages/react-router-dev/bin.cjs",
+);
 
 const run = (command: string[], options: Parameters<typeof spawnSync>[2]) =>
   spawnSync(nodeBin, [reactRouterBin, ...command], options);
+
+const getBinNodeEnv = (command: string[]) => {
+  let cwd = mkdtempSync(path.join(tmpdir(), "react-router-bin-"));
+  let env = { ...process.env };
+  delete env.NODE_ENV;
+
+  try {
+    mkdirSync(path.join(cwd, "dist/cli"), { recursive: true });
+    copyFileSync(reactRouterPackageBin, path.join(cwd, "bin.cjs"));
+    writeFileSync(
+      path.join(cwd, "dist/cli/index.js"),
+      "console.log(process.env.NODE_ENV);",
+    );
+
+    let { stdout, stderr, status } = spawnSync(
+      nodeBin,
+      ["bin.cjs", ...command],
+      { cwd, env },
+    );
+    expect(stderr.toString()).toBe("");
+    expect(status).toBe(0);
+    return stdout.toString().trim();
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+};
 
 const helpText = dedent`
   react-router
@@ -107,6 +148,17 @@ test.describe("cli", () => {
     expect(semver.valid(stdout.toString().trim())).not.toBeNull();
     expect(stderr.toString()).toBe("");
     expect(status).toBe(0);
+  });
+
+  test("bin sets NODE_ENV based on the positional command", async () => {
+    expect(getBinNodeEnv(["dev", "--host", "127.0.0.1"])).toBe("development");
+    expect(getBinNodeEnv(["--host", "127.0.0.1", "dev"])).toBe("development");
+    expect(getBinNodeEnv(["build", "--mode", "development"])).toBe(
+      "production",
+    );
+    expect(getBinNodeEnv(["--mode", "development", "build"])).toBe(
+      "production",
+    );
   });
 
   test("routes", async () => {

--- a/packages/create-react-router/.changes/patch.use-node-parse-args.md
+++ b/packages/create-react-router/.changes/patch.use-node-parse-args.md
@@ -1,1 +1,1 @@
-Use Node's built-in `parseArgs` utility for CLI argument parsing and remove the `arg` dependency.
+Use Node's built-in utilities for CLI argument parsing, ANSI-stripping, and child process execution to remove the `arg`, `strip-ansi`, and `execa` dependencies.

--- a/packages/create-react-router/__tests__/create-react-router-test.ts
+++ b/packages/create-react-router/__tests__/create-react-router-test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { execFileSync, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import {
   existsSync,
   mkdirSync,
@@ -13,8 +14,8 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { stripVTControlCharacters as stripAnsi } from "node:util";
 import semver from "semver";
-import stripAnsi from "strip-ansi";
 
 import { jestTimeout } from "./setupAfterEnv";
 import { server } from "./msw";
@@ -22,14 +23,16 @@ import { server } from "./msw";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const nodeRequire = createRequire(import.meta.url);
-const execaModuleId = nodeRequire.resolve("execa");
-const mockedExeca = jest.fn();
+const actualChildProcess = nodeRequire(
+  "node:child_process",
+) as typeof import("node:child_process");
+const mockedSpawn = jest.fn(actualChildProcess.spawn);
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const BUILT_CLI = path.resolve(__dirname, "../dist/cli.js");
 
-(jest as any).unstable_mockModule(execaModuleId, () => ({
-  default: mockedExeca,
-  execa: mockedExeca,
+(jest as any).unstable_mockModule("node:child_process", () => ({
+  ...actualChildProcess,
+  spawn: mockedSpawn,
 }));
 
 let createReactRouter: typeof import("../index").createReactRouter;
@@ -67,6 +70,7 @@ describe("create-react-router CLI", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedSpawn.mockImplementation(actualChildProcess.spawn);
   });
 
   afterEach(async () => {
@@ -75,6 +79,14 @@ describe("create-react-router CLI", () => {
     }
     tempDirs = new Set<string>();
   });
+
+  function mockSpawnSuccess() {
+    mockedSpawn.mockImplementation(() => {
+      let child = new EventEmitter();
+      process.nextTick(() => child.emit("exit", 0, null));
+      return child as ReturnType<typeof spawn>;
+    });
+  }
 
   function getProjectDir(name: string) {
     let tmpDir = path.join(TEMP_DIR, name);
@@ -580,8 +592,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("npm-install-default");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -599,7 +610,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "npm",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -615,8 +626,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("npm-install-on-unknown-package-manager");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -634,7 +644,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "npm",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -650,8 +660,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("npm-install-from-user-agent");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -669,7 +678,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "npm",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -684,8 +693,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("yarn-create-from-user-agent");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -703,7 +711,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "yarn",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -718,8 +726,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("pnpm-create-from-user-agent");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -737,7 +744,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -752,8 +759,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("bun-create-from-user-agent");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -771,7 +777,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "bun",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -786,8 +792,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("deno-create-from-user-agent");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -805,7 +810,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "deno",
       expect.arrayContaining(["install"]),
       expect.anything(),
@@ -820,8 +825,7 @@ describe("create-react-router CLI", () => {
 
     let projectDir = getProjectDir("pnpm-create-override");
 
-    let execa = mockedExeca;
-    execa.mockImplementation(async () => {});
+    mockSpawnSuccess();
 
     // Suppress terminal output
     let stdoutMock = jest
@@ -841,7 +845,7 @@ describe("create-react-router CLI", () => {
 
     stdoutMock.mockReset();
 
-    expect(execa).toHaveBeenCalledWith(
+    expect(mockedSpawn).toHaveBeenCalledWith(
       "pnpm",
       expect.arrayContaining(["install"]),
       expect.anything(),

--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -1,12 +1,11 @@
 import process from "node:process";
+import { spawn, type StdioOptions } from "node:child_process";
 import { existsSync } from "node:fs";
 import { cp, readFile, realpath, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseArgs } from "node:util";
-import stripAnsi from "strip-ansi";
-import { execa } from "execa";
+import { parseArgs, stripVTControlCharacters } from "node:util";
 import * as semver from "semver";
 import sortPackageJSON from "sort-package-json";
 
@@ -534,9 +533,9 @@ async function gitInitStep(ctx: Context) {
       let options = { cwd: ctx.cwd, stdio: "ignore" } as const;
       let commitMsg = "Initial commit from create-react-router";
       try {
-        await execa("git", ["init"], options);
-        await execa("git", ["add", "."], options);
-        await execa("git", ["commit", "-m", commitMsg], options);
+        await runCommand("git", ["init"], options);
+        await runCommand("git", ["add", "."], options);
+        await runCommand("git", ["commit", "-m", commitMsg], options);
       } catch (err) {
         error("Oh no!", "Failed to initialize git.");
         throw err;
@@ -560,7 +559,7 @@ async function doneStep(ctx: Context) {
       `\n${prefix}Enter your project directory using`,
       color.cyan(`cd .${path.sep}${projectDir}`),
     ];
-    let len = enter[0].length + stripAnsi(enter[1]).length;
+    let len = enter[0].length + stripVTControlCharacters(enter[1]).length;
     log(enter.join(len > max ? "\n" + prefix : " "));
   }
   log(
@@ -592,7 +591,7 @@ async function installDependencies({
   showInstallOutput: boolean;
 }) {
   try {
-    await execa(pkgManager, ["install"], {
+    await runCommand(pkgManager, ["install"], {
       cwd,
       stdio: showInstallOutput ? "inherit" : "ignore",
     });
@@ -600,6 +599,30 @@ async function installDependencies({
     error("Oh no!", "Failed to install dependencies.");
     throw err;
   }
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; stdio: StdioOptions },
+) {
+  return new Promise<void>((resolve, reject) => {
+    let child = spawn(command, args, options);
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            signal
+              ? `${command} exited with signal ${signal}`
+              : `${command} exited with code ${code}`,
+          ),
+        );
+      }
+    });
+  });
 }
 
 async function updatePackageJSON(ctx: Context) {

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -39,14 +39,12 @@
     }
   },
   "dependencies": {
-    "execa": "9.6.1",
     "gunzip-maybe": "^1.4.2",
     "log-update": "^8.0.0",
     "picocolors": "^1.1.1",
     "semver": "^7.8.1",
     "sisteransi": "^1.0.5",
     "sort-package-json": "^3.6.1",
-    "strip-ansi": "^7.2.0",
     "tar-fs": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/react-router-dev/bin.cjs
+++ b/packages/react-router-dev/bin.cjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
-void (async () => {
-  let { default: arg } = await import("arg");
+let { parseArgs } = require("node:util");
 
+const commands = new Set(["build", "dev", "reveal", "routes", "typegen"]);
+
+void (async () => {
   // Minimal replication of our actual parsing in `run.ts`. If not already set,
   // default `NODE_ENV` so React loads the proper version in its CJS entry script.
   // We have to do this before importing `run.ts` since that is what imports
   // `react` (indirectly via `react-router`)
-  let args = arg({}, { argv: process.argv.slice(2), permissive: true });
-  if (args._.length === 0 || args._[0] === "dev") {
+  let { positionals } = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    strict: false,
+  });
+  let command = positionals.find((positional) => commands.has(positional));
+  if (!command || command === "dev") {
     process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
   } else {
     process.env.NODE_ENV = process.env.NODE_ENV ?? "production";

--- a/packages/react-router-dev/cli/run.ts
+++ b/packages/react-router-dev/cli/run.ts
@@ -1,4 +1,4 @@
-import arg from "arg";
+import { parseArgs } from "node:util";
 import semver from "semver";
 import colors from "picocolors";
 
@@ -78,6 +78,26 @@ ${colors.blueBright("react-router")}
    $ react-router typegen --watch
 `;
 
+type ParsedValue = string | boolean | Array<string | boolean> | undefined;
+
+function getBooleanArg(value: ParsedValue) {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function getBooleanStringArg(value: ParsedValue) {
+  return typeof value === "boolean" || typeof value === "string"
+    ? value
+    : undefined;
+}
+
+function getNumberArg(value: ParsedValue) {
+  return typeof value === "string" ? Number(value) : undefined;
+}
+
+function getStringArg(value: ParsedValue) {
+  return typeof value === "string" ? value : undefined;
+}
+
 /**
  * Programmatic interface for running the react-router CLI with the given command line
  * arguments.
@@ -106,54 +126,66 @@ export async function run(
     return !nextArg || nextArg.startsWith("-");
   };
 
-  let args = arg(
-    {
-      "--force": Boolean,
-      "--help": Boolean,
-      "-h": "--help",
-      "--json": Boolean,
-      "--token": String,
-      "--typescript": Boolean,
-      "--no-typescript": Boolean,
-      "--version": Boolean,
-      "-v": "--version",
-      "--port": Number,
-      "-p": "--port",
-      "--config": String,
-      "-c": "--config",
-      "--assetsInlineLimit": Number,
-      "--clearScreen": Boolean,
-      "--cors": Boolean,
-      "--emptyOutDir": Boolean,
-      "--host": isBooleanFlag("--host") ? Boolean : String,
-      "--logLevel": String,
-      "-l": "--logLevel",
-      "--minify": String,
-      "--mode": String,
-      "-m": "--mode",
-      "--open": isBooleanFlag("--open") ? Boolean : String,
-      "--strictPort": Boolean,
-      "--profile": Boolean,
-      "--sourcemapClient": isBooleanFlag("--sourcemapClient")
-        ? Boolean
-        : String,
-      "--sourcemapServer": isBooleanFlag("--sourcemapServer")
-        ? Boolean
-        : String,
-      "--watch": Boolean,
+  let { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      assetsInlineLimit: { type: "string" },
+      clearScreen: { type: "boolean" },
+      config: { type: "string", short: "c" },
+      cors: { type: "boolean" },
+      emptyOutDir: { type: "boolean" },
+      force: { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+      host: { type: isBooleanFlag("--host") ? "boolean" : "string" },
+      json: { type: "boolean" },
+      logLevel: { type: "string", short: "l" },
+      minify: { type: "string" },
+      mode: { type: "string", short: "m" },
+      "no-typescript": { type: "boolean" },
+      open: { type: isBooleanFlag("--open") ? "boolean" : "string" },
+      port: { type: "string", short: "p" },
+      profile: { type: "boolean" },
+      sourcemapClient: {
+        type: isBooleanFlag("--sourcemapClient") ? "boolean" : "string",
+      },
+      sourcemapServer: {
+        type: isBooleanFlag("--sourcemapServer") ? "boolean" : "string",
+      },
+      strictPort: { type: "boolean" },
+      token: { type: "string" },
+      typescript: { type: "boolean" },
+      version: { type: "boolean", short: "v" },
+      watch: { type: "boolean" },
     },
-    {
-      argv,
-    },
-  );
+  });
 
-  let input = args._;
+  let input = positionals;
 
-  let flags: any = Object.entries(args).reduce((acc, [key, value]) => {
-    key = key.replace(/^--/, "");
-    acc[key] = value;
-    return acc;
-  }, {} as any);
+  let flags: any = {
+    assetsInlineLimit: getNumberArg(values.assetsInlineLimit),
+    clearScreen: getBooleanArg(values.clearScreen),
+    config: getStringArg(values.config),
+    cors: getBooleanArg(values.cors),
+    emptyOutDir: getBooleanArg(values.emptyOutDir),
+    force: getBooleanArg(values.force),
+    help: getBooleanArg(values.help),
+    host: getBooleanStringArg(values.host),
+    json: getBooleanArg(values.json),
+    logLevel: getStringArg(values.logLevel),
+    minify: getStringArg(values.minify),
+    mode: getStringArg(values.mode),
+    open: getBooleanStringArg(values.open),
+    port: getNumberArg(values.port),
+    profile: getBooleanArg(values.profile),
+    sourcemapClient: getBooleanStringArg(values.sourcemapClient),
+    sourcemapServer: getBooleanStringArg(values.sourcemapServer),
+    strictPort: getBooleanArg(values.strictPort),
+    token: getStringArg(values.token),
+    typescript: getBooleanArg(values.typescript),
+    version: getBooleanArg(values.version),
+    watch: getBooleanArg(values.watch),
+  };
 
   if (flags.help) {
     console.log(helpText);
@@ -165,7 +197,7 @@ export async function run(
   }
 
   flags.interactive = flags.interactive ?? isMain;
-  if (args["--no-typescript"]) {
+  if (values["no-typescript"]) {
     flags.typescript = false;
   }
 

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -75,7 +75,6 @@
     "@babel/types": "^7.29.7",
     "@react-router/node": "workspace:*",
     "@remix-run/node-fetch-server": "^0.13.3",
-    "arg": "^5.0.1",
     "babel-dead-code-elimination": "^1.0.12",
     "chokidar": "^5.0.0",
     "dedent": "^1.7.2",

--- a/packages/react-router-serve/.changes/patch.remove-get-port.md
+++ b/packages/react-router-serve/.changes/patch.remove-get-port.md
@@ -1,0 +1,1 @@
+Use Node's built-in networking APIs to find an available port and remove the `get-port` dependency.

--- a/packages/react-router-serve/cli.ts
+++ b/packages/react-router-serve/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import url from "node:url";
@@ -11,7 +12,6 @@ import express from "express";
 import type { RequestHandler as ExpressRequestHandler } from "express";
 import morgan from "morgan";
 import sourceMapSupport from "source-map-support";
-import getPort from "get-port";
 
 process.env.NODE_ENV = process.env.NODE_ENV ?? "production";
 
@@ -69,6 +69,51 @@ function parseNumber(raw?: string) {
   return maybe;
 }
 
+async function getAvailablePort(
+  preferredPort: number,
+  host?: string,
+): Promise<number> {
+  let preferredAvailablePort = await checkPort(preferredPort, host);
+  let availablePort = preferredAvailablePort ?? (await checkPort(0, host));
+
+  if (availablePort === undefined) {
+    throw new Error("No available port found");
+  }
+
+  return availablePort;
+}
+
+function checkPort(port: number, host?: string): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    let server = net.createServer();
+    let listenOptions = host ? { port, host } : { port };
+
+    server.unref();
+
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EADDRINUSE" || error.code === "EACCES") {
+        resolve(undefined);
+      } else {
+        reject(error);
+      }
+    });
+
+    server.listen(listenOptions, () => {
+      let address = server.address();
+      let availablePort =
+        typeof address === "object" && address ? address.port : port;
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(availablePort);
+        }
+      });
+    });
+  });
+}
+
 function getExpressPath(publicPath: string) {
   // Vite allows `base` to be an absolute URL, but Express route paths must be
   // pathnames. Strip any origin before mounting static asset middleware.
@@ -84,7 +129,9 @@ function getExpressPath(publicPath: string) {
 }
 
 async function run() {
-  let port = parseNumber(process.env.PORT) ?? (await getPort({ port: 3000 }));
+  let port =
+    parseNumber(process.env.PORT) ??
+    (await getAvailablePort(3000, process.env.HOST));
 
   let buildPathArg = process.argv[2];
 

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -43,7 +43,6 @@
     "@remix-run/node-fetch-server": "^0.13.3",
     "compression": "^1.8.1",
     "express": "^5.2.1",
-    "get-port": "7.2.0",
     "morgan": "^1.10.1",
     "source-map-support": "^0.5.21"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,9 +595,6 @@ importers:
 
   packages/create-react-router:
     dependencies:
-      execa:
-        specifier: 9.6.1
-        version: 9.6.1
       gunzip-maybe:
         specifier: ^1.4.2
         version: 1.4.2
@@ -616,9 +613,6 @@ importers:
       sort-package-json:
         specifier: ^3.6.1
         version: 3.6.1
-      strip-ansi:
-        specifier: ^7.2.0
-        version: 7.2.0
       tar-fs:
         specifier: ^3.1.2
         version: 3.1.2
@@ -790,9 +784,6 @@ importers:
       '@remix-run/node-fetch-server':
         specifier: ^0.13.3
         version: 0.13.3
-      arg:
-        specifier: ^5.0.1
-        version: 5.0.2
       babel-dead-code-elimination:
         specifier: ^1.0.12
         version: 1.0.12
@@ -1028,9 +1019,6 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      get-port:
-        specifier: 7.2.0
-        version: 7.2.0
       morgan:
         specifier: ^1.10.1
         version: 1.10.1
@@ -5016,9 +5004,6 @@ packages:
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -12541,8 +12526,6 @@ snapshots:
   app-root-path@3.1.0: {}
 
   are-docs-informative@0.0.2: {}
-
-  arg@5.0.2: {}
 
   argparse@1.0.10:
     dependencies:


### PR DESCRIPTION
This change replaces a few small published CLI runtime dependencies with Node built-ins.

- Use `node:util.parseArgs` for `create-react-router` and `@react-router/dev` argument parsing.
- Use `node:util.stripVTControlCharacters` and `node:child_process.spawn` in `create-react-router`.
- Use `node:net` in `@react-router/serve` to prefer port `3000` and fall back to an available port.
- Remove the corresponding published runtime dependency entries from package manifests and refresh the lockfile.
