### PR TITLE
Fix Vite node conditions for non-Node runtimes

### DIFF
--- a/integration/vite-plugin-cloudflare-test.ts
+++ b/integration/vite-plugin-cloudflare-test.ts
@@ -8,8 +8,12 @@ const tsx = dedent;
 const css = dedent;
 
 function defineFiles({
+  conditionalExportsRoute = false,
   reversePlugins = false,
-}: { reversePlugins?: boolean } = {}): Files {
+}: {
+  conditionalExportsRoute?: boolean;
+  reversePlugins?: boolean;
+} = {}): Files {
   const files: Files = async ({ port }) => {
     const inspectorPort = await getPort();
 
@@ -52,6 +56,42 @@ function defineFiles({
           padding: 20px;
         }
       `,
+      ...(conditionalExportsRoute
+        ? {
+            "app/routes/conditional-export.tsx": tsx`
+              import { runtime } from "conditional-runtime";
+
+              export function loader() {
+                return { runtime };
+              }
+
+              export default function ConditionalExportsRoute({
+                loaderData,
+              }: {
+                loaderData: { runtime: string };
+              }) {
+                return <div data-runtime>{loaderData.runtime}</div>;
+              }
+            `,
+            "node_modules/conditional-runtime/package.json": JSON.stringify({
+              name: "conditional-runtime",
+              type: "module",
+              exports: {
+                ".": {
+                  node: "./node.js",
+                  default: "./worker.js",
+                },
+              },
+            }),
+            "node_modules/conditional-runtime/node.js": tsx`
+              import "node:http";
+              export const runtime = "node";
+            `,
+            "node_modules/conditional-runtime/worker.js": tsx`
+              export const runtime = "worker";
+            `,
+          }
+        : {}),
     };
   };
   return files;
@@ -91,6 +131,18 @@ test.describe("vite-plugin-cloudflare", () => {
     await expect(page.locator("[data-loader-message]")).toHaveText(
       "Hello from Cloudflare",
     );
+  });
+
+  test("does not force node export conditions", async ({ dev, page }) => {
+    const files = defineFiles({ conditionalExportsRoute: true });
+    const { port } = await dev(files, "vite-plugin-cloudflare-template");
+
+    await page.goto(`http://localhost:${port}/conditional-export`, {
+      waitUntil: "networkidle",
+    });
+
+    expect(page.errors).toEqual([]);
+    await expect(page.locator("[data-runtime]")).toHaveText("worker");
   });
 
   test.describe("without JavaScript", () => {

--- a/integration/vite-plugin-cloudflare-test.ts
+++ b/integration/vite-plugin-cloudflare-test.ts
@@ -8,12 +8,8 @@ const tsx = dedent;
 const css = dedent;
 
 function defineFiles({
-  conditionalExportsRoute = false,
   reversePlugins = false,
-}: {
-  conditionalExportsRoute?: boolean;
-  reversePlugins?: boolean;
-} = {}): Files {
+}: { reversePlugins?: boolean } = {}): Files {
   const files: Files = async ({ port }) => {
     const inspectorPort = await getPort();
 
@@ -56,42 +52,6 @@ function defineFiles({
           padding: 20px;
         }
       `,
-      ...(conditionalExportsRoute
-        ? {
-            "app/routes/conditional-export.tsx": tsx`
-              import { runtime } from "conditional-runtime";
-
-              export function loader() {
-                return { runtime };
-              }
-
-              export default function ConditionalExportsRoute({
-                loaderData,
-              }: {
-                loaderData: { runtime: string };
-              }) {
-                return <div data-runtime>{loaderData.runtime}</div>;
-              }
-            `,
-            "node_modules/conditional-runtime/package.json": JSON.stringify({
-              name: "conditional-runtime",
-              type: "module",
-              exports: {
-                ".": {
-                  node: "./node.js",
-                  default: "./worker.js",
-                },
-              },
-            }),
-            "node_modules/conditional-runtime/node.js": tsx`
-              import "node:http";
-              export const runtime = "node";
-            `,
-            "node_modules/conditional-runtime/worker.js": tsx`
-              export const runtime = "worker";
-            `,
-          }
-        : {}),
     };
   };
   return files;
@@ -134,7 +94,42 @@ test.describe("vite-plugin-cloudflare", () => {
   });
 
   test("does not force node export conditions", async ({ dev, page }) => {
-    const files = defineFiles({ conditionalExportsRoute: true });
+    const baseFiles = defineFiles();
+    const files: Files = async (args) => ({
+      ...(await baseFiles(args)),
+      "app/routes/conditional-export.tsx": tsx`
+        import { runtime } from "conditional-runtime";
+
+        export function loader() {
+          return { runtime };
+        }
+
+        export default function ConditionalExportsRoute({
+          loaderData,
+        }: {
+          loaderData: { runtime: string };
+        }) {
+          return <div data-runtime>{loaderData.runtime}</div>;
+        }
+      `,
+      "node_modules/conditional-runtime/package.json": JSON.stringify({
+        name: "conditional-runtime",
+        type: "module",
+        exports: {
+          ".": {
+            node: "./node.js",
+            default: "./worker.js",
+          },
+        },
+      }),
+      "node_modules/conditional-runtime/node.js": tsx`
+        import "node:http";
+        export const runtime = "node";
+      `,
+      "node_modules/conditional-runtime/worker.js": tsx`
+        export const runtime = "worker";
+      `,
+    });
     const { port } = await dev(files, "vite-plugin-cloudflare-template");
 
     await page.goto(`http://localhost:${port}/conditional-export`, {

--- a/packages/react-router-dev/.changes/patch.vite-node-external-conditions.md
+++ b/packages/react-router-dev/.changes/patch.vite-node-external-conditions.md
@@ -1,0 +1,3 @@
+Only add the `"node"` Vite server condition for Framework mode apps that declare a Node server adapter dependency
+
+This prevents non-Node SSR runtimes from resolving Node-specific package exports by default.

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -1125,14 +1125,6 @@ function omitRoutes(
   };
 }
 
-export function hasNodeDependency(deps: Record<string, string>) {
-  return (
-    deps["@react-router/node"] ||
-    deps["@react-router/express"] ||
-    deps["@react-router/serve"]
-  );
-}
-
 const entryExts = [".js", ".jsx", ".ts", ".tsx", ".mjs", ".mts"];
 
 function isEntryFile(entryBasename: string, filename: string) {

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -1125,6 +1125,14 @@ function omitRoutes(
   };
 }
 
+export function hasNodeDependency(deps: Record<string, string>) {
+  return (
+    deps["@react-router/node"] ||
+    deps["@react-router/express"] ||
+    deps["@react-router/serve"]
+  );
+}
+
 const entryExts = [".js", ".jsx", ".ts", ".tsx", ".mjs", ".mts"];
 
 function isEntryFile(entryBasename: string, filename: string) {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -82,7 +82,6 @@ import {
   resolveEntryFiles,
   configRouteToBranchRoute,
   type PrerenderPaths,
-  hasNodeDependency,
 } from "../config/config";
 import { getOptimizeDepsEntries } from "./optimize-deps-entries";
 import { decorateComponentExportsWithProps } from "./with-props";
@@ -3563,8 +3562,6 @@ export async function getEnvironmentOptionsResolvers(
     let maybeDevelopmentConditions =
       viteCommand === "build" ? [] : ["development"];
 
-    let isNode = hasNodeDependency(pkgJson.dependencies || {});
-
     // Default conditions are overridden by any custom conditions. If we wish
     // to retain the default conditions, we need to manually merge them using
     // the provided default conditions arrays exported from Vite.
@@ -3573,6 +3570,13 @@ export async function getEnvironmentOptionsResolvers(
 
     // Vite added this in 7.1, so we need to be defensive since our minimum version is 7.0
     let defaultExternalConditions = vite.defaultExternalConditions ?? ["node"];
+
+    // If we couldn't find the package.json, we assume node for backwards compatibility
+    let isNode =
+      !pkgJson.dependencies ||
+      pkgJson.dependencies["@react-router/node"] ||
+      pkgJson.dependencies["@react-router/express"] ||
+      pkgJson.dependencies["@react-router/serve"];
 
     if (!isNode) {
       maybeDefaultServerConditions = maybeDefaultServerConditions.filter(

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -36,6 +36,7 @@ import pick from "lodash/pick.js";
 import jsesc from "jsesc";
 import colors from "picocolors";
 import kebabCase from "lodash/kebabCase.js";
+import { readPackageJSON, type PackageJson } from "pkg-types";
 
 const nodeRequire = createRequire(import.meta.url);
 
@@ -81,6 +82,7 @@ import {
   resolveEntryFiles,
   configRouteToBranchRoute,
   type PrerenderPaths,
+  hasNodeDependency,
 } from "../config/config";
 import { getOptimizeDepsEntries } from "./optimize-deps-entries";
 import { decorateComponentExportsWithProps } from "./with-props";
@@ -3500,6 +3502,9 @@ export async function getEnvironmentOptionsResolvers(
   viteCommand: Vite.ResolvedConfig["command"],
 ): Promise<EnvironmentOptionsResolvers> {
   let { serverBuildFile, serverModuleFormat } = ctx.reactRouterConfig;
+  let pkgJson: PackageJson = await readPackageJSON(ctx.rootDirectory).catch(
+    () => ({}),
+  );
 
   let packageRoot = path.dirname(
     nodeRequire.resolve("@react-router/dev/package.json"),
@@ -3558,16 +3563,25 @@ export async function getEnvironmentOptionsResolvers(
     let maybeDevelopmentConditions =
       viteCommand === "build" ? [] : ["development"];
 
+    let isNode = hasNodeDependency(pkgJson.dependencies || {});
+
     // Default conditions are overridden by any custom conditions. If we wish
     // to retain the default conditions, we need to manually merge them using
     // the provided default conditions arrays exported from Vite.
     // https://vite.dev/guide/migration.html#default-value-for-resolve-conditions
     let maybeDefaultServerConditions = vite.defaultServerConditions || [];
 
-    // There is no helpful export with the default external conditions (see
-    // https://github.com/vitejs/vite/pull/20279 for more details). So, for now,
-    // we are hardcording the default here.
-    let defaultExternalConditions = ["node"];
+    // Vite added this in 7.1, so we need to be defensive since our minimum version is 7.0
+    let defaultExternalConditions = vite.defaultExternalConditions ?? ["node"];
+
+    if (!isNode) {
+      maybeDefaultServerConditions = maybeDefaultServerConditions.filter(
+        (c) => c !== "node",
+      );
+      defaultExternalConditions = defaultExternalConditions.filter(
+        (c) => c !== "node",
+      );
+    }
 
     let baseConditions = [
       ...maybeDevelopmentConditions,


### PR DESCRIPTION
This updates the Vite plugin's SSR environment defaults to only include the `"node"` export condition when the app declares a Node server adapter dependency.

Non-Node runtimes such as Cloudflare Workers now resolve package conditional exports without React Router forcing the Node branch. This also keeps Vite 7.0 compatibility by falling back when `defaultExternalConditions` is not exported.

Closes #14730
Supersedes #14936
