### PR TITLE
test: fix "it's" to "its" in resource routes test description

### DIFF
--- a/integration/resource-routes-test.ts
+++ b/integration/resource-routes-test.ts
@@ -205,7 +205,7 @@ test.describe("loader in an app", async () => {
       );
     });
 
-    test("should let loader throw to it's own boundary without a default export", async ({
+    test("should let loader throw to its own boundary without a default export", async ({
       page,
     }) => {
       let app = new PlaywrightFixture(appFixture, page);


### PR DESCRIPTION
Fixes a possessive grammar typo in a test description: `it's own boundary` -> `its own boundary`.
