### PR TITLE
fix(router): preserve navigation blocker state through a revalidation

### DIFF
--- a/packages/react-router/.changes/patch.preserve-navigation-blocker-state-through-revalidation.md
+++ b/packages/react-router/.changes/patch.preserve-navigation-blocker-state-through-revalidation.md
@@ -1,0 +1,1 @@
+Preserve navigation blocker state through a revalidation

--- a/packages/react-router/__tests__/router/navigation-blocking-test.ts
+++ b/packages/react-router/__tests__/router/navigation-blocking-test.ts
@@ -175,6 +175,19 @@ describe("navigation blocking", () => {
         expect(router.state.location.pathname).toBe(pathnameBeforeNavigation);
       });
     });
+
+    describe("revalidation while blocked", () => {
+      let fn = () => true;
+      it("preserves a 'blocked' blocker through a revalidation", async () => {
+        router.getBlocker("KEY", fn);
+        await router.navigate("/about");
+        expect(router.getBlocker("KEY", fn).state).toBe("blocked");
+
+        // a revalidation is not a navigation, so it must not clear the blocker
+        await router.revalidate();
+        expect(router.getBlocker("KEY", fn).state).toBe("blocked");
+      });
+    });
   });
 
   describe("on history replace", () => {

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1544,9 +1544,10 @@ export function createRouter(init: RouterInit): Router {
       : state.loaderData;
 
     // On a successful navigation we can assume we got through all blockers
-    // so we can start fresh
+    // so we can start fresh.  A revalidation is not a navigation, so it must
+    // leave any active blocker untouched.
     let blockers = state.blockers;
-    if (blockers.size > 0) {
+    if (blockers.size > 0 && !isUninterruptedRevalidation) {
       blockers = new Map(blockers);
       blockers.forEach((_, k) => blockers.set(k, IDLE_BLOCKER));
     }


### PR DESCRIPTION
Closes #13439

A revalidation flows through `completeNavigation`, which reset every active blocker to the idle state. Because a revalidation is not a navigation, an in-progress blocker was cleared whenever loaders revalidated.

The reset now skips uninterrupted revalidations (`router.revalidate()` and loader-driven revalidations), so a blocked blocker keeps its state; real navigations still reset blockers as before.
