### PR TITLE
Avoid retaining chunks while monitoring writable stream errors

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -215,6 +215,7 @@
 - jenseng
 - JeraldVin
 - JesusTheHun
+- jianongHe
 - jimniels
 - jmargeta
 - jmjpro

--- a/packages/react-router-node/.changes/patch.stop-retaining-stream-chunks.md
+++ b/packages/react-router-node/.changes/patch.stop-retaining-stream-chunks.md
@@ -1,0 +1,1 @@
+Stop retaining streamed chunks while monitoring writable stream errors.

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -3,6 +3,8 @@
  */
 
 import { Writable } from "node:stream";
+import v8 from "node:v8";
+import vm from "node:vm";
 
 import {
   writeAsyncIterableToWritable,
@@ -43,6 +45,23 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([promise, timeoutPromise]).finally(() =>
     clearTimeout(timeout),
   );
+}
+
+function getGarbageCollector(): () => void {
+  let globalWithGc = globalThis as typeof globalThis & { gc?: () => void };
+  if (typeof globalWithGc.gc === "function") {
+    return globalWithGc.gc;
+  }
+
+  v8.setFlagsFromString("--expose-gc");
+  return vm.runInNewContext("gc") as () => void;
+}
+
+async function collectGarbage(gc: () => void) {
+  for (let i = 0; i < 5; i++) {
+    gc();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 describe("writeReadableStreamToWritable", () => {
@@ -91,6 +110,54 @@ describe("writeReadableStreamToWritable", () => {
     await expect(withTimeout(writePromise, 100)).rejects.toThrow(
       "Writable failed",
     );
+  });
+
+  it("does not retain written chunks while waiting for the next chunk", async () => {
+    let gc = getGarbageCollector();
+    let numChunks = 500;
+    let chunkSize = 16 * 1024;
+    let refs: WeakRef<Uint8Array>[] = [];
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    let resolveChunksWritten!: () => void;
+    let chunksWritten = new Promise<void>((resolve) => {
+      resolveChunksWritten = resolve;
+    });
+    let writeCount = 0;
+
+    let readable = new ReadableStream<Uint8Array>({
+      start(readableController) {
+        controller = readableController;
+
+        for (let i = 0; i < numChunks; i++) {
+          let chunk = new Uint8Array(chunkSize);
+          refs.push(new WeakRef(chunk));
+          readableController.enqueue(chunk);
+        }
+      },
+    });
+    let writable = new Writable({
+      highWaterMark: numChunks * chunkSize,
+      write(_chunk, _encoding, callback) {
+        writeCount++;
+        if (writeCount === numChunks) {
+          resolveChunksWritten();
+        }
+        callback();
+      },
+    });
+
+    let writePromise = writeReadableStreamToWritable(readable, writable);
+
+    try {
+      await chunksWritten;
+      await collectGarbage(gc);
+
+      let retainedChunks = refs.filter((ref) => ref.deref()).length;
+      expect(retainedChunks).toBeLessThan(numChunks / 10);
+    } finally {
+      controller.close();
+      await writePromise.catch(() => {});
+    }
   });
 });
 

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -58,15 +58,12 @@ interface WritableErrorMonitor {
 function monitorWritableError(writable: Writable): WritableErrorMonitor {
   let settled = false;
   let writableError: Error | undefined;
-  let rejectWritableError!: (error: Error) => void;
-  let writableErrorPromise = new Promise<never>((_, reject) => {
-    rejectWritableError = reject;
-  });
-  writableErrorPromise.catch(() => {});
+  let waiters = new Set<(error: Error) => void>();
 
   function cleanup() {
     writable.off("error", onError);
     writable.off("close", onClose);
+    waiters.clear();
   }
 
   function reject(error: Error) {
@@ -76,8 +73,13 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
 
     settled = true;
     writableError = error;
+    let pendingWaiters = Array.from(waiters);
+    waiters.clear();
     cleanup();
-    rejectWritableError(error);
+
+    for (let waiter of pendingWaiters) {
+      waiter(error);
+    }
   }
 
   function onError(error: Error) {
@@ -94,7 +96,29 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
   return {
     cleanup,
     race<T>(promise: Promise<T>) {
-      return Promise.race([promise, writableErrorPromise]);
+      if (writableError) {
+        return Promise.reject(writableError);
+      }
+
+      return new Promise<T>((resolve, reject) => {
+        function onWritableError(error: Error) {
+          waiters.delete(onWritableError);
+          reject(error);
+        }
+
+        waiters.add(onWritableError);
+
+        promise.then(
+          (value) => {
+            waiters.delete(onWritableError);
+            resolve(value);
+          },
+          (error) => {
+            waiters.delete(onWritableError);
+            reject(error);
+          },
+        );
+      });
     },
     throwIfClosed() {
       if (writableError) {


### PR DESCRIPTION
Fixes #15247.

`monitorWritableError` previously used `Promise.race` against one shared pending writable-error promise for every read/iterator/drain wait. While a stream stayed open, that shared promise retained the settled race promises and their streamed chunk values.

This replaces the shared promise with per-wait writable-error waiters that are removed as soon as the watched promise settles, while preserving the existing writable error/close behavior.

Verification:
- Added a regression test that fails on the old implementation with 500 retained chunks.
- Ran `pnpm test packages/react-router-node/__tests__/stream-test.ts --runInBand`.
- Ran `pnpm test packages/react-router-node --runInBand`.
- Ran `pnpm test --runInBand`.
- Ran `pnpm run --filter react-router build`.
- Ran `pnpm run --filter @react-router/dev build`.
- Ran `pnpm run --filter @react-router/node typecheck`.
- Ran `pnpm run --filter @react-router/node build`.
- Ran `pnpm run changes:validate`.
