### PR TITLE
docs: add note about ComponentProps.matches[n].data change in v7 upgrade guide

### DIFF
--- a/docs/upgrading/v7.md
+++ b/docs/upgrading/v7.md
@@ -289,7 +289,7 @@ If you have custom app, CDN, cache, or rewrite logic that matches `.data` reques
 
 The changes in this section are not controlled by future flags, but you can update your code in v7 to be ready for v8.
 
-### `meta` `data` Argument
+### `meta`/`matches` `data` Values
 
 [MODES: framework]
 
@@ -298,7 +298,13 @@ The changes in this section are not controlled by future flags, but you can upda
 
 **Background**
 
-The `data` fields passed to route module `meta` functions are deprecated and will be removed in React Router v8. Use `loaderData` instead on `MetaArgs` and each item in `MetaArgs.matches`.
+`data` fields are deprecated in favor of `loaderData` in a few places and are removed in v8:
+
+- `meta` function `data` argument
+- `meta` function `matches` argument (`matches[i].data`)
+- `useMatches()` (`matches[i].data`)
+
+Use `loaderData` instead on `MetaArgs`, each item in `MetaArgs.matches`, and each match returned from `useMatches()`
 
 👉 **Update your Code**
 
@@ -331,7 +337,16 @@ export function meta({ matches }: Route.MetaArgs) {
 }
 ```
 
-> Note: The same change applies to `ComponentProps` used in route components. If you access `matches[n].data` in your route component, update it to `matches[n].loaderData`.
+Replace `data` with `loaderData` on `useMatches()` calls:
+
+```diff
+export default function Component({ matches, loaderData }: ComponentProps) {
+  let matches = useMatches();
+- const rootLoaderData = matches[0].data;
++ const rootLoaderData = matches[0].loaderData;
+  // ...
+}
+```
 
 ### `react-router-dom`
 

--- a/docs/upgrading/v7.md
+++ b/docs/upgrading/v7.md
@@ -327,9 +327,11 @@ export function meta({ matches }: Route.MetaArgs) {
 -  let rootData = rootMatch?.data;
 +  let rootData = rootMatch?.loaderData;
 
-  return [{ title: rootData?.siteTitle }];
+  return [{ title: rootData?.siteTitle }  ];
 }
 ```
+
+> Note: The same change applies to `ComponentProps` used in route components. If you access `matches[n].data` in your route component, update it to `matches[n].loaderData`.
 
 ### `react-router-dom`
 

--- a/docs/upgrading/v7.md
+++ b/docs/upgrading/v7.md
@@ -327,7 +327,7 @@ export function meta({ matches }: Route.MetaArgs) {
 -  let rootData = rootMatch?.data;
 +  let rootData = rootMatch?.loaderData;
 
-  return [{ title: rootData?.siteTitle }  ];
+  return [{ title: rootData?.siteTitle }];
 }
 ```
 


### PR DESCRIPTION
Fixes #15244

Adds a note that the `data` → `loaderData` rename on `matches[n]` also affects `ComponentProps` in route components, not just `meta` functions.