### PR TITLE
Guard PR checks script changes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - name: Check changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
         id: changed-files
         run: |
           changed_files="$(gh pr diff "${{ github.event.pull_request.number }}" --repo "$GITHUB_REPOSITORY" --name-only)"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,22 +22,54 @@ jobs:
       pull-requests: read
 
     steps:
+      - name: Check changed files
+        id: changed-files
+        run: |
+          changed_files="$(gh pr diff "${{ github.event.pull_request.number }}" --repo "$GITHUB_REPOSITORY" --name-only)"
+
+          touches_scripts="false"
+          touches_packages="false"
+
+          while IFS= read -r file; do
+            case "$file" in
+              scripts/*) touches_scripts="true" ;;
+              packages/*) touches_packages="true" ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$touches_scripts" = "true" ] && [ "$touches_packages" = "true" ]; then
+            echo "PR checks cannot safely run when a PR changes both scripts/ and packages/."
+            echo "Please split automation changes and package changes into separate PRs."
+            exit 1
+          elif [ "$touches_scripts" = "true" ]; then
+            echo "PR touches scripts/ without touching packages/; skipping community helper checks."
+            echo '{"prNumber":${{ github.event.pull_request.number }},"actions":[]}' > pr-checks-result.json
+            echo "mode=skip" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=run" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repo
+        if: steps.changed-files.outputs.mode == 'run'
         uses: actions/checkout@v7
 
       - name: Setup pnpm
+        if: steps.changed-files.outputs.mode == 'run'
         uses: pnpm/action-setup@v6
 
       - name: Setup node
+        if: steps.changed-files.outputs.mode == 'run'
         uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: pnpm
 
       - name: Install deps
+        if: steps.changed-files.outputs.mode == 'run'
         run: pnpm install --frozen-lockfile
 
       - name: Run checks
+        if: steps.changed-files.outputs.mode == 'run'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -144,6 +144,9 @@ async function changeFileCheck(ctx: CheckContext): Promise<Action[]> {
   }
 
   let files = await getPrFiles(ctx.prNumber);
+  let touchesPackageFiles = files.some((f) =>
+    f.filename.startsWith("packages/"),
+  );
   let regex =
     /^packages\/[^/]+\/\.changes\/(major|minor|patch|unstable)\.[^/]+\.md$/;
   let summaries: ChangeFileSummary[] = files
@@ -161,6 +164,11 @@ async function changeFileCheck(ctx: CheckContext): Promise<Action[]> {
     });
 
   console.log(`changeFileCheck: found ${summaries.length} change files`);
+
+  if (summaries.length === 0 && !touchesPackageFiles) {
+    console.log("changeFileCheck: no package files changed");
+    return [];
+  }
 
   let body = CHANGE_FILE_MISSING_COMMENT;
 


### PR DESCRIPTION
This change guards the PR Checks workflow from running PR-modified automation scripts.

If a PR touches both `scripts/` and `packages/`, the workflow now fails early and asks the author to split the work. If a PR only touches `scripts/`, it uploads an empty action artifact and skips the community helper checks.
