### PR TITLE
Update docs diff code fences

### DIFF
--- a/docs/explanation/hot-module-replacement.md
+++ b/docs/explanation/hot-module-replacement.md
@@ -111,7 +111,7 @@ export default function Component({ loaderData }) {
 
 If you change the key `pet` to `dog`:
 
-```diff
+```tsx diff
  export default function Component() {
 -  const { pet } = useMyCustomHook();
 +  const { dog } = useMyCustomHook();

--- a/docs/how-to/data-strategy.md
+++ b/docs/how-to/data-strategy.md
@@ -166,7 +166,7 @@ With `shouldCallHandler`, you are in charge of which handlers should be called s
 
 Here's an example change from the prior API to the new API. Note that we pre-filter the `matchesToLoad` before calling `resolve()`:
 
-```diff
+```tsx diff
 let results = {};
 +let matchesToLoad = matches.filter(m => m.shouldCallHandler());
 await Promise.all(() =>

--- a/docs/upgrading/component-routes.md
+++ b/docs/upgrading/component-routes.md
@@ -49,7 +49,7 @@ npm install @react-router/node
 
 **👉 Swap out the React plugin for React Router.**
 
-```diff filename=vite.config.ts
+```tsx diff filename=vite.config.ts
 -import react from '@vitejs/plugin-react'
 +import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";

--- a/docs/upgrading/router-provider.md
+++ b/docs/upgrading/router-provider.md
@@ -85,7 +85,7 @@ Instead of importing your route modules directly, lazy load and convert them to 
 
 Not only does your route definition now conform to the Route Module API, but you also get the benefits of code-splitting your routes.
 
-```diff filename=src/main.tsx
+```tsx diff filename=src/main.tsx
 let router = createBrowserRouter([
   // ... other routes
   {
@@ -120,7 +120,7 @@ npm install @react-router/node
 
 **👉 Swap out the React plugin for React Router**
 
-```diff filename=vite.config.ts
+```tsx diff filename=vite.config.ts
 -import react from '@vitejs/plugin-react'
 +import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
@@ -247,7 +247,7 @@ export default function App() {
 
 You would move everything above the `RouterProvider` into `root.tsx`.
 
-```diff filename=src/root.tsx
+```tsx diff filename=src/root.tsx
 +import "./index.css";
 
 // ... other imports and Layout
@@ -326,7 +326,7 @@ touch src/routes.ts src/catchall.tsx
 
 Move your route definitions to `routes.ts`. Note that the schemas don't match exactly, so you will get type errors; we'll fix this next.
 
-```diff filename=src/routes.ts
+```tsx diff filename=src/routes.ts
 +import type { RouteConfig } from "@react-router/dev/routes";
 
 -const router = createBrowserRouter([
@@ -362,7 +362,7 @@ Move your route definitions to `routes.ts`. Note that the schemas don't match ex
 
 **👉 Replace the `lazy` loader with a `file` loader**
 
-```diff filename=src/routes.ts
+```tsx diff filename=src/routes.ts
 export default [
   {
     path: "/",

--- a/docs/upgrading/v7.md
+++ b/docs/upgrading/v7.md
@@ -140,7 +140,7 @@ Most users won't need to make any changes. However, if you have custom Vite conf
 
 For example, a custom server build should move its SSR `rollupOptions` from the top-level `build` config into `environments.ssr.build`:
 
-```diff filename=vite.config.ts
+```tsx diff filename=vite.config.ts
 import { reactRouter } from "@react-router/dev/vite";
 import { defineConfig } from "vite";
 
@@ -310,7 +310,7 @@ Use `loaderData` instead on `MetaArgs`, each item in `MetaArgs.matches`, and eac
 
 Replace `data` with `loaderData` in your `meta` functions:
 
-```diff
+```tsx diff
 export function meta({
 -  data,
 +  loaderData,
@@ -327,7 +327,7 @@ export function meta({
 
 If you read data from parent matches, update those references too:
 
-```diff
+```tsx diff
 export function meta({ matches }: Route.MetaArgs) {
   let rootMatch = matches.find((match) => match.id === "root");
 -  let rootData = rootMatch?.data;
@@ -339,7 +339,7 @@ export function meta({ matches }: Route.MetaArgs) {
 
 Replace `data` with `loaderData` on `useMatches()` calls:
 
-```diff
+```tsx diff
 export default function Component({ matches, loaderData }: ComponentProps) {
   let matches = useMatches();
 - const rootLoaderData = matches[0].data;
@@ -369,14 +369,14 @@ npm uninstall react-router-dom
 
 Replace `react-router-dom` imports with `react-router` imports:
 
-```diff
+```tsx diff
 -import { Link, useLocation } from "react-router-dom";
 +import { Link, useLocation } from "react-router";
 ```
 
 For DOM-specific APIs, import from `react-router/dom`:
 
-```diff
+```tsx diff
 -import { RouterProvider } from "react-router-dom";
 +import { RouterProvider } from "react-router/dom";
 ```
@@ -396,7 +396,7 @@ React Router v8 removes the React Router Cloudflare dev proxy. Cloudflare projec
 
 Replace `cloudflareDevProxy` with `cloudflare`:
 
-```diff filename=vite.config.ts
+```tsx diff filename=vite.config.ts
 import { reactRouter } from "@react-router/dev/vite";
 -import { cloudflareDevProxy } from "@react-router/dev/vite/cloudflare";
 +import { cloudflare } from "@cloudflare/vite-plugin";


### PR DESCRIPTION
**Requires https://github.com/remix-run/react-router-website/pull/255 to be merged** 

This updates docs examples that show code diffs to use `tsx diff` fences now that the website renderer supports TypeScript highlighting with normal diff indicators.

The snippets keep their existing `+`/`-` markers and filename metadata while switching away from plain `diff` fences.
