### PR TITLE
feat: optional clientMiddleware on-leave function

### DIFF
--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -421,6 +421,21 @@ const middleware = async ({ context }, next) => {
 };
 ```
 
+Client middleware can also return a function that React Router will call when
+the route or layout that registered it is left during a later navigation:
+
+```ts
+const clientMiddleware = async ({ context }) => {
+  // Code here runs when entering or revalidating this route
+  console.log("Enter");
+
+  return async () => {
+    // Code here runs when leaving this route
+    console.log("Leave");
+  };
+};
+```
+
 <docs-warning>You can only call `next()` once per middleware. Calling it multiple times will throw an error</docs-warning>
 
 ### Skipping `next()`

--- a/docs/start/data/route-object.md
+++ b/docs/start/data/route-object.md
@@ -84,6 +84,16 @@ async function loggingMiddleware({ request }, next) {
   console.log(`Navigation completed in ${duration}ms`);
 }
 
+// You can also return a callback that runs when this route is left
+// during a later navigation.
+async function leaveLoggingMiddleware({ request }) {
+  let url = new URL(request.url);
+  console.log(`Entering route from: ${url.pathname}${url.search}`);
+  return async () => {
+    console.log(`Leaving route from: ${url.pathname}${url.search}`);
+  };
+}
+
 const userContext = createContext<User>();
 
 async function authMiddleware ({ context }) {

--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -158,6 +158,24 @@ async function loggingMiddleware(
 export const clientMiddleware = [loggingMiddleware];
 ```
 
+Client middleware can also return a callback, which will run when this route or
+layout is left during a later navigation:
+
+```tsx filename=root.tsx
+async function leaveLoggingMiddleware({ request }) {
+  console.log(
+    `${new Date().toISOString()} Enter ${request.method} ${request.url}`,
+  );
+  return async () => {
+    console.log(
+      `${new Date().toISOString()} Leave ${request.method} ${request.url}`,
+    );
+  };
+}
+
+export const clientMiddleware = [leaveLoggingMiddleware];
+```
+
 See also:
 
 - [Middleware][middleware]

--- a/packages/react-router/.changes/minor.middleware-return-callback.md
+++ b/packages/react-router/.changes/minor.middleware-return-callback.md
@@ -1,0 +1,3 @@
+Allow client-side route middleware to return a callback that runs when leaving a route
+
+- Supports Data mode `middleware` and Framework mode `clientMiddleware` returning an async/sync callback that is invoked when the route or layout that registered it is left during a later navigation.

--- a/packages/react-router/__tests__/router/context-middleware-test.tsx
+++ b/packages/react-router/__tests__/router/context-middleware-test.tsx
@@ -300,6 +300,116 @@ describe("context/middleware", () => {
         ]);
       });
 
+      it("runs returned middleware callbacks when leaving routes", async () => {
+        let context = new RouterContextProvider();
+        context.set(orderContext, []);
+        router = createRouter({
+          history: createMemoryHistory(),
+          getContext: () => context,
+          routes: [
+            {
+              path: "/",
+            },
+            {
+              id: "parent",
+              path: "/parent",
+              middleware: [
+                async ({ context }) => {
+                  context.get(orderContext).push("parent middleware - enter");
+                  await tick();
+                  return async () => {
+                    await tick();
+                    context.get(orderContext).push("parent middleware - leave");
+                  };
+                },
+              ],
+              loader({ context }) {
+                context.get(orderContext).push("parent loader");
+              },
+              children: [
+                {
+                  id: "child",
+                  path: "child",
+                  middleware: [
+                    async ({ context }) => {
+                      context.get(orderContext).push("child middleware - enter");
+                      await tick();
+                      return async () => {
+                        await tick();
+                        context.get(orderContext).push(
+                          "child middleware - leave",
+                        );
+                      };
+                    },
+                  ],
+                  loader({ context }) {
+                    context.get(orderContext).push("child loader");
+                  },
+                },
+                {
+                  id: "sibling",
+                  path: "sibling",
+                  middleware: [
+                    async ({ context }) => {
+                      context
+                        .get(orderContext)
+                        .push("sibling middleware - enter");
+                      await tick();
+                      return async () => {
+                        await tick();
+                        context
+                          .get(orderContext)
+                          .push("sibling middleware - leave");
+                      };
+                    },
+                  ],
+                  loader({ context }) {
+                    context.get(orderContext).push("sibling loader");
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        await router.navigate("/parent/child");
+
+        expect(context.get(orderContext)).toEqual([
+          "parent middleware - enter",
+          "child middleware - enter",
+          "parent loader",
+          "child loader",
+        ]);
+
+        await router.navigate("/parent/sibling");
+
+        expect(context.get(orderContext)).toEqual([
+          "parent middleware - enter",
+          "child middleware - enter",
+          "parent loader",
+          "child loader",
+          "child middleware - leave",
+          "parent middleware - enter",
+          "sibling middleware - enter",
+          "sibling loader",
+        ]);
+
+        await router.navigate("/");
+
+        expect(context.get(orderContext)).toEqual([
+          "parent middleware - enter",
+          "child middleware - enter",
+          "parent loader",
+          "child loader",
+          "child middleware - leave",
+          "parent middleware - enter",
+          "sibling middleware - enter",
+          "sibling loader",
+          "sibling middleware - leave",
+          "parent middleware - leave",
+        ]);
+      });
+
       it("runs middleware on initialization even if no loaders exist", async () => {
         let snapshot;
         router = createRouter({

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -50,6 +50,7 @@ import type {
   ActionFunction,
   MiddlewareFunction,
   MiddlewareNextFunction,
+  MiddlewareReturnFunction,
   PatchRoutesOnNavigationFunction,
   RouteBranch,
   MapRoutePropertiesFunction,
@@ -824,6 +825,10 @@ type PendingActionResult =
   | [string, SuccessResult | ErrorResult]
   | [string, SuccessResult | ErrorResult, string];
 
+type ClientMiddlewareLeaveCallbackHandler = {
+  onCallback(routeId: string, callback: MiddlewareReturnFunction): void;
+};
+
 interface HandleActionResult extends ShortCircuitable {
   /**
    * Route matches which may have been updated from fog of war discovery
@@ -1054,6 +1059,10 @@ export function createRouter(init: RouterInit): Router {
     basename = `/${basename}`;
   }
   let dataStrategyImpl = init.dataStrategy || defaultDataStrategyWithMiddleware;
+  let activeClientMiddlewareLeaveCallbacks = new Map<
+    string,
+    MiddlewareReturnFunction[]
+  >();
 
   // Config driven behavior flags
   let future: FutureConfig = {
@@ -1936,6 +1945,10 @@ export function createRouter(init: RouterInit): Router {
     let fogOfWar = checkFogOfWar(matches, routesToUse, location.pathname);
     if (fogOfWar.active && fogOfWar.matches) {
       matches = fogOfWar.matches;
+    }
+
+    if (!opts?.initialHydration) {
+      await runClientMiddlewareLeaveCallbacks(matches);
     }
 
     if (opts?.instrumentationNavigateMetaReceiver) {
@@ -3358,6 +3371,8 @@ export function createRouter(init: RouterInit): Router {
   ): Promise<Record<string, DataResult>> {
     let results: Record<string, DataStrategyResult>;
     let dataResults: Record<string, DataResult> = {};
+    let pendingLeaveCallbacks =
+      fetcherKey == null ? new Map<string, MiddlewareReturnFunction[]>() : null;
     try {
       results = await callDataStrategyImpl(
         dataStrategyImpl as DataStrategyFunction<unknown>,
@@ -3367,6 +3382,18 @@ export function createRouter(init: RouterInit): Router {
         fetcherKey,
         scopedContext,
         false,
+        pendingLeaveCallbacks
+          ? {
+              onCallback(routeId, callback) {
+                let callbacks = pendingLeaveCallbacks.get(routeId);
+                if (callbacks) {
+                  callbacks.push(callback);
+                } else {
+                  pendingLeaveCallbacks.set(routeId, [callback]);
+                }
+              },
+            }
+          : undefined,
       );
     } catch (e) {
       // If the outer dataStrategy method throws, just return the error for all
@@ -3384,6 +3411,10 @@ export function createRouter(init: RouterInit): Router {
 
     if (request.signal.aborted) {
       return dataResults;
+    }
+
+    if (pendingLeaveCallbacks) {
+      updateClientMiddlewareLeaveCallbacks(pendingLeaveCallbacks);
     }
 
     // Stub errors where needed if they skipped returning data for routes
@@ -3432,6 +3463,43 @@ export function createRouter(init: RouterInit): Router {
     }
 
     return dataResults;
+  }
+
+  function updateClientMiddlewareLeaveCallbacks(
+    callbacksByRouteId: Map<string, MiddlewareReturnFunction[]>,
+  ) {
+    callbacksByRouteId.forEach((callbacks, routeId) => {
+      activeClientMiddlewareLeaveCallbacks.set(routeId, callbacks);
+    });
+  }
+
+  async function runClientMiddlewareLeaveCallbacks(
+    nextMatches: DataRouteMatch[] | null,
+  ) {
+    if (
+      !state.initialized ||
+      activeClientMiddlewareLeaveCallbacks.size === 0
+    ) {
+      return;
+    }
+
+    let nextRouteIds = new Set(nextMatches?.map((m) => m.route.id) || []);
+    let callbacksToRun: MiddlewareReturnFunction[] = [];
+
+    for (let match of [...state.matches].reverse()) {
+      let routeId = match.route.id;
+      let callbacks = activeClientMiddlewareLeaveCallbacks.get(routeId);
+      if (!nextRouteIds.has(routeId)) {
+        activeClientMiddlewareLeaveCallbacks.delete(routeId);
+        if (callbacks) {
+          callbacksToRun.push(...callbacks);
+        }
+      }
+    }
+
+    for (let callback of callbacksToRun) {
+      await callback();
+    }
   }
 
   async function callLoadersAndMaybeResolveData(
@@ -6147,7 +6215,17 @@ async function defaultDataStrategyWithMiddleware(
     return defaultDataStrategy(args);
   }
 
-  return runClientMiddlewarePipeline(args, () => defaultDataStrategy(args));
+  let clientMiddlewareLeaveCallbackHandler = (
+    args as DataStrategyFunctionArgs<RouterContextProvider> & {
+      __clientMiddlewareLeaveCallbackHandler?: ClientMiddlewareLeaveCallbackHandler;
+    }
+  ).__clientMiddlewareLeaveCallbackHandler;
+
+  return runClientMiddlewarePipeline(
+    args,
+    () => defaultDataStrategy(args),
+    clientMiddlewareLeaveCallbackHandler,
+  );
 }
 
 function runServerMiddlewarePipeline(
@@ -6188,6 +6266,7 @@ function runClientMiddlewarePipeline(
     "fetcherKey" | "runClientMiddleware"
   >,
   handler: () => Promise<Record<string, DataStrategyResult>>,
+  clientMiddlewareLeaveCallbackHandler?: ClientMiddlewareLeaveCallbackHandler,
 ): Promise<Record<string, DataStrategyResult>> {
   return runMiddlewarePipeline(
     args,
@@ -6201,6 +6280,7 @@ function runClientMiddlewarePipeline(
     },
     isDataStrategyResults,
     errorHandler,
+    clientMiddlewareLeaveCallbackHandler,
   );
 
   // Handle error bubbling on the client
@@ -6279,6 +6359,7 @@ async function runMiddlewarePipeline<Result>(
     routeId: string,
     nextResult: { value: Result } | undefined,
   ) => Promise<Result>,
+  clientMiddlewareLeaveCallbackHandler?: ClientMiddlewareLeaveCallbackHandler,
 ): Promise<Result> {
   let { matches, ...dataFnArgs } = args;
   let tuples = matches.flatMap((m) =>
@@ -6292,6 +6373,7 @@ async function runMiddlewarePipeline<Result>(
     processResult,
     isResult,
     errorHandler,
+    clientMiddlewareLeaveCallbackHandler,
   );
   return result;
 }
@@ -6309,6 +6391,7 @@ async function callRouteMiddleware<Result>(
     routeId: string,
     pendingResult: { value: Result } | undefined,
   ) => Promise<Result>,
+  clientMiddlewareLeaveCallbackHandler?: ClientMiddlewareLeaveCallbackHandler,
   idx = 0,
 ): Promise<Result> {
   let { request } = args;
@@ -6341,6 +6424,7 @@ async function callRouteMiddleware<Result>(
         processResult,
         isResult,
         errorHandler,
+        clientMiddlewareLeaveCallbackHandler,
         idx + 1,
       );
 
@@ -6354,9 +6438,25 @@ async function callRouteMiddleware<Result>(
 
   try {
     let value = await middleware(args, next);
-    let result = value != null ? processResult(value) : undefined;
+    let returnCallback =
+      typeof value === "function"
+        ? (value as MiddlewareReturnFunction)
+        : undefined;
+    let result =
+      value != null && returnCallback == null
+        ? processResult(value as Result)
+        : undefined;
 
-    if (isResult(result)) {
+    if (returnCallback) {
+      if (!nextResult) {
+        nextResult = { value: await next() };
+      }
+      clientMiddlewareLeaveCallbackHandler?.onCallback(
+        routeId,
+        returnCallback,
+      );
+      return nextResult.value;
+    } else if (isResult(result)) {
       // Use short circuit values of the proper type without having called next()
       return result;
     } else if (nextResult) {
@@ -6547,6 +6647,7 @@ async function callDataStrategyImpl(
   fetcherKey: string | null,
   scopedContext: unknown,
   isStaticHandler: boolean,
+  clientMiddlewareLeaveCallbackHandler?: ClientMiddlewareLeaveCallbackHandler,
 ): Promise<Record<string, DataStrategyResult>> {
   // Ensure all middleware is loaded before we start executing routes
   if (matches.some((m) => m._lazyPromises?.middleware)) {
@@ -6579,24 +6680,34 @@ async function callDataStrategyImpl(
     : (cb: DataStrategyFunction<RouterContextProvider>) => {
         let typedDataStrategyArgs =
           dataStrategyArgs as DataStrategyFunctionArgs<RouterContextProvider>;
-        return runClientMiddlewarePipeline(typedDataStrategyArgs, () => {
-          return cb({
-            ...typedDataStrategyArgs,
-            fetcherKey,
-            runClientMiddleware: () => {
-              throw new Error(
-                "Cannot call `runClientMiddleware()` from within an " +
-                  "`runClientMiddleware` handler",
-              );
-            },
-          });
-        });
+        return runClientMiddlewarePipeline(
+          typedDataStrategyArgs,
+          () => {
+            return cb({
+              ...typedDataStrategyArgs,
+              fetcherKey,
+              runClientMiddleware: () => {
+                throw new Error(
+                  "Cannot call `runClientMiddleware()` from within an " +
+                    "`runClientMiddleware` handler",
+                );
+              },
+            });
+          },
+          clientMiddlewareLeaveCallbackHandler,
+        );
       };
 
   let results = await dataStrategyImpl({
     ...dataStrategyArgs,
     fetcherKey,
     runClientMiddleware,
+    ...(clientMiddlewareLeaveCallbackHandler
+      ? {
+          __clientMiddlewareLeaveCallbackHandler:
+            clientMiddlewareLeaveCallbackHandler,
+        }
+      : {}),
   });
 
   // Wait for all routes to load here but swallow the error since we want

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -322,6 +322,14 @@ export interface MiddlewareNextFunction<Result = unknown> {
 }
 
 /**
+ * Client-side route middleware return function to complete work when the route
+ * is left during a later navigation.
+ */
+export interface MiddlewareReturnFunction {
+  (): MaybePromise<void>;
+}
+
+/**
  * Route middleware function signature.  Receives the same "data" arguments as a
  * `loader`/`action` (`request`, `params`, `context`) as the first parameter and
  * a `next` function as the second parameter which will call downstream handlers
@@ -330,7 +338,7 @@ export interface MiddlewareNextFunction<Result = unknown> {
 export type MiddlewareFunction<Result = unknown> = (
   args: DataFunctionArgs<Readonly<RouterContextProvider>>,
   next: MiddlewareNextFunction<Result>,
-) => MaybePromise<Result | void>;
+) => MaybePromise<Result | MiddlewareReturnFunction | void>;
 
 /**
  * Arguments passed to loader functions

--- a/packages/react-router/lib/types/route-module-annotations.ts
+++ b/packages/react-router/lib/types/route-module-annotations.ts
@@ -4,6 +4,7 @@ import type { LinkDescriptor } from "../router/links";
 import type {
   DataStrategyResult,
   MiddlewareNextFunction,
+  MiddlewareReturnFunction,
 } from "../router/utils";
 
 import type {
@@ -86,7 +87,9 @@ type CreateServerMiddlewareFunction<T extends RouteInfo> = (
 type CreateClientMiddlewareFunction<T extends RouteInfo> = (
   args: ClientDataFunctionArgs<T["params"]>,
   next: MiddlewareNextFunction<Record<string, DataStrategyResult>>,
-) => MaybePromise<Record<string, DataStrategyResult> | void>;
+) => MaybePromise<
+  Record<string, DataStrategyResult> | MiddlewareReturnFunction | void
+>;
 
 type CreateServerLoaderArgs<T extends RouteInfo> = ServerDataFunctionArgs<
   T["params"]


### PR DESCRIPTION
Hi! 😄 

I recently encountered an issue. I wanted to run a clean-up function when a user leaves a page/layout. The options for doing that aren't great, it's either `useEffect` or root-level middleware and then filtering target url. This PR adds the ability to return a function from a middleware and the function is then called when a user leaves the page. This allows you to keep page-specific cleanup code localized to that page, without having to expose it to root routes, or use flaky `useEffect`s.

Example:

```ts
const clientMiddleware = async ({ context }) => {
  // Code here runs when entering or revalidating this route
  console.log("Enter");

  return async () => {
    // Code here runs when leaving this route
    console.log("Leave");
  };
};
```

The PR is vibed, since I wanted to see if it's possible, but with your guidance, I'd be happy to work on it until it meets your standards!