### PR TITLE
feat(create-react-router): detect nub package manager

### DIFF
--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -574,7 +574,7 @@ async function doneStep(ctx: Context) {
   await sleep(200);
 }
 
-const validPackageManagers = ["npm", "yarn", "pnpm", "bun", "deno"] as const;
+const validPackageManagers = ["npm", "yarn", "pnpm", "bun", "deno", "nub"] as const;
 type PackageManager = (typeof validPackageManagers)[number];
 
 function validatePackageManager(pkgManager: string): PackageManager {


### PR DESCRIPTION
When invoked through nub, create-react-router falls back to npm. It reads the invoking package manager from `npm_config_user_agent`, then `validatePackageManager` keeps it only if it's in `validPackageManagers` (otherwise npm). [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't in the list and is dropped.

nub is a Rust CLI with a pnpm-compatible command grammar. This adds `"nub"` to `validPackageManagers`; `installDependencies` spawns `<pkgManager> install`, so it resolves to `nub install`.
