### PR TITLE
docs: add Hostinger as a hosting provider

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -41,6 +41,7 @@
 - arjunyel
 - arka1002
 - Armanio
+- ArnasDon
 - arnassavickas
 - aroyan
 - arpitjain099

--- a/docs/start/framework/deploying.md
+++ b/docs/start/framework/deploying.md
@@ -98,3 +98,7 @@ EdgeOne Pages maintains their own template for React Router. Checkout the [EdgeO
 ### DeployHQ
 
 DeployHQ maintains their own guide for deploying React Router to your own server. Checkout the [DeployHQ Guide](https://www.deployhq.com/guides/deploy-react-router-from-github) for more information.
+
+### Hostinger
+
+Hostinger supports deploying React Router applications with server rendering on its managed Node.js hosting, including automatic deployments from GitHub. Checkout the [Hostinger Guide](https://www.hostinger.com/web-apps-hosting/react-router-hosting) for more information.


### PR DESCRIPTION
## Summary

Adds **Hostinger** to the list of hosting providers on the [Deploying](https://reactrouter.com/start/framework/deploying) page, alongside the other third-party providers (Vercel, Cloudflare Workers, Netlify, EdgeOne Pages, DeployHQ).

Hostinger supports deploying React Router applications with server rendering on its managed Node.js hosting, including automatic deployments from a connected GitHub repository. The new entry follows the same one-line "maintains their own guide" pattern as the surrounding providers and links to Hostinger's React Router hosting page.

## Change

```md
### Hostinger

Hostinger supports deploying React Router applications with server rendering on its managed Node.js hosting, including automatic deployments from GitHub. Checkout the [Hostinger Guide](https://www.hostinger.com/web-apps-hosting/react-router-hosting) for more information.
```

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)