### PR TITLE
fix(dev): read rolldownOptions.input/output from user environments config (Vite v8)

### DIFF
--- a/packages/react-router-dev/.changes/patch.properly-detect-user-rolldownoptions-config-vite.md
+++ b/packages/react-router-dev/.changes/patch.properly-detect-user-rolldownoptions-config-vite.md
@@ -1,0 +1,1 @@
+Properly detect user `rolldownOptions` config in Vite 8+

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -73,7 +73,13 @@ import {
   getRouteChunkModuleId,
   getRouteChunkNameFromModuleId,
 } from "./route-chunks";
-import { preloadVite, getVite, defineCompilerOptions } from "./vite";
+import {
+  preloadVite,
+  getVite,
+  defineCompilerOptions,
+  getUserBuildInput,
+  getUserBuildOutput,
+} from "./vite";
 import {
   type ResolvedReactRouterConfig,
   type BuildManifest,
@@ -3610,7 +3616,7 @@ export async function getEnvironmentOptionsResolvers(
         copyPublicDir: false, // The client only uses assets in the public directory
         rollupOptions: {
           input:
-            viteUserConfig.environments?.ssr?.build?.rollupOptions?.input ??
+            getUserBuildInput(viteUserConfig.environments?.ssr?.build) ??
             virtual.serverBuild.id,
           output: {
             entryFileNames: serverBuildFile,
@@ -3653,8 +3659,9 @@ export async function getEnvironmentOptionsResolvers(
                 },
               ),
             ],
-            output: viteUserConfig?.environments?.client?.build?.rollupOptions
-              ?.output ?? {
+            output: getUserBuildOutput(
+              viteUserConfig?.environments?.client?.build,
+            ) ?? {
               entryFileNames: ({ moduleIds }) => {
                 let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
                 let routeChunkName = routeChunkModuleId

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -77,8 +77,7 @@ import {
   preloadVite,
   getVite,
   defineCompilerOptions,
-  getUserBuildInput,
-  getUserBuildOutput,
+  getUserBuildRollupOptions,
 } from "./vite";
 import {
   type ResolvedReactRouterConfig,
@@ -3615,8 +3614,9 @@ export async function getEnvironmentOptionsResolvers(
         ssrEmitAssets: true,
         copyPublicDir: false, // The client only uses assets in the public directory
         rollupOptions: {
+          // prettier-ignore
           input:
-            getUserBuildInput(viteUserConfig.environments?.ssr?.build) ??
+            getUserBuildRollupOptions(viteUserConfig.environments?.ssr)?.input ??
             virtual.serverBuild.id,
           output: {
             entryFileNames: serverBuildFile,
@@ -3659,30 +3659,31 @@ export async function getEnvironmentOptionsResolvers(
                 },
               ),
             ],
-            output: getUserBuildOutput(
-              viteUserConfig?.environments?.client?.build,
-            ) ?? {
-              entryFileNames: ({ moduleIds }) => {
-                let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
-                let routeChunkName = routeChunkModuleId
-                  ? getRouteChunkNameFromModuleId(routeChunkModuleId)?.replace(
-                      "unstable_",
-                      "",
-                    )
-                  : null;
-                let routeChunkSuffix = routeChunkName
-                  ? `-${kebabCase(routeChunkName)}`
-                  : "";
-                let assetsDir =
-                  viteUserConfig?.environments?.client?.build?.assetsDir ??
-                  viteUserConfig?.build?.assetsDir ??
-                  "assets";
-                return path.posix.join(
-                  assetsDir,
-                  `[name]${routeChunkSuffix}-[hash].js`,
-                );
+            // prettier-ignore
+            output:
+              getUserBuildRollupOptions(viteUserConfig?.environments?.client)?.output ??
+              {
+                entryFileNames: ({ moduleIds }) => {
+                  let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
+                  let routeChunkName = routeChunkModuleId
+                    ? getRouteChunkNameFromModuleId(routeChunkModuleId)?.replace(
+                        "unstable_",
+                        "",
+                      )
+                    : null;
+                  let routeChunkSuffix = routeChunkName
+                    ? `-${kebabCase(routeChunkName)}`
+                    : "";
+                  let assetsDir =
+                    viteUserConfig?.environments?.client?.build?.assetsDir ??
+                    viteUserConfig?.build?.assetsDir ??
+                    "assets";
+                  return path.posix.join(
+                    assetsDir,
+                    `[name]${routeChunkSuffix}-[hash].js`,
+                  );
+                },
               },
-            },
           },
           outDir: getClientBuildDirectory(ctx.reactRouterConfig),
         },

--- a/packages/react-router-dev/vite/vite.ts
+++ b/packages/react-router-dev/vite/vite.ts
@@ -73,3 +73,31 @@ export function defineOptimizeDepsCompilerOptions(options: {
     ? { rolldownOptions: options.rolldown }
     : { esbuildOptions: options.esbuild };
 }
+
+/**
+ * Read the user-supplied build entry input from either `rollupOptions` (Vite ≤7)
+ * or `rolldownOptions` (Vite ≥8). The two options are mutually exclusive in
+ * practice — this helper lets callers stay agnostic of the Vite major version.
+ */
+export function getUserBuildInput(
+  buildOpts: import("vite").BuildEnvironmentOptions | undefined,
+): import("rollup").InputOption | undefined {
+  return (
+    buildOpts?.rollupOptions?.input ??
+    // In Vite v8+, rolldownOptions replaces rollupOptions.
+    (buildOpts as Record<string, any> | undefined)?.rolldownOptions?.input
+  );
+}
+
+/**
+ * Read the user-supplied build output options from either `rollupOptions`
+ * (Vite ≤7) or `rolldownOptions` (Vite ≥8).
+ */
+export function getUserBuildOutput(
+  buildOpts: import("vite").BuildEnvironmentOptions | undefined,
+): import("rollup").OutputOptions | import("rollup").OutputOptions[] | undefined {
+  return (
+    buildOpts?.rollupOptions?.output ??
+    (buildOpts as Record<string, any> | undefined)?.rolldownOptions?.output
+  );
+}

--- a/packages/react-router-dev/vite/vite.ts
+++ b/packages/react-router-dev/vite/vite.ts
@@ -1,6 +1,11 @@
 import { createRequire } from "node:module";
 import path from "pathe";
-import type { DepOptimizationConfig, ESBuildOptions } from "vite";
+import type {
+  DepOptimizationConfig,
+  ESBuildOptions,
+  EnvironmentOptions,
+  BuildEnvironmentOptions,
+} from "vite";
 
 import invariant from "../invariant";
 import { isReactRouterRepo } from "../config/is-react-router-repo";
@@ -75,29 +80,20 @@ export function defineOptimizeDepsCompilerOptions(options: {
 }
 
 /**
- * Read the user-supplied build entry input from either `rollupOptions` (Vite ≤7)
- * or `rolldownOptions` (Vite ≥8). The two options are mutually exclusive in
- * practice — this helper lets callers stay agnostic of the Vite major version.
+ * Read the user-supplied build options from either `rollupOptions` (Vite ≤7)
+ * or `rolldownOptions` (Vite ≥8)
  */
-export function getUserBuildInput(
-  buildOpts: import("vite").BuildEnvironmentOptions | undefined,
-): import("rollup").InputOption | undefined {
-  return (
-    buildOpts?.rollupOptions?.input ??
-    // In Vite v8+, rolldownOptions replaces rollupOptions.
-    (buildOpts as Record<string, any> | undefined)?.rolldownOptions?.input
-  );
-}
-
-/**
- * Read the user-supplied build output options from either `rollupOptions`
- * (Vite ≤7) or `rolldownOptions` (Vite ≥8).
- */
-export function getUserBuildOutput(
-  buildOpts: import("vite").BuildEnvironmentOptions | undefined,
-): import("rollup").OutputOptions | import("rollup").OutputOptions[] | undefined {
-  return (
-    buildOpts?.rollupOptions?.output ??
-    (buildOpts as Record<string, any> | undefined)?.rolldownOptions?.output
-  );
+export function getUserBuildRollupOptions(
+  environment: EnvironmentOptions | undefined,
+): BuildEnvironmentOptions["rollupOptions"] | undefined {
+  if (environment?.build) {
+    if ("rollupOptions" in environment.build) {
+      return environment.build.rollupOptions;
+    }
+    if ("rolldownOptions" in environment.build) {
+      return environment.build
+        .rolldownOptions as BuildEnvironmentOptions["rollupOptions"];
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
Fixes #15251

## Problem

In Vite v8, `rollupOptions` under `environments.<name>.build` is replaced by `rolldownOptions`. The `@react-router/dev` plugin only ever read `rollupOptions.input` when resolving the SSR entry point and `rollupOptions.output` for the client environment — so any user config using the v8 form was silently dropped and the build fell back to defaults.

## Fix

Add two version-agnostic helpers to `vite.ts`:

- **`getUserBuildInput`** — reads `.input` from `rollupOptions` first, falls back to `rolldownOptions` (Vite v8+).
- **`getUserBuildOutput`** — same pattern for `.output`.

Use these helpers in the SSR and client environment option resolvers instead of directly accessing `rollupOptions`. No change in behavior for Vite v7 projects since `rolldownOptions` is `undefined` there.

```ts
// Before
input: viteUserConfig.environments?.ssr?.build?.rollupOptions?.input ?? virtual.serverBuild.id

// After
input: getUserBuildInput(viteUserConfig.environments?.ssr?.build) ?? virtual.serverBuild.id
```

The pattern mirrors `defineOptimizeDepsCompilerOptions` already in `vite.ts`, which similarly abstracts over `rolldownOptions` / `esbuildOptions`.