### PR TITLE
Add CLA check to PR checks workflow

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -14,7 +14,7 @@ jobs:
   actions:
     name: Actions
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
+      contains(fromJSON('["success","failure"]'), github.event.workflow_run.conclusion) &&
       github.repository == 'remix-run/react-router'
     runs-on: ubuntu-latest
     permissions:
@@ -40,6 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download result from upstream workflow
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: pr-checks-result

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,6 +79,7 @@ jobs:
           PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.name }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          CLA_DRY_RUN: "true"
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
         run: node scripts/pr.ts check pr-checks-result.json

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,7 +45,6 @@ jobs:
             exit 1
           elif [ "$touches_scripts" = "true" ]; then
             echo "PR touches scripts/ without touching packages/; skipping community helper checks."
-            echo '{"prNumber":${{ github.event.pull_request.number }},"actions":[]}' > pr-checks-result.json
             echo "mode=skip" >> "$GITHUB_OUTPUT"
           else
             echo "mode=run" >> "$GITHUB_OUTPUT"
@@ -76,12 +75,18 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
-        run: node scripts/pr.ts check
+        run: node scripts/pr.ts check pr-checks-result.json
 
       - name: Upload result
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: pr-checks-result
           path: pr-checks-result.json
+          if-no-files-found: ignore

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -79,7 +79,6 @@ jobs:
           PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.name }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          CLA_DRY_RUN: "true"
           EVENT_ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
         run: node scripts/pr.ts check pr-checks-result.json

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -5,21 +5,25 @@
  * See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
  *
  *   check    Inspects the PR via the GitHub API and writes a list of
- *            "actions" to pr-checks-result.json. Safe to run with a
+ *            "actions" to the given result file. Safe to run with a
  *            read-only token (Workflow A: 🔍 Check PR).
  *
- *   actions  Reads pr-checks-result.json and applies each action. Runs
+ *   actions  Reads the given result file and applies each action. Runs
  *            in Workflow B (PR (Actions)) under `workflow_run` with
  *            write permissions but never executes any PR code.
  *
  * Usage:
- *   node scripts/pr.ts check
+ *   node scripts/pr.ts check <result-file>
  *   node scripts/pr.ts actions <result-file>
  *
  * Environment (check):
  *   GITHUB_TOKEN  - Required (read-only PR scope is enough).
  *   PR_NUMBER     - Required. github.event.pull_request.number
  *   PR_BASE       - Required. github.event.pull_request.base.ref
+ *   PR_AUTHOR     - Required. github.event.pull_request.user.login
+ *   PR_HEAD_OWNER - Required. github.event.pull_request.head.repo.owner.login
+ *   PR_HEAD_REPO  - Required. github.event.pull_request.head.repo.name
+ *   PR_HEAD_REF   - Required. github.event.pull_request.head.ref
  *   EVENT_ACTION  - Required. github.event.action (opened|synchronize|reopened|labeled)
  *   LABEL_NAME    - Optional. github.event.label.name (set when EVENT_ACTION=labeled)
  *
@@ -30,6 +34,7 @@ import * as fs from "node:fs";
 import * as util from "node:util";
 
 import {
+  addPrLabels,
   closePr,
   createPrComment,
   getPrComments,
@@ -41,19 +46,31 @@ import {
 type Action =
   | { type: "upsert-sticky-comment"; marker: string; body: string }
   | { type: "create-comment"; body: string }
+  | { type: "add-label"; label: string }
   | { type: "remove-label"; label: string }
   | { type: "close-pr" };
 
 type CheckContext = {
   prNumber: number;
   baseBranch: string;
+  author: string;
+  headOwner: string;
+  headRepo: string;
+  headRef: string;
   eventAction: string;
   labelName: string;
 };
 
-type Check = (ctx: CheckContext) => Promise<Action[]>;
+type CheckResult = {
+  actions: Action[];
+  failureMessage?: string;
+};
+
+type Check = (ctx: CheckContext) => Promise<CheckResult>;
 
 const CHANGE_FILE_MARKER = "<!-- change-file-check -->";
+const CLA_MARKER = "<!-- cla-check -->";
+const CLA_SIGNED_LABEL = "CLA Signed";
 
 type ChangeFileSummary = {
   type: string;
@@ -91,14 +108,36 @@ If this PR already has a Proposal but it has not yet been accepted, let's contin
 If you have any questions, you can always reach out on [Discord](https://remix.run/discord). Thanks again for providing feedback and helping us make React Router even better!
 `;
 
+function getClaMissingComment(ctx: CheckContext) {
+  return `${CLA_MARKER}
+### ⚠️ CLA Signature Required
+
+Hi @${ctx.author}, thanks for contributing to React Router!
+
+Before we consider your pull request, we ask that you sign our **Contributor License Agreement** (CLA). We require this only once.
+
+You may [review the CLA](https://github.com/remix-run/react-router/blob/main/CLA.md) and sign it by [adding your GitHub username to contributors.yml](https://github.com/${ctx.headOwner}/${ctx.headRepo}/edit/${ctx.headRef}/contributors.yml).
+
+Once the CLA is signed, the \`${CLA_SIGNED_LABEL}\` label will be added to the pull request and the CI check will pass.
+
+Thanks!
+
+\\- The Remix team
+`;
+}
+
 let { positionals } = util.parseArgs({ allowPositionals: true });
-let [mode, arg] = positionals;
+let [mode, filename] = positionals;
+
+if (!filename) {
+  usage();
+  process.exit(1);
+}
 
 if (mode === "check") {
   await runChecks();
 } else if (mode === "actions") {
-  if (!arg) usage();
-  await runActions(arg);
+  await runActions();
 } else {
   usage();
 }
@@ -112,11 +151,15 @@ async function runChecks() {
     process.exit(1);
   }
 
-  let checks: Check[] = [changeFileCheck, featurePrCheck];
+  let checks: Check[] = [claCheck, changeFileCheck, featurePrCheck];
 
   let ctx: CheckContext = {
     prNumber,
     baseBranch: requireEnv("PR_BASE"),
+    author: requireEnv("PR_AUTHOR"),
+    headOwner: requireEnv("PR_HEAD_OWNER"),
+    headRepo: requireEnv("PR_HEAD_REPO"),
+    headRef: requireEnv("PR_HEAD_REF"),
     eventAction: requireEnv("EVENT_ACTION"),
     labelName: process.env.LABEL_NAME ?? "",
   };
@@ -126,21 +169,66 @@ async function runChecks() {
     prNumber,
     actions: [],
   };
+  let failures = "";
 
   for (let check of checks) {
-    result.actions.push(...(await check(ctx)));
+    let checkResult = await check(ctx);
+    result.actions.push(...checkResult.actions);
+    failures += checkResult.failureMessage
+      ? ` - ${checkResult.failureMessage}\n`
+      : "";
   }
 
-  // Matches pr-checks.yml/pr-actions.yml workflow artifact name
-  let filename = "pr-checks-result.json";
   console.log(`Writing ${filename}:`, JSON.stringify(result));
   fs.writeFileSync(filename, JSON.stringify(result));
+
+  if (failures.length > 0) {
+    console.error(`Failures:\n${failures}`);
+    process.exit(1);
+  }
 }
 
-async function changeFileCheck(ctx: CheckContext): Promise<Action[]> {
-  if (ctx.baseBranch !== "main") return [];
+async function claCheck(ctx: CheckContext): Promise<CheckResult> {
   if (!["opened", "synchronize", "reopened"].includes(ctx.eventAction)) {
-    return [];
+    return { actions: [] };
+  }
+
+  let author = ctx.author.toLowerCase();
+  if (author === "dependabot[bot]") {
+    console.log(`claCheck: ignoring ${ctx.author}`);
+    return { actions: [] };
+  }
+
+  let contributors = fs
+    .readFileSync("contributors.yml", "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*-\s*(.+?)\s*$/)?.[1]?.toLowerCase())
+    .filter((contributor): contributor is string => Boolean(contributor));
+  let signedCla = contributors.includes(author);
+  console.log(`claCheck: ${ctx.author} signed CLA: ${signedCla}`);
+
+  if (signedCla) {
+    return {
+      actions: [{ type: "add-label", label: CLA_SIGNED_LABEL }],
+    };
+  }
+
+  return {
+    actions: [
+      {
+        type: "upsert-sticky-comment",
+        marker: CLA_MARKER,
+        body: getClaMissingComment(ctx),
+      },
+    ],
+    failureMessage: `CLA check failed: ${ctx.author} is not listed in contributors.yml`,
+  };
+}
+
+async function changeFileCheck(ctx: CheckContext): Promise<CheckResult> {
+  if (ctx.baseBranch !== "main") return { actions: [] };
+  if (!["opened", "synchronize", "reopened"].includes(ctx.eventAction)) {
+    return { actions: [] };
   }
 
   let files = await getPrFiles(ctx.prNumber);
@@ -167,7 +255,7 @@ async function changeFileCheck(ctx: CheckContext): Promise<Action[]> {
 
   if (summaries.length === 0 && !touchesPackageFiles) {
     console.log("changeFileCheck: no package files changed");
-    return [];
+    return { actions: [] };
   }
 
   let body = CHANGE_FILE_MISSING_COMMENT;
@@ -183,33 +271,43 @@ async function changeFileCheck(ctx: CheckContext): Promise<Action[]> {
     ].join("\n");
   }
 
-  return [
-    {
-      type: "upsert-sticky-comment",
-      marker: CHANGE_FILE_MARKER,
-      body,
-    },
-  ];
+  return {
+    actions: [
+      {
+        type: "upsert-sticky-comment",
+        marker: CHANGE_FILE_MARKER,
+        body,
+      },
+    ],
+  };
 }
 
-async function featurePrCheck(ctx: CheckContext): Promise<Action[]> {
-  if (ctx.eventAction !== "labeled") return [];
-  if (ctx.labelName !== "feature-request") return [];
+async function featurePrCheck(ctx: CheckContext): Promise<CheckResult> {
+  if (ctx.eventAction !== "labeled") return { actions: [] };
+  if (ctx.labelName !== "feature-request") return { actions: [] };
 
   console.log(`featurePrCheck: closing PR ${ctx.prNumber}`);
-  return [
-    { type: "create-comment", body: CLOSE_FEATURE_PR_COMMENT },
-    { type: "remove-label", label: ctx.labelName },
-    { type: "close-pr" },
-  ];
+  return {
+    actions: [
+      { type: "create-comment", body: CLOSE_FEATURE_PR_COMMENT },
+      { type: "remove-label", label: ctx.labelName },
+      { type: "close-pr" },
+    ],
+  };
 }
 
 // ---------- Action dispatch ----------
 
-async function runActions(resultPath: string) {
-  let { prNumber, actions } = JSON.parse(
-    fs.readFileSync(resultPath, "utf8"),
-  ) as { prNumber: number; actions: Action[] };
+async function runActions() {
+  if (!fs.existsSync(filename)) {
+    console.log(`No result file found at ${filename}; skipping actions`);
+    return;
+  }
+
+  let { prNumber, actions } = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+    prNumber: number;
+    actions: Action[];
+  };
 
   if (actions.length === 0) {
     console.log("No actions to apply");
@@ -241,6 +339,11 @@ async function runActions(resultPath: string) {
         await createPrComment(prNumber, action.body);
         break;
       }
+      case "add-label": {
+        console.log(`Adding label '${action.label}'`);
+        await addPrLabels(prNumber, [action.label]);
+        break;
+      }
       case "remove-label": {
         console.log(`Removing label '${action.label}'`);
         await removePrLabel(prNumber, action.label);
@@ -260,7 +363,7 @@ async function runActions(resultPath: string) {
 function usage(): never {
   console.error(
     "Usage:\n" +
-      "  node scripts/pr.ts check\n" +
+      "  node scripts/pr.ts check <result-file>\n" +
       "  node scripts/pr.ts actions <result-file>",
   );
   process.exit(1);

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -24,6 +24,7 @@
  *   PR_HEAD_OWNER - Required. github.event.pull_request.head.repo.owner.login
  *   PR_HEAD_REPO  - Required. github.event.pull_request.head.repo.name
  *   PR_HEAD_REF   - Required. github.event.pull_request.head.ref
+ *   CLA_DRY_RUN   - Optional. Set to "true" to log CLA results without actions/failures.
  *   EVENT_ACTION  - Required. github.event.action (opened|synchronize|reopened|labeled)
  *   LABEL_NAME    - Optional. github.event.label.name (set when EVENT_ACTION=labeled)
  *
@@ -212,6 +213,19 @@ async function claCheck(ctx: CheckContext): Promise<CheckResult> {
     .filter((contributor): contributor is string => Boolean(contributor));
   let signedCla = contributors.includes(author);
   console.log(`claCheck: ${ctx.author} signed CLA: ${signedCla}`);
+
+  if (process.env.CLA_DRY_RUN === "true") {
+    if (signedCla) {
+      console.log(
+        `claCheck: dry run; would add '${CLA_SIGNED_LABEL}' label and update existing CLA comment`,
+      );
+    } else {
+      console.log(
+        `claCheck: dry run; would request CLA signature and fail PR checks`,
+      );
+    }
+    return { actions: [] };
+  }
 
   if (signedCla) {
     return {

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -24,7 +24,6 @@
  *   PR_HEAD_OWNER - Required. github.event.pull_request.head.repo.owner.login
  *   PR_HEAD_REPO  - Required. github.event.pull_request.head.repo.name
  *   PR_HEAD_REF   - Required. github.event.pull_request.head.ref
- *   CLA_DRY_RUN   - Optional. Set to "true" to log CLA results without actions/failures.
  *   EVENT_ACTION  - Required. github.event.action (opened|synchronize|reopened|labeled)
  *   LABEL_NAME    - Optional. github.event.label.name (set when EVENT_ACTION=labeled)
  *
@@ -46,7 +45,6 @@ import {
 
 type Action =
   | { type: "upsert-sticky-comment"; marker: string; body: string }
-  | { type: "update-sticky-comment"; marker: string; body: string }
   | { type: "create-comment"; body: string }
   | { type: "add-label"; label: string }
   | { type: "remove-label"; label: string }
@@ -138,7 +136,6 @@ let [mode, filename] = positionals;
 
 if (!filename) {
   usage();
-  process.exit(1);
 }
 
 if (mode === "check") {
@@ -214,10 +211,12 @@ async function claCheck(ctx: CheckContext): Promise<CheckResult> {
   let signedCla = contributors.includes(author);
   console.log(`claCheck: ${ctx.author} signed CLA: ${signedCla}`);
 
-  if (process.env.CLA_DRY_RUN === "true") {
+  // Dry runs to start so we can monitor the flow alongside the bot
+  let DRY_RUN = true;
+  if (DRY_RUN) {
     if (signedCla) {
       console.log(
-        `claCheck: dry run; would add '${CLA_SIGNED_LABEL}' label and update existing CLA comment`,
+        `claCheck: dry run; would add '${CLA_SIGNED_LABEL}' label and comment that the CLA is signed`,
       );
     } else {
       console.log(
@@ -232,7 +231,7 @@ async function claCheck(ctx: CheckContext): Promise<CheckResult> {
       actions: [
         { type: "add-label", label: CLA_SIGNED_LABEL },
         {
-          type: "update-sticky-comment",
+          type: "upsert-sticky-comment",
           marker: CLA_MARKER,
           body: CLA_SIGNED_COMMENT,
         },
@@ -358,21 +357,6 @@ async function runActions() {
         } else {
           console.log("Creating sticky comment");
           await createPrComment(prNumber, action.body);
-        }
-        break;
-      }
-      case "update-sticky-comment": {
-        let comments = await getPrComments(prNumber);
-        let existing = comments.find(
-          (c) =>
-            c.user?.login === "github-actions[bot]" &&
-            c.body?.includes(action.marker),
-        );
-        if (existing) {
-          console.log(`Updating sticky comment #${existing.id}`);
-          await updatePrComment(existing.id, action.body);
-        } else {
-          console.log("No sticky comment found to update");
         }
         break;
       }

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -45,6 +45,7 @@ import {
 
 type Action =
   | { type: "upsert-sticky-comment"; marker: string; body: string }
+  | { type: "update-sticky-comment"; marker: string; body: string }
   | { type: "create-comment"; body: string }
   | { type: "add-label"; label: string }
   | { type: "remove-label"; label: string }
@@ -107,6 +108,11 @@ If this PR already has a Proposal but it has not yet been accepted, let's contin
 
 If you have any questions, you can always reach out on [Discord](https://remix.run/discord). Thanks again for providing feedback and helping us make React Router even better!
 `;
+
+const CLA_SIGNED_COMMENT = `${CLA_MARKER}
+### ✅ CLA Signed
+
+Thanks for signing the [Contributor License Agreement](https://github.com/remix-run/react-router/blob/main/CLA.md).`;
 
 function getClaMissingComment(ctx: CheckContext) {
   return `${CLA_MARKER}
@@ -209,7 +215,14 @@ async function claCheck(ctx: CheckContext): Promise<CheckResult> {
 
   if (signedCla) {
     return {
-      actions: [{ type: "add-label", label: CLA_SIGNED_LABEL }],
+      actions: [
+        { type: "add-label", label: CLA_SIGNED_LABEL },
+        {
+          type: "update-sticky-comment",
+          marker: CLA_MARKER,
+          body: CLA_SIGNED_COMMENT,
+        },
+      ],
     };
   }
 
@@ -331,6 +344,21 @@ async function runActions() {
         } else {
           console.log("Creating sticky comment");
           await createPrComment(prNumber, action.body);
+        }
+        break;
+      }
+      case "update-sticky-comment": {
+        let comments = await getPrComments(prNumber);
+        let existing = comments.find(
+          (c) =>
+            c.user?.login === "github-actions[bot]" &&
+            c.body?.includes(action.marker),
+        );
+        if (existing) {
+          console.log(`Updating sticky comment #${existing.id}`);
+          await updatePrComment(existing.id, action.body);
+        } else {
+          console.log("No sticky comment found to update");
         }
         break;
       }


### PR DESCRIPTION
Adds CLA enforcement to the existing PR Checks/PR Actions workflow pair so the in-repo automation can replace the external CLA bot.

- PR Checks now verifies the PR opener against contributors.yml, fails unsigned PRs, and emits a sticky comment action with a branch-specific contributors.yml edit link.
- PR Actions now consumes artifacts from successful or failed PR Checks runs, applies the comment actions, and adds the `CLA Signed` label for signed authors.
- Empty skip paths no longer manufacture no-op result artifacts; the action script treats a missing result file as nothing to do.
