### PR TITLE
docs: add match properties table and breadcrumbs example to useMatches

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -397,6 +397,7 @@
 - rururux
 - ryanflorence
 - ryanhiebert
+- ryanleichty
 - saengmotmi
 - SailorStat
 - samimsu

--- a/docs/api/hooks/useMatches.md
+++ b/docs/api/hooks/useMatches.md
@@ -24,30 +24,64 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/ho
 
 Returns the active route matches, useful for accessing `loaderData` for
 parent/child routes or the route [`handle`](../../start/framework/route-module#handle)
-property
-
-Pairing the route `handle` with `useMatches` gets very powerful since you can put
-whatever you want on a route handle and have access to `useMatches` anywhere.
-Please see the [handle](../../how-to/using-handle) documentation for an example
-of breadcrumbs via `useMatches`/`handle`.
+property.
 
 ```tsx
 import { useMatches } from "react-router";
 
 function SomeComponent() {
   const matches = useMatches();
-  // matches[i].id          // route id
-  // matches[i].pathname    // the portion of the URL the route matched
-  // matches[i].params      // the parsed params from the URL
-  // matches[i].loaderData  // the data from the loader
-  // matches[i].handle      // the route handle with any app specific data
 }
 ```
+
+Each match object contains the following properties:
+
+| Property     | Description                                                                                                |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `id`         | The route id                                                                                                 |
+| `pathname`   | The portion of the URL that the route matched                                                               |
+| `params`     | The route's parsed [URL params](../../start/framework/routing#dynamic-segments)                             |
+| `loaderData` | The data returned from the route's [`loader`](../../start/framework/route-module#loader) or [`clientLoader`](../../start/framework/route-module#clientloader) |
+| `handle`     | The route's [`handle`](../../start/framework/route-module#handle) export, with any app-specific data on it  |
 
 <docs-info>useMatches only works with a data router like `createBrowserRouter`,
 since they know the full route tree up front and can provide all of the current
 matches. Additionally, `useMatches` will not match down into any descendant route
 trees since the router isn't aware of the descendant routes.</docs-info>
+
+### Breadcrumbs
+
+Pairing the route `handle` with `useMatches` gets very powerful since you can put
+whatever you want on a route handle and have access to it anywhere via `useMatches`.
+The proverbial use case is rendering breadcrumbs in a layout route from data owned
+by its child routes:
+
+```tsx
+// Give each route a `breadcrumb` handle
+export const handle = {
+  breadcrumb: () => <Link to="/parent">Some Route</Link>,
+};
+```
+
+```tsx
+// Read the handles back out in a layout/root component
+function Breadcrumbs() {
+  let matches = useMatches();
+  let crumbs = matches
+    .filter((match) => Boolean(match.handle?.breadcrumb))
+    .map((match) => match.handle.breadcrumb(match));
+
+  return (
+    <ol>
+      {crumbs.map((crumb, index) => (
+        <li key={index}>{crumb}</li>
+      ))}
+    </ol>
+  );
+}
+```
+
+See [Using `handle`](../../how-to/using-handle) for a complete, working example.
 
 ## Signature
 

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1531,30 +1531,64 @@ export function useRevalidator(): {
 /**
  * Returns the active route matches, useful for accessing `loaderData` for
  * parent/child routes or the route [`handle`](../../start/framework/route-module#handle)
- * property
- *
- * Pairing the route `handle` with `useMatches` gets very powerful since you can put
- * whatever you want on a route handle and have access to `useMatches` anywhere.
- * Please see the [handle](../../how-to/using-handle) documentation for an example
- * of breadcrumbs via `useMatches`/`handle`.
+ * property.
  *
  * ```tsx
  * import { useMatches } from "react-router";
  *
  * function SomeComponent() {
  *   const matches = useMatches();
- *   // matches[i].id          // route id
- *   // matches[i].pathname    // the portion of the URL the route matched
- *   // matches[i].params      // the parsed params from the URL
- *   // matches[i].loaderData  // the data from the loader
- *   // matches[i].handle      // the route handle with any app specific data
  * }
  * ```
+ *
+ * Each match object contains the following properties:
+ *
+ * | Property     | Description                                                                                                |
+ * | ------------ | ----------------------------------------------------------------------------------------------------------- |
+ * | `id`         | The route id                                                                                                 |
+ * | `pathname`   | The portion of the URL that the route matched                                                               |
+ * | `params`     | The route's parsed [URL params](../../start/framework/routing#dynamic-segments)                             |
+ * | `loaderData` | The data returned from the route's [`loader`](../../start/framework/route-module#loader) or [`clientLoader`](../../start/framework/route-module#clientloader) |
+ * | `handle`     | The route's [`handle`](../../start/framework/route-module#handle) export, with any app-specific data on it  |
  *
  * <docs-info>useMatches only works with a data router like `createBrowserRouter`,
  * since they know the full route tree up front and can provide all of the current
  * matches. Additionally, `useMatches` will not match down into any descendant route
  * trees since the router isn't aware of the descendant routes.</docs-info>
+ *
+ * ### Breadcrumbs
+ *
+ * Pairing the route `handle` with `useMatches` gets very powerful since you can put
+ * whatever you want on a route handle and have access to it anywhere via `useMatches`.
+ * The proverbial use case is rendering breadcrumbs in a layout route from data owned
+ * by its child routes:
+ *
+ * ```tsx
+ * // Give each route a `breadcrumb` handle
+ * export const handle = {
+ *   breadcrumb: () => <Link to="/parent">Some Route</Link>,
+ * };
+ * ```
+ *
+ * ```tsx
+ * // Read the handles back out in a layout/root component
+ * function Breadcrumbs() {
+ *   let matches = useMatches();
+ *   let crumbs = matches
+ *     .filter((match) => Boolean(match.handle?.breadcrumb))
+ *     .map((match) => match.handle.breadcrumb(match));
+ *
+ *   return (
+ *     <ol>
+ *       {crumbs.map((crumb, index) => (
+ *         <li key={index}>{crumb}</li>
+ *       ))}
+ *     </ol>
+ *   );
+ * }
+ * ```
+ *
+ * See [Using `handle`](../../how-to/using-handle) for a complete, working example.
  *
  * @public
  * @category Hooks


### PR DESCRIPTION
Expands the `useMatches` API reference, following up on #15267.

- Replaces the inline code-comment property list with a searchable table describing each match property (`id`, `pathname`, `params`, `loaderData`, `handle`) that links to the relevant route module APIs.
- Notes that `loaderData` may come from `loader` or `clientLoader`, matching the `UIMatch` type.
- Adds a dedicated breadcrumbs example on the reference page, linking to the Using `handle` guide for the full walkthrough.
- Regenerates `docs/api/hooks/useMatches.md` from the JSDoc.

Follow-up to #15205.
