### PR TITLE
fix: href() doesn't URL-encode param values

### DIFF
--- a/packages/react-router/.changes/patch.encode-href-params.md
+++ b/packages/react-router/.changes/patch.encode-href-params.md
@@ -1,0 +1,3 @@
+Fix `href()` to properly stringify and URL-encode param values, matching `generatePath()`
+
+- splat params preserve path separators while encoding each segment individually

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -1,4 +1,5 @@
 import { href } from "../lib/href";
+import { matchPath } from "../lib/router/utils";
 
 describe("href", () => {
   it("works with param-less paths", () => {
@@ -39,5 +40,41 @@ describe("href", () => {
 
   it("works with periods", () => {
     expect(href("/a/:b.zip", { b: "hello" })).toBe("/a/hello.zip");
+  });
+
+  it("encodes param values that contain a /", () => {
+    expect(href("/products/:id", { id: "shoes/2026-summer" })).toBe(
+      "/products/shoes%2F2026-summer",
+    );
+  });
+
+  it("encodes param values that contain # or ?", () => {
+    expect(href("/products/:id", { id: "abc#frag" })).toBe(
+      "/products/abc%23frag",
+    );
+    expect(href("/products/:id", { id: "abc?x=1" })).toBe(
+      "/products/abc%3Fx%3D1",
+    );
+  });
+
+  it("encodes splat param values while preserving segments", () => {
+    expect(href("/:param/*", { param: "a?b/c#d", "*": "e?f/g#h" })).toBe(
+      "/a%3Fb%2Fc%23d/e%3Ff/g%23h",
+    );
+  });
+
+  it("round-trips through matchPath for param values with special characters", () => {
+    let pattern = "/products/:id";
+    for (let id of ["shoes/2026-summer", "abc#frag", "abc?x=1", "a b"]) {
+      let result = href(pattern, { id });
+      // before the fix, href()'s own output didn't match its own pattern
+      let match = matchPath(pattern, result);
+      expect(match).not.toBeNull();
+      expect(decodeURIComponent(match!.params.id!)).toBe(id);
+    }
+  });
+
+  it("coerces values to strings", () => {
+    expect(href("/:a/:b", { a: 1, b: true })).toBe("/1/true");
   });
 });

--- a/packages/react-router/lib/href.ts
+++ b/packages/react-router/lib/href.ts
@@ -12,6 +12,10 @@ type ToArgs<Params extends Record<string, string | undefined>> =
   // otherwise, require `params` arg
   [Params];
 
+function stringify(p: any) {
+  return p == null ? "" : typeof p === "string" ? p : String(p);
+}
+
 /**
   Returns a resolved URL path for the specified route.
 
@@ -38,16 +42,18 @@ export function href<Path extends keyof Args>(
             `Path '${path}' requires param '${param}' but it was not provided`,
           );
         }
-        return value === undefined ? "" : "/" + value;
+        return value == null ? "" : "/" + encodeURIComponent(stringify(value));
       },
     );
 
   if (path.endsWith("*")) {
     // treat trailing splat the same way as compilePath, and force it to be as if it were `/*`.
-    // `react-router typegen` will not generate the params for a malformed splat, causing a type error, but we can still do the correct thing here.
+    // `react-router typegen` will not generate the params for a malformed splat,
+    // causing a type error, but we can still do the correct thing here.
     const value = params?.["*"];
     if (value !== undefined) {
-      result += "/" + value;
+      result +=
+        "/" + stringify(value).split("/").map(encodeURIComponent).join("/");
     }
   }
 


### PR DESCRIPTION
This is a maintainer-authored replacement for #15265 so the `href()` param-encoding fix can move forward while the original contributor PR is blocked on CLA status.

`href()` now stringifies and URL-encodes named params to match `generatePath()`. Splat params preserve path separators while encoding each segment individually.
