### PR TITLE
fix(dev): read rolldownOptions.input/output from user environments config (Vite v8)

### DIFF
--- a/packages/react-router-dev/.changes/patch.properly-detect-user-rolldownoptions-config-vite.md
+++ b/packages/react-router-dev/.changes/patch.properly-detect-user-rolldownoptions-config-vite.md
@@ -1,0 +1,1 @@
+Properly detect user `rolldownOptions` config in Vite 8+

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -73,7 +73,12 @@ import {
   getRouteChunkModuleId,
   getRouteChunkNameFromModuleId,
 } from "./route-chunks";
-import { preloadVite, getVite, defineCompilerOptions } from "./vite";
+import {
+  preloadVite,
+  getVite,
+  defineCompilerOptions,
+  getUserBuildRollupOptions,
+} from "./vite";
 import {
   type ResolvedReactRouterConfig,
   type BuildManifest,
@@ -3609,8 +3614,9 @@ export async function getEnvironmentOptionsResolvers(
         ssrEmitAssets: true,
         copyPublicDir: false, // The client only uses assets in the public directory
         rollupOptions: {
+          // prettier-ignore
           input:
-            viteUserConfig.environments?.ssr?.build?.rollupOptions?.input ??
+            getUserBuildRollupOptions(viteUserConfig.environments?.ssr)?.input ??
             virtual.serverBuild.id,
           output: {
             entryFileNames: serverBuildFile,
@@ -3653,29 +3659,31 @@ export async function getEnvironmentOptionsResolvers(
                 },
               ),
             ],
-            output: viteUserConfig?.environments?.client?.build?.rollupOptions
-              ?.output ?? {
-              entryFileNames: ({ moduleIds }) => {
-                let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
-                let routeChunkName = routeChunkModuleId
-                  ? getRouteChunkNameFromModuleId(routeChunkModuleId)?.replace(
-                      "unstable_",
-                      "",
-                    )
-                  : null;
-                let routeChunkSuffix = routeChunkName
-                  ? `-${kebabCase(routeChunkName)}`
-                  : "";
-                let assetsDir =
-                  viteUserConfig?.environments?.client?.build?.assetsDir ??
-                  viteUserConfig?.build?.assetsDir ??
-                  "assets";
-                return path.posix.join(
-                  assetsDir,
-                  `[name]${routeChunkSuffix}-[hash].js`,
-                );
+            // prettier-ignore
+            output:
+              getUserBuildRollupOptions(viteUserConfig?.environments?.client)?.output ??
+              {
+                entryFileNames: ({ moduleIds }) => {
+                  let routeChunkModuleId = moduleIds.find(isRouteChunkModuleId);
+                  let routeChunkName = routeChunkModuleId
+                    ? getRouteChunkNameFromModuleId(routeChunkModuleId)?.replace(
+                        "unstable_",
+                        "",
+                      )
+                    : null;
+                  let routeChunkSuffix = routeChunkName
+                    ? `-${kebabCase(routeChunkName)}`
+                    : "";
+                  let assetsDir =
+                    viteUserConfig?.environments?.client?.build?.assetsDir ??
+                    viteUserConfig?.build?.assetsDir ??
+                    "assets";
+                  return path.posix.join(
+                    assetsDir,
+                    `[name]${routeChunkSuffix}-[hash].js`,
+                  );
+                },
               },
-            },
           },
           outDir: getClientBuildDirectory(ctx.reactRouterConfig),
         },

--- a/packages/react-router-dev/vite/vite.ts
+++ b/packages/react-router-dev/vite/vite.ts
@@ -1,6 +1,11 @@
 import { createRequire } from "node:module";
 import path from "pathe";
-import type { DepOptimizationConfig, ESBuildOptions } from "vite";
+import type {
+  DepOptimizationConfig,
+  ESBuildOptions,
+  EnvironmentOptions,
+  BuildEnvironmentOptions,
+} from "vite";
 
 import invariant from "../invariant";
 import { isReactRouterRepo } from "../config/is-react-router-repo";
@@ -72,4 +77,23 @@ export function defineOptimizeDepsCompilerOptions(options: {
   return parseInt(vite.version.split(".")[0], 10) >= 8
     ? { rolldownOptions: options.rolldown }
     : { esbuildOptions: options.esbuild };
+}
+
+/**
+ * Read the user-supplied build options from either `rollupOptions` (Vite <=7)
+ * or `rolldownOptions` (Vite >=8).
+ */
+export function getUserBuildRollupOptions(
+  environment: EnvironmentOptions | undefined,
+): BuildEnvironmentOptions["rollupOptions"] | undefined {
+  if (environment?.build) {
+    if ("rollupOptions" in environment.build) {
+      return environment.build.rollupOptions;
+    }
+    if ("rolldownOptions" in environment.build) {
+      return environment.build
+        .rolldownOptions as BuildEnvironmentOptions["rollupOptions"];
+    }
+  }
+  return undefined;
 }


### PR DESCRIPTION
This is a maintainer-authored replacement for #15269 because the original contributor has not signed the CLA.

It updates the Vite plugin environment option resolvers to read user-provided build options from `rolldownOptions` when running under Vite 8, while preserving the existing `rollupOptions` behavior for older Vite versions.

Closes #15251
