### PR TITLE
Fix writable stream race leak

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -191,6 +191,7 @@
 - imjordanxd
 - infoxicator
 - ioNihal
+- ishaanlabs-gg
 - IsaiStormBlesed
 - Isammoc
 - iskanderbroere

--- a/packages/react-router-node/.changes/patch.stream-writable-race.md
+++ b/packages/react-router-node/.changes/patch.stream-writable-race.md
@@ -1,0 +1,1 @@
+Avoid retaining stream chunks while waiting for writable errors

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -92,6 +92,30 @@ describe("writeReadableStreamToWritable", () => {
       "Writable failed",
     );
   });
+
+  it("does not race each read against a long-lived writable promise", async () => {
+    let raceSpy = jest.spyOn(Promise, "race");
+    let writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    let readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1));
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+
+    try {
+      await writeReadableStreamToWritable(readable, writable);
+
+      expect(raceSpy).not.toHaveBeenCalled();
+    } finally {
+      raceSpy.mockRestore();
+    }
+  });
 });
 
 describe("writeAsyncIterableToWritable", () => {

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -58,11 +58,7 @@ interface WritableErrorMonitor {
 function monitorWritableError(writable: Writable): WritableErrorMonitor {
   let settled = false;
   let writableError: Error | undefined;
-  let rejectWritableError!: (error: Error) => void;
-  let writableErrorPromise = new Promise<never>((_, reject) => {
-    rejectWritableError = reject;
-  });
-  writableErrorPromise.catch(() => {});
+  let rejectPendingRace: ((error: Error) => void) | undefined;
 
   function cleanup() {
     writable.off("error", onError);
@@ -77,7 +73,8 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
     settled = true;
     writableError = error;
     cleanup();
-    rejectWritableError(error);
+    rejectPendingRace?.(error);
+    rejectPendingRace = undefined;
   }
 
   function onError(error: Error) {
@@ -94,7 +91,18 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
   return {
     cleanup,
     race<T>(promise: Promise<T>) {
-      return Promise.race([promise, writableErrorPromise]);
+      if (writableError) {
+        return Promise.reject(writableError);
+      }
+
+      return new Promise<T>((resolve, reject) => {
+        rejectPendingRace = reject;
+        void promise.then(resolve, reject).finally(() => {
+          if (rejectPendingRace === reject) {
+            rejectPendingRace = undefined;
+          }
+        });
+      });
     },
     throwIfClosed() {
       if (writableError) {


### PR DESCRIPTION
## Summary

- avoid racing every stream read against the same long-lived writable error promise
- keep writable error/close propagation for pending reads
- add a regression test and package change file

Fixes remix-run/react-router#15247

## Testing

- `git diff --check -- contributors.yml packages/react-router-node/stream.ts packages/react-router-node/__tests__/stream-test.ts packages/react-router-node/.changes/patch.stream-writable-race.md`
- `node --check packages/react-router-node/stream.ts`
- `node --check packages/react-router-node/__tests__/stream-test.ts`
- source guard confirming `monitorWritableError` no longer uses `Promise.race([promise, writableErrorPromise])`

I could not run the focused Jest test locally because `pnpm` tried to create its store under the home directory in this sandbox before running tests.
