### PR TITLE
fix(express): respect "X-Forwarded-Proto" for trust proxy requests

### DIFF
--- a/packages/react-router-express/.changes/patch.use-xforwardedproto-header-trust-proxy-requests.md
+++ b/packages/react-router-express/.changes/patch.use-xforwardedproto-header-trust-proxy-requests.md
@@ -1,0 +1,1 @@
+Use `X-Forwarded-Proto` header for trust proxy requests in express defaulting to req.protocol

--- a/packages/react-router-express/__tests__/server-test.ts
+++ b/packages/react-router-express/__tests__/server-test.ts
@@ -345,6 +345,46 @@ describe("express createRemixRequest", () => {
     expect(remixRequest.url).toBe("http://example.com:8443/foo/bar");
   });
 
+  it("does not use x-forwarded-proto unless trust proxy is enabled", async () => {
+    let expressRequest = createRequest({
+      url: "/foo/bar",
+      method: "GET",
+      protocol: "http",
+      hostname: "localhost",
+      headers: {
+        Host: "localhost:3000",
+        "x-forwarded-proto": "https",
+      },
+    });
+    let expressResponse = createResponse();
+
+    let remixRequest = createRemixRequest(expressRequest, expressResponse);
+
+    expect(remixRequest.url).toBe("http://localhost:3000/foo/bar");
+  });
+
+  it("uses x-forwarded-proto when trust proxy is enabled", async () => {
+    let app = express();
+    app.set("trust proxy", true);
+    let expressRequest = createRequest({
+      app,
+      url: "/foo/bar",
+      method: "GET",
+      protocol: "http",
+      hostname: "example.com",
+      headers: {
+        Host: "localhost:3000",
+        "x-forwarded-host": "example.com:8443",
+        "x-forwarded-proto": "https, http",
+      },
+    });
+    let expressResponse = createResponse();
+
+    let remixRequest = createRemixRequest(expressRequest, expressResponse);
+
+    expect(remixRequest.url).toBe("https://example.com:8443/foo/bar");
+  });
+
   it("ignores invalid characters in host values", async () => {
     let expressRequest = createRequest({
       url: "/foo/bar",

--- a/packages/react-router-express/server.ts
+++ b/packages/react-router-express/server.ts
@@ -2,6 +2,7 @@
 // YAY PROJECT REFERENCES!
 /// <reference lib="DOM.Iterable" />
 
+import type { TLSSocket } from "node:tls";
 import type * as express from "express";
 import type { ServerBuild, RouterContextProvider } from "react-router";
 import { createRequestHandler as createRemixRequestHandler } from "react-router";
@@ -89,9 +90,10 @@ export function createRemixRequest(
   req: express.Request,
   res: express.Response,
 ): Request {
+  let trustProxyEnabled = req.app?.enabled("trust proxy");
   // req.hostname doesn't include port information so grab that from
   // `X-Forwarded-Host` or `Host`
-  let [, hostnamePortStr] = req.app?.enabled("trust proxy")
+  let [, hostnamePortStr] = trustProxyEnabled
     ? (req.get("X-Forwarded-Host")?.split(":") ?? [])
     : [];
   let [, hostPortStr] = req.get("host")?.split(":") ?? [];
@@ -105,8 +107,16 @@ export function createRemixRequest(
   // Use req.hostname here as it respects the "trust proxy" setting
   let hostname = req.hostname.split(/[\\/?#@]/)[0] || "localhost";
   let resolvedHost = `${hostname}${port ? `:${port}` : ""}`;
+
+  // req.protocol might not have the correct protocol when using behind a proxy
+  // so we grab from `X-Forwarded-Proto` or encrypted for sockets.
+  let protocol =
+    (trustProxyEnabled && req.get("X-Forwarded-Proto")?.split(",")[0].trim()) ||
+    ((req.socket as TLSSocket).encrypted && "https") ||
+    req.protocol ||
+    "http";
   // Use `req.originalUrl` so Remix is aware of the full path
-  let url = new URL(`${req.protocol}://${resolvedHost}${req.originalUrl}`);
+  let url = new URL(`${protocol}://${resolvedHost}${req.originalUrl}`);
 
   // Abort action/loaders once we can no longer write a response
   let controller: AbortController | null = new AbortController();


### PR DESCRIPTION
When a react-router server is being hosted under a proxy, the `req.protocol` of express can sometime be `http` instead of the original `https` causing the request url origin being incorrect. 

This should also fix a comment from this [issue here](https://github.com/remix-run/react-router/issues/13622#issuecomment-2895514681).