### PR TITLE
docs: fix useNavigate example to pass state in the options argument

### DIFF
--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -259,12 +259,16 @@ const navigateEffectWarning =
  * All properties are optional.
  *
  * ```tsx
- * navigate({
- *   pathname: "/some/route",
- *   search: "?search=param",
- *   hash: "#hash",
- *   state: { some: "state" },
- * });
+ * navigate(
+ *   {
+ *     pathname: "/some/route",
+ *     search: "?search=param",
+ *     hash: "#hash",
+ *   },
+ *   {
+ *     state: { some: "state" },
+ *   },
+ * );
  * ```
  *
  * If you use `state`, that will be available on the {@link Location} object on


### PR DESCRIPTION
The `useNavigate` example for navigating with a `To` object places `state` inside the `To` object:

```tsx
navigate({
  pathname: "/some/route",
  search: "?search=param",
  hash: "#hash",
  state: { some: "state" },
});
```

But `state` is not a property of `To` (`To = string | Partial<Path>`, and `Path` is only `pathname` / `search` / `hash`), so this is a TypeScript excess-property error. At runtime `navigate` reads `state` from its second argument (`NavigateOptions`), so the `state` above is silently dropped, and `useLocation().state` is empty on the next page, which is the opposite of what the sentence right below the example promises.

This moves `state` into the options argument so the example type-checks and actually populates `location.state`.