### PR TITLE
fix: handle cancellation in injectRSCPayload to avoid post-abort server crash

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -281,6 +281,7 @@
 - m-kawafuji
 - m-shojaei
 - machour
+- MahinAnowar
 - majamarijan
 - Malien
 - Manc

--- a/packages/react-router/.changes/patch.rsc-html-stream-cancel.md
+++ b/packages/react-router/.changes/patch.rsc-html-stream-cancel.md
@@ -1,0 +1,1 @@
+Fix server crash (`TypeError: Invalid state: Unable to enqueue`) when a request is aborted while the RSC HTML stream has a pending flush — `injectRSCPayload` now handles cancellation of its readable side, clears the pending flush, and cancels the underlying RSC payload stream

--- a/packages/react-router/__tests__/rsc/html-stream-test.ts
+++ b/packages/react-router/__tests__/rsc/html-stream-test.ts
@@ -1,19 +1,45 @@
 import { injectRSCPayload } from "../../lib/rsc/html-stream/server";
+import { routeRSCServerRequest } from "../../lib/rsc/server.ssr";
 
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
-function createRSCStream() {
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  let promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createRSCStream({
+  keepOpen = false,
+  chunks = ['S1:"hello"'],
+}: {
+  keepOpen?: boolean;
+  chunks?: string[];
+} = {}) {
   let cancelled = false;
+  let cancelReason: unknown;
   let stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      controller.enqueue(encoder.encode('S1:"hello"'));
-      // Keep the stream open so cancellation happens mid-stream.
+      chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+      if (!keepOpen) {
+        controller.close();
+      }
     },
-    cancel() {
+    cancel(reason) {
       cancelled = true;
+      cancelReason = reason;
     },
   });
-  return { stream, isCancelled: () => cancelled };
+  return {
+    stream,
+    isCancelled: () => cancelled,
+    cancelReason: () => cancelReason,
+  };
 }
 
 async function withUnhandledRejections(run: () => Promise<void>) {
@@ -29,12 +55,72 @@ async function withUnhandledRejections(run: () => Promise<void>) {
   return unhandledRejections;
 }
 
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+async function withTimeout<T>(promise: Promise<T>, message: string) {
+  let timeout: ReturnType<typeof setTimeout>;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), 1000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout!);
+  }
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  let reader = stream.getReader();
+  let chunks: Uint8Array[] = [];
+
+  while (true) {
+    let { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+  }
+
+  let length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  let merged = new Uint8Array(length);
+  let offset = 0;
+  for (let chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return decoder.decode(merged);
+}
+
 describe("injectRSCPayload", () => {
+  it("streams buffered HTML, RSC payload chunks, and the HTML trailer", async () => {
+    let html = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("<html><body>"));
+        controller.enqueue(encoder.encode("hi</body></html>"));
+        controller.close();
+      },
+    });
+
+    let result = await readStream(
+      html.pipeThrough(injectRSCPayload(createRSCStream().stream)),
+    );
+
+    expect(result).toBe(
+      '<html><body>hi<script>(self.__FLIGHT_DATA||=[]).push("S1:\\"hello\\"")</script></body></html>',
+    );
+  });
+
   it("does not crash when the readable side is cancelled while a flush is pending", async () => {
-    let rsc = createRSCStream();
+    let rsc = createRSCStream({ keepOpen: true });
     let transform = injectRSCPayload(rsc.stream);
     let writer = transform.writable.getWriter();
     let reader = transform.readable.getReader();
+    let reason = new Error("client aborted");
 
     let unhandledRejections = await withUnhandledRejections(async () => {
       // Schedule the buffered flush (`setTimeout(..., 0)`) by writing a chunk,
@@ -43,23 +129,25 @@ describe("injectRSCPayload", () => {
       writer
         .write(encoder.encode("<html><body>hi</body></html>"))
         .catch(() => {});
-      await reader.cancel(new Error("client aborted"));
+      await reader.cancel(reason);
 
       // Let the pending flush timer fire.
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await tick();
     });
 
     // Without a cancel handler the pending flush enqueues into a cancelled
     // stream, and the rejection from the timer callback kills the process.
     expect(unhandledRejections).toEqual([]);
     expect(rsc.isCancelled()).toBe(true);
+    expect(rsc.cancelReason()).toBe(reason);
   });
 
   it("does not crash when the readable side is cancelled while the RSC payload is streaming", async () => {
-    let rsc = createRSCStream();
+    let rsc = createRSCStream({ keepOpen: true });
     let transform = injectRSCPayload(rsc.stream);
     let writer = transform.writable.getWriter();
     let reader = transform.readable.getReader();
+    let reason = new Error("client aborted");
 
     let unhandledRejections = await withUnhandledRejections(async () => {
       writer
@@ -69,12 +157,66 @@ describe("injectRSCPayload", () => {
       // payload stream is being consumed, then abort.
       await reader.read();
       await reader.read();
-      await reader.cancel(new Error("client aborted"));
+      await reader.cancel(reason);
 
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await tick();
     });
 
     expect(unhandledRejections).toEqual([]);
     expect(rsc.isCancelled()).toBe(true);
+    expect(rsc.cancelReason()).toBe(reason);
+  });
+});
+
+describe("routeRSCServerRequest", () => {
+  it("does not crash when an RSC Framework document response is cancelled while payload injection has a pending flush", async () => {
+    let htmlPulled = createDeferred();
+    let htmlCancelled = createDeferred<unknown>();
+    let response = await routeRSCServerRequest({
+      request: new Request("https://remix.run/"),
+      serverResponse: new Response(createRSCStream().stream),
+      createFromReadableStream: async (body) => {
+        await readStream(body);
+        return { type: "render" } as never;
+      },
+      async renderHTML(getPayload) {
+        await getPayload();
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              return;
+            }
+            sent = true;
+            controller.enqueue(encoder.encode("<html><body>hi</body></html>"));
+            htmlPulled.resolve();
+          },
+          cancel(reason) {
+            htmlCancelled.resolve(reason);
+          },
+        });
+      },
+    });
+    let reader = response.body!.getReader();
+    let reason = new Error("client aborted");
+
+    let unhandledRejections = await withUnhandledRejections(async () => {
+      let read = reader.read().catch(() => {});
+
+      await htmlPulled.promise;
+      await Promise.resolve();
+      await withTimeout(
+        reader.cancel(reason),
+        "Timed out cancelling document response body",
+      );
+      await withTimeout(read, "Timed out settling pending document body read");
+
+      await tick();
+    });
+
+    expect(unhandledRejections).toEqual([]);
+    await expect(
+      withTimeout(htmlCancelled.promise, "Timed out cancelling HTML stream"),
+    ).resolves.toBe(reason);
   });
 });

--- a/packages/react-router/__tests__/rsc/html-stream-test.ts
+++ b/packages/react-router/__tests__/rsc/html-stream-test.ts
@@ -1,0 +1,80 @@
+import { injectRSCPayload } from "../../lib/rsc/html-stream/server";
+
+const encoder = new TextEncoder();
+
+function createRSCStream() {
+  let cancelled = false;
+  let stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('S1:"hello"'));
+      // Keep the stream open so cancellation happens mid-stream.
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  return { stream, isCancelled: () => cancelled };
+}
+
+async function withUnhandledRejections(run: () => Promise<void>) {
+  let unhandledRejections: unknown[] = [];
+  let onUnhandledRejection = (reason: unknown) =>
+    unhandledRejections.push(reason);
+  process.on("unhandledRejection", onUnhandledRejection);
+  try {
+    await run();
+  } finally {
+    process.off("unhandledRejection", onUnhandledRejection);
+  }
+  return unhandledRejections;
+}
+
+describe("injectRSCPayload", () => {
+  it("does not crash when the readable side is cancelled while a flush is pending", async () => {
+    let rsc = createRSCStream();
+    let transform = injectRSCPayload(rsc.stream);
+    let writer = transform.writable.getWriter();
+    let reader = transform.readable.getReader();
+
+    let unhandledRejections = await withUnhandledRejections(async () => {
+      // Schedule the buffered flush (`setTimeout(..., 0)`) by writing a chunk,
+      // then cancel the readable side (client aborted the request) before the
+      // timer fires.
+      writer
+        .write(encoder.encode("<html><body>hi</body></html>"))
+        .catch(() => {});
+      await reader.cancel(new Error("client aborted"));
+
+      // Let the pending flush timer fire.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    // Without a cancel handler the pending flush enqueues into a cancelled
+    // stream, and the rejection from the timer callback kills the process.
+    expect(unhandledRejections).toEqual([]);
+    expect(rsc.isCancelled()).toBe(true);
+  });
+
+  it("does not crash when the readable side is cancelled while the RSC payload is streaming", async () => {
+    let rsc = createRSCStream();
+    let transform = injectRSCPayload(rsc.stream);
+    let writer = transform.writable.getWriter();
+    let reader = transform.readable.getReader();
+
+    let unhandledRejections = await withUnhandledRejections(async () => {
+      writer
+        .write(encoder.encode("<html><body>hi</body></html>"))
+        .catch(() => {});
+      // Read the flushed HTML and the first RSC script chunk so the RSC
+      // payload stream is being consumed, then abort.
+      await reader.read();
+      await reader.read();
+      await reader.cancel(new Error("client aborted"));
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(unhandledRejections).toEqual([]);
+    expect(rsc.isCancelled()).toBe(true);
+  });
+});

--- a/packages/react-router/lib/rsc/html-stream/server.ts
+++ b/packages/react-router/lib/rsc/html-stream/server.ts
@@ -10,6 +10,8 @@ export function injectRSCPayload(rscStream: ReadableStream<Uint8Array>) {
     (resolve) => (resolveFlightDataPromise = resolve),
   );
   let startedRSC = false;
+  let cancelled = false;
+  let rscReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
   // Buffer all HTML chunks enqueued during the current tick of the event loop (roughly)
   // and write them to the output stream all at once. This ensures that we don't generate
@@ -31,7 +33,9 @@ export function injectRSCPayload(rscStream: ReadableStream<Uint8Array>) {
     timeout = null;
   }
 
-  return new TransformStream({
+  let transformer: Transformer<Uint8Array, Uint8Array> & {
+    cancel?: (reason: unknown) => void | Promise<void>;
+  } = {
     transform(chunk, controller) {
       buffered.push(chunk);
       if (timeout) {
@@ -39,10 +43,16 @@ export function injectRSCPayload(rscStream: ReadableStream<Uint8Array>) {
       }
 
       timeout = setTimeout(async () => {
+        // The readable side may have been cancelled (e.g., the client aborted
+        // the request) while this flush was pending — enqueueing would throw.
+        if (cancelled) {
+          return;
+        }
         flushBufferedChunks(controller);
         if (!startedRSC) {
           startedRSC = true;
-          writeRSCStream(rscStream, controller)
+          rscReader = rscStream.getReader();
+          writeRSCStream(rscReader, controller, () => cancelled)
             .catch((err) => controller.error(err))
             .then(resolveFlightDataPromise);
         }
@@ -56,18 +66,36 @@ export function injectRSCPayload(rscStream: ReadableStream<Uint8Array>) {
       }
       controller.enqueue(encoder.encode("</body></html>"));
     },
-  });
+    async cancel(reason) {
+      cancelled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      buffered.length = 0;
+      if (rscReader) {
+        await rscReader.cancel(reason).catch(() => {});
+      } else {
+        await rscStream.cancel(reason).catch(() => {});
+      }
+      resolveFlightDataPromise();
+    },
+  };
+  return new TransformStream(transformer);
 }
 
 async function writeRSCStream(
-  rscStream: ReadableStream<Uint8Array>,
+  reader: ReadableStreamDefaultReader<Uint8Array>,
   controller: TransformStreamDefaultController<Uint8Array>,
+  isCancelled: () => boolean,
 ) {
   let decoder = new TextDecoder("utf-8", { fatal: true });
-  const reader = rscStream.getReader();
   try {
     let read: ReadableStreamReadResult<Uint8Array>;
     while ((read = await reader.read()) && !read.done) {
+      if (isCancelled()) {
+        return;
+      }
       const chunk = read.value;
       // Try decoding the chunk to send as a string.
       // If that fails (e.g. binary data that is invalid unicode), write as base64.
@@ -92,7 +120,7 @@ async function writeRSCStream(
   }
 
   let remaining = decoder.decode();
-  if (remaining.length) {
+  if (remaining.length && !isCancelled()) {
     writeChunk(JSON.stringify(remaining), controller);
   }
 }


### PR DESCRIPTION
Fixes #15275

## Problem

In RSC Framework Mode, an aborted/cancelled document request can crash the production server:

```
TypeError: Invalid state: Unable to enqueue
    at flushBufferedChunks (...)
    at Timeout._onTimeout (...)
```

`injectRSCPayload` buffers HTML chunks and flushes them in a `setTimeout(..., 0)` callback. When the client aborts, the readable side of the `TransformStream` is cancelled while that flush is still pending — the timer then calls `controller.enqueue()` on a cancelled stream. Because the timer callback is `async`, the throw becomes an unhandled rejection, which exits the Node process. The transformer had no `cancel()` hook, so the pending timer and the RSC payload stream were never cleaned up.

## Fix

- Add a `cancel(reason)` handler to the transformer: it flags cancellation, clears the pending flush timer, drops the buffered chunks, cancels the underlying RSC payload stream (via its reader when streaming has started), and resolves the flight-data promise.
- Guard the flush timer callback and the `writeRSCStream` write loop so late timers / in-flight reads become no-ops after cancellation instead of enqueueing into a cancelled stream.

The transformer is typed with a small extension (`Transformer & { cancel? }`) since the repo's current TS lib doesn't yet include the standard `Transformer#cancel` member.

## Tests

Added `packages/react-router/__tests__/rsc/html-stream-test.ts` with two regression tests, covering an abort **while a flush is pending** (the reported crash) and an abort **mid-RSC-stream**. Both assert no unhandled rejection escapes a timer and that the RSC payload stream gets cancelled.

- Without the fix: both fail (the flush-pending case reproduces the exact `Invalid state: Unable to enqueue` rejection).
- With the fix: both pass. Typecheck, ESLint and Prettier are clean. (Note: the sibling `rsc/server-test.ts` suite currently fails to load on a clean `main` checkout in the same way, unrelated to this change.)

A change file is included (`patch.rsc-html-stream-cancel.md`), and I've signed the CLA in `contributors.yml` as part of this PR.
