### PR TITLE
patch: unstable traverse cache

### DIFF
--- a/packages/create-react-router/.changes/unstable.traverse-cache.md
+++ b/packages/create-react-router/.changes/unstable.traverse-cache.md
@@ -1,0 +1,6 @@
+Add the `future.unstable_traverseCache` flag to set client payload fetch cache behavior based on navigation type.
+
+- Back/forward traversals use `cache: "force-cache"` for `.data`/`.rsc` payload requests when enabled.
+- Other navigations and fetchers use `cache: "default"` when enabled.
+- `true` enables it only in production
+- `force` enables it in production and development

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -90,6 +90,7 @@ type ValidateConfigFunction = (config: ReactRouterConfig) => string | void;
 
 interface FutureConfig {
   unstable_optimizeDeps: boolean;
+  unstable_traverseCache: boolean | "force";
 }
 
 type SplitRouteModulesOption = boolean | "enforce";
@@ -438,8 +439,10 @@ async function resolveConfig({
   reactRouterConfigFile,
   skipRoutes,
   validateConfig,
+  mode,
 }: {
   root: string;
+  mode: string;
   viteRunnerContext: ViteRunner.Context;
   reactRouterConfigFile?: string;
   skipRoutes?: boolean;
@@ -737,9 +740,20 @@ async function resolveConfig({
     }
   }
 
-  let future: FutureConfig = {
+  const userTraverseCache = userAndPresetConfigs.future?.unstable_traverseCache;
+
+  let future: {
+    unstable_optimizeDeps: boolean;
+    unstable_traverseCache: boolean;
+  } = {
     unstable_optimizeDeps:
       userAndPresetConfigs.future?.unstable_optimizeDeps ?? false,
+    unstable_traverseCache:
+      userTraverseCache === true
+        ? mode !== "development"
+        : userTraverseCache === "force"
+          ? true
+          : false,
   };
 
   let allowedActionOrigins = userAndPresetConfigs.allowedActionOrigins ?? false;
@@ -832,12 +846,14 @@ export async function createConfigLoader({
       reactRouterConfigFile,
       skipRoutes,
       validateConfig,
+      mode,
     });
 
   let appDirectory: string;
 
   let initialConfigResult = await resolveConfig({
     root,
+    mode,
     viteRunnerContext,
     reactRouterConfigFile,
     skipRoutes,

--- a/packages/react-router-dev/config/default-rsc-entries/entry.rsc.tsx
+++ b/packages/react-router-dev/config/default-rsc-entries/entry.rsc.tsx
@@ -15,6 +15,7 @@ import {
 import routes from "virtual:react-router/unstable_rsc/routes";
 import routeDiscovery from "virtual:react-router/unstable_rsc/route-discovery";
 import basename from "virtual:react-router/unstable_rsc/basename";
+import future from "virtual:react-router/unstable_rsc/future";
 import unstable_reactRouterServeConfig from "virtual:react-router/unstable_rsc/react-router-serve-config";
 
 export { unstable_reactRouterServeConfig };
@@ -38,6 +39,8 @@ export function fetchServer(
     routes,
     // The route discovery configuration.
     routeDiscovery,
+    // Future flags from react-router.config.ts.
+    future,
     // Encode the match with the React Server implementation.
     generateResponse(match, options) {
       return new Response(renderToReadableStream(match.payload, options), {

--- a/packages/react-router-dev/rsc-types.d.ts
+++ b/packages/react-router-dev/rsc-types.d.ts
@@ -15,6 +15,14 @@ declare module "virtual:react-router/unstable_rsc/ssr" {
   export default ssr;
 }
 
+declare module "virtual:react-router/unstable_rsc/future" {
+  const future: {
+    unstable_optimizeDeps: boolean;
+    unstable_traverseCache: boolean;
+  };
+  export default future;
+}
+
 declare module "virtual:react-router/unstable_rsc/react-router-serve-config" {
   const unstable_reactRouterServeConfig: {
     publicPath: string;

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -554,6 +554,19 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
       },
     },
     {
+      name: "react-router/rsc/virtual-future",
+      resolveId(id) {
+        if (id === virtual.future.id) {
+          return virtual.future.resolvedId;
+        }
+      },
+      load(id) {
+        if (id === virtual.future.resolvedId) {
+          return `export default ${JSON.stringify(config.future)};`;
+        }
+      },
+    },
+    {
       name: "react-router/rsc/virtual-route-discovery",
       resolveId(id) {
         if (id === virtual.routeDiscovery.id) {
@@ -784,6 +797,7 @@ const virtual = {
   routeDiscovery: create("unstable_rsc/route-discovery"),
   injectHmrRuntime: create("unstable_rsc/inject-hmr-runtime"),
   basename: create("unstable_rsc/basename"),
+  future: create("unstable_rsc/future"),
   reactRouterServeConfig: create("unstable_rsc/react-router-serve-config"),
 };
 

--- a/packages/react-router/.changes/unstable.traverse-cache.md
+++ b/packages/react-router/.changes/unstable.traverse-cache.md
@@ -1,0 +1,6 @@
+Add the `future.unstable_traverseCache` flag to set client payload fetch cache behavior based on navigation type.
+
+- Back/forward traversals use `cache: "force-cache"` for `.data`/`.rsc` payload requests when enabled.
+- Other navigations and fetchers use `cache: "default"` when enabled.
+- `true` enables it only in production
+- `force` enables it in production and development

--- a/packages/react-router/__tests__/router/data-strategy-test.ts
+++ b/packages/react-router/__tests__/router/data-strategy-test.ts
@@ -1,3 +1,5 @@
+import { createSingleFetchRequestInit } from "../../lib/dom/ssr/single-fetch";
+import { Action as NavigationType } from "../../lib/router/history";
 import type {
   DataStrategyFunction,
   DataStrategyMatch,
@@ -52,6 +54,151 @@ describe("router dataStrategy", () => {
       {},
     );
   }
+
+  it("passes navigationType to dataStrategy for push and replace navigations", async () => {
+    let dataStrategy = mockDataStrategy(({ matches }) =>
+      Promise.all(matches.map((m) => m.resolve())).then((results) =>
+        keyedResults(matches, results),
+      ),
+    );
+    let t = setup({
+      routes: [
+        {
+          path: "/",
+        },
+        {
+          id: "parent",
+          path: "/parent",
+          loader: true,
+        },
+        {
+          id: "replace",
+          path: "/replace",
+          loader: true,
+        },
+      ],
+      dataStrategy,
+    });
+
+    let A = await t.navigate("/parent");
+    await A.loaders.parent.resolve("PARENT");
+    expect(dataStrategy.mock.calls[0][0].navigationType).toBe(
+      NavigationType.Push,
+    );
+
+    let B = await t.navigate("/replace", { replace: true });
+    await B.loaders.replace.resolve("REPLACE");
+    expect(dataStrategy.mock.calls[1][0].navigationType).toBe(
+      NavigationType.Replace,
+    );
+  });
+
+  it("passes POP navigationType to dataStrategy for back and forward navigations", async () => {
+    let dataStrategy = mockDataStrategy(({ matches }) =>
+      Promise.all(matches.map((m) => m.resolve())).then((results) =>
+        keyedResults(matches, results),
+      ),
+    );
+    let t = setup({
+      initialEntries: ["/a"],
+      routes: [
+        {
+          path: "/",
+        },
+        {
+          id: "a",
+          path: "/a",
+          loader: true,
+        },
+        {
+          id: "b",
+          path: "/b",
+          loader: true,
+        },
+      ],
+      hydrationData: {
+        loaderData: { a: "A" },
+      },
+      dataStrategy,
+    });
+
+    let A = await t.navigate("/b");
+    await A.loaders.b.resolve("B");
+    expect(dataStrategy.mock.calls[0][0].navigationType).toBe(
+      NavigationType.Push,
+    );
+
+    let B = await t.navigate(-1);
+    await B.loaders.a.resolve("A");
+    expect(dataStrategy.mock.calls[1][0].navigationType).toBe(
+      NavigationType.Pop,
+    );
+
+    let C = await t.navigate(1);
+    await C.loaders.b.resolve("B");
+    expect(dataStrategy.mock.calls[2][0].navigationType).toBe(
+      NavigationType.Pop,
+    );
+  });
+
+  it("gates single fetch cache behavior behind unstable_traverseCache", async () => {
+    let args = {
+      request: new Request("http://localhost/"),
+      fetcherKey: null,
+      navigationType: NavigationType.Pop,
+    } as Parameters<typeof createSingleFetchRequestInit>[0];
+
+    await expect(createSingleFetchRequestInit(args)).resolves.toEqual({
+      signal: args.request.signal,
+    });
+    await expect(createSingleFetchRequestInit(args, true)).resolves.toEqual({
+      signal: args.request.signal,
+      cache: "force-cache",
+    });
+    await expect(
+      createSingleFetchRequestInit(
+        { ...args, navigationType: NavigationType.Push },
+        true,
+      ),
+    ).resolves.toEqual({
+      signal: args.request.signal,
+      cache: "default",
+    });
+    await expect(
+      createSingleFetchRequestInit({ ...args, fetcherKey: "key" }, true),
+    ).resolves.toEqual({
+      signal: args.request.signal,
+      cache: "default",
+    });
+  });
+
+  it("does not pass navigationType to dataStrategy for fetchers", async () => {
+    let dataStrategy = mockDataStrategy(({ matches }) =>
+      Promise.all(matches.map((m) => m.resolve())).then((results) =>
+        keyedResults(matches, results),
+      ),
+    );
+    let t = setup({
+      routes: [
+        {
+          id: "root",
+          path: "/",
+        },
+        {
+          id: "fetch",
+          path: "/fetch",
+          loader: true,
+        },
+      ],
+      dataStrategy,
+    });
+
+    let A = await t.fetch("/fetch", "key", "root");
+    await A.loaders.fetch.resolve("FETCH");
+
+    expect(dataStrategy.mock.calls[0][0].fetcherKey).toBe("key");
+    expect(dataStrategy.mock.calls[0][0].navigationType).toBeUndefined();
+  });
 
   describe("loaders", () => {
     it("should allow a custom implementation to passthrough to default behavior", async () => {

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -176,6 +176,7 @@ function createHydratedRouter({
     history: createBrowserHistory(),
     basename: ssrInfo.context.basename,
     getContext,
+    future: ssrInfo.context.future,
     hydrationData,
     mapRouteProperties: defaultMapRouteProperties,
     hydrationRouteProperties,

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -49,7 +49,9 @@ export interface EntryContext extends FrameworkContextObject {
   serverHandoffStream?: ReadableStream<Uint8Array>;
 }
 
-export type FutureConfig = Record<string, never>;
+export type FutureConfig = {
+  unstable_traverseCache?: boolean;
+};
 
 export type CriticalCss = string | { rel: "stylesheet"; href: string };
 

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { decode } from "../../../vendor/turbo-stream-v2/turbo-stream";
+import { Action as NavigationType } from "../../router/history";
 import type { Router as DataRouter } from "../../router/router";
 import { isDataWithResponseInit, isResponse } from "../../router/router";
 import type {
@@ -188,7 +189,12 @@ export function getTurboStreamSingleFetchDataStrategy(
         hasClientLoader: manifestRoute.hasClientLoader,
       };
     },
-    fetchAndDecodeViaTurboStream,
+    (args, targetRoutes) =>
+      fetchAndDecodeViaTurboStream(
+        args,
+        targetRoutes,
+        getRouter().future.unstable_traverseCache === true,
+      ),
     ssr,
   );
   return async (args) => args.runClientMiddleware(dataStrategy);
@@ -583,6 +589,7 @@ export function singleFetchUrl(
 async function fetchAndDecodeViaTurboStream(
   args: DataStrategyFunctionArgs,
   targetRoutes?: string[],
+  unstableTraverseCache = false,
 ): Promise<{ status: number; data: DecodedSingleFetchResults }> {
   let { request } = args;
   let url = singleFetchUrl(request.url, "data");
@@ -593,7 +600,10 @@ async function fetchAndDecodeViaTurboStream(
     }
   }
 
-  let res = await fetch(url, await createRequestInit(request));
+  let res = await fetch(
+    url,
+    await createSingleFetchRequestInit(args, unstableTraverseCache),
+  );
 
   // If this error'd without hitting the running server, then bubble a normal
   // `ErrorResponse` and don't try to decode the body with `turbo-stream`.
@@ -669,6 +679,20 @@ async function fetchAndDecodeViaTurboStream(
     // bit restrictive.
     throw new Error("Unable to decode turbo-stream response");
   }
+}
+
+export async function createSingleFetchRequestInit(
+  args: DataStrategyFunctionArgs,
+  unstableTraverseCache = false,
+): Promise<RequestInit> {
+  let init = await createRequestInit(args.request);
+  if (unstableTraverseCache) {
+    init.cache =
+      args.fetcherKey == null && args.navigationType === NavigationType.Pop
+        ? "force-cache"
+        : "default";
+  }
+  return init;
 }
 
 // Note: If you change this function please change the corresponding

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -434,7 +434,9 @@ export type HydrationState = Partial<
 /**
  * Future flags to toggle new feature behavior
  */
-export interface FutureConfig {}
+export interface FutureConfig {
+  unstable_traverseCache?: boolean;
+}
 
 /**
  * Initialization options for createRouter
@@ -2215,6 +2217,7 @@ export function createRouter(init: RouterInit): Router {
         dsMatches,
         scopedContext,
         null,
+        historyAction,
       );
       result = results[actionMatch.route.id];
 
@@ -2494,6 +2497,7 @@ export function createRouter(init: RouterInit): Router {
         request,
         location,
         scopedContext,
+        initialHydration ? undefined : historyAction,
       );
 
     if (request.signal.aborted) {
@@ -3356,6 +3360,7 @@ export function createRouter(init: RouterInit): Router {
     matches: DataStrategyMatch[],
     scopedContext: RouterContextProvider,
     fetcherKey: string | null,
+    navigationType?: NavigationType,
   ): Promise<Record<string, DataResult>> {
     let results: Record<string, DataStrategyResult>;
     let dataResults: Record<string, DataResult> = {};
@@ -3368,6 +3373,7 @@ export function createRouter(init: RouterInit): Router {
         fetcherKey,
         scopedContext,
         false,
+        navigationType,
       );
     } catch (e) {
       // If the outer dataStrategy method throws, just return the error for all
@@ -3441,6 +3447,7 @@ export function createRouter(init: RouterInit): Router {
     request: Request,
     location: Location,
     scopedContext: RouterContextProvider,
+    navigationType?: NavigationType,
   ) {
     // Kick off loaders and fetchers in parallel
     let loaderResultsPromise = callDataStrategy(
@@ -3449,6 +3456,7 @@ export function createRouter(init: RouterInit): Router {
       matches,
       scopedContext,
       null,
+      navigationType,
     );
 
     let fetcherResultsPromise = Promise.all(
@@ -6548,6 +6556,7 @@ async function callDataStrategyImpl(
   fetcherKey: string | null,
   scopedContext: unknown,
   isStaticHandler: boolean,
+  navigationType?: NavigationType,
 ): Promise<Record<string, DataStrategyResult>> {
   // Ensure all middleware is loaded before we start executing routes
   if (matches.some((m) => m._lazyPromises?.middleware)) {
@@ -6567,6 +6576,7 @@ async function callDataStrategyImpl(
     params: matches[0].params,
     context: scopedContext,
     matches,
+    navigationType,
   };
   let runClientMiddleware = isStaticHandler
     ? () => {

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { Equal, Expect } from "../types/utils";
-import type { Location, Path, To } from "./history";
+import type { Action as NavigationType, Location, Path, To } from "./history";
 import { invariant, parsePath, warning } from "./history";
 import {
   ABSOLUTE_URL_REGEX,
@@ -529,6 +529,11 @@ export interface DataStrategyFunctionArgs<
    * for navigational executions
    */
   fetcherKey: string | null;
+  /**
+   * The type of navigation we are calling `dataStrategy` for. This is `undefined`
+   * for fetcher executions and non-navigational executions.
+   */
+  navigationType?: NavigationType;
 }
 
 /**

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -22,7 +22,6 @@ import type {
   DataRouteObject,
   DataStrategyFunction,
   DataStrategyFunctionArgs,
-  RouterContextProvider,
 } from "../router/utils";
 import { ErrorResponseImpl, createContext, resolvePath } from "../router/utils";
 import { PROTOCOL_RELATIVE_URL_REGEX } from "../router/url";
@@ -31,11 +30,11 @@ import type {
   FetchAndDecodeFunction,
 } from "../dom/ssr/single-fetch";
 import {
+  createSingleFetchRequestInit,
   getSingleFetchDataStrategyImpl,
   singleFetchUrl,
   stripIndexParam,
 } from "../dom/ssr/single-fetch";
-import { createRequestInit } from "../dom/ssr/data";
 import { getHydrationData } from "../dom/ssr/hydration";
 import {
   noActionDefinedError,
@@ -339,6 +338,7 @@ function createRouterFromPayload({
       );
     },
     // FIXME: Pass `build.ssr` into this function
+    future: payload.future,
     dataStrategy: getRSCSingleFetchDataStrategy(
       () => globalVar.__reactRouterDataRouter,
       true,
@@ -470,7 +470,11 @@ export function getRSCSingleFetchDataStrategy(
       };
     },
     // pass map into fetchAndDecode so it can add payloads
-    getFetchAndDecodeViaRSC(createFromReadableStream, fetchImplementation),
+    getFetchAndDecodeViaRSC(
+      createFromReadableStream,
+      fetchImplementation,
+      () => getRouter().future.unstable_traverseCache === true,
+    ),
     ssr,
     // If the route has a component but we don't have an element, we need to hit
     // the server loader flow regardless of whether the client loader calls
@@ -526,6 +530,7 @@ export function getRSCSingleFetchDataStrategy(
 function getFetchAndDecodeViaRSC(
   createFromReadableStream: BrowserCreateFromReadableStreamFunction,
   fetchImplementation: (request: Request) => Promise<Response>,
+  getUnstableTraverseCache: () => boolean,
 ): FetchAndDecodeFunction {
   return async (args: DataStrategyFunctionArgs, targetRoutes?: string[]) => {
     let { request, context } = args;
@@ -538,7 +543,10 @@ function getFetchAndDecodeViaRSC(
     }
 
     let res = await fetchImplementation(
-      new Request(url, await createRequestInit(request)),
+      new Request(
+        url,
+        await createSingleFetchRequestInit(args, getUnstableTraverseCache()),
+      ),
     );
 
     // If this error'd without hitting the running server, then bubble a normal
@@ -811,7 +819,7 @@ export function RSCHydratedRouter({
   }, [routeDiscovery, createFromReadableStream, fetchImplementation]);
 
   const frameworkContext: FrameworkContextObject = {
-    future: {},
+    future: payload.future || {},
     isSpaMode: false,
     ssr: true,
     criticalCss: "",

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import * as React from "react";
 import type { ReactFormState } from "react-dom/client";
 
+import type { FutureConfig } from "../dom/ssr/entry";
 import type {
   ClientActionFunction,
   ClientLoaderFunction,
@@ -247,6 +248,7 @@ export type RSCRenderPayload = {
   loaderData: Record<string, any>;
   location: Location;
   routeDiscovery: RouteDiscovery;
+  future?: FutureConfig;
   matches: RSCRouteMatch[];
   // Additional routes we should patch into the router for subsequent navigations.
   // Mostly a collection of pathless/index routes that may be needed for complete
@@ -372,6 +374,7 @@ export type RouteDiscovery =
  * @param opts.generateResponse A function responsible for using your
  * `renderToReadableStream` to generate a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
  * encoding the {@link unstable_RSCPayload}.
+ * @param opts.future Future flags to enable for the router.
  * @param opts.loadServerAction Your `react-server-dom-xyz/server`'s
  * `loadServerAction` function, used to load a server action by ID.
  * @param opts.onError An optional error handler that will be called with any
@@ -400,6 +403,7 @@ export async function matchRSCServerRequest({
   onError,
   request,
   routes,
+  future,
   generateResponse,
 }: {
   allowedActionOrigins?: string[];
@@ -414,6 +418,7 @@ export async function matchRSCServerRequest({
   request: Request;
   routes: RSCRouteConfigEntry[];
   routeDiscovery?: RouteDiscovery;
+  future?: FutureConfig;
   generateResponse: (
     match: RSCMatch,
     {
@@ -511,6 +516,7 @@ export async function matchRSCServerRequest({
     temporaryReferences,
     allowedActionOrigins,
     routeDiscovery,
+    future,
   );
   // The front end uses this to know whether a 4xx/5xx status came from app code
   // or never reached the origin server
@@ -814,6 +820,7 @@ async function generateRenderResponse(
   temporaryReferences: unknown,
   allowedActionOrigins: string[] | undefined,
   routeDiscovery: RouteDiscovery | undefined,
+  future: FutureConfig | undefined,
 ): Promise<Response> {
   // If this is a RR submission, we just want the `actionData` but don't want
   // to call any loaders or render any components back in the response - that
@@ -948,6 +955,7 @@ async function generateRenderResponse(
           skipRevalidation,
           ctx.redirect?.headers,
           routeDiscovery,
+          future,
         );
       },
     }),
@@ -1046,6 +1054,7 @@ async function generateStaticContextResponse(
   skipRevalidation: boolean,
   sideEffectRedirectHeaders: Headers | undefined,
   routeDiscovery: RouteDiscovery | undefined,
+  future: FutureConfig | undefined,
 ): Promise<Response> {
   statusCode = staticContext.statusCode ?? statusCode;
 
@@ -1100,6 +1109,7 @@ async function generateStaticContextResponse(
     errors: staticContext.errors,
     loaderData: staticContext.loaderData,
     location: staticContext.location,
+    future,
     formState,
   };
 

--- a/playground/framework/react-router.config.ts
+++ b/playground/framework/react-router.config.ts
@@ -4,5 +4,6 @@ export default {
   subResourceIntegrity: true,
   future: {
     unstable_optimizeDeps: true,
+    unstable_traverseCache: true,
   },
 } satisfies Config;

--- a/playground/rsc-vite-framework/app/entry.rsc.tsx
+++ b/playground/rsc-vite-framework/app/entry.rsc.tsx
@@ -15,6 +15,7 @@ import {
 import routes from "virtual:react-router/unstable_rsc/routes";
 import routeDiscovery from "virtual:react-router/unstable_rsc/route-discovery";
 import basename from "virtual:react-router/unstable_rsc/basename";
+import future from "virtual:react-router/unstable_rsc/future";
 import unstable_reactRouterServeConfig from "virtual:react-router/unstable_rsc/react-router-serve-config";
 
 export { unstable_reactRouterServeConfig };
@@ -40,6 +41,8 @@ export function fetchServer(
     routes,
     // The route discovery configuration.
     routeDiscovery,
+    // Future flags from react-router.config.ts.
+    future,
     // Encode the match with the React Server implementation.
     generateResponse(match, options) {
       return new Response(renderToReadableStream(match.payload, options), {


### PR DESCRIPTION
Add the `future.unstable_traverseCache` flag to set client payload fetch cache behavior based on navigation type.

- Back/forward traversals use `cache: "force-cache"` for `.data`/`.rsc` payload requests when enabled.
- Other navigations and fetchers use `cache: "default"` when enabled.
- `true` enables it only in production
- `force` enables it in production and development
