### PR TITLE
fix(react-router): strip optional markers from static segments in href

### DIFF
--- a/packages/react-router/.changes/patch.href-optional-static-segments.md
+++ b/packages/react-router/.changes/patch.href-optional-static-segments.md
@@ -1,0 +1,4 @@
+Fix `href()` to strip optional markers from optional static path segments, matching `generatePath()`
+
+- `href("/users/:userId/edit?", { userId: "5" })` now returns `/users/5/edit` instead of `/users/5/edit?`
+- the trailing `?` previously leaked into the returned path and was parsed as a query string delimiter

--- a/packages/react-router/__tests__/href-test.ts
+++ b/packages/react-router/__tests__/href-test.ts
@@ -42,6 +42,19 @@ describe("href", () => {
     expect(href("/a/:b.zip", { b: "hello" })).toBe("/a/hello.zip");
   });
 
+  it("strips optional markers from static segments", () => {
+    expect(href("/users/:userId/edit?", { userId: "5" })).toBe("/users/5/edit");
+    expect(href("/shop?/products/:id", { id: "5" })).toBe("/shop/products/5");
+    expect(href("/one?/two?/:three?", { three: "3" })).toBe("/one/two/3");
+    expect(href("/one?/two?/:three?", {})).toBe("/one/two");
+  });
+
+  it("round-trips optional static segments through matchPath", () => {
+    let pattern = "/shop?/products/:id";
+    let result = href(pattern, { id: "5" });
+    expect(matchPath(pattern, result)).not.toBeNull();
+  });
+
   it("encodes param values that contain a /", () => {
     expect(href("/products/:id", { id: "shoes/2026-summer" })).toBe(
       "/products/shoes%2F2026-summer",

--- a/packages/react-router/lib/href.ts
+++ b/packages/react-router/lib/href.ts
@@ -44,7 +44,8 @@ export function href<Path extends keyof Args>(
         }
         return value == null ? "" : "/" + encodeURIComponent(stringify(value));
       },
-    );
+    )
+    .replace(/\/([\w-]+)\?(?=\/|$)/g, "/$1"); // Optional static segment
 
   if (path.endsWith("*")) {
     // treat trailing splat the same way as compilePath, and force it to be as if it were `/*`.


### PR DESCRIPTION
`href()` only stripped the optional `?` marker from dynamic `:param?` segments and left it on optional static segments. A route path such as `/users/:userId/edit?` produced `/users/5/edit?`, where the trailing `?` is parsed as a query string delimiter. For a leading or middle optional static segment like `/shop?/products/:id` the result `/shop?/products/5` split into pathname `/shop` and search `?/products/5`, breaking navigation. The output also failed to match its own pattern via `matchPath`.

This strips the optional marker from static segments after interpolating dynamic params, matching `generatePath()`. Adds tests for the interpolation output and the `matchPath` round trip.
