### PR TITLE
fix(dev): resolve ENOTEMPTY crash during concurrent typegen

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -51,6 +51,7 @@
 - AviVahl
 - awreese
 - aymanemadidi
+- ayush23chaudhary
 - ayushchaudhary
 - ayushmanchhabra
 - babafemij-k

--- a/packages/react-router-dev/.changes/patch.fix-resolve-enotempty-crash-during-concurrent.md
+++ b/packages/react-router-dev/.changes/patch.fix-resolve-enotempty-crash-during-concurrent.md
@@ -1,0 +1,1 @@
+fix: resolve ENOTEMPTY crash during concurrent typegen

--- a/packages/react-router-dev/typegen/index.ts
+++ b/packages/react-router-dev/typegen/index.ts
@@ -11,6 +11,7 @@ import {
   generateRoutes,
   generateServerBuild,
 } from "./generate";
+import { withTypegenLock } from "./lock";
 
 const { green, red } = pc;
 
@@ -35,8 +36,12 @@ export async function run(
   { mode, rsc }: { mode: string; rsc: boolean },
 ) {
   const ctx = await createContext({ rootDirectory, mode, rsc, watch: false });
-  await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
-  await write(generateServerBuild(ctx), ...generateRoutes(ctx));
+  const dotReactRouterDir = Path.dirname(typesDirectory(ctx));
+
+  await withTypegenLock(dotReactRouterDir, async () => {
+    await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
+    await write(generateServerBuild(ctx), ...generateRoutes(ctx));
+  });
 }
 
 export type Watcher = {
@@ -48,9 +53,13 @@ export async function watch(
   { mode, logger, rsc }: { mode: string; logger?: Logger; rsc: boolean },
 ): Promise<Watcher> {
   const ctx = await createContext({ rootDirectory, mode, rsc, watch: true });
-  await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
-  await write(generateServerBuild(ctx), ...generateRoutes(ctx));
-  logger?.info(green("generated types"), { timestamp: true, clear: true });
+  const dotReactRouterDir = Path.dirname(typesDirectory(ctx));
+
+  await withTypegenLock(dotReactRouterDir, async () => {
+    await fs.rm(typesDirectory(ctx), { recursive: true, force: true });
+    await write(generateServerBuild(ctx), ...generateRoutes(ctx));
+    logger?.info(green("generated types"), { timestamp: true, clear: true });
+  });
 
   ctx.configLoader.onChange(async ({ result, routeConfigChanged }) => {
     if (!result.ok) {
@@ -60,11 +69,13 @@ export async function watch(
     ctx.config = result.value;
 
     if (routeConfigChanged) {
-      await clearRouteModuleAnnotations(ctx);
-      await write(...generateRoutes(ctx));
-      logger?.info(green("regenerated types"), {
-        timestamp: true,
-        clear: true,
+      await withTypegenLock(dotReactRouterDir, async () => {
+        await clearRouteModuleAnnotations(ctx);
+        await write(...generateRoutes(ctx));
+        logger?.info(green("regenerated types"), {
+          timestamp: true,
+          clear: true,
+        });
       });
     }
   });

--- a/packages/react-router-dev/typegen/lock.ts
+++ b/packages/react-router-dev/typegen/lock.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises";
+import * as Path from "pathe";
+
+export async function withTypegenLock<T>(
+  dotReactRouterDir: string,
+  action: () => Promise<T>
+): Promise<T> {
+  await fs.mkdir(dotReactRouterDir, { recursive: true });
+  const lockPath = Path.join(dotReactRouterDir, ".typegen.lock");
+
+  while (true) {
+    try {
+      await fs.mkdir(lockPath);
+      break;
+    } catch (err: any) {
+      if (err.code !== "EEXIST") throw err;
+
+      try {
+        const stats = await fs.stat(lockPath);
+        if (Date.now() - stats.mtimeMs > 5000) {
+          await fs.rm(lockPath, { recursive: true, force: true });
+        }
+      } catch (statErr: any) {
+        if (statErr.code !== "ENOENT") throw statErr;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  try {
+    return await action();
+  } finally {
+    await fs.rm(lockPath, { recursive: true, force: true }).catch(() => {});
+  }
+}


### PR DESCRIPTION
Fixes #15283

### Description

This PR resolves a cross-process filesystem race condition that occurs when `react-router dev` and `react-router typegen` attempt to write to the `.react-router/types` directory at the same time. 

Previously, if a user triggered a manual `typegen` (e.g., via a `pre-commit` hook or a separate script) while the dev server watcher was actively running, one of the processes would crash with `Error: ENOTEMPTY: directory not empty, rmdir '.react-router/types/app'` because both processes were trying to recursively delete and rewrite the same files simultaneously.

### The Fix

Instead of simply adding a retry backoff to `fs.rm` (which would suppress the crash but could leave malformed or incomplete type files if Process B reads while Process A is writing), this PR introduces an atomic file-system spin-lock.

* **`lock.ts`**: Utilizes the atomic nature of `fs.mkdir` to create a cross-process mutex (`.typegen.lock`).
* **Implementation**: Wraps the destructive `fs.rm` and `write` operations inside `withTypegenLock` for both the CLI `run()` function and the `watch()` config-change listener.
* **Deadlock Prevention**: Includes a 5-second stale-lock timeout to ensure that if a process is killed (`SIGKILL`) mid-write, the lock is safely discarded on the next run.

### Testing Strategy

Manually verified by creating a fresh v8 React Router app. 
1. Started the dev server (`npx react-router dev`).
2. Triggered an aggressive concurrent bash loop in a separate terminal: 
   `for i in {1..20}; do npx react-router typegen; done`
3. **Result:** The processes queue up politely, both terminals complete successfully, and the `ENOTEMPTY` crash no longer occurs. No malformed type files are generated.

