### PR TITLE
fix: apply NavLink pending state when the to prop has a trailing slash

### DIFF
--- a/packages/react-router/.changes/patch.navlink-pending-trailing-slash.md
+++ b/packages/react-router/.changes/patch.navlink-pending-trailing-slash.md
@@ -1,0 +1,1 @@
+Fix `NavLink` not applying its `pending` state when `to` has a trailing slash

--- a/packages/react-router/__tests__/dom/nav-link-active-test.tsx
+++ b/packages/react-router/__tests__/dom/nav-link-active-test.tsx
@@ -696,6 +696,45 @@ describe("NavLink using a data router", () => {
     expect(screen.getByText("Link to Bar").className).toBe("active");
   });
 
+  it("applies the 'pending' className to a NavLink whose 'to' has a trailing slash", async () => {
+    let dfd = createDeferred();
+    let router = createBrowserRouter(
+      createRoutesFromElements(
+        <Route path="/" element={<Layout />}>
+          <Route path="home" element={<Outlet />}>
+            <Route
+              path="child"
+              loader={() => dfd.promise}
+              element={<p>Child page</p>}
+            />
+          </Route>
+        </Route>,
+      ),
+      {
+        window: getWindow("/"),
+      },
+    );
+    render(<RouterProvider router={router} />);
+
+    function Layout() {
+      return (
+        <>
+          <NavLink to="/home/">Home</NavLink>
+          <NavLink to="/home/child">Child</NavLink>
+          <Outlet />
+        </>
+      );
+    }
+
+    expect(screen.getByText("Home").className).toBe("");
+
+    fireEvent.click(screen.getByText("Child"));
+    expect(screen.getByText("Home").className).toBe("pending");
+
+    dfd.resolve(null);
+    await waitFor(() => screen.getByText("Child page"));
+  });
+
   it("applies its className correctly when provided as a function", async () => {
     let dfd = createDeferred();
     let router = createBrowserRouter(

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1690,7 +1690,7 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       (nextLocationPathname === toPathname ||
         (!end &&
           nextLocationPathname.startsWith(toPathname) &&
-          nextLocationPathname.charAt(toPathname.length) === "/"));
+          nextLocationPathname.charAt(endSlashPosition) === "/"));
 
     let renderProps = {
       isActive,


### PR DESCRIPTION
`NavLink` derives `isActive` and `isPending` from the same prefix match, but `isPending` uses the raw `toPathname.length` where `isActive` uses `endSlashPosition`. So when `to` has a trailing slash, the `pending` state is never applied while navigating to a child route.

For example, `<NavLink to="/home/">` correctly gets the `active` class once you land on `/home/child`, but never gets the `pending` class while that navigation is in flight.

This uses `endSlashPosition` in `isPending` so it matches `isActive`.
