### PR TITLE
Use random UUIDs for memory session ids

### DIFF
--- a/docs/explanation/sessions-and-cookies.md
+++ b/docs/explanation/sessions-and-cookies.md
@@ -278,7 +278,7 @@ The `expires` argument to `createData` and `updateData` is the same `Date` at wh
 There are also several other session utilities available if you need them:
 
 - [`isSession`][is-session]
-- [`createMemorySessionStorage`][create-memory-session-storage]
+- [`createMemorySessionStorage`][create-memory-session-storage] (local dev and testing)
 - [`createSession`][create-session] (custom storage)
 - [`createFileSessionStorage`][create-file-session-storage] (node)
 - [`createWorkersKVSessionStorage`][create-workers-kv-session-storage] (Cloudflare Workers)

--- a/packages/react-router/.changes/patch.memory-session-random-uuid.md
+++ b/packages/react-router/.changes/patch.memory-session-random-uuid.md
@@ -1,0 +1,3 @@
+Use `crypto.randomUUID()` for `createMemorySessionStorage` session ids
+
+- `createMemorySessionStorage` is only intended for local development and testing - sessions are lost when the server restarts

--- a/packages/react-router/__tests__/server-runtime/sessions-test.ts
+++ b/packages/react-router/__tests__/server-runtime/sessions-test.ts
@@ -66,7 +66,7 @@ describe("In-memory session storage", () => {
     expect(session.get("user")).toEqual("mjackson");
   });
 
-  it("uses random hash keys as session ids", async () => {
+  it("uses random UUIDs as session ids", async () => {
     let { getSession, commitSession } = createMemorySessionStorage({
       cookie: { secrets: ["secret1"] },
     });
@@ -74,7 +74,9 @@ describe("In-memory session storage", () => {
     session.set("user", "mjackson");
     let setCookie = await commitSession(session);
     session = await getSession(getCookieFromSetCookie(setCookie));
-    expect(session.id).toMatch(/^[a-z0-9]{8}$/);
+    expect(session.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });
 

--- a/packages/react-router/__tests__/server-runtime/sessions-test.ts
+++ b/packages/react-router/__tests__/server-runtime/sessions-test.ts
@@ -74,9 +74,7 @@ describe("In-memory session storage", () => {
     session.set("user", "mjackson");
     let setCookie = await commitSession(session);
     session = await getSession(getCookieFromSetCookie(setCookie));
-    expect(session.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
-    );
+    expect(session.id).toMatch(/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/);
   });
 });
 

--- a/packages/react-router/lib/server-runtime/sessions/memoryStorage.ts
+++ b/packages/react-router/lib/server-runtime/sessions/memoryStorage.ts
@@ -15,11 +15,10 @@ interface MemorySessionStorageOptions {
 }
 
 /**
- * Creates and returns a simple in-memory SessionStorage object, mostly useful
- * for testing and as a reference implementation.
+ * Creates and returns a simple in-memory SessionStorage object.
  *
- * Note: This storage does not scale beyond a single process, so it is not
- * suitable for most production scenarios.
+ * Intended for local development and testing. It does not scale beyond a single
+ * process, and all session data is lost when the server process stops/restarts.
  */
 export function createMemorySessionStorage<
   Data = SessionData,
@@ -36,7 +35,7 @@ export function createMemorySessionStorage<
   return createSessionStorage({
     cookie,
     async createData(data, expires) {
-      let id = Math.random().toString(36).substring(2, 10);
+      let id = crypto.randomUUID();
       map.set(id, { data, expires });
       return id;
     },


### PR DESCRIPTION
Switch from `Math.random` to `crypto.randomUUID` for in-memory session ids