### PR TITLE
fix: remove server build from build output when ssr:false

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -955,6 +955,27 @@ test.describe(`Prerendering`, () => {
     });
   });
 
+  test("keeps the server build directory when ssr is enabled", async () => {
+    let cwd = await createProject({
+      "react-router.config.ts": reactRouterConfig({
+        prerender: ["/"],
+      }),
+      "app/routes/_index.tsx": String.raw`
+        export default function Component() {
+          return "index";
+        }
+      `,
+    });
+    let result = build({ cwd });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).not.toMatch(
+      /Removing the server build/,
+    );
+    expect(
+      fs.existsSync(path.join(cwd, "build", "server", "index.js")),
+    ).toBe(true);
+  });
+
   test.describe("ssr: false", () => {
     function captureRequests(page: Page) {
       let requests: string[] = [];
@@ -975,6 +996,29 @@ test.describe(`Prerendering`, () => {
         requests.pop();
       }
     }
+
+    test("removes the server build directory from the build output", async () => {
+      let cwd = await createProject({
+        "react-router.config.ts": reactRouterConfig({
+          ssr: false,
+          prerender: ["/"],
+        }),
+        "app/routes/_index.tsx": String.raw`
+          export default function Component() {
+            return "index";
+          }
+        `,
+      });
+      let result = build({ cwd });
+      expect(result.status).toBe(0);
+      expect(result.stdout.toString("utf8")).toMatch(
+        /Removing the server build in .* due to ssr:false/,
+      );
+      expect(fs.existsSync(path.join(cwd, "build", "server"))).toBe(false);
+      expect(
+        fs.existsSync(path.join(cwd, "build", "client", "index.html")),
+      ).toBe(true);
+    });
 
     test("Errors on headers/action functions in any route", async () => {
       let cwd = await createProject({

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -1282,4 +1282,26 @@ test.describe("SPA Mode", () => {
       "app/routes/about.tsx",
     ]);
   });
+
+  test("removes the server build directory from the build output", async () => {
+    let cwd = await createProject({
+      "react-router.config.ts": reactRouterConfig({
+        ssr: false,
+      }),
+      "app/routes/_index.tsx": String.raw`
+        export default function Component() {
+          return "index";
+        }
+      `,
+    });
+    let result = build({ cwd });
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).toMatch(
+      /Removing the server build in .* due to ssr:false/,
+    );
+    expect(fs.existsSync(path.join(cwd, "build", "server"))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, "build", "client", "index.html"))).toBe(
+      true,
+    );
+  });
 });

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2,7 +2,7 @@
 // context but want to use Vite's ESM build since Vite 7+ is ESM only
 import type * as Vite from "vite";
 import { type BinaryLike, createHash } from "node:crypto";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import {
   cp,
   mkdir,
@@ -1359,19 +1359,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           },
         };
       },
-      // buildApp: {
-      //   order: "post",
-      //   handler: async (builder) => {
-      //     let { reactRouterConfig } = ctx;
-
-      //     let serverBuildDirectory =
-      //       builder.environments.ssr.config?.build?.outDir;
-      //     if (serverBuildDirectory && !reactRouterConfig.ssr) {
-      //       // For both SPA mode and prerendering, we can remove the server builds
-      //       rmSync(serverBuildDirectory, { force: true, recursive: true });
-      //     }
-      //   },
-      // },
       configEnvironment(name, options) {
         if (isReactRouterServerEnvironment(ctx, name)) {
           const vite = getVite();
@@ -2731,6 +2718,26 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                   invariant(viteConfig);
                   let { buildManifest, reactRouterConfig } = ctx;
                   invariant(buildManifest, "Expected build manifest");
+
+                  // For both SPA mode and prerendering, the server build is
+                  // only an intermediate artifact (it has already been used to
+                  // generate the SPA fallback and any prerendered pages above),
+                  // so remove it from the build output
+                  if (!reactRouterConfig.ssr) {
+                    let serverBuildDirectory =
+                      getServerBuildDirectory(reactRouterConfig);
+                    viteConfig.logger.info(
+                      [
+                        "Removing the server build in",
+                        colors.green(serverBuildDirectory),
+                        "due to ssr:false",
+                      ].join(" "),
+                    );
+                    rmSync(serverBuildDirectory, {
+                      force: true,
+                      recursive: true,
+                    });
+                  }
 
                   await reactRouterConfig.buildEnd?.({
                     buildManifest,


### PR DESCRIPTION
Fixes #15305

## Problem

In v8, `ssr: false` (SPA mode and static prerendering) leaves `build/server/` behind in the build output. v7 deleted it after the build (with a `Removing the server build in ... due to ssr:false` log); the Vite environment API migration (#15077 / 2bd8b8f) removed that code path and left its `buildApp`-hook replacement commented out, so the stale, unused server bundle now ships with every `ssr:false` build.

## Fix

Restore the removal inside the existing `react-router-build-end` `buildApp` wrapper. Ordering matters and this spot satisfies both constraints:

- it runs **after** the prerender plugin's wrapped `buildApp` (the prerender/SPA-fallback generation serves requests through the preview server, which reads the built server bundle — so the server build must still exist during that phase), and
- it runs **before** the user's `buildEnd` hook, so `buildEnd` authors observe the final output state, matching v7 semantics.

Uses the same log message as v7 and removes the stale commented-out block.

## Tests

- `vite-spa-mode-test.ts`: `ssr: false` build removes `build/server`, logs the removal, and `build/client/index.html` is still produced.
- `vite-prerender-test.ts` (`ssr: false`): same assertions with prerendering enabled.
- `vite-prerender-test.ts` (default `ssr: true`): guard test — server build is **kept** and no removal is logged.
- Full `vite-spa-mode-test.ts` + `vite-prerender-test.ts` suites: 85/85 passing locally (chromium).