### PR TITLE
test: failing test for hydration race when a subscriber exists before RouterProvider mounts

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -290,6 +290,7 @@
 - markdalgleish
 - markivancho
 - markmals
+- marlass
 - Marlon-Buckley
 - maruffahmed
 - marvinruder

--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -603,6 +603,56 @@ function testDomRouter(
         await waitFor(() => screen.getByText("Data:LOADER"));
         expect(screen.queryByText("Suspense Fallback")).toBeNull();
       });
+
+      it("handles the same race condition when an external subscriber was attached before RouterProvider mounted", async () => {
+        const sleep = (ms: number) =>
+          new Promise((resolve) => setTimeout(resolve, ms));
+
+        // Kick off some async data load _before_ any react stuff
+        let suspensePromise = sleep(100).then(() => "DATA");
+
+        // Create a router that will initialize shortly after the suspense boundary resolves
+        let router = createTestRouter([
+          {
+            path: "/",
+            // Only fails when this is around 200ms - passes if you bump it to ~500ms
+            loader: () => sleep(200).then(() => "LOADER"),
+            Component: () => <p>Data:{useLoaderData()}</p>,
+            HydrateFallback: () => "Hydrate Fallback",
+          },
+        ]);
+
+        // An external subscriber attached at router creation time, the way
+        // Sentry's `wrapCreateBrowserRouterV7` instrumentation does.
+        // `bufferedInitialStateUpdate` is only armed when the router updates
+        // with zero subscribers, so RouterProvider's later subscribe() gets
+        // no replay and misses the initialization update.
+        let unsubscribe = router.subscribe(() => {});
+        expect(router.state.initialized).toBe(false);
+
+        // Render a component that will suspend until `suspensePromise` resolves, then
+        // renders RouterProvider which sets up listeners for the router state
+        function App() {
+          // @ts-expect-error Needs React 19 types
+          React.use(suspensePromise);
+          return <RouterProvider router={router} />;
+        }
+
+        // Needs to be wrapped in `act()` for suspense to work properly
+        // https://github.com/testing-library/react-testing-library/issues/1375
+        await act(async () => {
+          render(
+            <React.Suspense fallback="Suspense Fallback">
+              <App />
+            </React.Suspense>,
+          );
+        });
+
+        expect(screen.getByText("Suspense Fallback")).toBeDefined();
+        await waitFor(() => screen.getByText("Data:LOADER"));
+        expect(screen.queryByText("Suspense Fallback")).toBeNull();
+        unsubscribe();
+      });
     });
 
     describe("navigations", () => {


### PR DESCRIPTION
Same scenario as the existing race-condition regression test, plus a single router.subscribe(() => {}) call before RouterProvider mounts, which is what Sentry's wrapCreateBrowserRouterV7 instrumentation does at router creation. Because bufferedInitialStateUpdate is only armed when updateState runs with zero subscribers, RouterProvider's layout-effect subscription gets no replay and the app renders the HydrateFallback forever.

The bug from #14356 is back in 7.16.0+ and 8.x, with one extra condition: a subscriber attached to the router before RouterProvider mounts. The most common real-world source is Sentry — wrapCreateBrowserRouterV7 calls router.subscribe(...) at router creation. Combined with anything suspending above RouterProvider (code-split shell, i18n bundle), fast loaders / cached route.lazy chunks resolve before RouterProvider's subscribe() layout effect runs, the initialization update is lost, and the app renders the HydrateFallback forever. Fast responses fail, slow ones work, so it presents as an intermittent hang that is worst on warm caches.

```tsx
const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))

// Something suspends above RouterProvider and resolves at ~100ms
// our app use case: loading translations
const suspensePromise = sleep(100)

const router = createBrowserRouter([
  {
    path: '*',
    // Hangs when this lands ~120-300ms after mount; 800ms works
    loader: () => sleep(200).then(() => 'LOADER_DATA'),
    Component: () => <p>Data: {useLoaderData()}</p>,
    HydrateFallback: () => <p>Hydrating... (stuck here forever)</p>,
  },
])

// THE TRIGGER: what Sentry's wrapCreateBrowserRouter does at creation.
// Comment this line out and the app renders fine.
router.subscribe(() => {})

function App() {
  use(suspensePromise)
  return <RouterProvider router={router} />
}

createRoot(document.getElementById('root')).render(
  <Suspense fallback={<p>Loading...</p>}>
    <App />
  </Suspense>
)
```