### PR TITLE
fix: keep ancestor layouts mounted when a data error surfaces to an error boundary

### DIFF
--- a/packages/react-router/.changes/patch.error-boundary-layout-remount.md
+++ b/packages/react-router/.changes/patch.error-boundary-layout-remount.md
@@ -1,0 +1,1 @@
+Keep ancestor layouts mounted when a data error surfaces to an error boundary — for data errors, `RenderErrorBoundary` now renders the same `RenderedRoute` element tree as the happy path instead of swapping in a different element type, which previously remounted the entire subtree (including the framework-mode root `Layout`) and lost its state

--- a/packages/react-router/__tests__/error-boundary-layout-remount-test.tsx
+++ b/packages/react-router/__tests__/error-boundary-layout-remount-test.tsx
@@ -1,0 +1,60 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { createMemoryRouter, Outlet, RouterProvider } from "../index";
+
+describe("RenderErrorBoundary", () => {
+  it("keeps ancestor layouts mounted when a data error surfaces", async () => {
+    let mountCount = 0;
+
+    function Layout({ children }: { children: React.ReactNode }) {
+      React.useEffect(() => {
+        mountCount += 1;
+      }, []);
+      return (
+        <div>
+          <h1>Layout</h1>
+          {children}
+        </div>
+      );
+    }
+
+    let router = createMemoryRouter([
+      {
+        path: "/",
+        element: (
+          <Layout>
+            <Outlet />
+          </Layout>
+        ),
+        errorElement: (
+          <Layout>
+            <p>Error!</p>
+          </Layout>
+        ),
+        children: [
+          { index: true, element: <h2>Home</h2> },
+          {
+            path: "bad",
+            loader() {
+              throw new Error("Kaboom!");
+            },
+            element: <h2>Bad</h2>,
+          },
+        ],
+      },
+    ]);
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => screen.getByText("Home"));
+    expect(mountCount).toBe(1);
+
+    router.navigate("/bad");
+    await waitFor(() => screen.getByText("Error!"));
+    expect(mountCount).toBe(1);
+
+    router.navigate("/");
+    await waitFor(() => screen.getByText("Home"));
+    expect(mountCount).toBe(1);
+  });
+});

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1088,16 +1088,35 @@ export class RenderErrorBoundary extends React.Component<
       if (decoded) error = decoded;
     }
 
+    // Data errors are already rendered as the route's `errorElement` inside
+    // the same `RenderedRoute` wrapper as the happy path (see
+    // `_renderMatches`), so for them we can render `children` and keep the
+    // element tree's shape stable — that way ancestor layouts don't remount
+    // (and lose their state) when an error appears or clears. The `children`
+    // are always wrapped in `RouteErrorContext.Provider` so the tree shape
+    // is identical with and without an error. The `component` branch below
+    // is still required for render errors caught via
+    // `getDerivedStateFromError` (the `children` tree is what crashed), for
+    // errors retained in state after router state cleared them, and for RSC
+    // errors whose digest was decoded above.
+    let isActiveDataError =
+      !this.context &&
+      this.props.error !== undefined &&
+      this.props.error === this.state.error;
+
     let result =
-      error !== undefined ? (
+      error === undefined || isActiveDataError ? (
+        <RouteErrorContext.Provider
+          value={this.props.error}
+          children={this.props.children}
+        />
+      ) : (
         <RouteContext.Provider value={this.props.routeContext}>
           <RouteErrorContext.Provider
             value={error}
             children={this.props.component}
           />
         </RouteContext.Provider>
-      ) : (
-        this.props.children
       );
 
     if (this.context) {


### PR DESCRIPTION
Fixes #13287

When a data error surfaces to an error boundary, `RenderErrorBoundary` swaps its output from the `RenderedRoute` children to a `RouteContext.Provider` wrapping the boundary component. The element type at that position changes, so React unmounts and remounts the whole subtree — including the framework-mode root `Layout` that wraps both the happy path and the `ErrorBoundary` — which contradicts the documented promise that the root `Layout` doesn't remount on errors, and causes the FOUC/state loss people describe in the issue.

For data errors that's unnecessary: `_renderMatches` already renders the route's `errorElement` inside the same `RenderedRoute` wrapper as the happy path when router state has an error. So this change renders `children` for active data errors, always wrapped in `RouteErrorContext.Provider` (value is the data error, or undefined when there's none) so the tree shape is identical with and without an error and nothing above the swap point remounts. `useRouteError` keeps working through the provider.

The `RouteContext.Provider` + `component` branch is preserved for the cases that genuinely need it: render errors caught via `getDerivedStateFromError` (the children tree is what crashed), errors retained in state after router state cleared them mid-revalidation, and RSC errors whose digest gets decoded in the boundary.

Added a regression test: a root layout with a mount counter, navigating to a route whose loader throws and back — on current `dev` the layout mounts twice (remount on error), with this change it mounts once. The full `packages/react-router` jest suite passes (2199 tests, all 822 snapshots), including the error boundary, revalidation-recovery, partial-hydration, and RSC suites.
