### PR TITLE
feat: allow typescript@7 to be used with react-router

### DIFF
--- a/packages/react-router-architect/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-architect/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "@react-router/node": "workspace:^",
     "react-router": "workspace:^",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-router-cloudflare/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-cloudflare/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.0.0",
     "react-router": "workspace:^",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-router-dev/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-dev/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -139,7 +139,7 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react-router": "workspace:^",
     "react-server-dom-webpack": "catalog:",
-    "typescript": "^5.1.0 || ^6.0.0",
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0",
     "vite": "^7.0.0 || ^8.0.0",
     "wrangler": "^4.0.0"
   },

--- a/packages/react-router-express/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-express/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -57,7 +57,7 @@
   "peerDependencies": {
     "express": "^4.22.2 || ^5",
     "react-router": "workspace:*",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-router-fs-routes/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-fs-routes/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "@react-router/dev": "workspace:^",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-router-node/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-node/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "react-router": "workspace:*",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/react-router-remix-routes-option-adapter/.changes/patch.allow-typescript7-used.md
+++ b/packages/react-router-remix-routes-option-adapter/.changes/patch.allow-typescript7-used.md
@@ -1,0 +1,1 @@
+allow typescript@7 to be used

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -47,7 +47,7 @@
   },
   "peerDependencies": {
     "@react-router/dev": "workspace:^",
-    "typescript": "^5.1.0 || ^6.0.0"
+    "typescript": "^5.1.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
fixes #15301 

extend the peer dep range to allow typescript v7
repository itself wasn't upgraded to the new version, as it uses typescript-eslint and the programmatic api in dev time (`scripts/docs.ts` and `packages/react-router-dev/__tests__/rsc-virtual-route-modules-test.ts`)