### PR TITLE
fix: avoid duplicate client HMR updates

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -493,6 +493,7 @@
 - vladinator1000
 - vonagam
 - WalkAlone0325
+- wanxiankai
 - whxhlgy
 - wilcoxmd
 - willemarcel

--- a/integration/vite-hmr-hdr-test.ts
+++ b/integration/vite-hmr-hdr-test.ts
@@ -26,6 +26,11 @@ templates.forEach((template) => {
           // imports
           import { useState, useEffect } from "react";
 
+          if (typeof window !== "undefined") {
+            const global = window as typeof window & { __routeEvaluations?: number };
+            global.__routeEvaluations = (global.__routeEvaluations ?? 0) + 1;
+          }
+
           export const meta = () => [{ title: "HMR updated title: 0" }]
 
           // loader
@@ -170,6 +175,15 @@ async function workflow({
 
   await expect(page).toHaveTitle("HMR updated title: 0");
   await expect(hmrStatus).toHaveText("HMR updated: 0");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __routeEvaluations?: number })
+            .__routeEvaluations,
+      ),
+    )
+    .toBe(1);
   let input = page.locator("#index input");
   await expect(input).toBeVisible();
   await input.fill("stateful");
@@ -187,6 +201,14 @@ async function workflow({
   await expect(page).toHaveTitle("HMR updated title: 1");
   await expect(hmrStatus).toHaveText("HMR updated: 1");
   await expect(input).toHaveValue("stateful");
+  await page.waitForTimeout(100);
+  expect(
+    await page.evaluate(
+      () =>
+        (window as typeof window & { __routeEvaluations?: number })
+          .__routeEvaluations,
+    ),
+  ).toBe(2);
   expect(page.errors).toEqual([]);
 
   // route: add loader

--- a/packages/react-router-dev/.changes/patch.avoid-duplicate-client-hmr.md
+++ b/packages/react-router-dev/.changes/patch.avoid-duplicate-client-hmr.md
@@ -1,0 +1,1 @@
+Avoid duplicate client HMR updates when source modules change in development

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2433,12 +2433,21 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       // each other, so we need to manually trigger client HMR updates if server
       // code has changed.
       hotUpdate(this, { server, modules }) {
-        if (this.environment.name !== "ssr" && modules.length <= 0) {
+        if (this.environment.name !== "ssr" || modules.length <= 0) {
           return;
         }
 
-        let clientModules = modules.flatMap((mod) =>
-          getParentClientNodes(server.environments.client.moduleGraph, mod),
+        let clientModuleGraph = server.environments.client.moduleGraph;
+        let clientModules = new Set(
+          modules.flatMap((mod) => {
+            // Modules that exist in the client graph already receive Vite's
+            // native client HMR update. Only propagate changes from modules
+            // that are exclusive to the server graph.
+            if (mod.id && clientModuleGraph.getModuleById(mod.id)) {
+              return [];
+            }
+            return getParentClientNodes(clientModuleGraph, mod);
+          }),
         );
 
         for (let clientModule of clientModules) {


### PR DESCRIPTION
Fixes #13774

## What changed

- restrict the server-to-client HMR bridge to the SSR environment
- skip modules that already receive Vite's native client HMR update
- deduplicate client parent modules reached from server-only changes
- add a browser evaluation-count regression covering Vite 7 and Vite 8, both with the built-in dev server and Express
- add the required patch change file and CLA signature

## Why

Vite invokes the `hotUpdate` hook for separate client and SSR environments. The React Router bridge also ran in the client environment and reloaded modules already present in the client graph. As a result, a single source edit evaluated the route module multiple times and could trigger unrelated updates.

The bridge now only propagates changes from SSR-only modules. Client modules continue to use Vite's native HMR path, while server-only loader dependencies still walk to and reload their client parents.

The regression reproduced four total browser evaluations (initial load plus three updates) before the fix and now verifies exactly two (initial load plus one update).

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (0 errors)
- `pnpm test --no-watchman` (2,629 passed, 15 skipped)
- `pnpm test:integration:run --project=chromium vite-hmr-hdr-test.ts` (6 passed)
- `pnpm format:check`
- `git diff --check`
