### PR TITLE
docs: fix useLinkClickHandler defaultShouldRevalidate default description

### DIFF
--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2205,7 +2205,8 @@ function useDataRouterState(hookName: DataRouterStateHook) {
  * for this navigation. To apply specific styles during the transition, see
  * {@link useViewTransitionState}. Defaults to `false`.
  * @param options.defaultShouldRevalidate Specify the default revalidation
- * behavior for the navigation. Defaults to `true`.
+ * behavior for the navigation. When not specified, loaders revalidate
+ * according to the router's standard revalidation behavior.
  * @param options.mask Masked location to display in the browser instead
  * of the router location. Defaults to `undefined`.
  * @param options.useTransitions Wraps the navigation in


### PR DESCRIPTION
The `useLinkClickHandler` JSDoc documents `defaultShouldRevalidate` as "Defaults to `true`", but the hook applies no default: when the option is omitted it is passed through as `undefined` and the router falls back to its standard revalidation behavior, which is not unconditional revalidation.

Updated the `@param` description to describe the actual default behavior.
