### PR TITLE
Prevent streaming disconnects from crashing Node

### DIFF
--- a/packages/react-router-node/.changes/patch.streaming-client-disconnect.md
+++ b/packages/react-router-node/.changes/patch.streaming-client-disconnect.md
@@ -1,0 +1,1 @@
+fix: Prevent client disconnects during streaming from crashing the Node process

--- a/packages/react-router-node/__tests__/fixtures/stream-cancelled-node-readable.ts
+++ b/packages/react-router-node/__tests__/fixtures/stream-cancelled-node-readable.ts
@@ -16,7 +16,8 @@ let writable = new Writable({
 source.write(Buffer.from("first chunk"));
 let writePromise = writeReadableStreamToWritable(readable, writable);
 
-setTimeout(() => writable.emit("close"), 10);
+await new Promise((resolve) => setImmediate(resolve));
+writable.emit("close");
 
 try {
   await writePromise;

--- a/packages/react-router-node/__tests__/fixtures/stream-client-disconnect.ts
+++ b/packages/react-router-node/__tests__/fixtures/stream-client-disconnect.ts
@@ -1,0 +1,33 @@
+import { PassThrough, Writable } from "node:stream";
+
+import {
+  createReadableStreamFromReadable,
+  writeReadableStreamToWritable,
+} from "../../stream.ts";
+
+let source = new PassThrough();
+let readable = createReadableStreamFromReadable(source);
+let writable = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+});
+
+source.write(Buffer.from("first chunk"));
+let writePromise = writeReadableStreamToWritable(readable, writable);
+
+setTimeout(() => writable.emit("close"), 10);
+
+try {
+  await writePromise;
+} catch (error) {
+  if (
+    !(error instanceof Error) ||
+    error.message !== "Writable closed before stream finished"
+  ) {
+    throw error;
+  }
+}
+
+await new Promise((resolve) => setImmediate(resolve));
+console.log("process survived");

--- a/packages/react-router-node/__tests__/fixtures/stream-closed-writable.ts
+++ b/packages/react-router-node/__tests__/fixtures/stream-closed-writable.ts
@@ -1,0 +1,35 @@
+import { Writable } from "node:stream";
+
+import { writeReadableStreamToWritable } from "../../stream.ts";
+
+let controller!: ReadableStreamDefaultController<Uint8Array>;
+let readable = new ReadableStream<Uint8Array>({
+  start(readableController) {
+    controller = readableController;
+  },
+});
+let writable = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+});
+
+controller.enqueue(new Uint8Array(1));
+let writePromise = writeReadableStreamToWritable(readable, writable);
+
+await new Promise((resolve) => setImmediate(resolve));
+writable.emit("close");
+
+try {
+  await writePromise;
+} catch (error) {
+  if (
+    !(error instanceof Error) ||
+    error.message !== "Writable closed before stream finished"
+  ) {
+    throw error;
+  }
+}
+
+await new Promise((resolve) => setImmediate(resolve));
+console.log("process survived");

--- a/packages/react-router-node/__tests__/fixtures/stream-pending-writable-error.ts
+++ b/packages/react-router-node/__tests__/fixtures/stream-pending-writable-error.ts
@@ -1,0 +1,38 @@
+import { Writable } from "node:stream";
+
+import { writeReadableStreamToWritable } from "../../stream.ts";
+
+let controller!: ReadableStreamDefaultController<Uint8Array>;
+let readable = new ReadableStream<Uint8Array>({
+  start(readableController) {
+    controller = readableController;
+  },
+});
+
+let finishDestroy!: () => void;
+let writable = new Writable({
+  write(_chunk, _encoding, callback) {
+    callback();
+  },
+  destroy(error, callback) {
+    finishDestroy = () => callback(error);
+  },
+});
+
+let writePromise = writeReadableStreamToWritable(readable, writable);
+let writableError = new Error("Writable failed");
+
+// Node marks the writable as destroyed before its destroy callback completes.
+writable.destroy(writableError);
+
+// Let the pending read complete while the writable's error is not yet emitted.
+controller.enqueue(new Uint8Array(1));
+
+// Wait for the stream pump to observe the destroyed state and clean up.
+await writePromise.catch(() => {});
+
+// Completing destruction schedules the writable's error after the stream
+// monitor's cleanup path has run.
+finishDestroy();
+await new Promise((resolve) => setImmediate(resolve));
+console.log("process survived");

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -92,6 +92,37 @@ describe("writeReadableStreamToWritable", () => {
       "Writable failed",
     );
   });
+
+  it("handles writable errors after the writable closes mid-stream", async () => {
+    let errorListenerCountOnDestroy: number | undefined;
+    let writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    let destroy = writable.destroy.bind(writable);
+    writable.destroy = function (error?: Error) {
+      errorListenerCountOnDestroy = writable.listenerCount("error");
+      // Prevent this regression test from crashing the Jest process when the
+      // implementation removes its error listener too early.
+      writable.once("error", () => {});
+      return destroy(error);
+    } as typeof writable.destroy;
+    let readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1));
+      },
+    });
+
+    let writePromise = writeReadableStreamToWritable(readable, writable);
+
+    setTimeout(() => writable.emit("close"), 10);
+
+    await expect(withTimeout(writePromise, 100)).rejects.toThrow(
+      "Writable closed before stream finished",
+    );
+    expect(errorListenerCountOnDestroy).toBeGreaterThan(0);
+  });
 });
 
 describe("writeAsyncIterableToWritable", () => {

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -2,7 +2,10 @@
  * @jest-environment node
  */
 
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
 
 import {
   writeAsyncIterableToWritable,
@@ -93,35 +96,29 @@ describe("writeReadableStreamToWritable", () => {
     );
   });
 
-  it("handles writable errors after the writable closes mid-stream", async () => {
-    let errorListenerCountOnDestroy: number | undefined;
-    let writable = new Writable({
-      write(_chunk, _encoding, callback) {
-        callback();
-      },
-    });
-    let destroy = writable.destroy.bind(writable);
-    writable.destroy = function (error?: Error) {
-      errorListenerCountOnDestroy = writable.listenerCount("error");
-      // Prevent this regression test from crashing the Jest process when the
-      // implementation removes its error listener too early.
-      writable.once("error", () => {});
-      return destroy(error);
-    } as typeof writable.destroy;
-    let readable = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(1));
-      },
-    });
-
-    let writePromise = writeReadableStreamToWritable(readable, writable);
-
-    setTimeout(() => writable.emit("close"), 10);
-
-    await expect(withTimeout(writePromise, 100)).rejects.toThrow(
-      "Writable closed before stream finished",
+  it("does not crash when the writable closes mid-stream", () => {
+    let fixture = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "fixtures",
+      "stream-client-disconnect.ts",
     );
-    expect(errorListenerCountOnDestroy).toBeGreaterThan(0);
+    let result = spawnSync(
+      process.execPath,
+      ["--experimental-strip-types", "--no-warnings", fixture],
+      { encoding: "utf8", timeout: 5_000 },
+    );
+
+    expect({
+      status: result.status,
+      signal: result.signal,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    }).toEqual({
+      status: 0,
+      signal: null,
+      stdout: "process survived\n",
+      stderr: "",
+    });
   });
 });
 

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -48,6 +48,33 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   );
 }
 
+function runFixtureProcess(fixtureName: string) {
+  let fixture = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "fixtures",
+    fixtureName,
+  );
+  let result = spawnSync(
+    process.execPath,
+    ["--experimental-strip-types", "--no-warnings", fixture],
+    { encoding: "utf8", timeout: 5_000 },
+  );
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+let survivedProcess = {
+  status: 0,
+  signal: null,
+  stdout: "process survived\n",
+  stderr: "",
+};
+
 describe("writeReadableStreamToWritable", () => {
   it("respects writable backpressure", async () => {
     let highWaterMark = 16;
@@ -96,29 +123,22 @@ describe("writeReadableStreamToWritable", () => {
     );
   });
 
-  it("does not crash when the writable closes mid-stream", () => {
-    let fixture = path.join(
-      path.dirname(fileURLToPath(import.meta.url)),
-      "fixtures",
-      "stream-client-disconnect.ts",
+  it("does not crash when a destination writable closes mid-stream", () => {
+    expect(runFixtureProcess("stream-closed-writable.ts")).toEqual(
+      survivedProcess,
     );
-    let result = spawnSync(
-      process.execPath,
-      ["--experimental-strip-types", "--no-warnings", fixture],
-      { encoding: "utf8", timeout: 5_000 },
-    );
+  });
 
-    expect({
-      status: result.status,
-      signal: result.signal,
-      stdout: result.stdout,
-      stderr: result.stderr,
-    }).toEqual({
-      status: 0,
-      signal: null,
-      stdout: "process survived\n",
-      stderr: "",
-    });
+  it("does not crash when a destination close cancels a Node readable", () => {
+    expect(runFixtureProcess("stream-cancelled-node-readable.ts")).toEqual(
+      survivedProcess,
+    );
+  });
+
+  it("does not crash while a destroyed writable has an error pending", () => {
+    expect(runFixtureProcess("stream-pending-writable-error.ts")).toEqual(
+      survivedProcess,
+    );
   });
 });
 

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -37,7 +37,7 @@ export async function writeReadableStreamToWritable(
     } catch {
       // Ignore cancellation errors so we preserve the original write failure.
     }
-    writable.destroy(error as Error);
+    destroyWritable(writable, error as Error);
     throw error;
   } finally {
     writableError.cleanup();
@@ -53,6 +53,18 @@ interface WritableErrorMonitor {
   cleanup(): void;
   race<T>(promise: Promise<T>): Promise<T>;
   throwIfClosed(): void;
+}
+
+function destroyWritable(writable: Writable, error: Error) {
+  if (writable.destroyed) {
+    return;
+  }
+
+  // The write promise carries this error to the caller. Also consume the
+  // asynchronous error event from destroy so it cannot crash the process
+  // after the writable error monitor has been cleaned up.
+  writable.once("error", () => {});
+  writable.destroy(error);
 }
 
 function monitorWritableError(writable: Writable): WritableErrorMonitor {
@@ -166,7 +178,7 @@ export async function writeAsyncIterableToWritable(
         // Ignore return errors so we preserve the original write failure.
       }
     }
-    writable.destroy(error);
+    destroyWritable(writable, error);
     throw error;
   } finally {
     writableError.cleanup();

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -33,7 +33,9 @@ export async function writeReadableStreamToWritable(
     }
   } catch (error: unknown) {
     try {
-      reader.cancel(error).catch(() => {});
+      reader
+        .cancel(error instanceof WritableClosedError ? undefined : error)
+        .catch(() => {});
     } catch {
       // Ignore cancellation errors so we preserve the original write failure.
     }
@@ -55,8 +57,10 @@ interface WritableErrorMonitor {
   throwIfClosed(): void;
 }
 
+class WritableClosedError extends Error {}
+
 function destroyWritable(writable: Writable, error: Error) {
-  if (writable.destroyed) {
+  if (error instanceof WritableClosedError || writable.destroyed) {
     return;
   }
 
@@ -97,7 +101,7 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
   }
 
   function onClose() {
-    reject(new Error("Writable closed before stream finished"));
+    reject(new WritableClosedError("Writable closed before stream finished"));
   }
 
   writable.once("error", onError);
@@ -114,7 +118,9 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
       }
 
       if (writable.destroyed || writable.writableEnded) {
-        throw new Error("Cannot write to a destroyed or ended writable stream");
+        throw new WritableClosedError(
+          "Cannot write to a destroyed or ended writable stream",
+        );
       }
     },
   };

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -72,7 +72,9 @@ function destroyWritable(writable: Writable, error: Error) {
 }
 
 function monitorWritableError(writable: Writable): WritableErrorMonitor {
+  let writableStartedDestroyed = writable.destroyed;
   let settled = false;
+  let writableErrorEmitted = false;
   let writableError: Error | undefined;
   let rejectWritableError!: (error: Error) => void;
   let writableErrorPromise = new Promise<never>((_, reject) => {
@@ -81,6 +83,17 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
   writableErrorPromise.catch(() => {});
 
   function cleanup() {
+    // `destroy(error)` sets these properties before a potentially async
+    // destroy callback emits the error, so keep listening during that gap.
+    if (
+      !writableStartedDestroyed &&
+      writable.destroyed &&
+      writable.errored &&
+      !writableErrorEmitted
+    ) {
+      return;
+    }
+
     writable.off("error", onError);
     writable.off("close", onClose);
   }
@@ -97,6 +110,7 @@ function monitorWritableError(writable: Writable): WritableErrorMonitor {
   }
 
   function onError(error: Error) {
+    writableErrorEmitted = true;
     reject(error);
   }
 


### PR DESCRIPTION
Client disconnects can close a Node writable while a response is still streaming. The stream pump then destroys the writable with an error after its monitor has removed the error listener, allowing the asynchronous `error` event to terminate the process.

This keeps destroy errors handled for both readable streams and async iterables, while avoiding redundant destruction of already-destroyed writables.

Closes #15287
