### PR TITLE
fix: request prerendered pages from the preview server's bound address

### DIFF
--- a/packages/react-router-dev/.changes/patch.prerender-preview-address.md
+++ b/packages/react-router-dev/.changes/patch.prerender-preview-address.md
@@ -1,0 +1,1 @@
+Fix intermittent `Prerender: Request failed for ... connect ECONNREFUSED` errors during prerendering — requests now target the literal address the Vite preview server actually bound to, instead of re-resolving `localhost` on every request, which could pick a different address family (`127.0.0.1` vs `::1`) than the one the server is listening on

--- a/packages/react-router-dev/__tests__/prerender-resolved-url-test.ts
+++ b/packages/react-router-dev/__tests__/prerender-resolved-url-test.ts
@@ -1,0 +1,52 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type * as Vite from "vite";
+
+import { getResolvedUrl } from "../vite/plugins/prerender";
+
+describe("getResolvedUrl", () => {
+  let server: http.Server;
+
+  afterEach(async () => {
+    if (server?.listening) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  async function listen(host: string): Promise<AddressInfo> {
+    server = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, host, resolve);
+    });
+    return server.address() as AddressInfo;
+  }
+
+  function fakePreviewServer(port: number): Vite.PreviewServer {
+    return {
+      httpServer: server,
+      resolvedUrls: { local: [`http://localhost:${port}/`], network: [] },
+    } as unknown as Vite.PreviewServer;
+  }
+
+  test("uses the literal IPv4 loopback address the server bound to", async () => {
+    const address = await listen("127.0.0.1");
+    const url = getResolvedUrl(fakePreviewServer(address.port));
+    expect(url.hostname).toBe("127.0.0.1");
+    expect(url.port).toBe(String(address.port));
+  });
+
+  test("uses the IPv6 loopback address the server bound to", async () => {
+    const address = await listen("::1");
+    const url = getResolvedUrl(fakePreviewServer(address.port));
+    expect(url.hostname).toBe("[::1]");
+    expect(url.port).toBe(String(address.port));
+  });
+
+  test("falls back to the printable URL for wildcard binds", async () => {
+    const address = await listen("0.0.0.0");
+    const url = getResolvedUrl(fakePreviewServer(address.port));
+    expect(url.hostname).toBe("localhost");
+    expect(url.port).toBe(String(address.port));
+  });
+});

--- a/packages/react-router-dev/vite/plugins/prerender.ts
+++ b/packages/react-router-dev/vite/plugins/prerender.ts
@@ -482,7 +482,9 @@ async function nodeHttpFetch(
     const req = http.request(
       {
         protocol: url.protocol,
-        hostname: url.hostname,
+        // `URL#hostname` keeps the brackets around IPv6 literals, but
+        // `http.request` expects them without.
+        hostname: url.hostname.replace(/^\[|\]$/g, ""),
         port: url.port || undefined,
         path: url.pathname + url.search,
         method: request.method,
@@ -564,14 +566,31 @@ async function startPreviewServer(
   }
 }
 
-function getResolvedUrl(previewServer: Vite.PreviewServer): URL {
-  const baseUrl = previewServer.resolvedUrls?.local[0];
+export function getResolvedUrl(previewServer: Vite.PreviewServer): URL {
+  const printableUrl = previewServer.resolvedUrls?.local[0];
 
-  if (!baseUrl) {
+  // Prefer the literal address the server actually bound to. The printable
+  // resolved URL uses a hostname like `localhost`, which gets re-resolved on
+  // every request and can pick a different address family (127.0.0.1 vs ::1)
+  // than the one the server is listening on.
+  const address = previewServer.httpServer?.address();
+  if (
+    address &&
+    typeof address === "object" &&
+    address.address !== "::" &&
+    address.address !== "0.0.0.0"
+  ) {
+    const protocol = printableUrl ? new URL(printableUrl).protocol : "http:";
+    const hostname =
+      address.family === "IPv6" ? `[${address.address}]` : address.address;
+    return new URL(`${protocol}//${hostname}:${address.port}/`);
+  }
+
+  if (!printableUrl) {
     throw new Error(
       "Prerender: No resolved URL is available from the Vite preview server",
     );
   }
 
-  return new URL(baseUrl);
+  return new URL(printableUrl);
 }


### PR DESCRIPTION
Fixes #15255

Prerendering starts a Vite preview server and then requests each path over HTTP, but the base URL comes from `previewServer.resolvedUrls.local[0]`, which is the printable `http://localhost:<port>/` form. `nodeHttpFetch` passes that hostname to `http.request`, so `localhost` gets re-resolved through dns.lookup on every single request — and that can pick a different address family (127.0.0.1 vs ::1) than the one the server actually bound, which is exactly the intermittent `connect ECONNREFUSED 127.0.0.1:<port>` from the issue. In environments where localhost resolution and the bind family disagree consistently (the Docker node report in the thread) it fails every time.

This makes `getResolvedUrl` prefer the literal address from `previewServer.httpServer.address()` — `127.0.0.1` or `[::1]` — so requests connect to the exact socket the server is listening on. Wildcard binds (`::` / `0.0.0.0`) and the case where `httpServer` isn't available keep the previous `resolvedUrls` behavior, and the protocol still comes from the resolved URL so https preview configs are unaffected. One small companion change in `nodeHttpFetch`: `URL#hostname` keeps brackets around IPv6 literals but `http.request` wants them without, so they're stripped there.

Added a unit test that binds real servers to `127.0.0.1`, `::1` and `0.0.0.0` and asserts the resolved URL uses the literal bound address (or falls back for wildcard). The first two fail on current main, which resolves to `localhost`. Full react-router-dev test suite passes (190 tests), plus prettier/eslint on the changed files. Change file included.
