### PR TITLE
fix: only enforce split route modules during builds

### DIFF
--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,127 +1,52 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import getPort from "get-port";
 
-import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
-import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
-import {
-  createAppFixture,
-  createFixture,
-  js,
-} from "./helpers/create-fixture.js";
+import { build, createProject, dev } from "./helpers/vite.js";
 
-let fixture: Fixture;
-let appFixture: AppFixture;
+test("splitRouteModules enforce accepts JSX exports in Vite dev", async ({
+  page,
+}) => {
+  let port = await getPort();
+  let cwd = await createProject(
+    {
+      "react-router.config.ts": `
+        import type { Config } from "@react-router/dev/config";
 
-////////////////////////////////////////////////////////////////////////////////
-// 👋 Hola! I'm here to help you write a great bug report pull request.
-//
-// You don't need to fix the bug, this is just to report one.
-//
-// The pull request you are submitting is supposed to fail when created, to let
-// the team see the erroneous behavior, and understand what's going wrong.
-//
-// If you happen to have a fix as well, it will have to be applied in a subsequent
-// commit to this pull request, and your now-succeeding test will have to be moved
-// to the appropriate file.
-//
-// First, make sure to install dependencies and build React Router. From the root of
-// the project, run this:
-//
-//    ```
-//    pnpm install && pnpm build
-//    ```
-//
-// If you have never installed playwright on your system before, you may also need
-// to install a browser engine:
-//
-//    ```
-//    pnpm exec playwright install chromium
-//    ```
-//
-// Now try running this test:
-//
-//    ```
-//    pnpm test:integration bug-report --project chromium
-//    ```
-//
-// You can add `--watch` to the end to have it re-run on file changes:
-//
-//    ```
-//    pnpm test:integration bug-report --project chromium --watch
-//    ```
-////////////////////////////////////////////////////////////////////////////////
-
-test.beforeEach(async ({ context }) => {
-  await context.route(/\.data$/, async (route) => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    route.continue();
-  });
-});
-
-test.beforeAll(async () => {
-  fixture = await createFixture({
-    ////////////////////////////////////////////////////////////////////////////
-    // 💿 Next, add files to this object, just like files in a real app,
-    // `createFixture` will make an app and run your tests against it.
-    ////////////////////////////////////////////////////////////////////////////
-    files: {
-      "app/routes/_index.tsx": js`
-        import { useLoaderData, Link } from "react-router";
-
-        export function loader() {
-          return "pizza";
-        }
-
-        export default function Index() {
-          let data = useLoaderData();
-          return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
-        }
+        export default {
+          splitRouteModules: "enforce",
+        } satisfies Config;
       `,
+      "vite.config.ts": `
+        import { reactRouter } from "@react-router/dev/vite";
+        import react from "@vitejs/plugin-react";
+        import { defineConfig } from "vite";
 
-      "app/routes/burgers.tsx": js`
+        export default defineConfig({
+          plugins: [reactRouter(), react()],
+          server: { port: ${port}, strictPort: true },
+        });
+      `,
+      "app/routes/_index.tsx": `
+        export function HydrateFallback() {
+          return <p>Loading...</p>;
+        }
+
         export default function Index() {
-          return <div>cheeseburger</div>;
+          return <h1>Ready</h1>;
         }
       `,
     },
-  });
+    "rsc-vite-framework",
+  );
 
-  // This creates an interactive app using playwright.
-  appFixture = await createAppFixture(fixture);
+  let buildResult = build({ cwd });
+  expect(buildResult.status).toBe(0);
+
+  let stop = await dev({ cwd, port });
+  try {
+    await page.goto(`http://localhost:${port}`);
+    await expect(page.getByRole("heading", { name: "Ready" })).toBeVisible();
+  } finally {
+    stop();
+  }
 });
-
-test.afterAll(() => {
-  appFixture.close();
-});
-
-////////////////////////////////////////////////////////////////////////////////
-// 💿 Almost done, now write your failing test case(s) down here Make sure to
-// add a good description for what you expect React Router to do 👇🏽
-////////////////////////////////////////////////////////////////////////////////
-
-test("[description of what you expect it to do]", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
-});
-
-////////////////////////////////////////////////////////////////////////////////
-// 💿 Finally, push your changes to your fork of React Router
-// and open a pull request!
-////////////////////////////////////////////////////////////////////////////////

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1079,16 +1079,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       ctx,
     );
 
-    let enforceSplitRouteModules =
-      ctx.reactRouterConfig.splitRouteModules === "enforce";
-
     for (let [key, route] of Object.entries(ctx.reactRouterConfig.routes)) {
-      let routeFile = route.file;
       let sourceExports = routeManifestExports[key];
       let hasClientAction = sourceExports.includes("clientAction");
       let hasClientLoader = sourceExports.includes("clientLoader");
       let hasClientMiddleware = sourceExports.includes("clientMiddleware");
-      let hasHydrateFallback = sourceExports.includes("HydrateFallback");
       let routeModulePath = combineURLs(
         ctx.publicPath,
         `${resolveFileUrl(
@@ -1096,31 +1091,6 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           resolveRelativeRouteFilePath(route, ctx.reactRouterConfig),
         )}`,
       );
-
-      if (enforceSplitRouteModules) {
-        let { hasRouteChunkByExportName } = await detectRouteChunksIfEnabled(
-          cache,
-          ctx,
-          routeFile,
-          { routeFile, viteChildCompiler },
-        );
-
-        validateRouteChunks({
-          ctx,
-          id: route.file,
-          valid: {
-            clientAction:
-              !hasClientAction || hasRouteChunkByExportName.clientAction,
-            clientLoader:
-              !hasClientLoader || hasRouteChunkByExportName.clientLoader,
-            clientMiddleware:
-              !hasClientMiddleware ||
-              hasRouteChunkByExportName.clientMiddleware,
-            HydrateFallback:
-              !hasHydrateFallback || hasRouteChunkByExportName.HydrateFallback,
-          },
-        });
-      }
 
       routes[key] = {
         id: route.id,


### PR DESCRIPTION
Fixes #15332.

## Observed behavior

With Vite 8 and `@vitejs/plugin-react`, the development transform can introduce a shared module-level `_jsxFileName` binding when multiple route exports contain JSX. The dev manifest's route-chunk analysis treats that generated binding as shared route code and rejects `HydrateFallback` under `splitRouteModules: "enforce"`.

The same route successfully splits in a production build because the production JSX transform does not produce the same shared development metadata. The regression test covers both outcomes: the build must succeed and the Vite dev server must render the route.

## Proposed change

Skip `splitRouteModules: "enforce"` validation while generating the non-RSC development manifest. Production enforcement remains in both existing build paths, including the assertion that genuinely shared route code cannot be split.

## Design rationale (open to maintainer feedback)

This patch assumes the production build is the authoritative enforcement boundary because:

- route module chunks are only generated in build mode;
- the development manifest explicitly leaves split chunk module fields undefined;
- the documented behavior describes `"enforce"` as causing build failures;
- development and production plugin transforms can produce structurally different modules, so dev analysis is not necessarily predictive of the production chunks.

The tradeoff is that a genuinely unsplittable route will now fail at build time rather than during dev-manifest generation. If early dev rejection is intended to be part of the contract, this patch is likely too broad. In that case, the alternative would be to analyze production-equivalent transformed code in development. I avoided special-casing `_jsxFileName` because it is generated transform output and would narrowly address only the currently observed shape.

## Tests

- `pnpm build`
- `pnpm test:integration:run bug-report --project chromium`
- `pnpm test:integration:run split-route-modules --project chromium`
- `pnpm run typecheck`
- `pnpm run lint` (no errors; unrelated existing warnings remain)
- `pnpm exec prettier --check packages/react-router-dev/vite/plugin.ts integration/bug-report-test.ts`

🤖 This pull request and its implementation were prepared with AI assistance.
