### PR TITLE
update changes files to use h4 instead of h3

### DIFF
--- a/packages/react-router-dev/.changes/unstable.rsc-subresource-integrity.md
+++ b/packages/react-router-dev/.changes/unstable.rsc-subresource-integrity.md
@@ -1,6 +1,6 @@
 Support the `subResourceIntegrity` config option in RSC Framework Mode
 
-### Migration guide
+#### Migration guide
 
 No changes are required when using the default RSC SSR entry. If you maintain a custom `app/entry.ssr.tsx`, import the new virtual module and pass its hashes to React's `importMap` render option:
 

--- a/packages/react-router/.changes/unstable.rsc-client-version.md
+++ b/packages/react-router/.changes/unstable.rsc-client-version.md
@@ -1,6 +1,6 @@
 Detect stale RSC clients during lazy route discovery and reload the destination document
 
-### Migration
+#### Migration
 
 Apps using the default RSC Framework entry do not need to make any changes. Apps with a custom `entry.rsc.tsx` should import the generated client version and pass it to `unstable_matchRSCServerRequest`:
 


### PR DESCRIPTION
I noticed that these files were causing `changes:validate` to fail on newly-opened PRs