### PR TITLE
fix: de-optimize route chunks with shared exported declarations

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -97,6 +97,7 @@
 - clonemycode
 - Cmoen11
 - codeape2
+- comp615
 - coolport
 - coryhouse
 - csamuel

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,127 +1,56 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import getPort from "get-port";
 
-import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
-import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
-import {
-  createAppFixture,
-  createFixture,
-  js,
-} from "./helpers/create-fixture.js";
+import { build, createProject, reactRouterServe } from "./helpers/vite.js";
 
-let fixture: Fixture;
-let appFixture: AppFixture;
+test("split route modules retain exported clientLoader dependencies", async ({
+  page,
+}) => {
+  let port = await getPort();
+  let cwd = await createProject({
+    "react-router.config.ts": `
+      import type { Config } from "@react-router/dev/config";
 
-////////////////////////////////////////////////////////////////////////////////
-// 👋 Hola! I'm here to help you write a great bug report pull request.
-//
-// You don't need to fix the bug, this is just to report one.
-//
-// The pull request you are submitting is supposed to fail when created, to let
-// the team see the erroneous behavior, and understand what's going wrong.
-//
-// If you happen to have a fix as well, it will have to be applied in a subsequent
-// commit to this pull request, and your now-succeeding test will have to be moved
-// to the appropriate file.
-//
-// First, make sure to install dependencies and build React Router. From the root of
-// the project, run this:
-//
-//    ```
-//    pnpm install && pnpm build
-//    ```
-//
-// If you have never installed playwright on your system before, you may also need
-// to install a browser engine:
-//
-//    ```
-//    pnpm exec playwright install chromium
-//    ```
-//
-// Now try running this test:
-//
-//    ```
-//    pnpm test:integration bug-report --project chromium
-//    ```
-//
-// You can add `--watch` to the end to have it re-run on file changes:
-//
-//    ```
-//    pnpm test:integration bug-report --project chromium --watch
-//    ```
-////////////////////////////////////////////////////////////////////////////////
+      export default {
+        splitRouteModules: true,
+      } satisfies Config;
+    `,
+    "app/routes/_index.tsx": `
+      import { Link } from "react-router";
 
-test.beforeEach(async ({ context }) => {
-  await context.route(/\.data$/, async (route) => {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    route.continue();
-  });
-});
+      export default function Index() {
+        return <Link to="/dependency">Load route</Link>;
+      }
+    `,
+    "app/routes/dependency.tsx": `
+      import { useLoaderData } from "react-router";
 
-test.beforeAll(async () => {
-  fixture = await createFixture({
-    ////////////////////////////////////////////////////////////////////////////
-    // 💿 Next, add files to this object, just like files in a real app,
-    // `createFixture` will make an app and run your tests against it.
-    ////////////////////////////////////////////////////////////////////////////
-    files: {
-      "app/routes/_index.tsx": js`
-        import { useLoaderData, Link } from "react-router";
+      export function exportedHelper() {
+        return "Loaded through exported helper";
+      }
 
-        export function loader() {
-          return "pizza";
-        }
+      export function clientLoader() {
+        return exportedHelper();
+      }
 
-        export default function Index() {
-          let data = useLoaderData();
-          return (
-            <div>
-              {data}
-              <Link to="/burgers">Other Route</Link>
-            </div>
-          )
-        }
-      `,
-
-      "app/routes/burgers.tsx": js`
-        export default function Index() {
-          return <div>cheeseburger</div>;
-        }
-      `,
-    },
+      export default function Dependency() {
+        let data = useLoaderData<typeof clientLoader>();
+        return <h1>{data}</h1>;
+      }
+    `,
   });
 
-  // This creates an interactive app using playwright.
-  appFixture = await createAppFixture(fixture);
+  let buildResult = build({ cwd });
+  expect(buildResult.status).toBe(0);
+
+  let stop = await reactRouterServe({ cwd, port });
+  try {
+    await page.goto(`http://localhost:${port}`);
+    await page.getByRole("link", { name: "Load route" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Loaded through exported helper" }),
+    ).toBeVisible();
+  } finally {
+    stop();
+  }
 });
-
-test.afterAll(() => {
-  appFixture.close();
-});
-
-////////////////////////////////////////////////////////////////////////////////
-// 💿 Almost done, now write your failing test case(s) down here Make sure to
-// add a good description for what you expect React Router to do 👇🏽
-////////////////////////////////////////////////////////////////////////////////
-
-test("[description of what you expect it to do]", async ({ page }) => {
-  let app = new PlaywrightFixture(appFixture, page);
-  // You can test any request your app might get using `fixture`.
-  let response = await fixture.requestDocument("/");
-  expect(await response.text()).toMatch("pizza");
-
-  // If you need to test interactivity use the `app`
-  await app.goto("/");
-  await app.clickLink("/burgers");
-  await page.waitForSelector("text=cheeseburger");
-
-  // If you're not sure what's going on, you can "poke" the app, it'll
-  // automatically open up in your browser for 20 seconds, so be quick!
-  // await app.poke(20);
-
-  // Go check out the other tests to see what else you can do.
-});
-
-////////////////////////////////////////////////////////////////////////////////
-// 💿 Finally, push your changes to your fork of React Router
-// and open a pull request!
-////////////////////////////////////////////////////////////////////////////////

--- a/integration/bug-report-test.ts
+++ b/integration/bug-report-test.ts
@@ -1,56 +1,127 @@
-import { expect, test } from "@playwright/test";
-import getPort from "get-port";
+import { test, expect } from "@playwright/test";
 
-import { build, createProject, reactRouterServe } from "./helpers/vite.js";
+import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
+import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
+import {
+  createAppFixture,
+  createFixture,
+  js,
+} from "./helpers/create-fixture.js";
 
-test("split route modules retain exported clientLoader dependencies", async ({
-  page,
-}) => {
-  let port = await getPort();
-  let cwd = await createProject({
-    "react-router.config.ts": `
-      import type { Config } from "@react-router/dev/config";
+let fixture: Fixture;
+let appFixture: AppFixture;
 
-      export default {
-        splitRouteModules: true,
-      } satisfies Config;
-    `,
-    "app/routes/_index.tsx": `
-      import { Link } from "react-router";
+////////////////////////////////////////////////////////////////////////////////
+// 👋 Hola! I'm here to help you write a great bug report pull request.
+//
+// You don't need to fix the bug, this is just to report one.
+//
+// The pull request you are submitting is supposed to fail when created, to let
+// the team see the erroneous behavior, and understand what's going wrong.
+//
+// If you happen to have a fix as well, it will have to be applied in a subsequent
+// commit to this pull request, and your now-succeeding test will have to be moved
+// to the appropriate file.
+//
+// First, make sure to install dependencies and build React Router. From the root of
+// the project, run this:
+//
+//    ```
+//    pnpm install && pnpm build
+//    ```
+//
+// If you have never installed playwright on your system before, you may also need
+// to install a browser engine:
+//
+//    ```
+//    pnpm exec playwright install chromium
+//    ```
+//
+// Now try running this test:
+//
+//    ```
+//    pnpm test:integration bug-report --project chromium
+//    ```
+//
+// You can add `--watch` to the end to have it re-run on file changes:
+//
+//    ```
+//    pnpm test:integration bug-report --project chromium --watch
+//    ```
+////////////////////////////////////////////////////////////////////////////////
 
-      export default function Index() {
-        return <Link to="/dependency">Load route</Link>;
-      }
-    `,
-    "app/routes/dependency.tsx": `
-      import { useLoaderData } from "react-router";
+test.beforeEach(async ({ context }) => {
+  await context.route(/\.data$/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    route.continue();
+  });
+});
 
-      export function exportedHelper() {
-        return "Loaded through exported helper";
-      }
+test.beforeAll(async () => {
+  fixture = await createFixture({
+    ////////////////////////////////////////////////////////////////////////////
+    // 💿 Next, add files to this object, just like files in a real app,
+    // `createFixture` will make an app and run your tests against it.
+    ////////////////////////////////////////////////////////////////////////////
+    files: {
+      "app/routes/_index.tsx": js`
+        import { useLoaderData, Link } from "react-router";
 
-      export function clientLoader() {
-        return exportedHelper();
-      }
+        export function loader() {
+          return "pizza";
+        }
 
-      export default function Dependency() {
-        let data = useLoaderData<typeof clientLoader>();
-        return <h1>{data}</h1>;
-      }
-    `,
+        export default function Index() {
+          let data = useLoaderData();
+          return (
+            <div>
+              {data}
+              <Link to="/burgers">Other Route</Link>
+            </div>
+          )
+        }
+      `,
+
+      "app/routes/burgers.tsx": js`
+        export default function Index() {
+          return <div>cheeseburger</div>;
+        }
+      `,
+    },
   });
 
-  let buildResult = build({ cwd });
-  expect(buildResult.status).toBe(0);
-
-  let stop = await reactRouterServe({ cwd, port });
-  try {
-    await page.goto(`http://localhost:${port}`);
-    await page.getByRole("link", { name: "Load route" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Loaded through exported helper" }),
-    ).toBeVisible();
-  } finally {
-    stop();
-  }
+  // This creates an interactive app using playwright.
+  appFixture = await createAppFixture(fixture);
 });
+
+test.afterAll(() => {
+  appFixture.close();
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// 💿 Almost done, now write your failing test case(s) down here Make sure to
+// add a good description for what you expect React Router to do 👇🏽
+////////////////////////////////////////////////////////////////////////////////
+
+test("[description of what you expect it to do]", async ({ page }) => {
+  let app = new PlaywrightFixture(appFixture, page);
+  // You can test any request your app might get using `fixture`.
+  let response = await fixture.requestDocument("/");
+  expect(await response.text()).toMatch("pizza");
+
+  // If you need to test interactivity use the `app`
+  await app.goto("/");
+  await app.clickLink("/burgers");
+  await page.waitForSelector("text=cheeseburger");
+
+  // If you're not sure what's going on, you can "poke" the app, it'll
+  // automatically open up in your browser for 20 seconds, so be quick!
+  // await app.poke(20);
+
+  // Go check out the other tests to see what else you can do.
+});
+
+////////////////////////////////////////////////////////////////////////////////
+// 💿 Finally, push your changes to your fork of React Router
+// and open a pull request!
+////////////////////////////////////////////////////////////////////////////////

--- a/integration/split-route-modules-test.ts
+++ b/integration/split-route-modules-test.ts
@@ -121,7 +121,9 @@ const files = {
     // chunk. The variable name is globally unique to prevent name mangling,
     // e.g. inUnsplittableMainChunk$1. The use of console.log prevents dead code
     // elimination in the build by introducing a side effect
-    export const inUnsplittableMainChunk = () => console.log() || true;
+    export function inUnsplittableMainChunk() {
+      return console.log() || true;
+    }
 
     export const clientLoader = async () => {
       inUnsplittableMainChunk();
@@ -177,7 +179,9 @@ const files = {
     // chunk. The variable name is globally unique to prevent name mangling,
     // e.g. inMixedMainChunk$1. The use of console.log prevents dead code
     // elimination in the build by introducing a side effect
-    export const inMixedMainChunk = () => console.log() || true;
+    export function inMixedMainChunk() {
+      return console.log() || true;
+    }
 
     export const clientLoader = async () => {
       inMixedMainChunk();

--- a/packages/react-router-dev/.changes/patch.split-route-export-dependencies.md
+++ b/packages/react-router-dev/.changes/patch.split-route-export-dependencies.md
@@ -1,0 +1,1 @@
+Avoid broken route chunks when exported function or class declarations are shared by multiple route exports

--- a/packages/react-router-dev/vite/route-chunks-test.ts
+++ b/packages/react-router-dev/vite/route-chunks-test.ts
@@ -11,17 +11,19 @@ let cache: [Cache, string] = [new Map(), "cacheKey"];
 
 describe("route chunks", () => {
   describe("chunkable", () => {
-    test("functions with no identifiers", () => {
+    test("independent declarations with no identifiers", () => {
       const code = dedent`
         export default function () { return null; }
         export function target1() { return null; }
         export function other1() { return null; }
+        export class OtherClass {}
         export const target2 = () => null;
         export const other2 = () => null;
       `;
       expect(hasChunkableExport(code, "default", ...cache)).toBe(true);
       expect(hasChunkableExport(code, "target1", ...cache)).toBe(true);
       expect(hasChunkableExport(code, "target2", ...cache)).toBe(true);
+      expect(hasChunkableExport(code, "OtherClass", ...cache)).toBe(true);
       expect(getChunkedExport(code, "default", {}, ...cache)?.code)
         .toMatchInlineSnapshot(`
         "export default function () {
@@ -38,9 +40,12 @@ describe("route chunks", () => {
         getChunkedExport(code, "target2", {}, ...cache)?.code,
       ).toMatchInlineSnapshot(`"export const target2 = () => null;"`);
       expect(
+        getChunkedExport(code, "OtherClass", {}, ...cache)?.code,
+      ).toMatchInlineSnapshot(`"export class OtherClass {}"`);
+      expect(
         omitChunkedExports(
           code,
-          ["default", "target1", "target2"],
+          ["default", "target1", "target2", "OtherClass"],
           {},
           ...cache,
         )?.code,
@@ -715,6 +720,108 @@ describe("route chunks", () => {
         export const other2 = () => getOtherMessage2();"
       `);
     });
+
+    test("function depending on an exported function declaration", () => {
+      const code = dedent`
+        export function exportedHelper() {
+          return "loaded";
+        }
+        export function clientLoader() {
+          return exportedHelper();
+        }
+        export default function Component() {
+          return null;
+        }
+      `;
+
+      expect(hasChunkableExport(code, "exportedHelper", ...cache)).toBe(false);
+      expect(hasChunkableExport(code, "clientLoader", ...cache)).toBe(false);
+      expect(hasChunkableExport(code, "default", ...cache)).toBe(true);
+      expect(
+        getChunkedExport(code, "clientLoader", {}, ...cache),
+      ).toBeUndefined();
+      expect(omitChunkedExports(code, ["clientLoader"], {}, ...cache)?.code)
+        .toMatchInlineSnapshot(`
+        "export function exportedHelper() {
+          return "loaded";
+        }
+        export function clientLoader() {
+          return exportedHelper();
+        }
+        export default function Component() {
+          return null;
+        }"
+      `);
+    });
+
+    test("function depending transitively on an exported class declaration", () => {
+      const code = dedent`
+        export class ExportedClass {
+          message = "loaded";
+        }
+        const createExportedClass = () => new ExportedClass();
+        export function clientLoader() {
+          return createExportedClass();
+        }
+        export default function Component() {
+          return null;
+        }
+      `;
+
+      expect(hasChunkableExport(code, "ExportedClass", ...cache)).toBe(false);
+      expect(hasChunkableExport(code, "clientLoader", ...cache)).toBe(false);
+      expect(hasChunkableExport(code, "default", ...cache)).toBe(true);
+      expect(
+        getChunkedExport(code, "clientLoader", {}, ...cache),
+      ).toBeUndefined();
+    });
+
+    test("retained default export depending on an exported route function", () => {
+      const code = dedent`
+        export function clientLoader() {
+          return "loaded";
+        }
+        export default function Component() {
+          return clientLoader();
+        }
+      `;
+
+      expect(hasChunkableExport(code, "clientLoader", ...cache)).toBe(false);
+      expect(hasChunkableExport(code, "default", ...cache)).toBe(false);
+      expect(
+        getChunkedExport(code, "clientLoader", {}, ...cache),
+      ).toBeUndefined();
+      expect(omitChunkedExports(code, ["clientLoader"], {}, ...cache)?.code)
+        .toMatchInlineSnapshot(`
+        "export function clientLoader() {
+          return "loaded";
+        }
+        export default function Component() {
+          return clientLoader();
+        }"
+      `);
+    });
+
+    test.each([
+      ["function", "export default function Component() {}"],
+      ["class", "export default class Component {}"],
+    ])(
+      "export depending on a named default %s declaration",
+      (_, defaultDeclaration) => {
+        const code = dedent`
+          ${defaultDeclaration}
+          export function clientLoader() {
+            return Component.name;
+          }
+        `;
+
+        expect(hasChunkableExport(code, "default", ...cache)).toBe(false);
+        expect(hasChunkableExport(code, "clientLoader", ...cache)).toBe(false);
+        expect(
+          getChunkedExport(code, "clientLoader", {}, ...cache),
+        ).toBeUndefined();
+      },
+    );
 
     test("functions sharing an imported identifier", () => {
       const code = dedent`

--- a/packages/react-router-dev/vite/route-chunks.ts
+++ b/packages/react-router-dev/vite/route-chunks.ts
@@ -109,15 +109,26 @@ function getExportDependencies(
           ...getTopLevelStatementsForPaths(identifiers),
         ]);
 
-        // We also keep track of non-import statements since import statements
-        // get more fine-grained filtering, meaning that we often need to
-        // exclude import statements in our chunking logic.
+        // We also keep track of non-module statements since most import/export
+        // statements get more fine-grained filtering. Exported function and
+        // class declarations are atomic, so keep them for shared code detection.
         let topLevelNonModuleStatements = new Set(
-          Array.from(topLevelStatements).filter(
-            (statement) =>
-              !t.isImportDeclaration(statement) &&
-              !t.isExportDeclaration(statement),
-          ),
+          Array.from(topLevelStatements).filter((statement) => {
+            if (t.isImportDeclaration(statement)) {
+              return false;
+            }
+
+            if (!t.isExportDeclaration(statement)) {
+              return true;
+            }
+
+            return (
+              (t.isExportNamedDeclaration(statement) ||
+                t.isExportDefaultDeclaration(statement)) &&
+              (t.isFunctionDeclaration(statement.declaration) ||
+                t.isClassDeclaration(statement.declaration))
+            );
+          }),
         );
 
         // We keep track of imported identifiers for each export since we


### PR DESCRIPTION
Fixes #15335.

## Problem

Route chunk dependency analysis follows references into exported function and class declarations, but previously excluded those declarations from shared-statement detection. Chunk generation then removed a sibling exported declaration whose name did not match the target export, leaving a dangling runtime reference in the emitted chunk.

This affects current main and the v8.2.0 release.

## Fix

Treat exported function and class declarations as atomic top-level dependencies. When they are shared by route exports:

- default route splitting de-optimizes the affected export and keeps the route module intact;
- `splitRouteModules: "enforce"` fails the build with the existing guidance to extract shared code into another module.

The generation path remains unchanged, avoiding duplicated class identity, static state, and module-local state across chunks. Independent exported declarations remain chunkable.

The first commit contains the failing runtime reproduction. The second moves that coverage into the split-route-module integration suite and applies the fix.

## Tests

- `pnpm test route-chunks-test --runInBand`
- `pnpm build`
- `pnpm test:integration:run split-route-modules --project chromium`
- `pnpm typecheck`
- `pnpm changes:validate`
- `pnpm lint` (passes with six existing warnings)

🤖 This pull request and its implementation were prepared with AI assistance.