### PR TITLE
feat(react-router-serve): add DISABLE_COMPRESSION environment variable

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -251,6 +251,7 @@
 - KimHyeongRae0
 - kirillgroshkov
 - kkirsche
+- kklem0
 - kno-raziel
 - knownasilya
 - koojaa

--- a/docs/api/other-api/serve.md
+++ b/docs/api/other-api/serve.md
@@ -46,6 +46,16 @@ You can change the port of the server with an environment variable.
 PORT=4000 npx react-router-serve build/index.js
 ```
 
+## `DISABLE_COMPRESSION` environment variable
+
+By default, responses are compressed with the [`compression`][compression] middleware. If a proxy or CDN in front of your app server handles compression instead, you can set `DISABLE_COMPRESSION` to `true` (or `1`) so the server sends identity-encoded responses with a `Content-Length` header.
+
+```shellscript nonumber
+DISABLE_COMPRESSION=true npx react-router-serve build/index.js
+```
+
+This is useful behind edge caches (for example Azure Front Door or other CDNs) that compress at the edge — compressing at both layers can break edge caching, since the origin's compressed responses are chunked and carry no `Content-Length` for the cache to store.
+
 ## Development Environment
 
 Depending on `process.env.NODE_ENV`, the server will boot in development or production mode.

--- a/docs/api/other-api/serve.md
+++ b/docs/api/other-api/serve.md
@@ -46,6 +46,14 @@ You can change the port of the server with an environment variable.
 PORT=4000 npx react-router-serve build/index.js
 ```
 
+## `DISABLE_COMPRESSION` environment variable
+
+By default, responses are compressed with the [`compression`][compression] middleware. If a proxy or CDN in front of your app server compresses responses at the edge, you can set `DISABLE_COMPRESSION` to `true` so the server sends uncompressed responses instead, since compressing at both layers can break edge caching.
+
+```shellscript nonumber
+DISABLE_COMPRESSION=true npx react-router-serve build/index.js
+```
+
 ## Development Environment
 
 Depending on `process.env.NODE_ENV`, the server will boot in development or production mode.

--- a/integration/helpers/create-fixture.ts
+++ b/integration/helpers/create-fixture.ts
@@ -281,7 +281,11 @@ export async function createFixture(init: FixtureInit, mode?: ServerMode) {
  * which has caused many integration tests to leak noisy logs for expected errors.
  * It also means that sometimes the CLI is skipped over in those tests, missing out on code paths that should be tested.
  */
-export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
+export async function createAppFixture(
+  fixture: Fixture,
+  mode?: ServerMode,
+  options?: { env?: Record<string, string> },
+) {
   let startAppServer = async (): Promise<{
     port: number;
     stop: VoidFunction;
@@ -298,6 +302,7 @@ export async function createAppFixture(fixture: Fixture, mode?: ServerMode) {
         env: {
           NODE_ENV: mode || "production",
           PORT: port.toFixed(0),
+          ...options?.env,
         },
         regex: /\[react-router-serve\] http:\/\/localhost:(\d+)\s/,
         validate: (matches) => {

--- a/integration/react-router-serve-test.ts
+++ b/integration/react-router-serve-test.ts
@@ -81,4 +81,57 @@ test.describe("react-router-serve", () => {
       });
     });
   }
+
+  test.describe("compression", () => {
+    let fixture: Fixture;
+
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        templateName: "vite-7-template",
+        useReactRouterServe: true,
+        files: {
+          "app/routes/_index.tsx": js`
+            import { useLoaderData } from "react-router";
+
+            // Large enough to clear the compression middleware's default
+            // 1kb threshold
+            export function loader() {
+              return "x".repeat(4096);
+            }
+
+            export default function Index() {
+              let data = useLoaderData();
+              return <div>{data}</div>;
+            }
+          `,
+        },
+      });
+    });
+
+    test("compresses responses by default", async () => {
+      let appFixture = await createAppFixture(fixture);
+      try {
+        let response = await fetch(appFixture.serverUrl);
+        expect(response.headers.get("content-encoding")).toMatch(
+          /\b(gzip|deflate|br|zstd)\b/,
+        );
+        expect(await response.text()).toContain("x".repeat(4096));
+      } finally {
+        appFixture.close();
+      }
+    });
+
+    test("does not compress responses when DISABLE_COMPRESSION is set", async () => {
+      let appFixture = await createAppFixture(fixture, undefined, {
+        env: { DISABLE_COMPRESSION: "true" },
+      });
+      try {
+        let response = await fetch(appFixture.serverUrl);
+        expect(response.headers.get("content-encoding")).toBeNull();
+        expect(await response.text()).toContain("x".repeat(4096));
+      } finally {
+        appFixture.close();
+      }
+    });
+  });
 });

--- a/integration/react-router-serve-test.ts
+++ b/integration/react-router-serve-test.ts
@@ -123,4 +123,59 @@ test.describe("react-router-serve", () => {
       });
     }
   });
+
+  test.describe("compression", () => {
+    let fixture: Fixture;
+
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        // RSC builds never get the compression middleware, so only the non-RSC
+        // template is exercised here
+        templateName: "vite-7-template",
+        useReactRouterServe: true,
+        files: {
+          "app/routes/_index.tsx": js`
+            import { useLoaderData } from "react-router";
+
+            // Large enough to clear the compression middleware's default
+            // 1kb threshold
+            export function loader() {
+              return "x".repeat(4096);
+            }
+
+            export default function Index() {
+              let data = useLoaderData();
+              return <div>{data}</div>;
+            }
+          `,
+        },
+      });
+    });
+
+    test("compresses responses by default", async () => {
+      let appFixture = await createAppFixture(fixture);
+      try {
+        let response = await fetch(appFixture.serverUrl);
+        expect(response.headers.get("content-encoding")).toMatch(
+          /\b(gzip|deflate|br|zstd)\b/,
+        );
+        expect(await response.text()).toContain("x".repeat(4096));
+      } finally {
+        appFixture.close();
+      }
+    });
+
+    test("does not compress responses when DISABLE_COMPRESSION is set", async () => {
+      let appFixture = await createAppFixture(fixture, undefined, {
+        env: { DISABLE_COMPRESSION: "true" },
+      });
+      try {
+        let response = await fetch(appFixture.serverUrl);
+        expect(response.headers.get("content-encoding")).toBeNull();
+        expect(await response.text()).toContain("x".repeat(4096));
+      } finally {
+        appFixture.close();
+      }
+    });
+  });
 });

--- a/packages/react-router-serve/.changes/minor.disable-compression-env-var.md
+++ b/packages/react-router-serve/.changes/minor.disable-compression-env-var.md
@@ -1,0 +1,1 @@
+Add support for a `DISABLE_COMPRESSION` environment variable that disables the built-in `compression` middleware, for deployments where a proxy or CDN in front of the app server handles compression instead

--- a/packages/react-router-serve/cli.ts
+++ b/packages/react-router-serve/cli.ts
@@ -188,7 +188,14 @@ async function run() {
   let app = express();
   app.disable("x-powered-by");
 
-  if (!isRSCBuild) {
+  // Compression can be disabled for deployments where a proxy/CDN in front of
+  // the app server handles it instead (e.g. edge caches that require an
+  // identity response with a `Content-Length` from the origin).
+  let disableCompression =
+    process.env.DISABLE_COMPRESSION === "true" ||
+    process.env.DISABLE_COMPRESSION === "1";
+
+  if (!isRSCBuild && !disableCompression) {
     // `compression` may resolve to Express 4 types from transitive deps while
     // `react-router-serve` uses Express 5, but the runtime middleware signature
     // is compatible.

--- a/packages/react-router-serve/cli.ts
+++ b/packages/react-router-serve/cli.ts
@@ -188,7 +188,12 @@ async function run() {
   let app = express();
   app.disable("x-powered-by");
 
-  if (!isRSCBuild) {
+  // Compression can be disabled for deployments where a proxy/CDN in front of
+  // the app server handles it instead (e.g. edge caches that compress at the
+  // edge and expect uncompressed responses from the origin).
+  let disableCompression = process.env.DISABLE_COMPRESSION === "true";
+
+  if (!isRSCBuild && !disableCompression) {
     // `compression` may resolve to Express 4 types from transitive deps while
     // `react-router-serve` uses Express 5, but the runtime middleware signature
     // is compatible.


### PR DESCRIPTION
## Problem

`react-router-serve` unconditionally applies the `compression` middleware (for non-RSC builds). When the app server runs behind a CDN / edge cache that also compresses — in our case Azure Front Door — origin-side compression breaks edge caching: the origin's compressed response is chunked with no `Content-Length`, and when Front Door caches it, it re-serves the compressed body stamped with the *uncompressed* `Content-Length`. Clients receive a truncated body and hang waiting for the rest (we hit ~91 s stalls in production). With the origin serving identity responses, the edge compresses and caches correctly.

Today the only escape hatch is the documented one: "migrate to `@react-router/express`". In practice that means maintaining a full re-implementation of `cli.ts` in order to remove a single middleware line — a copy that silently drifts as `react-router-serve` evolves (ours already lagged behind the RSC handling and the absolute-`base` `publicPath` fix that landed upstream since we forked it).

## Proposal

Support a `DISABLE_COMPRESSION` environment variable (set to `true`) that skips the `compression()` middleware:

```sh
DISABLE_COMPRESSION=true react-router-serve build/server/index.js
```

Why an env var, and why this doesn't conflict with the "no customization options by design" policy:

- **Env vars are already the configuration surface of `react-router-serve`** — `HOST` and `PORT` work exactly this way. This is deployment-environment adaptation, not server customization: the middleware itself cannot detect that a compressing cache sits in front of it.
- **`react-router-serve` already treats compression as conditional**: RSC builds run with compression fully disabled (#14381).
- The alternative (fully ejecting to Express) forces users to fork ~200 lines of server for a one-line toggle, which seems worse for the ecosystem than one narrowly-scoped env var.

## Changes

- `packages/react-router-serve/cli.ts` — skip `compression()` when `DISABLE_COMPRESSION` is `true`
- `docs/api/other-api/serve.md` — document the new env var alongside `HOST`/`PORT`
- `packages/react-router-serve/.changes/minor.disable-compression-env-var.md` — change file
- `integration/react-router-serve-test.ts` — tests asserting the default response is compressed and the `DISABLE_COMPRESSION=true` response is identity-encoded, against the real spawned server
- `integration/helpers/create-fixture.ts` — allow passing extra env vars to the spawned `react-router-serve` process (additive optional param)

## Testing

- `pnpm build`, then `playwright test --config ./integration/playwright.config.ts react-router-serve-test` — all pass, including the two new compression tests (verified across chromium/firefox/webkit/msedge projects).
- `tsc` for the serve package and `prettier --check` on all touched files pass.

