### PR TITLE
fix(react-router-serve): serve /.well-known files

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -251,6 +251,7 @@
 - KimHyeongRae0
 - kirillgroshkov
 - kkirsche
+- kklem0
 - kno-raziel
 - knownasilya
 - koojaa

--- a/integration/react-router-serve-test.ts
+++ b/integration/react-router-serve-test.ts
@@ -81,4 +81,46 @@ test.describe("react-router-serve", () => {
       });
     });
   }
+
+  test.describe("well-known URIs", () => {
+    for (const templateName of templateNames) {
+      test.describe(`template: ${templateName}`, () => {
+        let fixture: Fixture;
+        let appFixture: AppFixture;
+
+        test.beforeAll(async () => {
+          fixture = await createFixture({
+            templateName,
+            useReactRouterServe: true,
+            files: {
+              "public/.well-known/security.txt":
+                "Contact: mailto:security@example.com",
+              "public/.hidden.txt": "should not be served",
+            },
+          });
+          appFixture = await createAppFixture(fixture);
+        });
+
+        test.afterAll(() => {
+          appFixture.close();
+        });
+
+        test("serves files under /.well-known", async () => {
+          let response = await fetch(
+            `${appFixture.serverUrl}/.well-known/security.txt`,
+          );
+          expect(response.status).toBe(200);
+          expect(await response.text()).toContain(
+            "Contact: mailto:security@example.com",
+          );
+        });
+
+        test("keeps other dotfiles hidden", async () => {
+          let response = await fetch(`${appFixture.serverUrl}/.hidden.txt`);
+          expect(response.status).toBe(404);
+          expect(await response.text()).not.toContain("should not be served");
+        });
+      });
+    }
+  });
 });

--- a/packages/react-router-serve/.changes/patch.serve-well-known.md
+++ b/packages/react-router-serve/.changes/patch.serve-well-known.md
@@ -1,0 +1,1 @@
+Serve `/.well-known/*` files from the client build directory. Express 5's static middleware ignores every dot-segment path by default, so RFC 8615 well-known URIs — ACME challenges, Android's `assetlinks.json`, Apple's `apple-app-site-association` — fell through to the request handler and came back as app-rendered HTML instead of the static file. Other dotfiles remain hidden.

--- a/packages/react-router-serve/cli.ts
+++ b/packages/react-router-serve/cli.ts
@@ -206,6 +206,10 @@ async function run() {
   );
   app.use(expressPublicPath, express.static(build.assetsBuildDirectory));
   app.use(express.static("public", { maxAge: "1h" }));
+  app.use(
+    "/.well-known",
+    express.static(path.join(build.assetsBuildDirectory, ".well-known")),
+  );
   app.use(morgan("tiny"));
 
   if (build.fetch) {


### PR DESCRIPTION
## Problem

Express 5's static middleware ignores every dot-segment path by default — `send` v1 dropped v0's allowance for dot *directories* when the deprecated `hidden` option was removed. Since `react-router-serve` uses `express.static` with default options, any file under `/.well-known/` now falls through all static mounts into the request handler, which responds with app-rendered HTML (or a 404 route) instead of the file.

`/.well-known` is the RFC 8615 home for cross-cutting platform files, so this silently breaks real deployments:

- Android App Links (`/.well-known/assetlinks.json`)
- iOS Universal Links / associated domains (`/.well-known/apple-app-site-association`)
- ACME HTTP-01 challenges (Let's Encrypt)
- `security.txt`, OIDC discovery, and the rest of the well-known registry

We hit this in production: our Android `assetlinks.json` verification received an HTML page. Related friction with `.well-known` requests reaching the router has come up before in #13516 and #15337 (dev-server side). And because `react-router-serve` intentionally exposes no options, affected apps can't work around it without ejecting to a custom Express server.

## Fix

Mount the client build's `.well-known` directory explicitly, after the existing static mounts and before the request handler:

```ts
app.use(
  "/.well-known",
  express.static(path.join(build.assetsBuildDirectory, ".well-known")),
);
```

Only the `.well-known` directory is exposed — all other dotfiles remain hidden, matching what `sirv` (used by Vite preview) does by default (lukeed/sirv#50). This restores the Express 4-era behavior for the standardized directory without reintroducing broad dot-directory serving.

## Testing

Added integration tests in `integration/react-router-serve-test.ts` for both the classic and RSC Framework Mode templates, run against the real spawned `react-router-serve` process:

- `/.well-known/security.txt` (placed in `public/`) is served with a 200
- other dotfiles (e.g. `/.hidden.txt`) still fall through and 404

All existing tests in the file pass, along with `tsc` for the package and `prettier --check` on touched files.
