### PR TITLE
fix(dev): silence noisy DevTools well-known route probe in Vite dev s…

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -115,6 +115,7 @@
 - dchenk
 - decadentsavant
 - developit
+- deveshsinghal09
 - dfedoryshchev
 - dgrijuela
 - DigitalNaut

--- a/integration/vite-dev-test.ts
+++ b/integration/vite-dev-test.ts
@@ -554,4 +554,36 @@ test.describe("Vite dev", () => {
 
     expect(clientDeps).not.toMatch(/rsc[-_]server[-_]only[-_]package/);
   });
+
+  test("silently returns 204 for Chromium DevTools well-known route probe", async ({
+    dev,
+  }) => {
+    // Chrome requests /.well-known/appspecific/com.chrome.devtools.json on every
+    // localhost page load. Without the fix this triggers a noisy "No route matches URL"
+    // error in the dev server console. Verify it is intercepted and returns 204.
+    let files: Files = async ({ port }) => ({
+      "vite.config.ts": await viteConfig.basic({ port }),
+    });
+
+    let { port } = await dev(files);
+
+    // Verify the well-known URL is handled silently with 204 No Content.
+    let response = await fetch(
+      `http://localhost:${port}/.well-known/appspecific/com.chrome.devtools.json`,
+    );
+
+    // Should be 204 No Content — not a 404 or 500.
+    expect(response.status).toBe(204);
+
+    // Body must be empty.
+    let body = await response.text();
+    expect(body).toBe("");
+
+    // Cache-Control header should be no-store so browsers don't cache the 204.
+    expect(response.headers.get("cache-control")).toBe("no-store");
+
+    // Normal app routes must still be reachable after the well-known middleware.
+    let indexResponse = await fetch(`http://localhost:${port}/`);
+    expect(indexResponse.status).toBe(200);
+  });
 });

--- a/packages/react-router-dev/.changes/patch.devtools-well-known-route-miss.md
+++ b/packages/react-router-dev/.changes/patch.devtools-well-known-route-miss.md
@@ -1,0 +1,1 @@
+Silently return 204 No Content for Chromium DevTools `/.well-known/appspecific/com.chrome.devtools.json` requests in the Vite dev server to prevent noisy "No route matches URL" errors that are unrelated to application code.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1589,6 +1589,25 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           // Let user servers handle SSR requests in middleware mode,
           // otherwise the Vite plugin will handle the request
           if (!viteDevServer.config.server.middlewareMode) {
+            // Silently handle the Chromium DevTools Automatic Workspace Folders
+            // probe (https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/ecosystem/automatic_workspace_folders.md).
+            // Chrome requests /.well-known/appspecific/com.chrome.devtools.json
+            // on every localhost page load. Since there is no matching app route,
+            // React Router would otherwise log a noisy "No route matches URL"
+            // error that is unrelated to application code. We return 204 No
+            // Content here — before the request handler — so the error is
+            // suppressed without affecting any user-defined routes.
+            viteDevServer.middlewares.use((req, res, next) => {
+              if (
+                req.url === "/.well-known/appspecific/com.chrome.devtools.json"
+              ) {
+                res.writeHead(204, { "Cache-Control": "no-store" });
+                res.end();
+                return;
+              }
+              next();
+            });
+
             viteDevServer.middlewares.use(async (req, res, next) => {
               try {
                 let vite = getVite();


### PR DESCRIPTION
## Problem

Chrome requests `/.well-known/appspecific/com.chrome.devtools.json` on 
every localhost page load as part of its DevTools Automatic Workspace 
Folders feature. Since no app route matches this path, React Router logs 
a noisy "No route matches URL" error in the dev server console on every 
single page load — even though it has nothing to do with application code.

## Solution

Add a small middleware in the Vite dev server (non-middleware mode) that 
intercepts this specific path before the request handler and returns 
`204 No Content` with `Cache-Control: no-store`. This suppresses the 
error without affecting any user-defined routes.

## Changes
- `packages/react-router-dev/vite/plugin.ts` — add the well-known intercept middleware
- `integration/vite-dev-test.ts` — integration test verifying the 204 response
- `packages/react-router-dev/.changes/patch.devtools-well-known-route-miss.md` — change file
