### PR TITLE
fix(rsc): detect client version skew in createCallServer action responses

### DIFF
--- a/integration/rsc-client-version-test.ts
+++ b/integration/rsc-client-version-test.ts
@@ -225,6 +225,92 @@ test.describe("RSC client versions", () => {
     expect(documentRequests[1]).toBe(`${baseUrl}/other`);
   });
 
+  test("reloads when a server function rerender has a new client version", async ({
+    page,
+    vitePreview,
+  }) => {
+    let files: Files = async () => ({
+      ...getFiles(),
+      "app/actions.ts": js`
+        "use server";
+
+        export async function incrementCounter(count: number) {
+          return count + 1;
+        }
+      `,
+      "app/counter.client.tsx": js`
+        "use client";
+
+        import { useActionState } from "react";
+
+        import { incrementCounter } from "./actions";
+
+        export function Counter() {
+          const [count, increment] = useActionState(incrementCounter, 0);
+          return (
+            <form action={increment}>
+              <output data-count>{count}</output>
+              <button type="submit" data-submit>Increment</button>
+            </form>
+          );
+        }
+      `,
+      "app/routes/_index.tsx": js`
+        import { Counter } from "../counter.client";
+
+        export default function Index() {
+          return (
+            <div>
+              <h1>Home</h1>
+              <Counter />
+            </div>
+          );
+        }
+      `,
+    });
+    let { cwd, port } = await vitePreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+
+    let { default: assetsManifest } = await import(
+      pathToFileURL(
+        path.join(cwd, "build/server/__vite_rsc_assets_manifest.js"),
+      ).href
+    );
+    let clientVersion = assetsManifest.clientVersion as string;
+    let newVersion = clientVersion === "deadbeef" ? "feedface" : "deadbeef";
+
+    // Swap the client version inside the server function's rerender payload,
+    // simulating an action response from a newer deployment.
+    let replacedVersion = false;
+    await page.route(`${baseUrl}/`, async (route) => {
+      if (route.request().method() !== "POST" || replacedVersion) {
+        await route.continue();
+        return;
+      }
+
+      replacedVersion = true;
+      let response = await route.fetch();
+      let source = await response.text();
+      expect(source).toContain(clientVersion);
+      await route.fulfill({
+        response,
+        body: source.replaceAll(clientVersion, newVersion),
+      });
+    });
+
+    await page.goto(`${baseUrl}/`);
+    await expect(page.locator("[data-count]")).toHaveText("0");
+
+    await page.getByRole("button", { name: "Increment" }).click();
+
+    // The stale client must reload the document instead of applying the
+    // mismatched rerender.
+    await expect.poll(() => documentRequests.length).toBe(2);
+    expect(documentRequests[1]).toBe(`${baseUrl}/`);
+    await expect(page.locator("[data-count]")).toHaveText("0");
+  });
+
   test("does not reload repeatedly for the same stale client version", async ({
     page,
     vitePreview,

--- a/packages/react-router/.changes/unstable.rsc-call-server-client-version.md
+++ b/packages/react-router/.changes/unstable.rsc-call-server-client-version.md
@@ -1,0 +1,1 @@
+detect client version skew in `unstable_createCallServer` action responses — a stale client now reloads instead of applying a rerender payload from a newer deployment

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -69,6 +69,7 @@ export type EncodeReplyFunction = (
 type WindowWithRouterGlobals = Window &
   typeof globalThis & {
     __reactRouterDataRouter: DataRouter;
+    __reactRouterClientVersion?: string;
     __routerInitialized: boolean;
     __routerActionID: number;
   };
@@ -172,6 +173,27 @@ export function createCallServer({
           }
 
           const rerender = await payload.rerender;
+          // Version skew is a whole-client condition, so check before the
+          // action-supersede guard below — a superseded action must still
+          // reload a stale document. Redirect rerenders carry no version and
+          // are re-checked by the data strategy when they navigate.
+          const clientVersion = globalVar.__reactRouterClientVersion;
+          if (
+            rerender &&
+            rerender.type === "render" &&
+            clientVersion !== undefined &&
+            (await handleClientVersionMismatch(
+              rerender.clientVersion !== clientVersion,
+              clientVersion,
+              createPath(
+                globalVar.__reactRouterDataRouter.state.navigation.location ||
+                  globalVar.__reactRouterDataRouter.state.location,
+              ),
+            ))
+          ) {
+            // The stale rerender is never applied; the document is reloading.
+            return;
+          }
           if (
             rerender &&
             landedActionId < actionId &&
@@ -264,6 +286,9 @@ function createRouterFromPayload({
   if (payload.type !== "render") throw new Error("Invalid payload type");
 
   let { clientVersion } = payload;
+  // Baseline for skew detection in paths constructed outside this function
+  // (`createCallServer` is wired via `setServerCallback` before hydration).
+  globalVar.__reactRouterClientVersion = clientVersion;
 
   globalVar.__reactRouterRouteModules =
     globalVar.__reactRouterRouteModules ?? {};


### PR DESCRIPTION
The `clientVersion` stale-client detection shipped in #15318 covers lazy route discovery (`?version=` → 204 + `X-Remix-Reload-Document`) and the router data strategy (loaders and router-driven actions compare `payload.clientVersion`). Server functions invoked through `unstable_createCallServer` — client-component form actions / `useActionState` / imperative calls via `setServerCallback` — are the one payload-applying path with no check: the action's rerender is applied unconditionally, so a stale client patches new-build route manifests and `loaderData` into old-build modules via `patchRoutes` + `_internalSetState…`. That's precisely the mismatched-module state the feature exists to prevent, on what is many apps' highest-write-traffic boundary.

The rerender does carry the version: `baseRenderPayload` includes `clientVersion` and feeds the action payload's `rerender` (the **top-level** action payload deliberately has no version field — the check must read `rerender.clientVersion`).

## Change

- Store the hydration baseline alongside the other router globals (`__reactRouterClientVersion`). `createCallServer` is constructed via `setServerCallback` before `createRouterFromPayload` runs, so it cannot close over the payload; timing is safe because no action can fire before hydration populates the global. When the feature is unwired, both sides are `undefined` and behavior is unchanged.
- In the rerender path, call `handleClientVersionMismatch` **before** the action-supersede guard: skew is a whole-client condition, so a superseded action must still reload a stale document. On mismatch the stale rerender is never applied and the caller's already-resolved `actionResult` is unaffected (the mutation landed server-side). The existing sessionStorage loop guard applies unchanged.
- Redirect rerenders carry no version and are deliberately untouched — they either hard-reload or navigate through the data strategy, which already checks. `skipRevalidation` actions carry no rerender payload to check.

## Tests

Added to `integration/rsc-client-version-test.ts` in the file's existing pattern (route-intercept the action POST, swap the version in the rerender stream): a stale server-function rerender now reloads the destination document instead of applying. Verified red on `main` (test fails without the fix) and green with it; the file's four existing tests still pass.

One observation from working in this code, left out of scope: `landedActionId` in `createCallServer` is declared and read in the supersede guard but never assigned anywhere — half of that guard is dead. Happy to file separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of agcty