### PR TITLE
ci: read the PR head ref from env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -56,6 +56,7 @@ jobs:
         id: suites
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         # If `gh pr diff` exits with a non-zero code, it might be because the PR
         # has >300 files, or it could be for any number of unknown reasons.  If
         # that happens take the conservative route and run the larger `dev` suite.
@@ -63,7 +64,7 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Selected integration suite: full (push to main)"
             echo "type=full" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event.pull_request.head.ref }}" = "v8" ]; then
+          elif [ "$PR_HEAD_REF" = "v8" ]; then
             echo "Selected integration suite: dev (v8 PR)"
             echo "type=dev" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event.pull_request.draft }}" = "true" ]; then

--- a/contributors.yml
+++ b/contributors.yml
@@ -253,6 +253,7 @@
 - kkirsche
 - kno-raziel
 - knownasilya
+- kobihikri
 - koojaa
 - KostiantynPopovych
 - KubasuIvanSakwa


### PR DESCRIPTION
Hi, and thanks for React Router.

In `.github/workflows/test-integration.yml`, the "Select integration suites" step compares the PR's source branch name by interpolating it into the shell:

```yaml
elif [ "${{ github.event.pull_request.head.ref }}" = "v8" ]; then
```

Actions expands `${{ ... }}` into the script text before bash sees it, so the branch name lands as script rather than as a value. Git permits `$`, `(`, `)` and backticks in branch names, and `$(...)` runs inside double quotes — so a PR from a fork on a branch named, say, `v8$(id)` would run that on the runner.

Two things that keep this small, and I would rather say them than overstate the finding:

- the workflow is `pull_request`, not `pull_request_target`, so a fork PR gets a read-only token and no secrets;
- the step already does the right thing for its other inputs — `GH_TOKEN` is passed through `env:`, which is exactly the pattern this change extends to the branch name.

The diff adds one `env:` entry beside the existing `GH_TOKEN` and changes the comparison to use it:

```yaml
env:
  GH_TOKEN: ${{ github.token }}
  PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
...
elif [ "$PR_HEAD_REF" = "v8" ]; then
```

Same comparison and same suite selection. I left the neighbouring `github.event_name`, `pull_request.draft` and `pull_request.number` interpolations alone — those are values GitHub controls, not free text, so they do not carry the same problem.

Disclosure: I used AI assistance to help spot this and prepare the change, and I verified the workflow and its triggers myself.
