### PR TITLE
Release v7.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v7.18.2](#v7182)
   - [v7.18.1](#v7181)
   - [v7.18.0](#v7180)
     - [CSRF Check Logic Fix](#csrf-check-logic-fix)
@@ -179,6 +180,16 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v6.0.0](#v600)
 
 </details>
+
+## v7.18.2
+
+Date: 2026-07-28
+
+### Patch Changes
+
+- `react-router` - Harden RSC CSRF codepaths. ([#15353](https://github.com/remix-run/react-router/pull/15353))
+
+**Full Changelog**: [`v7.18.1...v7.18.2`](https://github.com/remix-run/react-router/compare/react-router@7.18.1...react-router@7.18.2)
 
 ## v7.18.1
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v7.18.2
+
+### Patch Changes
+
+- _No changes_
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-router",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/architect`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/architect",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/cloudflare",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/dev`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)
+  - [`@react-router/serve@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/dev",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Dev tools and CLI for React Router",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-dom/CHANGELOG.md
+++ b/packages/react-router-dom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # react-router-dom
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Declarative routing for React web applications",
   "keywords": [
     "react",

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/express`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/express",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/fs-routes",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/node`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/node",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/serve`
 
+## v7.18.2
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
+  - [`@react-router/express@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.18.2)
+  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-router/serve",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/patch.rsc-csrf.md
+++ b/packages/react-router/.changes/patch.rsc-csrf.md
@@ -1,1 +1,0 @@
-Harden RSC CSRF codepaths.

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `react-router`
 
+## v7.18.2
+
+### Patch Changes
+
+- Harden RSC CSRF codepaths. ([#15353](https://github.com/remix-run/react-router/pull/15353))
+
 ## v7.18.1
 
 ### Patch Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `7.18.1` → `7.18.2` |
| react-router-dom | `7.18.1` → `7.18.2` |
| @react-router/architect | `7.18.1` → `7.18.2` |
| @react-router/cloudflare | `7.18.1` → `7.18.2` |
| @react-router/dev | `7.18.1` → `7.18.2` |
| @react-router/express | `7.18.1` → `7.18.2` |
| @react-router/fs-routes | `7.18.1` → `7.18.2` |
| @react-router/node | `7.18.1` → `7.18.2` |
| @react-router/remix-routes-option-adapter | `7.18.1` → `7.18.2` |
| @react-router/serve | `7.18.1` → `7.18.2` |
| create-react-router | `7.18.1` → `7.18.2` |

# Changelogs

## react-router v7.18.2

### Patch Changes

- Harden RSC CSRF codepaths. ([#15353](https://github.com/remix-run/react-router/pull/15353))


## react-router-dom v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)


## @react-router/architect v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)


## @react-router/cloudflare v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)


## @react-router/dev v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)
  - [`@react-router/serve@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@7.18.2)


## @react-router/express v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)


## @react-router/fs-routes v7.18.2

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.2)


## @react-router/node v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)


## @react-router/remix-routes-option-adapter v7.18.2

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@7.18.2)


## @react-router/serve v7.18.2

### Patch Changes

- Updated dependencies:
  - [`react-router@7.18.2`](https://github.com/remix-run/react-router/releases/tag/react-router@7.18.2)
  - [`@react-router/express@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@7.18.2)
  - [`@react-router/node@7.18.2`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@7.18.2)


## create-react-router v7.18.2

### Patch Changes

- _No changes_
