### PR TITLE
docs: fix single-file integration test command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - **Build**: `pnpm build` (all packages) or `pnpm run --filter <package> build` (single package)
 - **Test (Jest)**: `pnpm test` (all packages), `pnpm test packages/<package>/` (single package), `pnpm test packages/react-router/__tests__/router/fetchers-test.ts` (single file), or `pnpm test -- -t "action fetch"` (tests matching name)
-- **Integration tests (Playwright)**: `pnpm test:integration --project chromium` (build + test all), `pnpm test:integration:run --project chromium` (test only, all), `pnpm test:integration:run --project chromium integration/middleware-test.ts` (single file), or `pnpm test:integration:run --project chromium -g "middleware"` (tests matching name)
+- **Integration tests (Playwright)**: `pnpm test:integration --project chromium` (build + test all), `pnpm test:integration:run --project chromium` (test only, all), `pnpm test:integration:run integration/middleware-test.ts --project chromium` (single file), or `pnpm test:integration:run --project chromium -g "middleware"` (tests matching name)
 - **Typecheck**: `pnpm run typecheck`
 - **Lint**: `pnpm run lint`
 - **Docs generation**: `pnpm run docs` (regenerates API docs from JSDoc)
@@ -56,7 +56,7 @@ Use Playwright for Vite plugin, build pipeline, SSR/hydration, RSC, type generat
 ```bash
 pnpm test:integration --project chromium                                     # Build + test all
 pnpm test:integration:run --project chromium                                 # Test only, all
-pnpm test:integration:run --project chromium integration/middleware-test.ts  # Single file
+pnpm test:integration:run integration/middleware-test.ts --project chromium  # Single file
 pnpm test:integration:run --project chromium -g "middleware"                 # Tests matching name
 ```
 

--- a/contributors.yml
+++ b/contributors.yml
@@ -23,6 +23,7 @@
 - Aleuck
 - alexandernanberg
 - alexanderson1993
+- alexandrosang21
 - alexlbr
 - AlexWebLab
 - amitdahan


### PR DESCRIPTION
The single-file integration test command in `AGENTS.md` fails as written. Playwright reads a
trailing positional path as another `--project` value:

```
$ pnpm test:integration:run --project chromium integration/middleware-test.ts
Error: Project(s) "integration/middleware-test.ts" not found.
       Available projects: "chromium", "webkit", "msedge", "firefox"
```

Putting the file before the flag resolves it:

```
$ pnpm test:integration:run integration/middleware-test.ts --project chromium
Total: 43 tests in 1 file
```

Both occurrences are updated, in the Commands list and in the Testing section. The `-g` variant
is left alone, since it is a flag rather than a positional and works either way.

Found while following `AGENTS.md` to reproduce #15350, where it was the first command I ran.

Also adds `alexandrosang21` to `contributors.yml` for the CLA.
