### PR TITLE
fix(react-router): skip manifest patch caching on aborted route discovery

### DIFF
--- a/packages/react-router/.changes/patch.fog-of-war-aborted-discovery.md
+++ b/packages/react-router/.changes/patch.fog-of-war-aborted-discovery.md
@@ -1,0 +1,3 @@
+Don't cache a lazily-discovered path when the navigation/fetcher that triggered discovery aborts mid-flight
+
+- Previously, if the signal aborted between the manifest response resolving and the patches being applied, the path was still added to the discovered-paths cache and the manifest while `patchRoutes` no-op'd on the aborted signal, so the route tree was never patched and every later navigation to that path skipped discovery for the rest of the session

--- a/packages/react-router/__tests__/dom/ssr/fog-of-war-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/fog-of-war-test.ts
@@ -1,4 +1,28 @@
-import { getPathsWithAncestors } from "../../../lib/dom/ssr/fog-of-war";
+import {
+  getPathsWithAncestors,
+  getPatchRoutesOnNavigationFunction,
+} from "../../../lib/dom/ssr/fog-of-war";
+import type { AssetsManifest } from "../../../lib/dom/ssr/entry";
+import type { EntryRoute } from "../../../lib/dom/ssr/routes";
+
+function entryRoute(id: string, init: Partial<EntryRoute> = {}): EntryRoute {
+  return {
+    id,
+    parentId: "root",
+    module: `/build/${id}.js`,
+    hasAction: false,
+    hasLoader: false,
+    hasClientAction: false,
+    hasClientLoader: false,
+    hasClientMiddleware: false,
+    hasErrorBoundary: false,
+    clientActionModule: undefined,
+    clientLoaderModule: undefined,
+    clientMiddlewareModule: undefined,
+    hydrateFallbackModule: undefined,
+    ...init,
+  };
+}
 
 describe("fog of war", () => {
   describe("getPathsWithAncestors", () => {
@@ -20,6 +44,115 @@ describe("fog of war", () => {
 
     test("normalizes paths without leading slashes", () => {
       expect(getPathsWithAncestors(["a/b"])).toEqual(["/a", "/a/b"]);
+    });
+  });
+
+  describe("lazy route discovery", () => {
+    let manifest: AssetsManifest;
+    let patched: string[];
+    let originalFetch = global.fetch;
+
+    // A `patch` implementation that mirrors the router's own callback, which
+    // no-ops once the triggering navigation/fetcher signal has aborted
+    // (see `patch` in `discoverRoutes` in router.ts)
+    function makePatch(signal: AbortSignal) {
+      return (routeId: string | null, children: unknown[]) => {
+        if (signal.aborted) return;
+        children.forEach((child) => patched.push((child as { id: string }).id));
+      };
+    }
+
+    // Resolve the manifest request, optionally aborting while the response body
+    // is being read so the request completes but the triggering
+    // navigation/fetcher is already gone when the patches would be applied
+    function mockManifestFetch(
+      patches: Record<string, EntryRoute>,
+      onJson?: () => void,
+    ) {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: async () => {
+          onJson?.();
+          return patches;
+        },
+      }) as unknown as typeof global.fetch;
+    }
+
+    function discover(path: string, signal: AbortSignal) {
+      let router = {
+        state: {
+          location: { pathname: "/", search: "", hash: "" },
+          navigation: { location: undefined },
+        },
+        basename: undefined,
+      };
+      let patchRoutesOnNavigation = getPatchRoutesOnNavigationFunction(
+        () => router as any,
+        manifest,
+        {},
+        true,
+        { mode: "lazy", manifestPath: "/__manifest" },
+        false,
+        undefined,
+      )!;
+      return patchRoutesOnNavigation({
+        path,
+        matches: [],
+        patch: makePatch(signal),
+        signal,
+      } as any);
+    }
+
+    beforeEach(() => {
+      manifest = {
+        entry: { imports: [], module: "/build/entry.js" },
+        routes: { root: entryRoute("root", { parentId: undefined, path: "" }) },
+        url: "/build/manifest.js",
+        version: "abc123",
+      };
+      patched = [];
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    test("re-discovers a path when a prior discovery was aborted mid-flight", async () => {
+      let controller = new AbortController();
+      mockManifestFetch(
+        { "routes/a": entryRoute("routes/a", { path: "a" }) },
+        () => controller.abort(),
+      );
+
+      await discover("/a", controller.signal);
+
+      expect(patched).toEqual([]);
+
+      // The aborted attempt must not leave the path cached as discovered, or
+      // the route tree stays unpatched for the rest of the session
+      mockManifestFetch({ "routes/a": entryRoute("routes/a", { path: "a" }) });
+      await discover("/a", new AbortController().signal);
+
+      expect(global.fetch).toHaveBeenCalled();
+      expect(patched).toEqual(["routes/a"]);
+      expect(Object.keys(manifest.routes)).toEqual(["root", "routes/a"]);
+    });
+
+    test("only discovers a path once when it is not aborted", async () => {
+      mockManifestFetch({ "routes/b": entryRoute("routes/b", { path: "b" }) });
+
+      await discover("/b", new AbortController().signal);
+
+      expect(patched).toEqual(["routes/b"]);
+      expect(Object.keys(manifest.routes)).toEqual(["root", "routes/b"]);
+
+      mockManifestFetch({});
+      await discover("/b", new AbortController().signal);
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -358,6 +358,15 @@ export async function fetchAndApplyManifestPatches(
     throw e;
   }
 
+  // If the triggering navigation/fetcher aborted while we were fetching, bail
+  // before mutating anything.  `patchRoutes` no-ops on an aborted signal, so
+  // updating the manifest and the discovered paths here would leave the paths
+  // cached as discovered with the route tree never patched, and subsequent
+  // navigations to those paths would skip discovery for the rest of the session
+  if (signal?.aborted) {
+    return;
+  }
+
   // Patch routes we don't know about yet into the manifest
   let knownRoutes = new Set(Object.keys(manifest.routes));
   let patches = Object.values(serverPatches).reduce((acc, route) => {


### PR DESCRIPTION
`fetchAndApplyManifestPatches` mutates `manifest.routes` and adds the requested paths to the module-level `discoveredPaths` cache as soon as the manifest response settles, but the `patch` callback the router hands to `patchRoutesOnNavigation` no-ops once the triggering navigation/fetcher signal has aborted ([router.ts](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/router.ts#L3853-L3863)).

If an abort lands in the window between the manifest JSON settling and the patches being applied, the paths end up cached as discovered while the client route tree was never patched. Every later navigation to those paths early-returns at the `discoveredPaths` check, so discovery never runs again for the rest of the session — a splat route can match instead and its server loader runs, or a later child patch fails with `No route found to patch children into`. Only a hard reload clears it, since the cache is module state.

This bails out before either mutation when the signal has aborted, so an aborted discovery leaves no trace and the next navigation to that path discovers it normally. The eager prefetch path in `useFogOFWarDiscovery` passes no signal, so it is unaffected.

Closes #15327

#### Tests

`packages/react-router/__tests__/dom/ssr/fog-of-war-test.ts` now drives `getPatchRoutesOnNavigationFunction` with a mocked `fetch` (as `lazy-discovery-test.ts` does) and a `patch` that mirrors the router's abort no-op:

- a discovery aborted while the manifest is being read is re-attempted and patched on the next navigation to the same path — this failed before the change, because the second attempt never re-fetched
- a discovery that is not aborted still patches once and is not fetched again
