### PR TITLE
fix: remove server build output when ssr is disabled

### DIFF
--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -1140,6 +1140,9 @@ test.describe(`Prerendering`, () => {
         "favicon.ico",
         "index.html",
       ]);
+      expect(
+        fs.existsSync(path.join(fixture.projectDir, "build", "server")),
+      ).toBe(false);
 
       let res = await fixture.requestDocument("/");
       let html = await res.text();

--- a/packages/react-router-dev/.changes/patch.remove-ssr-false-server-build.md
+++ b/packages/react-router-dev/.changes/patch.remove-ssr-false-server-build.md
@@ -1,0 +1,5 @@
+---
+"@react-router/dev": patch
+---
+
+Remove the unused server build output when building with `ssr: false`.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2728,6 +2728,15 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
                 try {
                   await buildApp?.(builder);
 
+                  // `ssr:false` still needs the server build while prerendering
+                  // the SPA fallback, but it has no runtime server to ship.
+                  if (!ctx.reactRouterConfig.ssr) {
+                    await rm(getServerBuildDirectory(ctx.reactRouterConfig), {
+                      force: true,
+                      recursive: true,
+                    });
+                  }
+
                   invariant(viteConfig);
                   let { buildManifest, reactRouterConfig } = ctx;
                   invariant(buildManifest, "Expected build manifest");


### PR DESCRIPTION
Closes #15305

## What changed

- remove the temporary server build after prerendering completes when `ssr: false`
- keep the server bundle available while the SPA fallback is being generated
- add an integration assertion that the server output directory is absent

## Testing

- `pnpm --filter @react-router/dev build`
- `pnpm --filter @react-router/dev typecheck`
- `pnpm changes:validate`
- `pnpm exec eslint packages/react-router-dev/vite/plugin.ts integration/vite-prerender-test.ts`
- `pnpm exec playwright test --config integration/playwright.config.ts integration/vite-prerender-test.ts --project=chromium` (37 passed)