### PR TITLE
docs: clarify "Guaranteed to exist" comment in middleware auth example

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -450,6 +450,7 @@
 - theMosaad
 - theostavrides
 - thepedroferrari
+- TheSeydiCharyyev
 - thethmuu
 - thisiskartik
 - thomasgauvin

--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -503,7 +503,9 @@ export const middleware: Route.MiddlewareFunction[] = [
 export async function loader({
   context,
 }: Route.LoaderArgs) {
-  const user = context.get(userContext); // Guaranteed to exist
+  // Guaranteed at runtime by authMiddleware, but still typed `User | null`;
+  // create the context as `createContext<User>()` if you want a non-nullable `User`.
+  const user = context.get(userContext);
   return { user };
 }
 ```


### PR DESCRIPTION
The middleware Authentication example creates `userContext` with `createContext<User | null>(null)`, but annotates `context.get(userContext)` as `// Guaranteed to exist`. That holds at runtime (the middleware sets the user or throws a redirect), but the static type is still `User | null`, so the comment reads like a type-level guarantee and is confusing.

This clarifies the comment: it is a runtime guarantee, the type is still `User | null`, and `createContext<User>()` (already shown in the "Type-safe context" section) is the way to get a non-nullable `User`.

Docs-only change. Surfaced in #15360.