### PR TITLE
fix(router): drop the reload id when a fetcher action is aborted mid-revalidation

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -13,6 +13,7 @@
 - adil62
 - adriananin
 - adrienharnay
+- afairbrother
 - afzalsayed96
 - AhmadMayo
 - Ajayff4

--- a/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
+++ b/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
@@ -1,0 +1,4 @@
+Fix an `Expected fetcher: <key>` invariant thrown on navigation when a fetcher is aborted during its post-action revalidation
+
+- `handleFetcherAction` bailed out on an aborted signal one line above its own `fetchReloadIds.delete(key)`, so the entry outlived the fetcher. An aborted fetcher goes idle and is pruned from `state.fetchers`, and the next `abortStaleFetchLoads`/`markFetchersDone` caller then invariants on a fetcher that is no longer there
+- Reachable through ordinary usage — `fetcher.submit()` followed by `fetcher.load()` on the same key, or `fetcher.reset()` mid-revalidation. It surfaced as an unhandled rejection, so no error boundary caught it and the in-flight navigation died

--- a/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
+++ b/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
@@ -1,4 +1,1 @@
-Fix an `Expected fetcher: <key>` invariant thrown on navigation when a fetcher is aborted during its post-action revalidation
-
-- `handleFetcherAction` bailed out on an aborted signal one line above its own `fetchReloadIds.delete(key)`, so the entry outlived the fetcher. An aborted fetcher goes idle and is pruned from `state.fetchers`, and the next `abortStaleFetchLoads`/`markFetchersDone` caller then invariants on a fetcher that is no longer there
-- Reachable through ordinary usage — `fetcher.submit()` followed by `fetcher.load()` on the same key, or `fetcher.reset()` mid-revalidation. It surfaced as an unhandled rejection, so no error boundary caught it and the in-flight navigation died
+Fix `Expected fetcher: <key>` error thrown on navigation when a fetcher is aborted during its post-action revalidation

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -3706,24 +3706,40 @@ describe("fetchers", () => {
 
   describe("fetchReloadIds cleanup", () => {
     it("does not strand a reload id when a load supersedes a submission on the same key", async () => {
-      let t = initializeTest({
-        url: "/foo",
-        hydrationData: { loaderData: { root: "ROOT", foo: "FOO" } },
-      });
+      let t = initializeTest();
       let key = "key";
 
       let A = await t.fetch("/foo", key, {
         formMethod: "post",
         formData: createFormData({ key: "value" }),
       });
+      expect(t.fetchers[key].state).toBe("submitting");
+
       await A.actions.foo.resolve("ACTION");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
+      expect(t.fetchers[key]).toMatchObject({
+        formMethod: "POST",
+        formAction: "/foo",
+        state: "loading",
+        data: "ACTION",
+      });
 
       let B = await t.fetch("/foo", key);
+      expect(t.fetchers[key]).toMatchObject({
+        formMethod: undefined,
+        formAction: undefined,
+        state: "loading",
+        data: "ACTION",
+      });
 
       await A.loaders.root.resolve("ROOT*");
-      await A.loaders.foo.resolve("FOO*");
-      await B.loaders.foo.resolve("FOO-LOADED");
+      await A.loaders.index.resolve("INDEX*");
+      await B.loaders.foo.resolve("FOO");
+      expect(t.fetchers[key]).toMatchObject({
+        formMethod: undefined,
+        formAction: undefined,
+        state: "idle",
+        data: "FOO",
+      });
 
       // idle fetchers are pruned from state.fetchers
       expect(t.router.state.fetchers.has(key)).toBe(false);
@@ -3731,39 +3747,60 @@ describe("fetchers", () => {
       let C = await t.navigate("/bar");
       await C.loaders.root.resolve("ROOT**");
       await C.loaders.bar.resolve("BAR");
-
-      expect(t.router.state.navigation.state).toBe("idle");
-      expect(t.router.state.location.pathname).toBe("/bar");
+      expect(t.router.state).toMatchObject({
+        location: { pathname: "/bar" },
+        navigation: { state: "idle" },
+        loaderData: {
+          root: "ROOT**",
+          bar: "BAR",
+        },
+      });
     });
 
     it("does not strand a reload id when a fetcher is reset during post-action revalidation", async () => {
-      let t = initializeTest({
-        url: "/foo",
-        hydrationData: { loaderData: { root: "ROOT", foo: "FOO" } },
-      });
+      let t = initializeTest();
       let key = "key";
 
       let A = await t.fetch("/foo", key, {
         formMethod: "post",
         formData: createFormData({ key: "value" }),
       });
-      expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
+      expect(t.fetchers[key]).toMatchObject({
+        formMethod: "POST",
+        formAction: "/foo",
+        state: "submitting",
+        data: undefined,
+      });
 
       await A.actions.foo.resolve("ACTION");
-      expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
+      expect(t.fetchers[key]).toMatchObject({
+        formMethod: "POST",
+        formAction: "/foo",
+        state: "loading",
+        data: "ACTION",
+      });
 
       t.router.resetFetcher(key);
+      expect(t.fetchers[key]).toMatchObject({
+        state: "idle",
+        data: null,
+      });
       expect(t.router.state.fetchers.has(key)).toBe(false);
 
       await A.loaders.root.resolve("ROOT*");
-      await A.loaders.foo.resolve("FOO*");
+      await A.loaders.index.resolve("INDEX*");
 
       let B = await t.navigate("/bar");
       await B.loaders.root.resolve("ROOT**");
       await B.loaders.bar.resolve("BAR");
-
-      expect(t.router.state.navigation.state).toBe("idle");
-      expect(t.router.state.location.pathname).toBe("/bar");
+      expect(t.router.state).toMatchObject({
+        location: { pathname: "/bar" },
+        navigation: { state: "idle" },
+        loaderData: {
+          root: "ROOT**",
+          bar: "BAR",
+        },
+      });
     });
   });
 

--- a/packages/react-router/__tests__/router/fetchers-test.ts
+++ b/packages/react-router/__tests__/router/fetchers-test.ts
@@ -3704,6 +3704,69 @@ describe("fetchers", () => {
     });
   });
 
+  describe("fetchReloadIds cleanup", () => {
+    it("does not strand a reload id when a load supersedes a submission on the same key", async () => {
+      let t = initializeTest({
+        url: "/foo",
+        hydrationData: { loaderData: { root: "ROOT", foo: "FOO" } },
+      });
+      let key = "key";
+
+      let A = await t.fetch("/foo", key, {
+        formMethod: "post",
+        formData: createFormData({ key: "value" }),
+      });
+      await A.actions.foo.resolve("ACTION");
+      expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
+
+      let B = await t.fetch("/foo", key);
+
+      await A.loaders.root.resolve("ROOT*");
+      await A.loaders.foo.resolve("FOO*");
+      await B.loaders.foo.resolve("FOO-LOADED");
+
+      // idle fetchers are pruned from state.fetchers
+      expect(t.router.state.fetchers.has(key)).toBe(false);
+
+      let C = await t.navigate("/bar");
+      await C.loaders.root.resolve("ROOT**");
+      await C.loaders.bar.resolve("BAR");
+
+      expect(t.router.state.navigation.state).toBe("idle");
+      expect(t.router.state.location.pathname).toBe("/bar");
+    });
+
+    it("does not strand a reload id when a fetcher is reset during post-action revalidation", async () => {
+      let t = initializeTest({
+        url: "/foo",
+        hydrationData: { loaderData: { root: "ROOT", foo: "FOO" } },
+      });
+      let key = "key";
+
+      let A = await t.fetch("/foo", key, {
+        formMethod: "post",
+        formData: createFormData({ key: "value" }),
+      });
+      expect(t.router.state.fetchers.get(key)?.state).toBe("submitting");
+
+      await A.actions.foo.resolve("ACTION");
+      expect(t.router.state.fetchers.get(key)?.state).toBe("loading");
+
+      t.router.resetFetcher(key);
+      expect(t.router.state.fetchers.has(key)).toBe(false);
+
+      await A.loaders.root.resolve("ROOT*");
+      await A.loaders.foo.resolve("FOO*");
+
+      let B = await t.navigate("/bar");
+      await B.loaders.root.resolve("ROOT**");
+      await B.loaders.bar.resolve("BAR");
+
+      expect(t.router.state.navigation.state).toBe("idle");
+      expect(t.router.state.location.pathname).toBe("/bar");
+    });
+  });
+
   describe("fetcher Map mutation", () => {
     // The root cause of the bug: after updateState({ fetchers: new Map(...) })
     // hands a Map (MapA) to React, a subsequent direct mutation of

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2951,6 +2951,11 @@ export function createRouter(init: RouterInit): Router {
         scopedContext,
       );
 
+    // Drop this before the aborted bail-out below.  An aborted fetcher goes
+    // idle and is pruned from state.fetchers, and abortStaleFetchLoads
+    // invariants on a fetcher existing for every key still in fetchReloadIds
+    fetchReloadIds.delete(key);
+
     if (abortController.signal.aborted) {
       return;
     }
@@ -2960,7 +2965,6 @@ export function createRouter(init: RouterInit): Router {
       abortPendingFetchRevalidations,
     );
 
-    fetchReloadIds.delete(key);
     fetchControllers.delete(key);
     revalidatingFetchers.forEach((r) => fetchControllers.delete(r.key));
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -2951,12 +2951,13 @@ export function createRouter(init: RouterInit): Router {
         scopedContext,
       );
 
-    // Drop this before the aborted bail-out below.  An aborted fetcher goes
-    // idle and is pruned from state.fetchers, and abortStaleFetchLoads
-    // invariants on a fetcher existing for every key still in fetchReloadIds
-    fetchReloadIds.delete(key);
-
     if (abortController.signal.aborted) {
+      // Drop this before the aborted bail-out below.  An aborted fetcher goes
+      // idle and is pruned from state.fetchers, and abortStaleFetchLoads
+      // invariants on a fetcher existing for every key still in fetchReloadIds
+      if (fetchReloadIds.get(key) === loadId) {
+        fetchReloadIds.delete(key);
+      }
       return;
     }
 
@@ -2965,6 +2966,7 @@ export function createRouter(init: RouterInit): Router {
       abortPendingFetchRevalidations,
     );
 
+    fetchReloadIds.delete(key);
     fetchControllers.delete(key);
     revalidatingFetchers.forEach((r) => fetchControllers.delete(r.key));
 


### PR DESCRIPTION
`handleFetcherAction` returns early on an aborted signal one line above its own `fetchReloadIds.delete(key)`, so an abort landing between "action resolved" and "revalidation loaders settled" leaves the reload id behind:

```ts
if (abortController.signal.aborted) {
  return;
}

fetchReloadIds.delete(key);
fetchControllers.delete(key);
```

The aborted fetcher then goes idle, and `updateState` prunes idle mounted fetchers from `state.fetchers` with a bare `state.fetchers.delete(key)` that doesn't touch the aux maps. The next call into `abortStaleFetchLoads` — or `markFetchersDone` / `markFetchRedirectsDone` — iterates `fetchReloadIds`, finds the stale key, and throws `invariant(fetcher, "Expected fetcher: " + key)`.

It throws out of a promise chain, so no error boundary catches it. It surfaces as an unhandled rejection and the in-flight navigation dies.

## Reproduction

Ordinary usage, no `unstable_` APIs — either of:

- `fetcher.submit()` then `fetcher.load()` on the same key while the submission's revalidation is in flight
- `fetcher.reset()` during that same window

Those two are asymmetric, which is the useful detail. A _resubmit_ is safe: it re-enters `handleFetcherAction`, which overwrites the same key and cleans it up on its own completion. A `load()` goes through `handleFetcherLoader`, which never touches `fetchReloadIds` — so nothing collects the orphan the aborted action left behind. `fetchControllers` doesn't have this problem because `abortFetcher` deletes from it as part of aborting; `fetchReloadIds` has no equivalent self-cleaning path, and that asymmetry is the bug.

Found on 7.15.1, via a fetcher reset landing during a post-save navigation. The relevant code is byte-identical on 7.18.2 and 8.3.0.

## The fix

Hoist `fetchReloadIds.delete(key)` above the aborted bail-out. One line moved — it covers every path that can abort during post-action revalidation, rather than hardening each reader individually.

Two tests in `__tests__/router/fetchers-test.ts`, one per repro above. Both fail on `main` with `Expected fetcher: key` and pass with the change.

## One point for review

There's precedent for fixing this from the reader side instead — #12049 / #12050 / #12054 dropped the `invariant` in `abortStaleFetchLoads` for the sibling `Expected fetch controller` error. The equivalent here would be to skip keys with no fetcher and delete the entry on the miss.

I went with the writer side because the stale entry is the defect itself, and this stops it being created rather than tolerating it at three read sites. Happy to switch if you'd rather the two stayed consistent.
