### PR TITLE
Release v8.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v8.3.1](#v831)
   - [v8.3.0](#v830)
     - [RSC Entry Updates](#rsc-entry-updates)
   - [v8.2.0](#v820)
@@ -110,6 +111,29 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v7.0.0](#v700)
 
 </details>
+
+## v8.3.1
+
+Date: 2026-08-27
+
+### Patch Changes
+
+- `react-router` - Fix `Expected fetcher: <key>` error thrown on navigation when a fetcher is aborted during its post-action revalidation ([#15365](https://github.com/remix-run/react-router/pull/15365))
+- `react-router` - Fix lazy route discovery caching a path as discovered when the triggering navigation was aborted after the manifest response settled but before the route tree was patched, which permanently (for the session) shadowed the real route behind a catch-all or produced 404s on every subsequent visit ([#15399](https://github.com/remix-run/react-router/pull/15399))
+- `react-router` - Improve route matching performance for long paths ([#15417](https://github.com/remix-run/react-router/pull/15417))
+- `react-router` - Improve validation of action request origins ([#15419](https://github.com/remix-run/react-router/pull/15419))
+- `react-router` - Fix `<ScrollRestoration>` leaving `history.scrollRestoration` set to `"auto"` after a bfcache restore, which let the browser restore scroll on subsequent history traversals before the destination route had rendered ([#15397](https://github.com/remix-run/react-router/pull/15397))
+- `react-router` - Properly respect the `relative` option in `useSubmit`/`fetcher.submit` when resolivng the `action` path ([#15400](https://github.com/remix-run/react-router/pull/15400))
+- `react-router` - Add additional URL validation on client side navigations/redirects ([#15445](https://github.com/remix-run/react-router/pull/15445))
+- `@react-router/dev` - Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- `@react-router/dev` - Generate JavaScript entry files at package build time so `react-router reveal --no-typescript` does not require Prettier at runtime ([#15373](https://github.com/remix-run/react-router/pull/15373))
+  - Deprecate the `--no-typescript` flag ahead of its removal in React Router v9
+- `@react-router/node` - Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- `@react-router/node` - fix: Prevent client disconnects during streaming from crashing the Node process ([#15324](https://github.com/remix-run/react-router/pull/15324))
+- `@react-router/serve` - Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- `@react-router/serve` - Serve `/.well-known/*` files from the client build directory. Express 5's static middleware ignores every dot-segment path by default, so RFC 8615 well-known URIs — ACME challenges, Android's `assetlinks.json`, Apple's `apple-app-site-association` — fell through to the request handler and came back as app-rendered HTML instead of the static file. Other dotfiles remain hidden. ([#15340](https://github.com/remix-run/react-router/pull/15340))
+
+**Full Changelog**: [`v8.3.0...v8.3.1`](https://github.com/remix-run/react-router/compare/react-router@8.3.0...react-router@8.3.1)
 
 ## v8.3.0
 

--- a/packages/create-react-router/CHANGELOG.md
+++ b/packages/create-react-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `create-react-router`
 
+## v8.3.1
+
+### Patch Changes
+
+- _No changes_
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/create-react-router/package.json
+++ b/packages/create-react-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-react-router",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Create a new React Router app",
   "homepage": "https://reactrouter.com",
   "bugs": {

--- a/packages/react-router-architect/CHANGELOG.md
+++ b/packages/react-router-architect/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/architect`
 
+## v8.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-architect/package.json
+++ b/packages/react-router-architect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/architect",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Architect server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-cloudflare/CHANGELOG.md
+++ b/packages/react-router-cloudflare/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/cloudflare`
 
+## v8.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-cloudflare/package.json
+++ b/packages/react-router-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/cloudflare",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Cloudflare platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-dev/.changes/patch.bump-remixrunnodefetchserver-dependency.md
+++ b/packages/react-router-dev/.changes/patch.bump-remixrunnodefetchserver-dependency.md
@@ -1,1 +1,0 @@
-Bump `@remix-run/node-fetch-server` dependency

--- a/packages/react-router-dev/.changes/patch.prebuild-javascript-entries.md
+++ b/packages/react-router-dev/.changes/patch.prebuild-javascript-entries.md
@@ -1,3 +1,0 @@
-Generate JavaScript entry files at package build time so `react-router reveal --no-typescript` does not require Prettier at runtime
-
-- Deprecate the `--no-typescript` flag ahead of its removal in React Router v9

--- a/packages/react-router-dev/CHANGELOG.md
+++ b/packages/react-router-dev/CHANGELOG.md
@@ -1,5 +1,17 @@
 # `@react-router/dev`
 
+## v8.3.1
+
+### Patch Changes
+
+- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- Generate JavaScript entry files at package build time so `react-router reveal --no-typescript` does not require Prettier at runtime ([#15373](https://github.com/remix-run/react-router/pull/15373))
+  - Deprecate the `--no-typescript` flag ahead of its removal in React Router v9
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)
+  - [`@react-router/serve@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@8.3.1)
+
 ## v8.3.0
 
 ### Minor Changes

--- a/packages/react-router-dev/package.json
+++ b/packages/react-router-dev/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/dev",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Dev tools and CLI for React Router",
   "keywords": [
     "react",

--- a/packages/react-router-express/CHANGELOG.md
+++ b/packages/react-router-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `@react-router/express`
 
+## v8.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-express/package.json
+++ b/packages/react-router-express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/express",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Express server request handler for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-fs-routes/CHANGELOG.md
+++ b/packages/react-router-fs-routes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/fs-routes`
 
+## v8.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-fs-routes/package.json
+++ b/packages/react-router-fs-routes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/fs-routes",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "File system routing conventions for React Router, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-node/.changes/patch.bump-remixrunnodefetchserver-dependency.md
+++ b/packages/react-router-node/.changes/patch.bump-remixrunnodefetchserver-dependency.md
@@ -1,1 +1,0 @@
-Bump `@remix-run/node-fetch-server` dependency

--- a/packages/react-router-node/.changes/patch.streaming-client-disconnect.md
+++ b/packages/react-router-node/.changes/patch.streaming-client-disconnect.md
@@ -1,1 +1,0 @@
-fix: Prevent client disconnects during streaming from crashing the Node process

--- a/packages/react-router-node/CHANGELOG.md
+++ b/packages/react-router-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `@react-router/node`
 
+## v8.3.1
+
+### Patch Changes
+
+- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- fix: Prevent client disconnects during streaming from crashing the Node process ([#15324](https://github.com/remix-run/react-router/pull/15324))
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-node/package.json
+++ b/packages/react-router-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/node",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Node.js platform abstractions for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
+++ b/packages/react-router-remix-routes-option-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `@react-router/remix-config-routes-adapter`
 
+## v8.3.1
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`@react-router/dev@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-remix-routes-option-adapter/package.json
+++ b/packages/react-router-remix-routes-option-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/remix-routes-option-adapter",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Adapter for Remix's \"routes\" config option, for use within routes.ts",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router-serve/.changes/patch.bump-remixrunnodefetchserver-dependency.md
+++ b/packages/react-router-serve/.changes/patch.bump-remixrunnodefetchserver-dependency.md
@@ -1,1 +1,0 @@
-Bump `@remix-run/node-fetch-server` dependency

--- a/packages/react-router-serve/.changes/patch.serve-well-known.md
+++ b/packages/react-router-serve/.changes/patch.serve-well-known.md
@@ -1,1 +1,0 @@
-Serve `/.well-known/*` files from the client build directory. Express 5's static middleware ignores every dot-segment path by default, so RFC 8615 well-known URIs — ACME challenges, Android's `assetlinks.json`, Apple's `apple-app-site-association` — fell through to the request handler and came back as app-rendered HTML instead of the static file. Other dotfiles remain hidden.

--- a/packages/react-router-serve/CHANGELOG.md
+++ b/packages/react-router-serve/CHANGELOG.md
@@ -1,5 +1,16 @@
 # `@react-router/serve`
 
+## v8.3.1
+
+### Patch Changes
+
+- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
+- Serve `/.well-known/*` files from the client build directory. Express 5's static middleware ignores every dot-segment path by default, so RFC 8615 well-known URIs — ACME challenges, Android's `assetlinks.json`, Apple's `apple-app-site-association` — fell through to the request handler and came back as app-rendered HTML instead of the static file. Other dotfiles remain hidden. ([#15340](https://github.com/remix-run/react-router/pull/15340))
+- Updated dependencies:
+  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
+  - [`@react-router/express@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@8.3.1)
+  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router-serve/package.json
+++ b/packages/react-router-serve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-router/serve",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Production application server for React Router",
   "bugs": {
     "url": "https://github.com/remix-run/react-router/issues"

--- a/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
+++ b/packages/react-router/.changes/patch.fetch-reload-ids-aborted-revalidation.md
@@ -1,1 +1,0 @@
-Fix `Expected fetcher: <key>` error thrown on navigation when a fetcher is aborted during its post-action revalidation

--- a/packages/react-router/.changes/patch.fog-of-war-aborted-discovery.md
+++ b/packages/react-router/.changes/patch.fog-of-war-aborted-discovery.md
@@ -1,1 +1,0 @@
-Fix lazy route discovery caching a path as discovered when the triggering navigation was aborted after the manifest response settled but before the route tree was patched, which permanently (for the session) shadowed the real route behind a catch-all or produced 404s on every subsequent visit

--- a/packages/react-router/.changes/patch.linear-route-matching.md
+++ b/packages/react-router/.changes/patch.linear-route-matching.md
@@ -1,1 +1,0 @@
-Improve route matching performance for long paths

--- a/packages/react-router/.changes/patch.schemeful-action-origins.md
+++ b/packages/react-router/.changes/patch.schemeful-action-origins.md
@@ -1,1 +1,0 @@
-Improve validation of action request origins

--- a/packages/react-router/.changes/patch.scroll-restoration-bfcache.md
+++ b/packages/react-router/.changes/patch.scroll-restoration-bfcache.md
@@ -1,1 +1,0 @@
-Fix `<ScrollRestoration>` leaving `history.scrollRestoration` set to `"auto"` after a bfcache restore, which let the browser restore scroll on subsequent history traversals before the destination route had rendered

--- a/packages/react-router/.changes/patch.submit-relative-option.md
+++ b/packages/react-router/.changes/patch.submit-relative-option.md
@@ -1,1 +1,0 @@
-Properly respect the `relative` option in `useSubmit`/`fetcher.submit` when resolivng the `action` path

--- a/packages/react-router/.changes/patch.validate-client-navigation-targets.md
+++ b/packages/react-router/.changes/patch.validate-client-navigation-targets.md
@@ -1,1 +1,0 @@
-Add additional URL validation on client side navigations/redirects

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,17 @@
 # `react-router`
 
+## v8.3.1
+
+### Patch Changes
+
+- Fix `Expected fetcher: <key>` error thrown on navigation when a fetcher is aborted during its post-action revalidation ([#15365](https://github.com/remix-run/react-router/pull/15365))
+- Fix lazy route discovery caching a path as discovered when the triggering navigation was aborted after the manifest response settled but before the route tree was patched, which permanently (for the session) shadowed the real route behind a catch-all or produced 404s on every subsequent visit ([#15399](https://github.com/remix-run/react-router/pull/15399))
+- Improve route matching performance for long paths ([#15417](https://github.com/remix-run/react-router/pull/15417))
+- Improve validation of action request origins ([#15419](https://github.com/remix-run/react-router/pull/15419))
+- Fix `<ScrollRestoration>` leaving `history.scrollRestoration` set to `"auto"` after a bfcache restore, which let the browser restore scroll on subsequent history traversals before the destination route had rendered ([#15397](https://github.com/remix-run/react-router/pull/15397))
+- Properly respect the `relative` option in `useSubmit`/`fetcher.submit` when resolivng the `action` path ([#15400](https://github.com/remix-run/react-router/pull/15400))
+- Add additional URL validation on client side navigations/redirects ([#15445](https://github.com/remix-run/react-router/pull/15445))
+
 ## v8.3.0
 
 ### Patch Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-router",
   "type": "module",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/main/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `8.3.0` → `8.3.1` |
| @react-router/architect | `8.3.0` → `8.3.1` |
| @react-router/cloudflare | `8.3.0` → `8.3.1` |
| @react-router/dev | `8.3.0` → `8.3.1` |
| @react-router/express | `8.3.0` → `8.3.1` |
| @react-router/fs-routes | `8.3.0` → `8.3.1` |
| @react-router/node | `8.3.0` → `8.3.1` |
| @react-router/remix-routes-option-adapter | `8.3.0` → `8.3.1` |
| @react-router/serve | `8.3.0` → `8.3.1` |
| create-react-router | `8.3.0` → `8.3.1` |

# Changelogs

## react-router v8.3.1

### Patch Changes

- Fix `Expected fetcher: <key>` error thrown on navigation when a fetcher is aborted during its post-action revalidation ([#15365](https://github.com/remix-run/react-router/pull/15365))
- Fix lazy route discovery caching a path as discovered when the triggering navigation was aborted after the manifest response settled but before the route tree was patched, which permanently (for the session) shadowed the real route behind a catch-all or produced 404s on every subsequent visit ([#15399](https://github.com/remix-run/react-router/pull/15399))
- Improve route matching performance for long paths ([#15417](https://github.com/remix-run/react-router/pull/15417))
- Improve validation of action request origins ([#15419](https://github.com/remix-run/react-router/pull/15419))
- Fix `<ScrollRestoration>` leaving `history.scrollRestoration` set to `"auto"` after a bfcache restore, which let the browser restore scroll on subsequent history traversals before the destination route had rendered ([#15397](https://github.com/remix-run/react-router/pull/15397))
- Properly respect the `relative` option in `useSubmit`/`fetcher.submit` when resolivng the `action` path ([#15400](https://github.com/remix-run/react-router/pull/15400))
- Add additional URL validation on client side navigations/redirects ([#15445](https://github.com/remix-run/react-router/pull/15445))


## @react-router/architect v8.3.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)


## @react-router/cloudflare v8.3.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)


## @react-router/dev v8.3.1

### Patch Changes

- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
- Generate JavaScript entry files at package build time so `react-router reveal --no-typescript` does not require Prettier at runtime ([#15373](https://github.com/remix-run/react-router/pull/15373))
  - Deprecate the `--no-typescript` flag ahead of its removal in React Router v9
- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)
  - [`@react-router/serve@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/serve@8.3.1)


## @react-router/express v8.3.1

### Patch Changes

- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)


## @react-router/fs-routes v8.3.1

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.3.1)


## @react-router/node v8.3.1

### Patch Changes

- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
- fix: Prevent client disconnects during streaming from crashing the Node process ([#15324](https://github.com/remix-run/react-router/pull/15324))
- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)


## @react-router/remix-routes-option-adapter v8.3.1

### Patch Changes

- Updated dependencies:
  - [`@react-router/dev@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/dev@8.3.1)


## @react-router/serve v8.3.1

### Patch Changes

- Bump `@remix-run/node-fetch-server` dependency ([#15447](https://github.com/remix-run/react-router/pull/15447))
- Serve `/.well-known/*` files from the client build directory. Express 5's static middleware ignores every dot-segment path by default, so RFC 8615 well-known URIs — ACME challenges, Android's `assetlinks.json`, Apple's `apple-app-site-association` — fell through to the request handler and came back as app-rendered HTML instead of the static file. Other dotfiles remain hidden. ([#15340](https://github.com/remix-run/react-router/pull/15340))
- Updated dependencies:
  - [`react-router@8.3.1`](https://github.com/remix-run/react-router/releases/tag/react-router@8.3.1)
  - [`@react-router/express@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/express@8.3.1)
  - [`@react-router/node@8.3.1`](https://github.com/remix-run/react-router/releases/tag/@react-router/node@8.3.1)


## create-react-router v8.3.1

### Patch Changes

- _No changes_
