### PR TITLE
fix: warn when multiple React Router versions are loaded

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -477,6 +477,7 @@
 - TrySound
 - ttys026
 - Tumas2
+- Turtle-Hwan
 - turansky
 - tyankatsu0105
 - underager

--- a/packages/react-router/.changes/patch.warn-mismatched-versions.md
+++ b/packages/react-router/.changes/patch.warn-mismatched-versions.md
@@ -1,0 +1,1 @@
+Warn when multiple React Router versions are loaded in the browser

--- a/packages/react-router/__tests__/dom/version-mismatch-test.ts
+++ b/packages/react-router/__tests__/dom/version-mismatch-test.ts
@@ -1,0 +1,68 @@
+describe("React Router version mismatch diagnostics", () => {
+  let consoleWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    Reflect.deleteProperty(window, "__reactRouterVersion");
+    (
+      globalThis as typeof globalThis & { REACT_ROUTER_VERSION: string }
+    ).REACT_ROUTER_VERSION = "8.3.0";
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+    Reflect.deleteProperty(window, "__reactRouterVersion");
+    Reflect.deleteProperty(globalThis, "REACT_ROUTER_VERSION");
+  });
+
+  it("warns when another React Router version loaded first", async () => {
+    window.__reactRouterVersion = "7.13.1";
+
+    await jest.isolateModulesAsync(async () => {
+      await import("../../lib/dom/lib");
+    });
+
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "React Router detected multiple versions loaded (7.13.1 and 8.3.0). " +
+        "This can cause routing failures. Make sure all react-router and " +
+        "react-router-dom packages use the same version.",
+    );
+    expect(window.__reactRouterVersion).toBe("8.3.0");
+  });
+
+  it("warns when another React Router version loads later", async () => {
+    let versionModule!: typeof import("../../lib/dom/version");
+
+    await jest.isolateModulesAsync(async () => {
+      versionModule = await import("../../lib/dom/version");
+    });
+
+    versionModule.registerReactRouterVersion();
+    expect(consoleWarn).not.toHaveBeenCalled();
+
+    window.__reactRouterVersion = "7.13.1";
+    versionModule.warnIfReactRouterVersionMismatch();
+    versionModule.warnIfReactRouterVersionMismatch();
+
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "React Router detected multiple versions loaded (7.13.1 and 8.3.0). " +
+        "This can cause routing failures. Make sure all react-router and " +
+        "react-router-dom packages use the same version.",
+    );
+  });
+
+  it("does not warn when the detected version matches", async () => {
+    window.__reactRouterVersion = "8.3.0";
+
+    await jest.isolateModulesAsync(async () => {
+      let versionModule = await import("../../lib/dom/version");
+      versionModule.registerReactRouterVersion();
+      versionModule.warnIfReactRouterVersionMismatch();
+    });
+
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -96,15 +96,11 @@ import {
 import type { SerializeFrom } from "../types/route-data";
 import type { ClientInstrumentation } from "../router/instrumentation";
 import { escapeHtml } from "./ssr/markup";
+import { registerReactRouterVersion } from "./version";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Global Stuff
 ////////////////////////////////////////////////////////////////////////////////
-
-const isBrowser =
-  typeof window !== "undefined" &&
-  typeof window.document !== "undefined" &&
-  typeof window.document.createElement !== "undefined";
 
 // HEY YOU! DON'T TOUCH THIS VARIABLE!
 //
@@ -115,18 +111,7 @@ const isBrowser =
 // Core Web Vitals Technology Report.  This way they can configure the `wappalyzer`
 // to detect and properly classify live websites as being built with React Router:
 // https://github.com/HTTPArchive/wappalyzer/blob/main/src/technologies/r.json
-try {
-  if (isBrowser) {
-    window.__reactRouterVersion =
-      // @ts-expect-error
-      REACT_ROUTER_VERSION;
-  }
-} catch (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  e
-) {
-  // no-op
-}
+registerReactRouterVersion();
 //#endregion
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/react-router/lib/dom/version.ts
+++ b/packages/react-router/lib/dom/version.ts
@@ -1,0 +1,67 @@
+// Provided by the build system
+declare const __DEV__: boolean;
+declare const REACT_ROUTER_VERSION: string;
+
+const detectedVersions = new Set<string>();
+let didWarn = false;
+
+function isBrowser() {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.document !== "undefined" &&
+    typeof window.document.createElement !== "undefined"
+  );
+}
+
+function recordVersion(version: string | undefined) {
+  if (version) {
+    detectedVersions.add(version);
+  }
+}
+
+export function warnIfReactRouterVersionMismatch() {
+  if (!__DEV__ || !isBrowser()) {
+    return;
+  }
+
+  try {
+    recordVersion(window.__reactRouterVersion);
+    recordVersion(REACT_ROUTER_VERSION);
+
+    if (!didWarn && detectedVersions.size > 1) {
+      didWarn = true;
+      let versions = Array.from(detectedVersions).sort((a, b) =>
+        a.localeCompare(b, undefined, { numeric: true }),
+      );
+      console.warn(
+        `React Router detected multiple versions loaded (${versions.join(
+          " and ",
+        )}). ` +
+          `This can cause routing failures. Make sure all react-router and ` +
+          `react-router-dom packages use the same version.`,
+      );
+    }
+  } catch (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    e
+  ) {
+    // no-op
+  }
+}
+
+export function registerReactRouterVersion() {
+  if (!isBrowser()) {
+    return;
+  }
+
+  warnIfReactRouterVersionMismatch();
+
+  try {
+    window.__reactRouterVersion = REACT_ROUTER_VERSION;
+  } catch (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    e
+  ) {
+    // no-op
+  }
+}

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -63,6 +63,7 @@ import {
   decodeRedirectErrorDigest,
   decodeRouteErrorResponseDigest,
 } from "./errors";
+import { warnIfReactRouterVersionMismatch } from "./dom/version";
 
 /**
  * Resolves a URL against the current {@link Location}.
@@ -123,6 +124,7 @@ export function useHref(
  * @returns Whether the component is within a {@link Router} context
  */
 export function useInRouterContext(): boolean {
+  warnIfReactRouterVersionMismatch();
   return React.useContext(LocationContext) != null;
 }
 
@@ -535,6 +537,7 @@ export function useOutletContext<Context = unknown>(): Context {
  * @returns The child route element or `null` if no child routes match
  */
 export function useOutlet(context?: unknown): React.ReactElement | null {
+  warnIfReactRouterVersionMismatch();
   let outlet = React.useContext(RouteContext).outlet;
   return React.useMemo(
     () =>


### PR DESCRIPTION
Fixes #15356.

## Problem

Loading `react-router` and `react-router-dom` versions that resolve to different
`react-router` module instances creates separate React contexts. Hooks can
report a generic missing-router error, while `<Outlet>` can render nothing
without explaining the version mismatch.

## Changes

- Reuse the existing `window.__reactRouterVersion` marker to track versions
  seen in the browser
- Warn once in development when more than one version is detected
- Check from context-consuming hooks so both module load orders and the silent
  `<Outlet>` path are covered
- Preserve existing SSR and production behavior
- Add regression tests for earlier, later, and matching version registration

The patch intentionally does not attempt to bridge incompatible React contexts.
The warning tells users to align their `react-router` and `react-router-dom`
versions.

## Validation

- `pnpm build`
- `pnpm test packages/react-router/ --runInBand`
  - 110 test suites passed
  - 2,214 tests passed
  - 15 tests skipped
- `pnpm typecheck`
- `pnpm lint` — 0 errors; existing warnings only
- `pnpm changes:validate`
- Prettier check for changed files
- Browser reproduction in Declarative and Data modes for `useNavigate` and
  `<Outlet>`
