### PR TITLE
Use optional catch bindings

### DIFF
--- a/packages/create-react-router/copy-template.ts
+++ b/packages/create-react-router/copy-template.ts
@@ -78,10 +78,7 @@ function isLocalFilePath(input: string): boolean {
         path.isAbsolute(input) ? input : path.resolve(process.cwd(), input),
       )
     );
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     return false;
   }
 }
@@ -331,10 +328,7 @@ async function downloadAndExtractTarball(
         },
       }),
     );
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     throw new CopyTemplateError(
       "There was a problem extracting the file from the provided template." +
         `  Template URL: \`${tarballUrl}\`` +
@@ -401,10 +395,7 @@ function isValidGithubRepoUrl(
         ? pathSegments[2] === "tree" && pathSegments.length >= 4
         : true)
     );
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     return false;
   }
 }

--- a/packages/create-react-router/prompt.ts
+++ b/packages/create-react-router/prompt.ts
@@ -61,10 +61,7 @@ export async function prompt<
       answer = await prompts[type](Object.assign({ stdin, stdout }, question));
       answers[name] = answer as any;
       quit = await onSubmit(question, answer, answers);
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {
+    } catch {
       quit = !(await onCancel(question, answers));
     }
     if (quit) {

--- a/packages/create-react-router/prompts-prompt-base.ts
+++ b/packages/create-react-router/prompts-prompt-base.ts
@@ -42,10 +42,7 @@ export class Prompt extends EventEmitter {
       if (a === false) {
         try {
           this._(str, key);
-        } catch (
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          e
-        ) {}
+        } catch {}
         // @ts-expect-error
       } else if (typeof this[a] === "function") {
         // @ts-expect-error

--- a/packages/create-react-router/utils.ts
+++ b/packages/create-react-router/utils.ts
@@ -226,10 +226,7 @@ export function isUrl(value: string | URL) {
   try {
     new URL(value);
     return true;
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     return false;
   }
 }

--- a/packages/react-router-dev/vite/has-dependency.ts
+++ b/packages/react-router-dev/vite/has-dependency.ts
@@ -11,10 +11,7 @@ export function hasDependency({
 }) {
   try {
     return Boolean(nodeRequire.resolve(name, { paths: [rootDirectory] }));
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     return false;
   }
 }

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -272,10 +272,7 @@ class StreamPump {
         if (available <= 0) {
           this.pause();
         }
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {
+      } catch {
         this.controller.error(
           new Error(
             "Could not create Buffer, chunk must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object",

--- a/packages/react-router/__tests__/dom/nav-link-active-test.tsx
+++ b/packages/react-router/__tests__/dom/nav-link-active-test.tsx
@@ -1084,19 +1084,13 @@ function createDeferred() {
       res(val);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
     reject = async (error?: Error) => {
       rej(error);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
   });
   return {

--- a/packages/react-router/__tests__/router/utils/data-router-setup.ts
+++ b/packages/react-router/__tests__/router/utils/data-router-setup.ts
@@ -381,10 +381,7 @@ export function setup({
           await internalHelpers.dfd.resolve(redirectResponse);
         }
         await tick();
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
       return helpers;
     }
 
@@ -404,10 +401,7 @@ export function setup({
       async reject(value) {
         try {
           await internalHelpers.dfd.reject(value);
-        } catch (
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          e
-        ) {}
+        } catch {}
       },
       async redirect(href, status = 301, headers = {}, shims = []) {
         return _redirect(true, href, status, headers, shims);

--- a/packages/react-router/__tests__/router/utils/utils.ts
+++ b/packages/react-router/__tests__/router/utils/utils.ts
@@ -40,19 +40,13 @@ export function createDeferred<T = unknown>() {
       res(val);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
     reject = async (error?: Error) => {
       rej(error);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
   });
   return {

--- a/packages/react-router/lib/dom/dom.ts
+++ b/packages/react-router/lib/dom/dom.ts
@@ -146,10 +146,7 @@ function isFormDataSubmitterSupported() {
         0,
       );
       _formDataSupportsSubmitter = false;
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {
+    } catch {
       _formDataSupportsSubmitter = true;
     }
   }

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -121,10 +121,7 @@ try {
       // @ts-expect-error
       REACT_ROUTER_VERSION;
   }
-} catch (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  e
-) {
+} catch {
   // no-op
 }
 //#endregion
@@ -751,10 +748,7 @@ function deserializeErrors(
             // because we don't serialize SSR stack traces for security reasons
             error.stack = "";
             serialized[key] = error;
-          } catch (
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            e
-          ) {
+          } catch {
             // no-op - fall through and create a normal Error
           }
         }
@@ -3143,10 +3137,7 @@ export function useScrollRestoration({
         if (sessionPositions) {
           savedScrollPositions = JSON.parse(sessionPositions);
         }
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {
+      } catch {
         // no-op, use default empty object
       }
     }, [storageKey]);

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -718,10 +718,7 @@ export function Meta(): React.JSX.Element {
                 dangerouslySetInnerHTML={{ __html: escapeHtml(json) }}
               />
             );
-          } catch (
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            e
-          ) {
+          } catch {
             return null;
           }
         }

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -511,10 +511,7 @@ async function bubbleMiddlewareErrors(
         }
       });
     }
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     // No-op - this logic is only intended to process successful responses
     // If the `.data` failed, the routes will handle those errors themselves
   }
@@ -657,10 +654,7 @@ async function fetchAndDecodeViaTurboStream(
       }
     }
     return { status: res.status, data };
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     // Can't clone after consuming the body via turbo-stream so we can't
     // include the body here.  In an ideal world we'd look for a turbo-stream
     // content type here, or even X-Remix-Response but then folks can't
@@ -776,19 +770,13 @@ function createDeferred<T = unknown>() {
       res(val);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
     reject = async (error?: unknown) => {
       rej(error);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
   });
   return {

--- a/packages/react-router/lib/router/history.ts
+++ b/packages/react-router/lib/router/history.ts
@@ -538,10 +538,7 @@ export function warning(cond: any, message: string) {
       // find the source for a warning that appears in the console by
       // enabling "pause on exceptions" in your JavaScript debugger.
       throw new Error(message);
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {}
+    } catch {}
   }
 }
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -5266,10 +5266,7 @@ function normalizeNavigateOptions(
             text: undefined,
           },
         };
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {
+      } catch {
         return getInvalidBodyError();
       }
     }
@@ -5299,10 +5296,7 @@ function normalizeNavigateOptions(
     try {
       searchParams = new URLSearchParams(opts.body);
       formData = convertSearchParamsToFormData(searchParams);
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {
+    } catch {
       return getInvalidBodyError();
     }
   }
@@ -6617,10 +6611,7 @@ async function callDataStrategyImpl(
         m._lazyPromises?.route,
       ]),
     );
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     // No-op
   }
 
@@ -6939,10 +6930,7 @@ function normalizeRedirectLocation(
     if (hasInvalidProtocol(url.toString())) {
       throw new Error("Invalid redirect location");
     }
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {}
+  } catch {}
 
   return location;
 }
@@ -7663,10 +7651,7 @@ function restoreAppliedTransitions(
         }
       }
     }
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     // no-op, use default empty object
   }
 }
@@ -7702,19 +7687,13 @@ function createDeferred<T = unknown>() {
       res(val);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
     reject = async (error?: Error) => {
       rej(error);
       try {
         await promise;
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {}
+      } catch {}
     };
   });
   return {

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -2425,10 +2425,7 @@ export function parseToInfo<T extends To | string>(
       } else {
         isExternal = true;
       }
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {
+    } catch {
       // We can't do external URL detection without a valid URL
       warning(
         false,

--- a/packages/react-router/lib/rsc/html-stream/server.ts
+++ b/packages/react-router/lib/rsc/html-stream/server.ts
@@ -109,10 +109,7 @@ async function writeRSCStream(
           controller,
           nonce,
         );
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        e
-      ) {
+      } catch {
         let base64 = JSON.stringify(btoa(String.fromCodePoint(...chunk)));
         writeChunk(
           `Uint8Array.from(atob(${base64}), m => m.codePointAt(0))`,

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -451,10 +451,7 @@ export async function routeRSCServerRequest({
         statusText,
         headers,
       });
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      error2
-    ) {
+    } catch {
       // Throw the original error below
     }
 

--- a/packages/react-router/lib/server-runtime/cookies.ts
+++ b/packages/react-router/lib/server-runtime/cookies.ts
@@ -204,10 +204,7 @@ function encodeData(value: any): string {
 function decodeData(value: string): any {
   try {
     return JSON.parse(decodeURIComponent(myEscape(atob(value))));
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     return {};
   }
 }

--- a/packages/react-router/lib/server-runtime/crypto.ts
+++ b/packages/react-router/lib/server-runtime/crypto.ts
@@ -28,10 +28,7 @@ export const unsign = async (
     let valid = await crypto.subtle.verify("HMAC", key, signature, data);
 
     return valid ? value : false;
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    e
-  ) {
+  } catch {
     // atob will throw a DOMException with name === 'InvalidCharacterError'
     // if the signature contains a non-base64 character, which should just
     // be treated as an invalid signature.

--- a/packages/react-router/lib/server-runtime/dev.ts
+++ b/packages/react-router/lib/server-runtime/dev.ts
@@ -25,10 +25,7 @@ export function getBuildTimeHeader(request: Request, headerName: string) {
       ) {
         return request.headers.get(headerName);
       }
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {}
+    } catch {}
   }
   return null;
 }

--- a/packages/react-router/lib/server-runtime/server.ts
+++ b/packages/react-router/lib/server-runtime/server.ts
@@ -593,10 +593,7 @@ async function handleDocumentRequest(
             error.statusText,
             data,
           );
-        } catch (
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          e
-        ) {
+        } catch {
           // If we can't unwrap the response - just leave it as-is
         }
       }

--- a/packages/react-router/lib/server-runtime/single-fetch.ts
+++ b/packages/react-router/lib/server-runtime/single-fetch.ts
@@ -49,10 +49,7 @@ export async function singleFetchAction(
           ? build.allowedActionOrigins
           : [],
       );
-    } catch (
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      e
-    ) {
+    } catch {
       return handleQueryError(new Error("Bad Request"), 400);
     }
 

--- a/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
+++ b/packages/react-router/vendor/turbo-stream-v2/turbo-stream.ts
@@ -70,10 +70,7 @@ async function decodeInitial(
   let line: unknown;
   try {
     line = JSON.parse(read.value);
-  } catch (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    reason
-  ) {
+  } catch {
     throw new SyntaxError();
   }
 
@@ -103,10 +100,7 @@ async function decodeDeferred(
         let jsonLine: unknown;
         try {
           jsonLine = JSON.parse(lineData);
-        } catch (
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          reason
-        ) {
+        } catch {
           throw new SyntaxError();
         }
 
@@ -126,10 +120,7 @@ async function decodeDeferred(
         let jsonLine: unknown;
         try {
           jsonLine = JSON.parse(lineData);
-        } catch (
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          reason
-        ) {
+        } catch {
           throw new SyntaxError();
         }
         const value = unflatten.call(this, jsonLine);


### PR DESCRIPTION
Replace unused catch bindings with optional catch bindings throughout the codebase. This removes 42 `no-unused-vars` suppressions while preserving existing error-handling behavior.
