### PR TITLE
perf: avoid unnecessary data router re-renders

### DIFF
--- a/packages/react-router/.changes/patch.reduce-data-router-renders.md
+++ b/packages/react-router/.changes/patch.reduce-data-router-renders.md
@@ -1,4 +1,3 @@
-Avoid unnecessary route component re-renders when unrelated data router state changes
+Switch to more granular internal router contexts to avoid unnecessary route component re-renders when unrelated data router state changes
 
-- **Breaking:** `UNSAFE_DataRouterStateContext` no longer exposes `navigation`, `revalidation`, `loaderData`, `actionData`, `errors`, or `fetchers`; use `UNSAFE_DataRouterNavigationContext`, `UNSAFE_DataRouterDataContext`, and `UNSAFE_FetchersContext` respectively
-- **Breaking:** `UNSAFE_FetchersContext` now provides `{ fetchers, fetcherData }` and defaults to `null` instead of providing the fetcher data `Map` directly
+- ⚠️ This contains some breaking changes to exported `UNSAFE_` contexts, so please review carefully if you are using those unsafe exports

--- a/packages/react-router/.changes/patch.reduce-data-router-renders.md
+++ b/packages/react-router/.changes/patch.reduce-data-router-renders.md
@@ -1,1 +1,4 @@
 Avoid unnecessary route component re-renders when unrelated data router state changes
+
+- **Breaking:** `UNSAFE_DataRouterStateContext` no longer exposes `navigation`, `revalidation`, `loaderData`, `actionData`, `errors`, or `fetchers`; use `UNSAFE_DataRouterNavigationContext`, `UNSAFE_DataRouterDataContext`, and `UNSAFE_FetchersContext` respectively
+- **Breaking:** `UNSAFE_FetchersContext` now provides `{ fetchers, fetcherData }` and defaults to `null` instead of providing the fetcher data `Map` directly

--- a/packages/react-router/.changes/patch.reduce-data-router-renders.md
+++ b/packages/react-router/.changes/patch.reduce-data-router-renders.md
@@ -1,0 +1,1 @@
+Avoid unnecessary route component re-renders when unrelated data router state changes

--- a/packages/react-router/__tests__/data-memory-router-test.tsx
+++ b/packages/react-router/__tests__/data-memory-router-test.tsx
@@ -797,15 +797,7 @@ describe("createMemoryRouter", () => {
 
     spy.mockClear();
     fireEvent.click(screen.getByText("Link to Bar"));
-    expect(spy).toHaveBeenCalledWith("Layout", [
-      {
-        data: undefined,
-        handle: undefined,
-        id: "0",
-        params: {},
-        pathname: "/",
-      },
-    ]);
+    expect(spy).not.toHaveBeenCalled();
 
     spy.mockClear();
     await waitFor(() => screen.getByText("Bar"));

--- a/packages/react-router/__tests__/data-router-context-test.tsx
+++ b/packages/react-router/__tests__/data-router-context-test.tsx
@@ -135,6 +135,55 @@ describe("data router contexts", () => {
     router.dispose();
   });
 
+  it("does not re-render useFetcher consumers when the route ID remains unchanged", async () => {
+    let fetcherRenders = 0;
+    let locationRenders = 0;
+
+    function Fetcher() {
+      fetcherRenders++;
+      useFetcher();
+      return null;
+    }
+
+    function Location() {
+      locationRenders++;
+      useLocation();
+      return null;
+    }
+
+    function Root() {
+      return (
+        <>
+          <Fetcher />
+          <Location />
+        </>
+      );
+    }
+
+    let router = createMemoryRouter(
+      [{ id: "root", path: "/", Component: Root }],
+      { initialEntries: ["/?value=before"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(fetcherRenders).toBe(1);
+    expect(locationRenders).toBe(1);
+
+    await TestRenderer.act(async () => {
+      await router.navigate("/?value=after");
+    });
+
+    expect(fetcherRenders).toBe(1);
+    expect(locationRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
   it("re-renders when a loader runs and returns the same reference", async () => {
     let loaderData = { message: "loader data" };
     let loaderCalls = 0;

--- a/packages/react-router/__tests__/data-router-context-test.tsx
+++ b/packages/react-router/__tests__/data-router-context-test.tsx
@@ -3,16 +3,19 @@ import * as TestRenderer from "react-test-renderer";
 import {
   createMemoryRouter,
   Outlet,
+  Route,
   RouterProvider,
+  Routes,
   UNSAFE_DataRouterDataContext as DataRouterDataContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
   useFetcher,
   useLoaderData,
   useLocation,
   useMatches,
+  useNavigate,
   useNavigation,
 } from "react-router";
-import { RouteIdContext } from "../lib/context";
+import { IsDataRouteContext, RouteIdContext } from "../lib/context";
 import { createDeferred } from "./router/utils/utils";
 
 describe.each([
@@ -188,6 +191,97 @@ describe.each([
 
     expect(fetcherRenders).toBe(1);
     expect(locationRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("does not re-render useNavigate consumers when the route context changes", async () => {
+    let navigateRenders = 0;
+    let locationRenders = 0;
+
+    function Navigate() {
+      navigateRenders++;
+      useNavigate();
+      return null;
+    }
+
+    function Location() {
+      locationRenders++;
+      useLocation();
+      return null;
+    }
+
+    function Root() {
+      return (
+        <>
+          <Navigate />
+          <Location />
+        </>
+      );
+    }
+
+    let router = createMemoryRouter(
+      [{ id: "root", path: "/", Component: Root }],
+      { initialEntries: ["/?value=before"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
+    });
+
+    expect(navigateRenders).toBe(1);
+    expect(locationRenders).toBe(1);
+
+    await TestRenderer.act(async () => {
+      await router.navigate("/?value=after");
+    });
+
+    expect(navigateRenders).toBe(1);
+    expect(locationRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("preserves route-relative navigation in nested declarative routes", async () => {
+    let navigate!: ReturnType<typeof useNavigate>;
+
+    function Child() {
+      navigate = useNavigate();
+      return null;
+    }
+
+    function Root() {
+      return (
+        <Routes>
+          <Route path="parent" element={<Outlet />}>
+            <Route path="child" Component={Child} />
+          </Route>
+        </Routes>
+      );
+    }
+
+    let router = createMemoryRouter(
+      [{ id: "root", path: "app/*", Component: Root }],
+      { initialEntries: ["/app/parent/child"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
+    });
+
+    await TestRenderer.act(async () => {
+      await navigate("..");
+    });
+
+    expect(router.state.location.pathname).toBe("/app/parent");
 
     TestRenderer.act(() => renderer.unmount());
     router.dispose();
@@ -392,6 +486,7 @@ describe.each([
     }
 
     function ErrorBoundary() {
+      expect(React.useContext(IsDataRouteContext)).toBe(true);
       expect(React.useContext(RouteIdContext)).toBe("broken");
       return <p>Error boundary</p>;
     }

--- a/packages/react-router/__tests__/data-router-context-test.tsx
+++ b/packages/react-router/__tests__/data-router-context-test.tsx
@@ -15,7 +15,10 @@ import {
 import { RouteIdContext } from "../lib/context";
 import { createDeferred } from "./router/utils/utils";
 
-describe("data router contexts", () => {
+describe.each([
+  { label: "default transitions", useTransitions: undefined },
+  { label: "optimistic transitions", useTransitions: true },
+])("data router contexts ($label)", ({ useTransitions }) => {
   it("does not re-render when the route ID remains unchanged", async () => {
     let parentRenders = 0;
     let childRenders = 0;
@@ -47,7 +50,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(parentRenders).toBe(1);
@@ -116,7 +121,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(loaderCalls).toBe(1);
@@ -167,7 +174,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(fetcherRenders).toBe(1);
@@ -212,7 +221,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(loaderCalls).toBe(1);
@@ -279,7 +290,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     let navigationPromise: Promise<void>;
@@ -337,7 +350,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     await TestRenderer.act(async () => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(matchesRenders).toBe(1);
@@ -392,7 +407,9 @@ describe("data router contexts", () => {
 
     let renderer: TestRenderer.ReactTestRenderer;
     TestRenderer.act(() => {
-      renderer = TestRenderer.create(<RouterProvider router={router} />);
+      renderer = TestRenderer.create(
+        <RouterProvider router={router} useTransitions={useTransitions} />,
+      );
     });
 
     expect(renderer.toJSON()).toEqual({

--- a/packages/react-router/__tests__/data-router-context-test.tsx
+++ b/packages/react-router/__tests__/data-router-context-test.tsx
@@ -12,23 +12,23 @@ import {
   useMatches,
   useNavigation,
 } from "react-router";
-import { useRouteId } from "../lib/hooks";
+import { RouteIdContext } from "../lib/context";
 import { createDeferred } from "./router/utils/utils";
 
-describe("useRouteId", () => {
+describe("data router contexts", () => {
   it("does not re-render when the route ID remains unchanged", async () => {
     let parentRenders = 0;
     let childRenders = 0;
 
     function Parent() {
       parentRenders++;
-      expect(useRouteId()).toBe("parent");
+      expect(React.useContext(RouteIdContext)).toBe("parent");
       return <Outlet />;
     }
 
     function Child() {
       childRenders++;
-      expect(useRouteId()).toBe("child");
+      expect(React.useContext(RouteIdContext)).toBe("child");
       useLocation();
       return null;
     }
@@ -328,7 +328,7 @@ describe("useRouteId", () => {
     }
 
     function ErrorBoundary() {
-      expect(useRouteId()).toBe("broken");
+      expect(React.useContext(RouteIdContext)).toBe("broken");
       return <p>Error boundary</p>;
     }
 

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -16,9 +16,14 @@ import {
   FrameworkContext,
   usePrefetchBehavior,
 } from "../../../lib/dom/ssr/components";
-import { DataRouterStateContext } from "../../../lib/context";
+import {
+  DataRouterDataContext,
+  DataRouterNavigationContext,
+  DataRouterStateContext,
+} from "../../../lib/context";
 import invariant from "../../../lib/dom/ssr/invariant";
 import { ServerRouter } from "../../../lib/dom/ssr/server";
+import { IDLE_NAVIGATION } from "../../../lib/router/router";
 import "@testing-library/jest-dom";
 import { mockEntryContext, mockFrameworkContext } from "../../utils/framework";
 
@@ -26,6 +31,33 @@ const setIntentEvents = ["focus", "mouseEnter", "touchStart"] as const;
 type PrefetchEventHandlerProps = {
   [Property in `on${Capitalize<(typeof setIntentEvents)[number]>}`]?: Function;
 };
+
+function DataRouterContexts({
+  value,
+  children,
+}: React.PropsWithChildren<{ value: any }>) {
+  let {
+    loaderData = {},
+    actionData = null,
+    errors = null,
+    navigation = IDLE_NAVIGATION,
+    revalidation = "idle",
+    ...state
+  } = value;
+  return (
+    <DataRouterStateContext.Provider value={state}>
+      <DataRouterNavigationContext.Provider
+        value={{ navigation, revalidation }}
+      >
+        <DataRouterDataContext.Provider
+          value={{ loaderData, actionData, errors }}
+        >
+          {children}
+        </DataRouterDataContext.Provider>
+      </DataRouterNavigationContext.Provider>
+    </DataRouterStateContext.Provider>
+  );
+}
 
 function itPrefetchesPageLinks<
   Props extends { to: any; prefetch?: any } & PrefetchEventHandlerProps,
@@ -298,13 +330,11 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
-        value={{ matches: [], errors: null } as any}
-      >
+      <DataRouterContexts value={{ matches: [], errors: null } as any}>
         <FrameworkContext.Provider value={context}>
           <Links />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let style = container.querySelector("style");
@@ -318,13 +348,11 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
-        value={{ matches: [], errors: null } as any}
-      >
+      <DataRouterContexts value={{ matches: [], errors: null } as any}>
         <FrameworkContext.Provider value={context}>
           <Links nonce="explicit-nonce" />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let style = container.querySelector("style");
@@ -337,13 +365,11 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
-        value={{ matches: [], errors: null } as any}
-      >
+      <DataRouterContexts value={{ matches: [], errors: null } as any}>
         <FrameworkContext.Provider value={context}>
           <Links nonce="test-nonce" />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let style = container.querySelector("style");
@@ -358,13 +384,11 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
-        value={{ matches: [], errors: null } as any}
-      >
+      <DataRouterContexts value={{ matches: [], errors: null } as any}>
         <FrameworkContext.Provider value={context}>
           <Links nonce="test-nonce" />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let link = container.querySelector("link[rel='stylesheet']");
@@ -405,7 +429,7 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
+      <DataRouterContexts
         value={
           {
             matches: [
@@ -419,7 +443,7 @@ describe("<Links />", () => {
         <FrameworkContext.Provider value={context}>
           <Links nonce="test-nonce" />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let link = container.querySelector("link[href='/style.css']");
@@ -459,7 +483,7 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterStateContext.Provider
+      <DataRouterContexts
         value={
           {
             matches: [
@@ -473,7 +497,7 @@ describe("<Links />", () => {
         <FrameworkContext.Provider value={context}>
           <Links />
         </FrameworkContext.Provider>
-      </DataRouterStateContext.Provider>,
+      </DataRouterContexts>,
     );
 
     let link = container.querySelector("link[href='/style.css']");

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -32,33 +32,6 @@ type PrefetchEventHandlerProps = {
   [Property in `on${Capitalize<(typeof setIntentEvents)[number]>}`]?: Function;
 };
 
-function DataRouterContexts({
-  value,
-  children,
-}: React.PropsWithChildren<{ value: any }>) {
-  let {
-    loaderData = {},
-    actionData = null,
-    errors = null,
-    navigation = IDLE_NAVIGATION,
-    revalidation = "idle",
-    ...state
-  } = value;
-  return (
-    <DataRouterStateContext.Provider value={state}>
-      <DataRouterNavigationContext.Provider
-        value={{ navigation, revalidation }}
-      >
-        <DataRouterDataContext.Provider
-          value={{ loaderData, actionData, errors }}
-        >
-          {children}
-        </DataRouterDataContext.Provider>
-      </DataRouterNavigationContext.Provider>
-    </DataRouterStateContext.Provider>
-  );
-}
-
 function itPrefetchesPageLinks<
   Props extends { to: any; prefetch?: any } & PrefetchEventHandlerProps,
 >(Component: React.ComponentType<Props>) {
@@ -330,11 +303,19 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts value={{ matches: [], errors: null } as any}>
-        <FrameworkContext.Provider value={context}>
-          <Links />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+      <DataRouterStateContext.Provider value={{ matches: [] } as any}>
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let style = container.querySelector("style");
@@ -348,11 +329,19 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts value={{ matches: [], errors: null } as any}>
-        <FrameworkContext.Provider value={context}>
-          <Links nonce="explicit-nonce" />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+      <DataRouterStateContext.Provider value={{ matches: [] } as any}>
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links nonce="explicit-nonce" />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let style = container.querySelector("style");
@@ -365,11 +354,19 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts value={{ matches: [], errors: null } as any}>
-        <FrameworkContext.Provider value={context}>
-          <Links nonce="test-nonce" />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+      <DataRouterStateContext.Provider value={{ matches: [] } as any}>
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links nonce="test-nonce" />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let style = container.querySelector("style");
@@ -384,11 +381,19 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts value={{ matches: [], errors: null } as any}>
-        <FrameworkContext.Provider value={context}>
-          <Links nonce="test-nonce" />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+      <DataRouterStateContext.Provider value={{ matches: [] } as any}>
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links nonce="test-nonce" />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let link = container.querySelector("link[rel='stylesheet']");
@@ -429,7 +434,7 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts
+      <DataRouterStateContext.Provider
         value={
           {
             matches: [
@@ -440,10 +445,18 @@ describe("<Links />", () => {
           } as any
         }
       >
-        <FrameworkContext.Provider value={context}>
-          <Links nonce="test-nonce" />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links nonce="test-nonce" />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let link = container.querySelector("link[href='/style.css']");
@@ -483,7 +496,7 @@ describe("<Links />", () => {
     });
 
     let { container } = render(
-      <DataRouterContexts
+      <DataRouterStateContext.Provider
         value={
           {
             matches: [
@@ -494,10 +507,18 @@ describe("<Links />", () => {
           } as any
         }
       >
-        <FrameworkContext.Provider value={context}>
-          <Links />
-        </FrameworkContext.Provider>
-      </DataRouterContexts>,
+        <DataRouterNavigationContext.Provider
+          value={{ navigation: IDLE_NAVIGATION, revalidation: "idle" }}
+        >
+          <DataRouterDataContext.Provider
+            value={{ loaderData: {}, actionData: null, errors: null }}
+          >
+            <FrameworkContext.Provider value={context}>
+              <Links />
+            </FrameworkContext.Provider>
+          </DataRouterDataContext.Provider>
+        </DataRouterNavigationContext.Provider>
+      </DataRouterStateContext.Provider>,
     );
 
     let link = container.querySelector("link[href='/style.css']");

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -2046,7 +2046,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              count:1
+              count:0
             </p>
           </nav>,
           <h1>
@@ -2076,7 +2076,7 @@ describe("useNavigate", () => {
               About
             </button>
             <p>
-              count:1
+              count:0
             </p>
           </nav>,
           <h1>

--- a/packages/react-router/__tests__/useRouteId-test.tsx
+++ b/packages/react-router/__tests__/useRouteId-test.tsx
@@ -1,0 +1,98 @@
+import * as React from "react";
+import * as TestRenderer from "react-test-renderer";
+import {
+  createMemoryRouter,
+  Outlet,
+  RouterProvider,
+  useLocation,
+} from "react-router";
+import { useRouteId } from "../lib/hooks";
+
+describe("useRouteId", () => {
+  it("does not re-render when the route ID remains unchanged", async () => {
+    let parentRenders = 0;
+    let childRenders = 0;
+
+    function Parent() {
+      parentRenders++;
+      expect(useRouteId()).toBe("parent");
+      return <Outlet />;
+    }
+
+    function Child() {
+      childRenders++;
+      expect(useRouteId()).toBe("child");
+      useLocation();
+      return null;
+    }
+
+    let router = createMemoryRouter(
+      [
+        {
+          id: "parent",
+          path: "/",
+          Component: Parent,
+          children: [{ id: "child", index: true, Component: Child }],
+        },
+      ],
+      { initialEntries: ["/?value=before"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(parentRenders).toBe(1);
+    expect(childRenders).toBe(1);
+
+    await TestRenderer.act(async () => {
+      await router.navigate("/?value=after");
+    });
+
+    expect(parentRenders).toBe(1);
+    expect(childRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("provides the route ID to error boundaries", () => {
+    let consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    function Broken() {
+      throw new Error("broken");
+    }
+
+    function ErrorBoundary() {
+      expect(useRouteId()).toBe("broken");
+      return <p>Error boundary</p>;
+    }
+
+    let router = createMemoryRouter([
+      {
+        id: "broken",
+        path: "/",
+        Component: Broken,
+        ErrorBoundary,
+      },
+    ]);
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(renderer.toJSON()).toEqual({
+      type: "p",
+      props: {},
+      children: ["Error boundary"],
+    });
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/react-router/__tests__/useRouteId-test.tsx
+++ b/packages/react-router/__tests__/useRouteId-test.tsx
@@ -4,9 +4,14 @@ import {
   createMemoryRouter,
   Outlet,
   RouterProvider,
+  UNSAFE_DataRouterDataContext as DataRouterDataContext,
+  UNSAFE_DataRouterStateContext as DataRouterStateContext,
+  useLoaderData,
   useLocation,
+  useNavigation,
 } from "react-router";
 import { useRouteId } from "../lib/hooks";
+import { createDeferred } from "./router/utils/utils";
 
 describe("useRouteId", () => {
   it("does not re-render when the route ID remains unchanged", async () => {
@@ -52,6 +57,198 @@ describe("useRouteId", () => {
 
     expect(parentRenders).toBe(1);
     expect(childRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("does not re-render when loader data remains unchanged", async () => {
+    let parentRenders = 0;
+    let childRenders = 0;
+    let loaderCalls = 0;
+
+    function Parent() {
+      parentRenders++;
+      expect(useLoaderData()).toEqual({ message: "parent data" });
+      return (
+        <>
+          <ContextObserver />
+          <Outlet />
+        </>
+      );
+    }
+
+    function ContextObserver() {
+      let state = React.useContext(DataRouterStateContext);
+      let data = React.useContext(DataRouterDataContext);
+      expect(state).not.toHaveProperty("loaderData");
+      expect(state).not.toHaveProperty("actionData");
+      expect(state).not.toHaveProperty("errors");
+      expect(data?.loaderData.parent).toEqual({ message: "parent data" });
+      return null;
+    }
+
+    function Child() {
+      childRenders++;
+      useLocation();
+      return null;
+    }
+
+    let router = createMemoryRouter(
+      [
+        {
+          id: "parent",
+          path: "/",
+          loader() {
+            loaderCalls++;
+            return { message: "parent data" };
+          },
+          shouldRevalidate: () => false,
+          HydrateFallback: () => null,
+          Component: Parent,
+          children: [{ id: "child", index: true, Component: Child }],
+        },
+      ],
+      { initialEntries: ["/?value=before"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(parentRenders).toBe(1);
+    expect(childRenders).toBe(1);
+
+    await TestRenderer.act(async () => {
+      await router.navigate("/?value=after");
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(parentRenders).toBe(1);
+    expect(childRenders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("re-renders when a loader runs and returns the same reference", async () => {
+    let loaderData = { message: "loader data" };
+    let loaderCalls = 0;
+    let renders = 0;
+
+    function Component() {
+      renders++;
+      expect(useLoaderData()).toBe(loaderData);
+      return null;
+    }
+
+    let router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          loader() {
+            loaderCalls++;
+            return loaderData;
+          },
+          HydrateFallback: () => null,
+          Component,
+        },
+      ],
+      { initialEntries: ["/?value=before"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(loaderCalls).toBe(1);
+    expect(renders).toBe(1);
+
+    await TestRenderer.act(async () => {
+      await router.navigate("/?value=after");
+    });
+
+    expect(loaderCalls).toBe(2);
+    expect(renders).toBe(2);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("does not re-render useLocation consumers for pending navigation state", async () => {
+    let loaderDfd = createDeferred();
+    let renders: string[] = [];
+    let stateContextRenders = 0;
+    let navigationStates: string[] = [];
+
+    let StateContextObserver = React.memo(function StateContextObserver() {
+      let state = React.useContext(DataRouterStateContext);
+      expect(state).not.toHaveProperty("navigation");
+      expect(state).not.toHaveProperty("revalidation");
+      stateContextRenders++;
+      return null;
+    });
+
+    let NavigationObserver = React.memo(function NavigationObserver() {
+      navigationStates.push(useNavigation().state);
+      return null;
+    });
+
+    function Root() {
+      renders.push(useLocation().pathname);
+      return (
+        <>
+          <StateContextObserver />
+          <NavigationObserver />
+          <Outlet />
+        </>
+      );
+    }
+
+    let router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          Component: Root,
+          children: [
+            { index: true, Component: () => null },
+            {
+              path: "next",
+              loader: () => loaderDfd.promise,
+              Component: () => null,
+            },
+          ],
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    let navigationPromise: Promise<void>;
+    await TestRenderer.act(async () => {
+      navigationPromise = router.navigate("/next");
+    });
+
+    expect(router.state.navigation.state).toBe("loading");
+    expect(renders).toEqual(["/"]);
+    expect(stateContextRenders).toBe(1);
+    expect(navigationStates).toEqual(["idle", "loading"]);
+
+    await TestRenderer.act(async () => {
+      loaderDfd.resolve(null);
+      await navigationPromise;
+    });
+
+    expect(renders).toEqual(["/", "/next"]);
+    expect(stateContextRenders).toBe(2);
+    expect(navigationStates).toEqual(["idle", "loading", "idle"]);
 
     TestRenderer.act(() => renderer.unmount());
     router.dispose();

--- a/packages/react-router/__tests__/useRouteId-test.tsx
+++ b/packages/react-router/__tests__/useRouteId-test.tsx
@@ -6,8 +6,10 @@ import {
   RouterProvider,
   UNSAFE_DataRouterDataContext as DataRouterDataContext,
   UNSAFE_DataRouterStateContext as DataRouterStateContext,
+  useFetcher,
   useLoaderData,
   useLocation,
+  useMatches,
   useNavigation,
 } from "react-router";
 import { useRouteId } from "../lib/hooks";
@@ -249,6 +251,68 @@ describe("useRouteId", () => {
     expect(renders).toEqual(["/", "/next"]);
     expect(stateContextRenders).toBe(2);
     expect(navigationStates).toEqual(["idle", "loading", "idle"]);
+
+    TestRenderer.act(() => renderer.unmount());
+    router.dispose();
+  });
+
+  it("does not re-render useMatches consumers for fetcher state changes", async () => {
+    let loaderDfd = createDeferred();
+    let matchesRenders = 0;
+    let fetcherStates: string[] = [];
+    let fetcher!: ReturnType<typeof useFetcher>;
+
+    function Fetcher() {
+      fetcher = useFetcher();
+      fetcherStates.push(`${fetcher.state}:${fetcher.data}`);
+      return null;
+    }
+
+    function Matches() {
+      matchesRenders++;
+      useMatches();
+      return <Fetcher />;
+    }
+
+    let router = createMemoryRouter(
+      [
+        { path: "/", Component: Matches },
+        {
+          path: "/fetch",
+          loader: () => loaderDfd.promise,
+          Component: () => null,
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+
+    let renderer: TestRenderer.ReactTestRenderer;
+    await TestRenderer.act(async () => {
+      renderer = TestRenderer.create(<RouterProvider router={router} />);
+    });
+
+    expect(matchesRenders).toBe(1);
+    expect(fetcherStates).toEqual(["idle:undefined"]);
+
+    let fetchPromise: Promise<void>;
+    await TestRenderer.act(async () => {
+      fetchPromise = fetcher.load("/fetch");
+    });
+
+    expect(matchesRenders).toBe(1);
+    expect(fetcherStates).toEqual(["idle:undefined", "loading:undefined"]);
+
+    await TestRenderer.act(async () => {
+      loaderDfd.resolve("FETCHED");
+      await fetchPromise;
+    });
+
+    expect(matchesRenders).toBe(1);
+    expect(fetcherStates).toEqual([
+      "idle:undefined",
+      "loading:undefined",
+      "idle:FETCHED",
+    ]);
 
     TestRenderer.act(() => renderer.unmount());
     router.dispose();

--- a/packages/react-router/index.ts
+++ b/packages/react-router/index.ts
@@ -369,6 +369,8 @@ export {
 /** @internal */
 export {
   DataRouterContext as UNSAFE_DataRouterContext,
+  DataRouterDataContext as UNSAFE_DataRouterDataContext,
+  DataRouterNavigationContext as UNSAFE_DataRouterNavigationContext,
   DataRouterStateContext as UNSAFE_DataRouterStateContext,
   FetchersContext as UNSAFE_FetchersContext,
   LocationContext as UNSAFE_LocationContext,

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -48,6 +48,8 @@ import type { Navigator, ViewTransitionContextObject } from "./context";
 import {
   AwaitContext,
   DataRouterContext,
+  DataRouterDataContext,
+  DataRouterNavigationContext,
   DataRouterStateContext,
   FetchersContext,
   LocationContext,
@@ -647,6 +649,48 @@ export function RouterProvider({
     [router, navigator, basename, onError],
   );
 
+  let dataRouterState = React.useMemo(
+    () => ({
+      historyAction: state.historyAction,
+      location: state.location,
+      matches: state.matches,
+      initialized: state.initialized,
+      renderFallback: state.renderFallback,
+      restoreScrollPosition: state.restoreScrollPosition,
+      preventScrollReset: state.preventScrollReset,
+      fetchers: state.fetchers,
+      blockers: state.blockers,
+    }),
+    [
+      state.historyAction,
+      state.location,
+      state.matches,
+      state.initialized,
+      state.renderFallback,
+      state.restoreScrollPosition,
+      state.preventScrollReset,
+      state.fetchers,
+      state.blockers,
+    ],
+  );
+
+  let dataRouterNavigation = React.useMemo(
+    () => ({
+      navigation: state.navigation,
+      revalidation: state.revalidation,
+    }),
+    [state.navigation, state.revalidation],
+  );
+
+  let dataRouterData = React.useMemo(
+    () => ({
+      loaderData: state.loaderData,
+      actionData: state.actionData,
+      errors: state.errors,
+    }),
+    [state.loaderData, state.actionData, state.errors],
+  );
+
   // The fragment and {null} here are important!  We need them to keep React 18's
   // useId happy when we are server-rendering since we may have a <script> here
   // containing the hydrated server-side staticContext (from StaticRouterProvider).
@@ -656,27 +700,31 @@ export function RouterProvider({
   return (
     <>
       <DataRouterContext.Provider value={dataRouterContext}>
-        <DataRouterStateContext.Provider value={state}>
-          <FetchersContext.Provider value={fetcherData.current}>
-            <ViewTransitionContext.Provider value={vtContext}>
-              <Router
-                basename={basename}
-                location={state.location}
-                navigationType={state.historyAction}
-                navigator={navigator}
-                useTransitions={useTransitions}
-              >
-                <MemoizedDataRoutes
-                  routes={router.routes}
-                  manifest={router.manifest}
-                  future={router.future}
-                  state={state}
-                  isStatic={false}
-                  onError={onError}
-                />
-              </Router>
-            </ViewTransitionContext.Provider>
-          </FetchersContext.Provider>
+        <DataRouterStateContext.Provider value={dataRouterState}>
+          <DataRouterNavigationContext.Provider value={dataRouterNavigation}>
+            <DataRouterDataContext.Provider value={dataRouterData}>
+              <FetchersContext.Provider value={fetcherData.current}>
+                <ViewTransitionContext.Provider value={vtContext}>
+                  <Router
+                    basename={basename}
+                    location={state.location}
+                    navigationType={state.historyAction}
+                    navigator={navigator}
+                    useTransitions={useTransitions}
+                  >
+                    <MemoizedDataRoutes
+                      routes={router.routes}
+                      manifest={router.manifest}
+                      future={router.future}
+                      state={state}
+                      isStatic={false}
+                      onError={onError}
+                    />
+                  </Router>
+                </ViewTransitionContext.Provider>
+              </FetchersContext.Provider>
+            </DataRouterDataContext.Provider>
+          </DataRouterNavigationContext.Provider>
         </DataRouterStateContext.Provider>
       </DataRouterContext.Provider>
       {null}

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -658,7 +658,6 @@ export function RouterProvider({
       renderFallback: state.renderFallback,
       restoreScrollPosition: state.restoreScrollPosition,
       preventScrollReset: state.preventScrollReset,
-      fetchers: state.fetchers,
       blockers: state.blockers,
     }),
     [
@@ -669,7 +668,6 @@ export function RouterProvider({
       state.renderFallback,
       state.restoreScrollPosition,
       state.preventScrollReset,
-      state.fetchers,
       state.blockers,
     ],
   );
@@ -691,6 +689,14 @@ export function RouterProvider({
     [state.loaderData, state.actionData, state.errors],
   );
 
+  let fetchersContext = React.useMemo(
+    () => ({
+      fetchers: state.fetchers,
+      fetcherData: fetcherData.current,
+    }),
+    [state.fetchers],
+  );
+
   // The fragment and {null} here are important!  We need them to keep React 18's
   // useId happy when we are server-rendering since we may have a <script> here
   // containing the hydrated server-side staticContext (from StaticRouterProvider).
@@ -703,7 +709,7 @@ export function RouterProvider({
         <DataRouterStateContext.Provider value={dataRouterState}>
           <DataRouterNavigationContext.Provider value={dataRouterNavigation}>
             <DataRouterDataContext.Provider value={dataRouterData}>
-              <FetchersContext.Provider value={fetcherData.current}>
+              <FetchersContext.Provider value={fetchersContext}>
                 <ViewTransitionContext.Provider value={vtContext}>
                   <Router
                     basename={basename}

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -85,10 +85,8 @@ export type FetchersContextObject = {
   fetcherData: Map<string, any>;
 };
 
-export const FetchersContext = React.createContext<FetchersContextObject>({
-  fetchers: new Map(),
-  fetcherData: new Map(),
-});
+export const FetchersContext =
+  React.createContext<FetchersContextObject | null>(null);
 FetchersContext.displayName = "Fetchers";
 
 export const AwaitContext = React.createContext<TrackedPromise | null>(null);

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -171,6 +171,9 @@ export const RouteContext = React.createContext<RouteContextObject>({
 });
 RouteContext.displayName = "Route";
 
+export const IsDataRouteContext = React.createContext(false);
+IsDataRouteContext.displayName = "IsDataRoute";
+
 export const RouteIdContext = React.createContext<string | undefined>(
   undefined,
 );

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -39,7 +39,9 @@ export type DataRouterNavigationContextObject = Pick<
 
 export type DataRouterStateContextObject = Omit<
   Router["state"],
-  keyof DataRouterDataContextObject | keyof DataRouterNavigationContextObject
+  | keyof DataRouterDataContextObject
+  | keyof DataRouterNavigationContextObject
+  | "fetchers"
 >;
 
 export const DataRouterStateContext =
@@ -77,12 +79,16 @@ export const ViewTransitionContext =
   });
 ViewTransitionContext.displayName = "ViewTransition";
 
-// TODO: (v9) Change the useFetcher data from `any` to `unknown`
-export type FetchersContextObject = Map<string, any>;
+export type FetchersContextObject = {
+  fetchers: Router["state"]["fetchers"];
+  // TODO: (v9) Change the useFetcher data from `any` to `unknown`
+  fetcherData: Map<string, any>;
+};
 
-export const FetchersContext = React.createContext<FetchersContextObject>(
-  new Map(),
-);
+export const FetchersContext = React.createContext<FetchersContextObject>({
+  fetchers: new Map(),
+  fetcherData: new Map(),
+});
 FetchersContext.displayName = "Fetchers";
 
 export const AwaitContext = React.createContext<TrackedPromise | null>(null);

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -27,10 +27,32 @@ export const DataRouterContext =
   React.createContext<DataRouterContextObject | null>(null);
 DataRouterContext.displayName = "DataRouter";
 
-export const DataRouterStateContext = React.createContext<
-  Router["state"] | null
->(null);
+export type DataRouterDataContextObject = Pick<
+  Router["state"],
+  "loaderData" | "actionData" | "errors"
+>;
+
+export type DataRouterNavigationContextObject = Pick<
+  Router["state"],
+  "navigation" | "revalidation"
+>;
+
+export type DataRouterStateContextObject = Omit<
+  Router["state"],
+  keyof DataRouterDataContextObject | keyof DataRouterNavigationContextObject
+>;
+
+export const DataRouterStateContext =
+  React.createContext<DataRouterStateContextObject | null>(null);
 DataRouterStateContext.displayName = "DataRouterState";
+
+export const DataRouterDataContext =
+  React.createContext<DataRouterDataContextObject | null>(null);
+DataRouterDataContext.displayName = "DataRouterData";
+
+export const DataRouterNavigationContext =
+  React.createContext<DataRouterNavigationContextObject | null>(null);
+DataRouterNavigationContext.displayName = "DataRouterNavigation";
 
 export const RSCRouterContext = React.createContext<boolean>(false);
 

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -145,5 +145,10 @@ export const RouteContext = React.createContext<RouteContextObject>({
 });
 RouteContext.displayName = "Route";
 
+export const RouteIdContext = React.createContext<string | undefined>(
+  undefined,
+);
+RouteIdContext.displayName = "RouteId";
+
 export const RouteErrorContext = React.createContext<any>(null);
 RouteErrorContext.displayName = "RouteError";

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -77,6 +77,7 @@ import { Router, hydrationRouteProperties } from "../components";
 import type { NavigateOptions } from "../context";
 import {
   DataRouterContext,
+  DataRouterNavigationContext,
   DataRouterStateContext,
   FetchersContext,
   NavigationContext,
@@ -1639,10 +1640,10 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
   ) {
     let path = useResolvedPath(to, { relative: rest.relative });
     let location = useLocation();
-    let routerState = React.useContext(DataRouterStateContext);
+    let routerNavigation = React.useContext(DataRouterNavigationContext);
     let { navigator, basename } = React.useContext(NavigationContext);
     let isTransitioning =
-      routerState != null &&
+      routerNavigation != null &&
       // Conditional usage is OK here because the usage of a data router is static
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useViewTransitionState(path) &&
@@ -1652,10 +1653,9 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       ? navigator.encodeLocation(path).pathname
       : path.pathname;
     let locationPathname = location.pathname;
-    let nextLocationPathname =
-      routerState && routerState.navigation && routerState.navigation.location
-        ? routerState.navigation.location.pathname
-        : null;
+    let nextLocationPathname = routerNavigation?.navigation.location
+      ? routerNavigation.navigation.location.pathname
+      : null;
 
     if (!caseSensitive) {
       locationPathname = locationPathname.toLowerCase();

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -76,10 +76,7 @@ import {
 import { Router, hydrationRouteProperties } from "../components";
 import type { NavigateOptions } from "../context";
 import {
-  DataRouterContext,
   DataRouterNavigationContext,
-  DataRouterStateContext,
-  FetchersContext,
   NavigationContext,
   RouteContext,
   ViewTransitionContext,
@@ -87,6 +84,9 @@ import {
 import {
   useBlocker,
   useCurrentRouteId,
+  useDataRouterContext,
+  useDataRouterFetchers,
+  useDataRouterState,
   useHref,
   useLocation,
   useMatches,
@@ -2146,40 +2146,6 @@ ScrollRestoration.displayName = "ScrollRestoration";
 //#region Hooks
 ////////////////////////////////////////////////////////////////////////////////
 
-enum DataRouterHook {
-  UseScrollRestoration = "useScrollRestoration",
-  UseSubmit = "useSubmit",
-  UseSubmitFetcher = "useSubmitFetcher",
-  UseFetcher = "useFetcher",
-  useViewTransitionState = "useViewTransitionState",
-}
-
-enum DataRouterStateHook {
-  UseFetcher = "useFetcher",
-  UseFetchers = "useFetchers",
-  UseScrollRestoration = "useScrollRestoration",
-}
-
-// Internal hooks
-
-function getDataRouterConsoleError(
-  hookName: DataRouterHook | DataRouterStateHook,
-) {
-  return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
-}
-
-function useDataRouterContext(hookName: DataRouterHook) {
-  let ctx = React.useContext(DataRouterContext);
-  invariant(ctx, getDataRouterConsoleError(hookName));
-  return ctx;
-}
-
-function useDataRouterState(hookName: DataRouterStateHook) {
-  let state = React.useContext(DataRouterStateContext);
-  invariant(state, getDataRouterConsoleError(hookName));
-  return state;
-}
-
 // External hooks
 
 /**
@@ -2590,9 +2556,9 @@ let getUniqueFetcherId = () => `__${String(++fetcherId)}__`;
  * @returns A function that can be called to submit a {@link Form} imperatively.
  */
 export function useSubmit(): SubmitFunction {
-  let { router } = useDataRouterContext(DataRouterHook.UseSubmit);
+  let { router } = useDataRouterContext("useSubmit");
   let { basename } = React.useContext(NavigationContext);
-  let currentRouteId = useCurrentRouteId(DataRouterHook.UseSubmit);
+  let currentRouteId = useCurrentRouteId("useSubmit");
 
   let routerFetch = router.fetch;
   let routerNavigate = router.navigate;
@@ -2916,14 +2882,9 @@ export function useFetcher<T = any>({
 }: {
   key?: string;
 } = {}): FetcherWithComponents<SerializeFrom<T>> {
-  let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
-  let fetchersContext = React.useContext(FetchersContext);
-  let routeId = useCurrentRouteId(DataRouterHook.UseFetcher);
-
-  invariant(
-    fetchersContext,
-    `useFetcher must be used inside a FetchersContext`,
-  );
+  let { router } = useDataRouterContext("useFetcher");
+  let fetchersContext = useDataRouterFetchers("useFetcher");
+  let routeId = useCurrentRouteId("useFetcher");
 
   // Fetcher key handling
   let defaultKey = React.useId();
@@ -3019,7 +2980,7 @@ export function useFetcher<T = any>({
  * property.
  */
 export function useFetchers(): (Fetcher & { key: string })[] {
-  let { fetchers } = React.useContext(FetchersContext);
+  let { fetchers } = useDataRouterFetchers("useFetchers");
   return React.useMemo(
     () =>
       Array.from(fetchers.entries()).map(([key, fetcher]) => ({
@@ -3089,9 +3050,9 @@ export function useScrollRestoration({
   getKey?: GetScrollRestorationKeyFunction;
   storageKey?: string;
 } = {}): void {
-  let { router } = useDataRouterContext(DataRouterHook.UseScrollRestoration);
+  let { router } = useDataRouterContext("useScrollRestoration");
   let { restoreScrollPosition, preventScrollReset } = useDataRouterState(
-    DataRouterStateHook.UseScrollRestoration,
+    "useScrollRestoration",
   );
   let { basename } = React.useContext(NavigationContext);
   let location = useLocation();
@@ -3365,9 +3326,7 @@ export function useViewTransitionState(
       "Did you accidentally import `RouterProvider` from `react-router`?",
   );
 
-  let { basename } = useDataRouterContext(
-    DataRouterHook.useViewTransitionState,
-  );
+  let { basename } = useDataRouterContext("useViewTransitionState");
   let path = useResolvedPath(to, { relative });
   if (!vtContext.isTransitioning) {
     return false;

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2917,12 +2917,14 @@ export function useFetcher<T = any>({
   key?: string;
 } = {}): FetcherWithComponents<SerializeFrom<T>> {
   let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
-  let state = useDataRouterState(DataRouterStateHook.UseFetcher);
-  let fetcherData = React.useContext(FetchersContext);
+  let fetchersContext = React.useContext(FetchersContext);
   let route = React.useContext(RouteContext);
   let routeId = route.matches[route.matches.length - 1]?.route.id;
 
-  invariant(fetcherData, `useFetcher must be used inside a FetchersContext`);
+  invariant(
+    fetchersContext,
+    `useFetcher must be used inside a FetchersContext`,
+  );
   invariant(route, `useFetcher must be used inside a RouteContext`);
   invariant(
     routeId != null,
@@ -2983,8 +2985,8 @@ export function useFetcher<T = any>({
   }, [fetcherKey]);
 
   // Exposed FetcherWithComponents
-  let fetcher = state.fetchers.get(fetcherKey) || IDLE_FETCHER;
-  let data = fetcherData.get(fetcherKey);
+  let fetcher = fetchersContext.fetchers.get(fetcherKey) || IDLE_FETCHER;
+  let data = fetchersContext.fetcherData.get(fetcherKey);
   let fetcherWithComponents = React.useMemo(
     () => ({
       Form: FetcherForm,
@@ -3023,14 +3025,14 @@ export function useFetcher<T = any>({
  * property.
  */
 export function useFetchers(): (Fetcher & { key: string })[] {
-  let state = useDataRouterState(DataRouterStateHook.UseFetchers);
+  let { fetchers } = React.useContext(FetchersContext);
   return React.useMemo(
     () =>
-      Array.from(state.fetchers.entries()).map(([key, fetcher]) => ({
+      Array.from(fetchers.entries()).map(([key, fetcher]) => ({
         ...fetcher,
         key,
       })),
-    [state.fetchers],
+    [fetchers],
   );
 }
 

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -86,13 +86,13 @@ import {
 } from "../context";
 import {
   useBlocker,
+  useCurrentRouteId,
   useHref,
   useLocation,
   useMatches,
   useNavigate,
   useNavigation,
   useResolvedPath,
-  useRouteId,
 } from "../hooks";
 import type { SerializeFrom } from "../types/route-data";
 import type { ClientInstrumentation } from "../router/instrumentation";
@@ -2592,7 +2592,7 @@ let getUniqueFetcherId = () => `__${String(++fetcherId)}__`;
 export function useSubmit(): SubmitFunction {
   let { router } = useDataRouterContext(DataRouterHook.UseSubmit);
   let { basename } = React.useContext(NavigationContext);
-  let currentRouteId = useRouteId();
+  let currentRouteId = useCurrentRouteId(DataRouterHook.UseSubmit);
 
   let routerFetch = router.fetch;
   let routerNavigate = router.navigate;

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2918,17 +2918,11 @@ export function useFetcher<T = any>({
 } = {}): FetcherWithComponents<SerializeFrom<T>> {
   let { router } = useDataRouterContext(DataRouterHook.UseFetcher);
   let fetchersContext = React.useContext(FetchersContext);
-  let route = React.useContext(RouteContext);
-  let routeId = route.matches[route.matches.length - 1]?.route.id;
+  let routeId = useCurrentRouteId(DataRouterHook.UseFetcher);
 
   invariant(
     fetchersContext,
     `useFetcher must be used inside a FetchersContext`,
-  );
-  invariant(route, `useFetcher must be used inside a RouteContext`);
-  invariant(
-    routeId != null,
-    `useFetcher can only be used on routes that contain a unique "id"`,
   );
 
   // Fetcher key handling

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -28,6 +28,8 @@ import { ABSOLUTE_URL_REGEX } from "../router/url";
 import { DataRoutes, Router } from "../components";
 import {
   DataRouterContext,
+  DataRouterDataContext,
+  DataRouterNavigationContext,
   DataRouterStateContext,
   FetchersContext,
   ViewTransitionContext,
@@ -191,31 +193,57 @@ export function StaticRouterProvider({
   }
 
   let { state } = dataRouterContext.router;
+  let dataRouterState = {
+    historyAction: state.historyAction,
+    location: state.location,
+    matches: state.matches,
+    initialized: state.initialized,
+    renderFallback: state.renderFallback,
+    restoreScrollPosition: state.restoreScrollPosition,
+    preventScrollReset: state.preventScrollReset,
+    fetchers: state.fetchers,
+    blockers: state.blockers,
+  };
+  let dataRouterNavigation = {
+    navigation: state.navigation,
+    revalidation: state.revalidation,
+  };
+  let dataRouterData = {
+    loaderData: state.loaderData,
+    actionData: state.actionData,
+    errors: state.errors,
+  };
 
   return (
     <>
       <DataRouterContext.Provider value={dataRouterContext}>
-        <DataRouterStateContext.Provider value={state}>
-          <FetchersContext.Provider value={fetchersContext}>
-            <ViewTransitionContext.Provider value={{ isTransitioning: false }}>
-              <Router
-                basename={dataRouterContext.basename}
-                location={state.location}
-                navigationType={state.historyAction}
-                navigator={dataRouterContext.navigator}
-                static={dataRouterContext.static}
-                useTransitions={false}
-              >
-                <DataRoutes
-                  manifest={router.manifest}
-                  routes={router.routes}
-                  future={router.future}
-                  state={state}
-                  isStatic={true}
-                />
-              </Router>
-            </ViewTransitionContext.Provider>
-          </FetchersContext.Provider>
+        <DataRouterStateContext.Provider value={dataRouterState}>
+          <DataRouterNavigationContext.Provider value={dataRouterNavigation}>
+            <DataRouterDataContext.Provider value={dataRouterData}>
+              <FetchersContext.Provider value={fetchersContext}>
+                <ViewTransitionContext.Provider
+                  value={{ isTransitioning: false }}
+                >
+                  <Router
+                    basename={dataRouterContext.basename}
+                    location={state.location}
+                    navigationType={state.historyAction}
+                    navigator={dataRouterContext.navigator}
+                    static={dataRouterContext.static}
+                    useTransitions={false}
+                  >
+                    <DataRoutes
+                      manifest={router.manifest}
+                      routes={router.routes}
+                      future={router.future}
+                      state={state}
+                      isStatic={true}
+                    />
+                  </Router>
+                </ViewTransitionContext.Provider>
+              </FetchersContext.Provider>
+            </DataRouterDataContext.Provider>
+          </DataRouterNavigationContext.Provider>
         </DataRouterStateContext.Provider>
       </DataRouterContext.Provider>
       {hydrateScript ? (

--- a/packages/react-router/lib/dom/server.tsx
+++ b/packages/react-router/lib/dom/server.tsx
@@ -174,8 +174,6 @@ export function StaticRouterProvider({
     basename: context.basename || "/",
   };
 
-  let fetchersContext = new Map();
-
   let hydrateScript = "";
 
   if (hydrate !== false) {
@@ -201,7 +199,6 @@ export function StaticRouterProvider({
     renderFallback: state.renderFallback,
     restoreScrollPosition: state.restoreScrollPosition,
     preventScrollReset: state.preventScrollReset,
-    fetchers: state.fetchers,
     blockers: state.blockers,
   };
   let dataRouterNavigation = {
@@ -212,6 +209,10 @@ export function StaticRouterProvider({
     loaderData: state.loaderData,
     actionData: state.actionData,
     errors: state.errors,
+  };
+  let fetchersContext = {
+    fetchers: state.fetchers,
+    fetcherData: new Map(),
   };
 
   return (

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -27,43 +27,16 @@ import type {
   MetaMatches,
 } from "./routeModules";
 import { singleFetchUrl } from "./single-fetch";
-import {
-  DataRouterContext,
-  DataRouterDataContext,
-  DataRouterStateContext,
-  useIsRSCRouterContext,
-} from "../../context";
+import { useIsRSCRouterContext } from "../../context";
 import { warnOnce } from "../../server-runtime/warnings";
-import { useLocation } from "../../hooks";
+import {
+  useDataRouterContext,
+  useDataRouterData,
+  useDataRouterState,
+  useLocation,
+} from "../../hooks";
 import { getPartialManifest, isFogOfWarEnabled } from "./fog-of-war";
 import type { PageLinkDescriptor } from "../../router/links";
-
-function useDataRouterContext() {
-  let context = React.useContext(DataRouterContext);
-  invariant(
-    context,
-    "You must render this element inside a <DataRouterContext.Provider> element",
-  );
-  return context;
-}
-
-function useDataRouterStateContext() {
-  let context = React.useContext(DataRouterStateContext);
-  invariant(
-    context,
-    "You must render this element inside a <DataRouterStateContext.Provider> element",
-  );
-  return context;
-}
-
-function useDataRouterDataContext() {
-  let context = React.useContext(DataRouterDataContext);
-  invariant(
-    context,
-    "You must render this element inside a <DataRouterDataContext.Provider> element",
-  );
-  return context;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // FrameworkContext
@@ -283,8 +256,8 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
     criticalCss,
     nonce: contextNonce,
   } = useFrameworkContext();
-  let { matches: routerMatches } = useDataRouterStateContext();
-  let { errors } = useDataRouterDataContext();
+  let { matches: routerMatches } = useDataRouterState("Links");
+  let { errors } = useDataRouterData("Links");
 
   let matches = getActiveMatches(routerMatches, errors, isSpaMode);
 
@@ -366,7 +339,7 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
 export function PrefetchPageLinks({ page, ...linkProps }: PageLinkDescriptor) {
   let rsc = useIsRSCRouterContext();
   let { nonce: contextNonce } = useFrameworkContext();
-  let { router } = useDataRouterContext();
+  let { router } = useDataRouterContext("PrefetchPageLinks");
   let matches = React.useMemo(
     () => matchRoutes(router.routes, page, router.basename),
     [router.routes, page, router.basename],
@@ -467,8 +440,8 @@ function PrefetchPageLinksImpl({
 }) {
   let location = useLocation();
   let { manifest, routeModules } = useFrameworkContext();
-  let { matches } = useDataRouterStateContext();
-  let { loaderData } = useDataRouterDataContext();
+  let { matches } = useDataRouterState("PrefetchPageLinks");
+  let { loaderData } = useDataRouterData("PrefetchPageLinks");
 
   let newMatchesForData = React.useMemo(
     () =>
@@ -613,8 +586,8 @@ function PrefetchPageLinksImpl({
  */
 export function Meta(): React.JSX.Element {
   let { isSpaMode, routeModules } = useFrameworkContext();
-  let { matches: routerMatches } = useDataRouterStateContext();
-  let { errors, loaderData } = useDataRouterDataContext();
+  let { matches: routerMatches } = useDataRouterState("Meta");
+  let { errors, loaderData } = useDataRouterData("Meta");
   let location = useLocation();
 
   let _matches = getActiveMatches(routerMatches, errors, isSpaMode);
@@ -835,8 +808,12 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
     ssr,
     nonce: contextNonce,
   } = useFrameworkContext();
-  let { router, static: isStatic, staticContext } = useDataRouterContext();
-  let { matches: routerMatches } = useDataRouterStateContext();
+  let {
+    router,
+    static: isStatic,
+    staticContext,
+  } = useDataRouterContext("Scripts");
+  let { matches: routerMatches } = useDataRouterState("Scripts");
   let isRSCRouterContext = useIsRSCRouterContext();
   let enableFogOfWar = isFogOfWarEnabled(routeDiscovery, ssr);
 

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -29,6 +29,7 @@ import type {
 import { singleFetchUrl } from "./single-fetch";
 import {
   DataRouterContext,
+  DataRouterDataContext,
   DataRouterStateContext,
   useIsRSCRouterContext,
 } from "../../context";
@@ -51,6 +52,15 @@ function useDataRouterStateContext() {
   invariant(
     context,
     "You must render this element inside a <DataRouterStateContext.Provider> element",
+  );
+  return context;
+}
+
+function useDataRouterDataContext() {
+  let context = React.useContext(DataRouterDataContext);
+  invariant(
+    context,
+    "You must render this element inside a <DataRouterDataContext.Provider> element",
   );
   return context;
 }
@@ -273,7 +283,8 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
     criticalCss,
     nonce: contextNonce,
   } = useFrameworkContext();
-  let { errors, matches: routerMatches } = useDataRouterStateContext();
+  let { matches: routerMatches } = useDataRouterStateContext();
+  let { errors } = useDataRouterDataContext();
 
   let matches = getActiveMatches(routerMatches, errors, isSpaMode);
 
@@ -456,7 +467,8 @@ function PrefetchPageLinksImpl({
 }) {
   let location = useLocation();
   let { manifest, routeModules } = useFrameworkContext();
-  let { loaderData, matches } = useDataRouterStateContext();
+  let { matches } = useDataRouterStateContext();
+  let { loaderData } = useDataRouterDataContext();
 
   let newMatchesForData = React.useMemo(
     () =>
@@ -601,11 +613,8 @@ function PrefetchPageLinksImpl({
  */
 export function Meta(): React.JSX.Element {
   let { isSpaMode, routeModules } = useFrameworkContext();
-  let {
-    errors,
-    matches: routerMatches,
-    loaderData,
-  } = useDataRouterStateContext();
+  let { matches: routerMatches } = useDataRouterStateContext();
+  let { errors, loaderData } = useDataRouterDataContext();
   let location = useLocation();
 
   let _matches = getActiveMatches(routerMatches, errors, isSpaMode);

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -6,6 +6,7 @@ import {
   DataRouterDataContext,
   DataRouterNavigationContext,
   DataRouterStateContext,
+  FetchersContext,
   LocationContext,
   NavigationContext,
   RSCRouterContext,
@@ -1388,51 +1389,35 @@ export function _renderMatches(
   );
 }
 
-enum DataRouterHook {
-  UseBlocker = "useBlocker",
-  UseRevalidator = "useRevalidator",
-  UseNavigateStable = "useNavigate",
-}
-
-enum DataRouterStateHook {
-  UseBlocker = "useBlocker",
-  UseLoaderData = "useLoaderData",
-  UseActionData = "useActionData",
-  UseRouteError = "useRouteError",
-  UseNavigation = "useNavigation",
-  UseRouteLoaderData = "useRouteLoaderData",
-  UseMatches = "useMatches",
-  UseRevalidator = "useRevalidator",
-  UseNavigateStable = "useNavigate",
-  UseRoute = "useRoute",
-  UseRouterState = "unstable_useRouterState",
-}
-
-function getDataRouterConsoleError(
-  hookName: DataRouterHook | DataRouterStateHook,
-) {
+function getDataRouterConsoleError(hookName: string) {
   return `${hookName} must be used within a data router.  See https://reactrouter.com/en/main/routers/picking-a-router.`;
 }
 
-function useDataRouterContext(hookName: DataRouterHook) {
+export function useDataRouterContext(hookName: string) {
   let ctx = React.useContext(DataRouterContext);
   invariant(ctx, getDataRouterConsoleError(hookName));
   return ctx;
 }
 
-function useDataRouterState(hookName: DataRouterStateHook) {
+export function useDataRouterState(hookName: string) {
   let state = React.useContext(DataRouterStateContext);
   invariant(state, getDataRouterConsoleError(hookName));
   return state;
 }
 
-function useDataRouterData(hookName: DataRouterStateHook) {
+export function useDataRouterFetchers(hookName: string) {
+  let fetchers = React.useContext(FetchersContext);
+  invariant(fetchers, getDataRouterConsoleError(hookName));
+  return fetchers;
+}
+
+export function useDataRouterData(hookName: string) {
   let data = React.useContext(DataRouterDataContext);
   invariant(data, getDataRouterConsoleError(hookName));
   return data;
 }
 
-function useDataRouterNavigation(hookName: DataRouterStateHook) {
+function useDataRouterNavigation(hookName: string) {
   let navigation = React.useContext(DataRouterNavigationContext);
   invariant(navigation, getDataRouterConsoleError(hookName));
   return navigation;
@@ -1481,9 +1466,7 @@ type UseNavigationResultStates = {
  * @returns The current {@link Navigation} object
  */
 export function useNavigation(): UseNavigationResult {
-  let { navigation } = useDataRouterNavigation(
-    DataRouterStateHook.UseNavigation,
-  );
+  let { navigation } = useDataRouterNavigation("useNavigation");
   return React.useMemo<UseNavigationResult>(() => {
     let { matches, historyAction, ...rest } = navigation;
     return rest;
@@ -1529,10 +1512,8 @@ export function useRevalidator(): {
   revalidate: () => Promise<void>;
   state: DataRouter["state"]["revalidation"];
 } {
-  let dataRouterContext = useDataRouterContext(DataRouterHook.UseRevalidator);
-  let { revalidation } = useDataRouterNavigation(
-    DataRouterStateHook.UseRevalidator,
-  );
+  let dataRouterContext = useDataRouterContext("useRevalidator");
+  let { revalidation } = useDataRouterNavigation("useRevalidator");
   let revalidate = React.useCallback(async () => {
     await dataRouterContext.router.revalidate();
   }, [dataRouterContext.router]);
@@ -1578,8 +1559,8 @@ export function useRevalidator(): {
  * @returns An array of {@link UIMatch | UI matches} for the current route hierarchy
  */
 export function useMatches(): UIMatch[] {
-  let { matches } = useDataRouterState(DataRouterStateHook.UseMatches);
-  let { loaderData } = useDataRouterData(DataRouterStateHook.UseMatches);
+  let { matches } = useDataRouterState("useMatches");
+  let { loaderData } = useDataRouterData("useMatches");
   return React.useMemo(
     () => matches.map((m) => convertRouteMatchToUiMatch(m, loaderData)),
     [matches, loaderData],
@@ -1610,8 +1591,8 @@ export function useMatches(): UIMatch[] {
  * @returns The data returned from the route's [`loader`](../../start/framework/route-module#loader) or [`clientLoader`](../../start/framework/route-module#clientloader) function
  */
 export function useLoaderData<T = any>(): SerializeFrom<T> {
-  let data = useDataRouterData(DataRouterStateHook.UseLoaderData);
-  let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
+  let data = useDataRouterData("useLoaderData");
+  let routeId = useCurrentRouteId("useLoaderData");
   return data.loaderData[routeId] as SerializeFrom<T>;
 }
 
@@ -1650,7 +1631,7 @@ export function useLoaderData<T = any>(): SerializeFrom<T> {
 export function useRouteLoaderData<T = any>(
   routeId: string,
 ): SerializeFrom<T> | undefined {
-  let data = useDataRouterData(DataRouterStateHook.UseRouteLoaderData);
+  let data = useDataRouterData("useRouteLoaderData");
   return data.loaderData[routeId] as SerializeFrom<T> | undefined;
 }
 
@@ -1687,8 +1668,8 @@ export function useRouteLoaderData<T = any>(
  * has been called
  */
 export function useActionData<T = any>(): SerializeFrom<T> | undefined {
-  let data = useDataRouterData(DataRouterStateHook.UseActionData);
-  let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
+  let data = useDataRouterData("useActionData");
+  let routeId = useCurrentRouteId("useActionData");
   return (data.actionData ? data.actionData[routeId] : undefined) as
     | SerializeFrom<T>
     | undefined;
@@ -1716,8 +1697,8 @@ export function useActionData<T = any>(): SerializeFrom<T> | undefined {
  */
 export function useRouteError(): unknown {
   let error = React.useContext(RouteErrorContext);
-  let data = useDataRouterData(DataRouterStateHook.UseRouteError);
-  let routeId = useCurrentRouteId(DataRouterStateHook.UseRouteError);
+  let data = useDataRouterData("useRouteError");
+  let routeId = useCurrentRouteId("useRouteError");
 
   // If this was a render error, we put it in a RouteError context inside
   // of RenderErrorBoundary
@@ -1896,8 +1877,8 @@ let blockerId = 0;
  * @returns A {@link Blocker} object with state and reset functionality
  */
 export function useBlocker(shouldBlock: boolean | BlockerFunction): Blocker {
-  let { router, basename } = useDataRouterContext(DataRouterHook.UseBlocker);
-  let state = useDataRouterState(DataRouterStateHook.UseBlocker);
+  let { router, basename } = useDataRouterContext("useBlocker");
+  let state = useDataRouterState("useBlocker");
 
   let [blockerKey, setBlockerKey] = React.useState("");
   let blockerFunction = React.useCallback<BlockerFunction>(
@@ -1960,8 +1941,8 @@ export function useBlocker(shouldBlock: boolean | BlockerFunction): Blocker {
 // Stable version of useNavigate that is used when we are in the context of
 // a RouterProvider.
 function useNavigateStable(): NavigateFunction {
-  let { router } = useDataRouterContext(DataRouterHook.UseNavigateStable);
-  let id = useCurrentRouteId(DataRouterStateHook.UseNavigateStable);
+  let { router } = useDataRouterContext("useNavigate");
+  let id = useCurrentRouteId("useNavigate");
 
   let activeRef = React.useRef(false);
   React.useLayoutEffect(() => {
@@ -2025,13 +2006,11 @@ type UseRoute<RouteId extends keyof RouteModules | unknown> = {
 export function useRoute<Args extends UseRouteArgs>(
   ...args: Args
 ): UseRouteResult<Args> {
-  const currentRouteId: keyof RouteModules = useCurrentRouteId(
-    DataRouterStateHook.UseRoute,
-  );
+  const currentRouteId: keyof RouteModules = useCurrentRouteId("useRoute");
   const id: keyof RouteModules = args[0] ?? currentRouteId;
 
-  const state = useDataRouterState(DataRouterStateHook.UseRoute);
-  const data = useDataRouterData(DataRouterStateHook.UseRoute);
+  const state = useDataRouterState("useRoute");
+  const data = useDataRouterData("useRoute");
   const route = state.matches.find(({ route }) => route.id === id);
 
   if (route === undefined) return undefined as UseRouteResult<Args>;
@@ -2148,10 +2127,8 @@ export function useRouterState(): unstable_RouterState {
     location,
     historyAction: type,
     matches,
-  } = useDataRouterState(DataRouterStateHook.UseRouterState);
-  let { navigation } = useDataRouterNavigation(
-    DataRouterStateHook.UseRouterState,
-  );
+  } = useDataRouterState("unstable_useRouterState");
+  let { navigation } = useDataRouterNavigation("unstable_useRouterState");
 
   let active = React.useMemo<unstable_RouterStateActiveVariant>(
     () => ({

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -9,6 +9,7 @@ import {
   RSCRouterContext,
   RouteContext,
   RouteErrorContext,
+  RouteIdContext,
 } from "./context";
 import type { Location, Path, To } from "./router/history";
 import {
@@ -1091,10 +1092,18 @@ export class RenderErrorBoundary extends React.Component<
     let result =
       error !== undefined ? (
         <RouteContext.Provider value={this.props.routeContext}>
-          <RouteErrorContext.Provider
-            value={error}
-            children={this.props.component}
-          />
+          <RouteIdContext.Provider
+            value={
+              this.props.routeContext.matches[
+                this.props.routeContext.matches.length - 1
+              ]?.route.id
+            }
+          >
+            <RouteErrorContext.Provider
+              value={error}
+              children={this.props.component}
+            />
+          </RouteIdContext.Provider>
         </RouteContext.Provider>
       ) : (
         this.props.children
@@ -1178,7 +1187,9 @@ function RenderedRoute({ routeContext, match, children }: RenderedRouteProps) {
 
   return (
     <RouteContext.Provider value={routeContext}>
-      {children}
+      <RouteIdContext.Provider value={match.route.id}>
+        {children}
+      </RouteIdContext.Provider>
     </RouteContext.Provider>
   );
 }
@@ -1414,21 +1425,14 @@ function useDataRouterState(hookName: DataRouterStateHook) {
   return state;
 }
 
-function useRouteContext(hookName: DataRouterStateHook) {
-  let route = React.useContext(RouteContext);
-  invariant(route, getDataRouterConsoleError(hookName));
-  return route;
-}
-
 // Internal version with hookName-aware debugging
 function useCurrentRouteId(hookName: DataRouterStateHook) {
-  let route = useRouteContext(hookName);
-  let thisRoute = route.matches[route.matches.length - 1];
+  let routeId = React.useContext(RouteIdContext);
   invariant(
-    thisRoute.route.id,
+    routeId,
     `${hookName} can only be used on routes that contain a unique "id"`,
   );
-  return thisRoute.route.id;
+  return routeId;
 }
 
 /**

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -1404,7 +1404,6 @@ enum DataRouterStateHook {
   UseMatches = "useMatches",
   UseRevalidator = "useRevalidator",
   UseNavigateStable = "useNavigate",
-  UseRouteId = "useRouteId",
   UseRoute = "useRoute",
   UseRouterState = "unstable_useRouterState",
 }
@@ -1439,24 +1438,14 @@ function useDataRouterNavigation(hookName: DataRouterStateHook) {
   return navigation;
 }
 
-// Internal version with hookName-aware debugging
-function useCurrentRouteId(hookName: DataRouterStateHook) {
+// Internal helper with hookName-aware debugging
+export function useCurrentRouteId(hookName: string) {
   let routeId = React.useContext(RouteIdContext);
   invariant(
     routeId,
     `${hookName} can only be used on routes that contain a unique "id"`,
   );
   return routeId;
-}
-
-/**
- * Returns the ID for the nearest contextual route
- *
- * @category Hooks
- * @returns The ID of the nearest contextual route
- */
-export function useRouteId() {
-  return useCurrentRouteId(DataRouterStateHook.UseRouteId);
 }
 
 // Omit the fields from each navigation state individually to preserve the discriminated union

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -3,6 +3,8 @@ import type { NavigateOptions, RouteContextObject } from "./context";
 import {
   AwaitContext,
   DataRouterContext,
+  DataRouterDataContext,
+  DataRouterNavigationContext,
   DataRouterStateContext,
   LocationContext,
   NavigationContext,
@@ -1425,6 +1427,18 @@ function useDataRouterState(hookName: DataRouterStateHook) {
   return state;
 }
 
+function useDataRouterData(hookName: DataRouterStateHook) {
+  let data = React.useContext(DataRouterDataContext);
+  invariant(data, getDataRouterConsoleError(hookName));
+  return data;
+}
+
+function useDataRouterNavigation(hookName: DataRouterStateHook) {
+  let navigation = React.useContext(DataRouterNavigationContext);
+  invariant(navigation, getDataRouterConsoleError(hookName));
+  return navigation;
+}
+
 // Internal version with hookName-aware debugging
 function useCurrentRouteId(hookName: DataRouterStateHook) {
   let routeId = React.useContext(RouteIdContext);
@@ -1478,11 +1492,13 @@ type UseNavigationResultStates = {
  * @returns The current {@link Navigation} object
  */
 export function useNavigation(): UseNavigationResult {
-  let state = useDataRouterState(DataRouterStateHook.UseNavigation);
+  let { navigation } = useDataRouterNavigation(
+    DataRouterStateHook.UseNavigation,
+  );
   return React.useMemo<UseNavigationResult>(() => {
-    let { matches, historyAction, ...rest } = state.navigation;
+    let { matches, historyAction, ...rest } = navigation;
     return rest;
-  }, [state.navigation]);
+  }, [navigation]);
 }
 
 /**
@@ -1525,14 +1541,16 @@ export function useRevalidator(): {
   state: DataRouter["state"]["revalidation"];
 } {
   let dataRouterContext = useDataRouterContext(DataRouterHook.UseRevalidator);
-  let state = useDataRouterState(DataRouterStateHook.UseRevalidator);
+  let { revalidation } = useDataRouterNavigation(
+    DataRouterStateHook.UseRevalidator,
+  );
   let revalidate = React.useCallback(async () => {
     await dataRouterContext.router.revalidate();
   }, [dataRouterContext.router]);
 
   return React.useMemo(
-    () => ({ revalidate, state: state.revalidation }),
-    [revalidate, state.revalidation],
+    () => ({ revalidate, state: revalidation }),
+    [revalidate, revalidation],
   );
 }
 
@@ -1571,9 +1589,8 @@ export function useRevalidator(): {
  * @returns An array of {@link UIMatch | UI matches} for the current route hierarchy
  */
 export function useMatches(): UIMatch[] {
-  let { matches, loaderData } = useDataRouterState(
-    DataRouterStateHook.UseMatches,
-  );
+  let { matches } = useDataRouterState(DataRouterStateHook.UseMatches);
+  let { loaderData } = useDataRouterData(DataRouterStateHook.UseMatches);
   return React.useMemo(
     () => matches.map((m) => convertRouteMatchToUiMatch(m, loaderData)),
     [matches, loaderData],
@@ -1604,9 +1621,9 @@ export function useMatches(): UIMatch[] {
  * @returns The data returned from the route's [`loader`](../../start/framework/route-module#loader) or [`clientLoader`](../../start/framework/route-module#clientloader) function
  */
 export function useLoaderData<T = any>(): SerializeFrom<T> {
-  let state = useDataRouterState(DataRouterStateHook.UseLoaderData);
+  let data = useDataRouterData(DataRouterStateHook.UseLoaderData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
-  return state.loaderData[routeId] as SerializeFrom<T>;
+  return data.loaderData[routeId] as SerializeFrom<T>;
 }
 
 /**
@@ -1644,8 +1661,8 @@ export function useLoaderData<T = any>(): SerializeFrom<T> {
 export function useRouteLoaderData<T = any>(
   routeId: string,
 ): SerializeFrom<T> | undefined {
-  let state = useDataRouterState(DataRouterStateHook.UseRouteLoaderData);
-  return state.loaderData[routeId] as SerializeFrom<T> | undefined;
+  let data = useDataRouterData(DataRouterStateHook.UseRouteLoaderData);
+  return data.loaderData[routeId] as SerializeFrom<T> | undefined;
 }
 
 /**
@@ -1681,9 +1698,9 @@ export function useRouteLoaderData<T = any>(
  * has been called
  */
 export function useActionData<T = any>(): SerializeFrom<T> | undefined {
-  let state = useDataRouterState(DataRouterStateHook.UseActionData);
+  let data = useDataRouterData(DataRouterStateHook.UseActionData);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseLoaderData);
-  return (state.actionData ? state.actionData[routeId] : undefined) as
+  return (data.actionData ? data.actionData[routeId] : undefined) as
     | SerializeFrom<T>
     | undefined;
 }
@@ -1710,7 +1727,7 @@ export function useActionData<T = any>(): SerializeFrom<T> | undefined {
  */
 export function useRouteError(): unknown {
   let error = React.useContext(RouteErrorContext);
-  let state = useDataRouterState(DataRouterStateHook.UseRouteError);
+  let data = useDataRouterData(DataRouterStateHook.UseRouteError);
   let routeId = useCurrentRouteId(DataRouterStateHook.UseRouteError);
 
   // If this was a render error, we put it in a RouteError context inside
@@ -1719,8 +1736,8 @@ export function useRouteError(): unknown {
     return error;
   }
 
-  // Otherwise look for errors from our data router state
-  return state.errors?.[routeId];
+  // Otherwise look for errors from our data router data
+  return data.errors?.[routeId];
 }
 
 /**
@@ -2025,13 +2042,14 @@ export function useRoute<Args extends UseRouteArgs>(
   const id: keyof RouteModules = args[0] ?? currentRouteId;
 
   const state = useDataRouterState(DataRouterStateHook.UseRoute);
+  const data = useDataRouterData(DataRouterStateHook.UseRoute);
   const route = state.matches.find(({ route }) => route.id === id);
 
   if (route === undefined) return undefined as UseRouteResult<Args>;
   return {
     handle: route.route.handle,
-    loaderData: state.loaderData[id],
-    actionData: state.actionData?.[id],
+    loaderData: data.loaderData[id],
+    actionData: data.actionData?.[id],
   } as UseRouteResult<Args>;
 }
 
@@ -2141,8 +2159,10 @@ export function useRouterState(): unstable_RouterState {
     location,
     historyAction: type,
     matches,
-    navigation,
   } = useDataRouterState(DataRouterStateHook.UseRouterState);
+  let { navigation } = useDataRouterNavigation(
+    DataRouterStateHook.UseRouterState,
+  );
 
   let active = React.useMemo<unstable_RouterStateActiveVariant>(
     () => ({

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -7,6 +7,7 @@ import {
   DataRouterNavigationContext,
   DataRouterStateContext,
   FetchersContext,
+  IsDataRouteContext,
   LocationContext,
   NavigationContext,
   RSCRouterContext,
@@ -369,7 +370,7 @@ const navigateEffectWarning =
  * @returns A navigate function for programmatic navigation
  */
 export function useNavigate(): NavigateFunction {
-  let { isDataRoute } = React.useContext(RouteContext);
+  let isDataRoute = React.useContext(IsDataRouteContext);
   // Conditional usage is OK here because the usage of a data router is static
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return isDataRoute ? useNavigateStable() : useNavigateUnstable();
@@ -1095,18 +1096,22 @@ export class RenderErrorBoundary extends React.Component<
     let result =
       error !== undefined ? (
         <RouteContext.Provider value={this.props.routeContext}>
-          <RouteIdContext.Provider
-            value={
-              this.props.routeContext.matches[
-                this.props.routeContext.matches.length - 1
-              ]?.route.id
-            }
+          <IsDataRouteContext.Provider
+            value={this.props.routeContext.isDataRoute}
           >
-            <RouteErrorContext.Provider
-              value={error}
-              children={this.props.component}
-            />
-          </RouteIdContext.Provider>
+            <RouteIdContext.Provider
+              value={
+                this.props.routeContext.matches[
+                  this.props.routeContext.matches.length - 1
+                ]?.route.id
+              }
+            >
+              <RouteErrorContext.Provider
+                value={error}
+                children={this.props.component}
+              />
+            </RouteIdContext.Provider>
+          </IsDataRouteContext.Provider>
         </RouteContext.Provider>
       ) : (
         this.props.children
@@ -1190,9 +1195,11 @@ function RenderedRoute({ routeContext, match, children }: RenderedRouteProps) {
 
   return (
     <RouteContext.Provider value={routeContext}>
-      <RouteIdContext.Provider value={match.route.id}>
-        {children}
-      </RouteIdContext.Provider>
+      <IsDataRouteContext.Provider value={routeContext.isDataRoute}>
+        <RouteIdContext.Provider value={match.route.id}>
+          {children}
+        </RouteIdContext.Provider>
+      </IsDataRouteContext.Provider>
     </RouteContext.Provider>
   );
 }

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -7200,7 +7200,18 @@ function mergeLoaderData(
       break;
     }
   }
-  return mergedLoaderData;
+
+  let loaderDataKeys = Object.keys(loaderData);
+  let mergedLoaderDataKeys = Object.keys(mergedLoaderData);
+  // If no loaders produced new data and the merge retained every existing
+  // entry, reuse the prior object so data context consumers aren't notified.
+  // Don't reuse it after a loader ran, even if it returned the same reference.
+  let canReuseLoaderData =
+    Object.keys(newLoaderData).length === 0 &&
+    loaderDataKeys.length === mergedLoaderDataKeys.length &&
+    mergedLoaderDataKeys.every((key) => loaderData.hasOwnProperty(key));
+
+  return canReuseLoaderData ? loaderData : mergedLoaderData;
 }
 
 function getActionDataForCommit(

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -7185,6 +7185,7 @@ function mergeLoaderData(
 
   // Preserve existing `loaderData` for routes not included in `newLoaderData` and
   // where a loader wasn't removed by HMR
+  let preservedCount = 0;
   for (let match of matches) {
     let id = match.route.id;
     if (
@@ -7193,6 +7194,7 @@ function mergeLoaderData(
       match.route.loader
     ) {
       mergedLoaderData[id] = loaderData[id];
+      preservedCount++;
     }
 
     if (errors && errors.hasOwnProperty(id)) {
@@ -7201,15 +7203,14 @@ function mergeLoaderData(
     }
   }
 
-  let loaderDataKeys = Object.keys(loaderData);
-  let mergedLoaderDataKeys = Object.keys(mergedLoaderData);
   // If no loaders produced new data and the merge retained every existing
   // entry, reuse the prior object so data context consumers aren't notified.
   // Don't reuse it after a loader ran, even if it returned the same reference.
+  // When `newLoaderData` is empty, `mergedLoaderData` can only contain entries
+  // preserved from `loaderData`, so a matching count means nothing was dropped.
   let canReuseLoaderData =
     Object.keys(newLoaderData).length === 0 &&
-    loaderDataKeys.length === mergedLoaderDataKeys.length &&
-    mergedLoaderDataKeys.every((key) => loaderData.hasOwnProperty(key));
+    preservedCount === Object.keys(loaderData).length;
 
   return canReuseLoaderData ? loaderData : mergedLoaderData;
 }


### PR DESCRIPTION
Reduce unnecessary Data and Framework Mode route component re-renders by separating route IDs, active router state, route data, pending navigation state, and fetcher state into stable React contexts.

- Keep parent route components stable when only a descendant location changes.
- Avoid notifying useLoaderData consumers when no loader data changed.
- Avoid notifying active-state consumers when navigation enters a pending state, while preserving updates for useNavigation, useRevalidator, NavLink, and unstable_useRouterState.
- Avoid notifying useMatches and useRoute consumers when fetchers update, while preserving updates for useFetcher and useFetchers.