### PR TITLE
Fix uncaught exception when canceling streams created by createReadableStreamFromReadable

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -147,6 +147,7 @@
 - FilipJirsak
 - focusotter
 - foxscotch
+- FrancoKaddour
 - frodi-karlsson
 - frontsideair
 - fucancode

--- a/packages/react-router-node/.changes/patch.stream-pump-cancel-uncaught-error.md
+++ b/packages/react-router-node/.changes/patch.stream-pump-cancel-uncaught-error.md
@@ -1,0 +1,1 @@
+Fix process crash (`uncaughtException`) when a stream created by `createReadableStreamFromReadable` is canceled, e.g. when a client disconnects mid-response behind compression middleware. `StreamPump.cancel` removed its `error` listener immediately after calling `destroy()`, but `destroy()` emits its error asynchronously, so the error fired with no listener attached.

--- a/packages/react-router-node/__tests__/stream-test.ts
+++ b/packages/react-router-node/__tests__/stream-test.ts
@@ -2,9 +2,10 @@
  * @jest-environment node
  */
 
-import { Writable } from "node:stream";
+import { PassThrough, Writable } from "node:stream";
 
 import {
+  createReadableStreamFromReadable,
   writeAsyncIterableToWritable,
   writeReadableStreamToWritable,
 } from "../stream";
@@ -136,5 +137,51 @@ describe("writeAsyncIterableToWritable", () => {
     await expect(withTimeout(writePromise, 100)).rejects.toThrow(
       "Writable closed before stream finished",
     );
+  });
+});
+
+describe("createReadableStreamFromReadable", () => {
+  it("handles the error emitted asynchronously by destroy() when canceled with a reason", async () => {
+    let source = new PassThrough();
+    let stream = createReadableStreamFromReadable(source);
+    let reader = stream.getReader();
+
+    source.write("<!DOCTYPE html><html>");
+    await reader.read();
+
+    // Mirrors a client disconnecting mid-stream: Node's web streams machinery
+    // cancels the source stream with an `AbortError`.
+    let cancelPromise = reader.cancel(new Error("The operation was aborted"));
+
+    // `destroy(reason)` emits "error" on a later tick, so the pump must keep
+    // its "error" listener attached or the emit escalates to an
+    // uncaughtException and crashes the process.
+    expect(source.listenerCount("error")).toBe(1);
+
+    await cancelPromise;
+
+    // Let `destroy()` flush its asynchronous "error" event, then verify the
+    // once-listener consumed it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(source.listenerCount("error")).toBe(0);
+  });
+
+  it("swallows errors emitted by the source after cancelation", async () => {
+    let source = new PassThrough();
+    let stream = createReadableStreamFromReadable(source);
+    let reader = stream.getReader();
+
+    source.write("<!DOCTYPE html><html>");
+    await reader.read();
+
+    await reader.cancel();
+
+    expect(source.listenerCount("error")).toBe(1);
+
+    // With no "error" listener attached this `emit` would throw synchronously
+    // (ERR_UNHANDLED_ERROR) — the production crash.
+    source.emit("error", new Error("premature close"));
+
+    expect(source.listenerCount("error")).toBe(0);
   });
 });

--- a/packages/react-router-node/stream.ts
+++ b/packages/react-router-node/stream.ts
@@ -249,14 +249,19 @@ class StreamPump {
   }
 
   cancel(reason?: Error) {
+    this.stream.off("data", this.enqueue);
+    this.stream.off("end", this.close);
+    this.stream.off("close", this.close);
+
+    // Intentionally keep the "error" listener attached: `destroy()` emits its
+    // error asynchronously (on a later tick), so removing the listener here
+    // would leave that error unhandled and crash the process with an
+    // uncaughtException. The listener was registered with `once`, so it cleans
+    // itself up once the error (if any) is emitted, and erroring the
+    // controller of an already-canceled stream is a no-op.
     if (this.stream.destroy) {
       this.stream.destroy(reason);
     }
-
-    this.stream.off("data", this.enqueue);
-    this.stream.off("error", this.error);
-    this.stream.off("end", this.close);
-    this.stream.off("close", this.close);
   }
 
   enqueue(chunk: Uint8Array | string) {


### PR DESCRIPTION
Closes #15364

## Problem

`StreamPump.cancel` calls `this.stream.destroy(reason)` and then synchronously removes its `"error"` listener. Node's `destroy()` emits its error asynchronously (via `process.nextTick`), so by the time the error fires the stream has no `"error"` listener left — and a Node stream emitting `"error"` with no listeners rethrows, surfacing as an `uncaughtException` that crashes the whole server process.

In production this happens when a client disconnects during a streamed SSR response behind compression middleware: the web streams machinery cancels the source with an `AbortError`, which is then emitted with no listener attached.

## Solution

Keep the `"error"` listener attached when canceling (as proposed by @raulfdm in the issue — thanks for the great analysis). The listener was registered with `once`, so it cleans itself up after the destroy error (if any) is emitted, and forwarding to `controller.error()` is a spec no-op once the stream has been canceled, so the error is safely absorbed. Also reordered so the `"data"`/`"end"`/`"close"` listeners are detached before `destroy()` runs.

## Testing

Two new unit tests in `packages/react-router-node/__tests__/stream-test.ts` covering the async error from `destroy(reason)` and errors emitted by the source after cancelation — both fail on `main`.
