### PR TITLE
fix(prerender): use Vite base as default basename

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -495,6 +495,7 @@
 - vladinator1000
 - vonagam
 - WalkAlone0325
+- wanxiankai
 - whxhlgy
 - wilcoxmd
 - willemarcel

--- a/integration/vite-prerender-test.ts
+++ b/integration/vite-prerender-test.ts
@@ -1154,6 +1154,32 @@ test.describe(`Prerendering`, () => {
       expect(html).toMatch("<p>Loading...</p>");
     });
 
+    test("Prerenders a spa fallback under the Vite base path", async () => {
+      fixture = await createFixture({
+        prerender: true,
+        files: {
+          "react-router.config.ts": reactRouterConfig({
+            ssr: false,
+            prerender: ["/"],
+          }),
+          "vite.config.ts": files["vite.config.ts"].replace(
+            "export default defineConfig({",
+            'export default defineConfig({ base: "/app/",',
+          ),
+          "app/root.tsx": files["app/root.tsx"],
+          "app/routes/_index.tsx": files["app/routes/_index.tsx"],
+        },
+      });
+
+      let clientDir = path.join(fixture.projectDir, "build", "client");
+      expect(listAllFiles(clientDir).sort()).toEqual([
+        "app/_.data",
+        "app/index.html",
+        "favicon.ico",
+        "index.html",
+      ]);
+    });
+
     test("Hydrates into a navigable app", async ({ page }) => {
       fixture = await createFixture({
         prerender: true,

--- a/packages/react-router-dev/.changes/patch.prerender-vite-base.md
+++ b/packages/react-router-dev/.changes/patch.prerender-vite-base.md
@@ -1,0 +1,1 @@
+Use the Vite base path as the production basename when no React Router basename is configured

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -693,6 +693,15 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     let publicPath = viteUserConfig.base ?? "/";
 
     if (
+      viteCommand === "build" &&
+      reactRouterConfig.basename === "/" &&
+      publicPath.startsWith("/") &&
+      !publicPath.startsWith("//")
+    ) {
+      reactRouterConfig = { ...reactRouterConfig, basename: publicPath };
+    }
+
+    if (
       reactRouterConfig.basename !== "/" &&
       viteCommand === "serve" &&
       !viteUserConfig.server?.middlewareMode &&


### PR DESCRIPTION
Closes #15350

## What changed

- Use a local absolute Vite `base` as the production basename when the React Router `basename` is left at its default.
- Preserve explicit basenames as well as relative, external, and protocol-relative Vite base URLs.
- Add a regression test covering SPA prerender output under `/app/`.

## Why

In v8, the prerender preview server is served under the Vite base path, but build-time requests were still created from the default React Router basename (`/`). This caused requests such as `/_.data` to return 404 instead of being handled under `/app/`.

## Testing

- `pnpm test:integration:run integration/vite-prerender-test.ts --project chromium -g "Prerenders a spa fallback"` (2 passed)
- `pnpm run typecheck`
- `pnpm run lint` (0 errors)
- `pnpm run format:check`
- `pnpm build`
