### PR TITLE
fix(create-react-router): report why the install failed

### DIFF
--- a/packages/create-react-router/.changes/patch.report-install-failure-output.md
+++ b/packages/create-react-router/.changes/patch.report-install-failure-output.md
@@ -1,0 +1,1 @@
+Report the package manager's output when dependency installation fails, instead of only reporting that it failed

--- a/packages/create-react-router/__tests__/create-react-router-test.ts
+++ b/packages/create-react-router/__tests__/create-react-router-test.ts
@@ -1264,6 +1264,75 @@ describe("create-react-router CLI", () => {
       expect(status).toBe(1);
     });
   });
+
+  // https://github.com/remix-run/react-router/issues/15385
+  describe("reporting a failed install", () => {
+    function mockSpawnFailure(stderrOutput: string | null) {
+      mockedSpawn.mockImplementation(() => {
+        let child = new EventEmitter();
+        if (stderrOutput !== null) {
+          let stderrStream = new EventEmitter();
+          (child as unknown as { stderr: EventEmitter }).stderr = stderrStream;
+          process.nextTick(() => stderrStream.emit("data", stderrOutput));
+        }
+        process.nextTick(() => child.emit("exit", 1, null));
+        return child as ReturnType<typeof spawn>;
+      });
+    }
+
+    async function runFailingInstall(name: string) {
+      let projectDir = getProjectDir(name);
+      let stdoutMock = jest
+        .spyOn(process.stdout, "write")
+        .mockImplementation(() => true);
+      let written: string[] = [];
+      let stderrMock = jest
+        .spyOn(process.stderr, "write")
+        .mockImplementation((chunk: any) => {
+          written.push(String(chunk));
+          return true;
+        });
+
+      try {
+        await expect(
+          createReactRouter([
+            projectDir,
+            "--template",
+            path.join(__dirname, "fixtures", "blank"),
+            "--no-git-init",
+            "--yes",
+            "--no-agent-skills",
+          ]),
+        ).rejects.toThrow();
+      } finally {
+        stdoutMock.mockReset();
+        stderrMock.mockReset();
+      }
+
+      return stripAnsi(written.join(""));
+    }
+
+    it("includes the package manager output when the install fails", async () => {
+      mockSpawnFailure(
+        "npm error code EACCES\nnpm error syscall mkdir\nnpm error path /usr/lib/node_modules\n",
+      );
+
+      let output = await runFailingInstall("install-failure-stderr");
+
+      expect(output).toContain("Failed to install dependencies.");
+      expect(output).toContain("npm error code EACCES");
+      expect(output).toContain("npm error syscall mkdir");
+    });
+
+    it("points at --show-install-output when there is nothing to report", async () => {
+      mockSpawnFailure(null);
+
+      let output = await runFailingInstall("install-failure-silent");
+
+      expect(output).toContain("Failed to install dependencies.");
+      expect(output).toContain("--show-install-output");
+    });
+  });
 });
 
 async function execCreateReactRouter({

--- a/packages/create-react-router/index.ts
+++ b/packages/create-react-router/index.ts
@@ -622,11 +622,45 @@ async function installDependencies({
   try {
     await runCommand(pkgManager, ["install"], {
       cwd,
-      stdio: showInstallOutput ? "inherit" : "ignore",
+      // Capture stderr when it isn't already being streamed, so that a failure
+      // can report why it failed rather than only that it did.
+      stdio: showInstallOutput ? "inherit" : ["ignore", "ignore", "pipe"],
     });
   } catch (err) {
-    error("Oh no!", "Failed to install dependencies.");
+    error("Oh no!", [
+      "Failed to install dependencies.",
+      ...(showInstallOutput ? [] : installFailureDetails(err)),
+    ]);
     throw err;
+  }
+}
+
+// A package manager can print a lot before the line that actually explains the
+// failure, so only the tail is surfaced here.
+const INSTALL_ERROR_LINES = 10;
+
+function installFailureDetails(err: unknown): string[] {
+  let stderr = err instanceof RunCommandError ? err.stderr : "";
+  let lines = stderr
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return [
+      `Re-run with ${color.bold("--show-install-output")} to see the full output.`,
+    ];
+  }
+
+  return lines.slice(-INSTALL_ERROR_LINES);
+}
+
+class RunCommandError extends Error {
+  stderr: string;
+  constructor(message: string, stderr: string) {
+    super(message);
+    this.name = "RunCommandError";
+    this.stderr = stderr;
   }
 }
 
@@ -637,16 +671,21 @@ function runCommand(
 ) {
   return new Promise<void>((resolve, reject) => {
     let child = spawn(command, args, options);
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
     child.on("error", reject);
     child.on("exit", (code, signal) => {
       if (code === 0) {
         resolve();
       } else {
         reject(
-          new Error(
+          new RunCommandError(
             signal
               ? `${command} exited with signal ${signal}`
               : `${command} exited with code ${code}`,
+            stderr,
           ),
         );
       }


### PR DESCRIPTION
Related to #15385, though it does not fix the underlying install failure there. It makes that
failure, and every one like it, reportable.

## The problem

`installDependencies` runs the package manager with `stdio: "ignore"` unless
`--show-install-output` is passed, and that flag defaults to `false`:

```ts
await runCommand(pkgManager, ["install"], {
  cwd,
  stdio: showInstallOutput ? "inherit" : "ignore",
});
```

So on failure the package manager's stderr has already been discarded. What is left is a
synthetic error built from the exit code:

```ts
reject(new Error(`${command} exited with code ${code}`));
```

and that never reaches the user either. `createReactRouter` only prints the error when
`--debug` is set, and `cli.ts` drops the rejection value:

```ts
createReactRouter(argv).then(
  () => process.exit(0),
  () => process.exit(1),
);
```

The result is that a user whose install fails sees exactly one line:

```
▲  Oh no! Failed to install dependencies.
```

with no indication that `--show-install-output` exists. #15385 is a good example: the reporter
cannot supply more detail, because the tool threw it away.

## The change

Pipe stderr when it is not already being inherited, keep it on the rejection, and print the
tail of it under the existing message. When the package manager produced nothing, point at
`--show-install-output` instead.

```
▲  Oh no! Failed to install dependencies.
   npm error code EACCES
   npm error syscall mkdir
   npm error path /usr/lib/node_modules
```

Only the last 10 lines are shown, since npm can print a lot before the line that matters.
`--show-install-output` is unchanged and still streams everything live.

## Test Plan

Two tests added under `reporting a failed install`, using the existing `spawn` mock: one
asserts the package manager's stderr appears in the output, the other asserts the
`--show-install-output` hint appears when there is no stderr. Both fail without the change.

```
jest packages/create-react-router
Tests:       49 passed, 49 total
Snapshots:   12 passed, 12 total
```

`eslint`, `tsc --noEmit` and `prettier --check` are clean on the changed files.

Worth noting for review: the existing `spawn` mock returns a bare `EventEmitter` with no
`stderr`, which is why the new listener is attached with `child.stderr?.on`. The other 47 tests
pass unchanged.
