### PR TITLE
fix(architect): restore x-forwarded-host default handling for lambda servers

### DIFF
--- a/packages/react-router-architect/.changes/patch.restore-x-forwarded-host-priority.md
+++ b/packages/react-router-architect/.changes/patch.restore-x-forwarded-host-priority.md
@@ -1,0 +1,1 @@
+Restore `x-forwarded-host` as a priority candidate when deriving the request host in the Architect adapter

--- a/packages/react-router-architect/__tests__/server-test.ts
+++ b/packages/react-router-architect/__tests__/server-test.ts
@@ -140,7 +140,6 @@ describe("architect createRequestHandler", () => {
           createMockEvent({
             headers: {
               host: "localhost:3333",
-              "x-forwarded-host": "ignore.com",
             },
             requestContext: {
               domainName: "example.com",
@@ -289,12 +288,27 @@ describe("architect createReactRouterRequest", () => {
     expect(request.headers.get("cookie")).toBe("__session=value");
   });
 
+  it("uses x-forwarded-host when present", () => {
+    let request = createReactRouterRequest(
+      createMockEvent({
+        headers: {
+          host: "abcdefghijklmnopqrstuvwxyz.lambda-url.eu-west-1.on.aws",
+          "x-forwarded-host": "abcdefghijkl.cloudfront.net",
+        },
+        requestContext: {
+          domainName: "abcdefghijklmnopqrstuvwxyz.lambda-url.eu-west-1.on.aws",
+        },
+      }),
+    );
+
+    expect(request.url).toBe("https://abcdefghijkl.cloudfront.net/");
+  });
+
   it("uses request context domain name", () => {
     let request = createReactRouterRequest(
       createMockEvent({
         headers: {
           host: "localhost:3333",
-          "x-forwarded-host": "ignore.com",
         },
         requestContext: {
           domainName: "example.com",
@@ -303,6 +317,20 @@ describe("architect createReactRouterRequest", () => {
     );
 
     expect(request.url).toBe("https://example.com/");
+  });
+
+  it("ignores invalid characters in x-forwarded-host", () => {
+    let request = createReactRouterRequest(
+      createMockEvent({
+        headers: {
+          host: "localhost:3333",
+          "x-forwarded-host": "example.com:4444/invalid@chars",
+        },
+        rawPath: "/foo",
+      }),
+    );
+
+    expect(request.url).toBe("https://example.com:4444/foo");
   });
 
   it("ignores invalid characters in request context domain name", () => {

--- a/packages/react-router-architect/server.ts
+++ b/packages/react-router-architect/server.ts
@@ -53,7 +53,11 @@ export function createRequestHandler({
 export function createReactRouterRequest(
   event: APIGatewayProxyEventV2,
 ): Request {
-  let rawHost = event.requestContext.domainName || event.headers.host || "";
+  let rawHost =
+    event.headers["x-forwarded-host"] ||
+    event.requestContext.domainName ||
+    event.headers.host ||
+    "";
   let [hostname, portStr] = rawHost.split(":");
   hostname = hostname.split(/[\\/?#@]/)[0] || "localhost";
   let hostPort = Number.parseInt(portStr ?? "", 10);


### PR DESCRIPTION
Fixes #15378.

PR #15188 removed the `useRequestContextDomainName` option from the `@react-router/architect` adapter and made `event.requestContext.domainName` the sole default when deriving the request host, dropping `x-forwarded-host` from consideration entirely.

For Lambda Function URLs deployed behind CloudFront, `requestContext.domainName` is the internal `*.lambda-url...on.aws` host while the viewer-facing host is carried in the `x-forwarded-host` header populated by CloudFront. Because `request.url` was now built with the Lambda URL host, React Router's single-fetch `throwIfPotentialCSRFAttack` check compared the browser `Origin` (`https://...cloudfront.net`) against the Lambda URL and rejected legitimate same-origin browser POSTs.

This restores `x-forwarded-host` as the priority candidate when constructing the request URL, falling back to `requestContext.domainName` and then the `Host` header. That matches the pre-#15188 default behavior for proxied deployments while still preferring the request-context domain name when no proxy header is present.