### PR TITLE
fix(rsc): don't render a Component element for an errored route on data requests

### DIFF
--- a/packages/react-router/.changes/patch.rsc-errored-route-element.md
+++ b/packages/react-router/.changes/patch.rsc-errored-route-element.md
@@ -1,0 +1,1 @@
+Fix RSC data requests rendering a Component element for a route whose loader errored, crashing on undefined `loaderData` instead of surfacing the original error

--- a/packages/react-router/__tests__/rsc/server-loader-error-test.ts
+++ b/packages/react-router/__tests__/rsc/server-loader-error-test.ts
@@ -1,0 +1,77 @@
+import {
+  matchRSCServerRequest,
+  type RSCMatch,
+  type RSCRouteConfigEntry,
+} from "../../lib/rsc/server.rsc";
+
+describe("RSC server loader errors", () => {
+  it("does not create a Component element for an errored route on a data request", async () => {
+    let match: RSCMatch | undefined;
+
+    let routes: RSCRouteConfigEntry[] = [
+      {
+        id: "root",
+        path: "/",
+        Component: () => null,
+        ErrorBoundary: () => null,
+        children: [
+          {
+            id: "detail",
+            path: "p/:id",
+            loader: () => {
+              throw new Response(JSON.stringify({ error: "not_found" }), {
+                status: 404,
+              });
+            },
+            Component: () => null,
+            ErrorBoundary: () => null,
+          },
+        ],
+      },
+    ];
+
+    await matchRSCServerRequest({
+      // A `.rsc` suffix marks this as a data request, so
+      // `skipLoaderErrorBubbling: true` keys the loader error to the `detail`
+      // route itself instead of bubbling it up to an ancestor boundary.
+      request: new Request("https://example.test/p/123.rsc"),
+      routes,
+      createTemporaryReferenceSet: () => ({}),
+      generateResponse(nextMatch) {
+        match = nextMatch;
+        return new Response(null, {
+          status: nextMatch.statusCode,
+          headers: nextMatch.headers,
+        });
+      },
+    });
+
+    expect(match).toBeDefined();
+    expect(match?.statusCode).toBe(404);
+
+    let payload = match?.payload;
+    if (payload?.type !== "render") {
+      throw new Error("Expected a render payload");
+    }
+    await payload.patches;
+
+    // The 404 error must be attributed to the `detail` route itself
+    expect(payload.errors).toHaveProperty("detail");
+    // ...whose loaderData is never backfilled (errored routes are skipped by
+    // the `null` backfill), so rendering its Component would crash on
+    // `loaderData === undefined`.
+    expect(payload.loaderData.detail).toBeUndefined();
+
+    let detailMatch = payload.matches.find((m) => m.id === "detail");
+    expect(detailMatch).toBeDefined();
+    // The errored route must NOT ship a renderable Component element - the
+    // client renders the errorElement (or the nearest boundary) instead.
+    expect(detailMatch!.element).toBeUndefined();
+    expect(detailMatch!.errorElement).toBeDefined();
+
+    // Sanity: a non-errored route still gets its Component element.
+    let rootMatch = payload.matches.find((m) => m.id === "root");
+    expect(rootMatch).toBeDefined();
+    expect(rootMatch!.element).toBeDefined();
+  });
+});

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -1262,12 +1262,22 @@ async function getRSCRouteMatch({
   // TODO: DRY this up once it's fully fleshed out
   let element: React.ReactElement | undefined = undefined;
   let shouldLoadRoute = !routeIdsToLoad || routeIdsToLoad.includes(route.id);
+  // On data requests (`skipLoaderErrorBubbling`), a loader error is keyed to
+  // the route that threw rather than bubbled to an ancestor boundary, so that
+  // route sits exactly at `deepestRenderedRouteIdx` and `isBelowErrorBoundary`
+  // stays false.  Without this guard we'd still render its Component element
+  // with `loaderData === undefined`, crashing the server component and masking
+  // the real error - the errored route should render its `errorElement` (or
+  // nothing, letting the client fall back to the nearest boundary) instead.
+  let routeHasError = Boolean(
+    staticContext.errors && route.id in staticContext.errors,
+  );
   // Only bother rendering Server Components for routes that we're surfacing,
   // so nothing at/below an error boundary and prune routes if included in
   // `routeIdsToLoad`.  This is specifically important when a middleware
   // or loader throws and we don't have any `loaderData` to pass through as
   // props leading to render-time errors of the server component
-  if (Component && shouldLoadRoute) {
+  if (Component && shouldLoadRoute && !routeHasError) {
     element = !isBelowErrorBoundary
       ? React.createElement(
           Layout,


### PR DESCRIPTION
## Problem

On an RSC **data request** (`.rsc`), when a route loader throws a non-redirect `Response` (or any error), `matchRSCServerRequest` runs with `skipLoaderErrorBubbling: true` so the error is keyed to the route's own id. `getRSCRouteMatch` still creates that route's `element`, while `loaderData[routeId]` is left `undefined` (the `null` backfill skips errored routes). The server then renders the route Component with `loaderData === undefined`, crashing with e.g. `TypeError: Cannot destructure property 'x' of 'loaderData'` and masking the original 404/5xx error. An `ErrorBoundary` export does not help because `element` is still created alongside `errorElement`.

## Root cause

In `getRSCRouteMatch` (`packages/react-router/lib/rsc/server.rsc.ts`), `deepestRenderedRouteIdx` is set to the shallowest errored route and `isBelowErrorBoundary = i > deepestRenderedRouteIdx` only suppresses `element` for routes *below* the boundary. On a data request the errored route itself sits exactly at `deepestRenderedRouteIdx`, so `isBelowErrorBoundary` is `false` and its Component `element` is created with `loaderData === undefined`. (Document requests are unaffected because error bubbling re-keys the error to an ancestor boundary.)

## Fix

Skip creating the Component `element` when the route itself is present in `staticContext.errors` (`routeHasError`). The errored route now ships only its `errorElement` (or nothing, letting the client fall back to the nearest boundary from `payload.errors`), mirroring the document-request / below-error-boundary shape. Non-errored routes are unchanged.

## Test

New unit test `packages/react-router/__tests__/rsc/server-loader-error-test.ts` drives `matchRSCServerRequest` with a `.rsc` data request whose `detail` loader throws a 404 `Response`, then asserts:
- the errored `detail` match has **no** `element` (and its `loaderData` is `undefined`),
- it still has an `errorElement`,
- the non-errored `root` match keeps its `element`.

Fails on `main` (the errored route's `element` is present), passes with the fix.

Fixes #15338