### PR TITLE
Fix `<StreamTransfer>` permanently dropping the hydration payload when a component above `<Scripts>` suspends

### DIFF
--- a/packages/react-router/.changes/patch.stream-transfer-suspense-above-scripts.md
+++ b/packages/react-router/.changes/patch.stream-transfer-suspense-above-scripts.md
@@ -1,0 +1,1 @@
+Fix `<StreamTransfer>` permanently dropping the hydration payload when a component above `<Scripts>` suspends during server rendering

--- a/packages/react-router/__tests__/dom/ssr/stream-transfer-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/stream-transfer-test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @jest-environment node
+ */
+import * as React from "react";
+import { renderToPipeableStream } from "react-dom/server";
+import { PassThrough } from "node:stream";
+
+import { createStaticHandler } from "react-router";
+import { Scripts } from "../../../index";
+import { ServerRouter } from "../../../lib/dom/ssr/server";
+import invariant from "../../../lib/dom/ssr/invariant";
+import { mockEntryContext } from "../../utils/framework";
+
+// Renders the document to completion (`onAllReady`) and resolves with the
+// full HTML output
+function renderDocument(element: React.ReactElement): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let { pipe } = renderToPipeableStream(element, {
+      onAllReady() {
+        let sink = new PassThrough();
+        let html = "";
+        sink.on("data", (chunk) => {
+          html += chunk.toString();
+        });
+        sink.on("end", () => resolve(html));
+        pipe(sink);
+      },
+      onShellError(error) {
+        reject(error);
+      },
+      onError() {},
+    });
+  });
+}
+
+// A hook that suspends on the first render and settles in a microtask,
+// mimicking libraries like react-i18next that initialize asynchronously
+// above `<Scripts>` (https://github.com/remix-run/react-router/issues/15390)
+function createSuspendingGate() {
+  let ready = false;
+  let promise: Promise<void> | undefined;
+  return function useGate() {
+    if (ready) return;
+    if (!promise) {
+      promise = Promise.resolve().then(() => {
+        ready = true;
+      });
+    }
+    throw promise;
+  };
+}
+
+function createServerHandoffStream(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('[["loaderData"]]'));
+      controller.close();
+    },
+  });
+}
+
+async function createContext(Root: React.ComponentType) {
+  let staticHandlerContext = await createStaticHandler([
+    { id: "root", path: "/" },
+  ]).query(new Request("http://localhost/"));
+  invariant(!(staticHandlerContext instanceof Response), "Expected a context");
+
+  return mockEntryContext({
+    manifest: {
+      routes: {
+        root: {
+          hasLoader: false,
+          hasAction: false,
+          hasErrorBoundary: false,
+          id: "root",
+          module: "root.js",
+          path: "/",
+        },
+      },
+      entry: { imports: [], module: "" },
+      url: "",
+      version: "",
+    },
+    routeModules: {
+      root: { default: Root },
+    },
+    staticHandlerContext,
+    serverHandoffString: "{}",
+    serverHandoffStream: createServerHandoffStream(),
+    renderMeta: {},
+  });
+}
+
+describe("<StreamTransfer>", () => {
+  it("streams the handoff when a component above <Scripts> suspends", async () => {
+    let useGate = createSuspendingGate();
+
+    function Root() {
+      useGate();
+      return (
+        <html lang="en">
+          <body>
+            <h1>Root</h1>
+            <Scripts />
+          </body>
+        </html>
+      );
+    }
+
+    let context = await createContext(Root);
+    let html = await renderDocument(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    expect(html).toMatch("<h1>Root</h1>");
+    expect(html).toContain(
+      "window.__reactRouterContext.streamController.enqueue(",
+    );
+    expect(html).toContain(
+      "window.__reactRouterContext.streamController.close();",
+    );
+  });
+
+  it("streams the handoff when nothing suspends", async () => {
+    function Root() {
+      return (
+        <html lang="en">
+          <body>
+            <h1>Root</h1>
+            <Scripts />
+          </body>
+        </html>
+      );
+    }
+
+    let context = await createContext(Root);
+    let html = await renderDocument(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    expect(html).toContain(
+      "window.__reactRouterContext.streamController.enqueue(",
+    );
+    expect(html).toContain(
+      "window.__reactRouterContext.streamController.close();",
+    );
+  });
+
+  it("does not stream anything when the document never renders <Scripts>", async () => {
+    function Root() {
+      return (
+        <html lang="en">
+          <body>
+            <h1>No scripts</h1>
+          </body>
+        </html>
+      );
+    }
+
+    let context = await createContext(Root);
+    let html = await renderDocument(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    expect(html).toMatch("<h1>No scripts</h1>");
+    expect(html).not.toContain("streamController.enqueue(");
+    expect(html).not.toContain("streamController.close();");
+  });
+
+  it("does not stream anything when a suspending document never renders <Scripts>", async () => {
+    let useGate = createSuspendingGate();
+
+    function Root() {
+      useGate();
+      return (
+        <html lang="en">
+          <body>
+            <h1>No scripts</h1>
+          </body>
+        </html>
+      );
+    }
+
+    let context = await createContext(Root);
+    let html = await renderDocument(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    expect(html).toMatch("<h1>No scripts</h1>");
+    expect(html).not.toContain("streamController.enqueue(");
+    expect(html).not.toContain("streamController.close();");
+  });
+});

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -840,6 +840,9 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
   // fetch streaming scripts
   if (renderMeta) {
     renderMeta.didRenderScripts = true;
+    // If `<StreamTransfer>` rendered before us (because a component above
+    // `<Scripts>` suspended) it's suspended waiting on this signal
+    renderMeta.onScriptsRendered?.();
   }
 
   let matches = getActiveMatches(routerMatches, null, isSpaMode);

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -28,6 +28,9 @@ export interface FrameworkContextObject {
   serializeError?(error: Error): SerializedError;
   renderMeta?: {
     didRenderScripts?: boolean;
+    onScriptsRendered?: () => void;
+    scriptsPromise?: Promise<void>;
+    scriptsTimedOut?: boolean;
     streamCache?: Record<
       number,
       Promise<void> & {

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -76,6 +76,11 @@ export const SINGLE_FETCH_REDIRECT_STATUS = 202;
 // with the cached body content.
 export const NO_BODY_STATUS_CODES = new Set([100, 101, 204, 205]);
 
+// How long we wait for `<Scripts>` to render before concluding the document
+// never renders it and there's nothing to stream in.  Only relevant when a
+// component above `<Scripts>` suspends during server rendering -- see below.
+const SCRIPTS_RENDER_TIMEOUT_MS = 500;
+
 // StreamTransfer recursively renders down chunks of the `serverHandoffStream`
 // into the client-side `streamController`
 export function StreamTransfer({
@@ -85,10 +90,40 @@ export function StreamTransfer({
   textDecoder,
   nonce,
 }: StreamTransferProps) {
-  // If the user didn't render the <Scripts> component then we don't have to
-  // bother streaming anything in
-  if (!context.renderMeta || !context.renderMeta.didRenderScripts) {
+  if (!context.renderMeta) {
     return null;
+  }
+
+  let { renderMeta } = context;
+
+  if (!renderMeta.didRenderScripts) {
+    // `<Scripts>` sets `didRenderScripts` during its render, and since we
+    // render as a later sibling of the app, the flag is normally set by the
+    // time we get here.  However, if a component above `<Scripts>` suspends,
+    // React renders us in the initial pass before `<Scripts>` has had a
+    // chance to run.  Returning `null` at that point would permanently drop
+    // the stream -- a successfully completed boundary is never retried -- and
+    // leave hydration hanging on the client.  So instead of bailing right
+    // away we suspend until `<Scripts>` renders, giving up after a timeout so
+    // that documents which never render `<Scripts>` still complete.
+    if (renderMeta.scriptsTimedOut) {
+      // The user didn't render the `<Scripts>` component, so we don't have to
+      // bother streaming anything in
+      return null;
+    }
+    if (!renderMeta.scriptsPromise) {
+      renderMeta.scriptsPromise = new Promise<void>((resolve) => {
+        let timeout = setTimeout(() => {
+          renderMeta.scriptsTimedOut = true;
+          resolve();
+        }, SCRIPTS_RENDER_TIMEOUT_MS);
+        renderMeta.onScriptsRendered = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+      });
+    }
+    throw renderMeta.scriptsPromise;
   }
 
   if (!context.renderMeta.streamCache) {


### PR DESCRIPTION
Closes #15390

When a component above `<Scripts>` suspends during server rendering (e.g. react-i18next initializing in the root layout), React evaluates the `<StreamTransfer>` sibling in the initial pass, before `<Scripts>` has set `renderMeta.didRenderScripts`. `StreamTransfer` then returns `null` — and since a successfully completed boundary is never retried, the stream is permanently dropped: the document ships the stream bootstrap but no `enqueue`/`close` scripts, and client hydration hangs silently on a 200 response. Huge credit to @funcpp for the precise diagnosis and for proposing the suspend-instead-of-bail direction — this PR implements it.

**The fix:** instead of bailing when the flag isn't set yet, `<StreamTransfer>` now suspends on a promise that `<Scripts>` resolves from its render, with a timeout escape hatch so documents that never render `<Scripts>` still complete and keep today's no-stream behavior. The fast path (Scripts already rendered) is untouched — no promise is ever created.

Notes for review: the 500ms timeout only matters for documents that never render `<Scripts>` (they complete after a short grace period) — happy to adjust the value or the give-up policy. I believe this also explains #12783, which described the same disappearing `streamController` scripts with i18next but was closed without a mechanism.

Tests: new unit suite for `<StreamTransfer>` (4 cases). The regression case fails on `main` reproducing the exact signature (bootstrap without enqueue/close) and passes with the fix; the no-`<Scripts>` and no-suspense cases pass on both, pinning existing behavior.
