### PR TITLE
refactor(router): use definite assignment assertions in createDeferred

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -521,3 +521,4 @@
 - zeroqs
 - zheng-chuang
 - zxTomw
+- syedsohailhussain1

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -7680,11 +7680,11 @@ function persistAppliedTransitions(
 }
 
 function createDeferred<T = unknown>() {
-  let resolve: (val?: any) => Promise<void>;
-  let reject: (error?: Error) => Promise<void>;
+  let resolve!: (val?: T) => Promise<void>;
+  let reject!: (error?: Error) => Promise<void>;
   let promise = new Promise<T>((res, rej) => {
-    resolve = async (val: T) => {
-      res(val);
+    resolve = async (val?: T) => {
+      res(val as T);
       try {
         await promise;
       } catch {}
@@ -7698,9 +7698,7 @@ function createDeferred<T = unknown>() {
   });
   return {
     promise,
-    //@ts-ignore
     resolve,
-    //@ts-ignore
     reject,
   };
 }


### PR DESCRIPTION
Refactors `createDeferred` to use definite assignment assertions (`!`) for `resolve` and `reject`, completely eliminating the need for `@ts-ignore` comments.
Because the `Promise` executor runs synchronously, `resolve` and `reject` are guaranteed to be assigned before they are returned. Using `!` explicitly communicates this guarantee to the TypeScript compiler in a type-safe way.