### PR TITLE
fix(react-router): re-enable manual scroll restoration after a bfcache restore

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -109,6 +109,7 @@
 - danielberndt
 - danielweinmann
 - daniilguit
+- Dante-Cho
 - dauletbaev
 - david-bezero
 - david-crespo

--- a/packages/react-router/.changes/patch.scroll-restoration-bfcache.md
+++ b/packages/react-router/.changes/patch.scroll-restoration-bfcache.md
@@ -1,0 +1,1 @@
+Fix `<ScrollRestoration>` leaving `history.scrollRestoration` set to `"auto"` after a bfcache restore, which let the browser restore scroll on subsequent history traversals before the destination route had rendered

--- a/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
+++ b/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
@@ -193,6 +193,8 @@ describe(`ScrollRestoration`, () => {
   });
 
   it("re-enables manual scroll restoration when the page is restored from the bfcache", () => {
+    jest.restoreAllMocks();
+
     let testWindow = getWindow("/base");
     window.scrollTo = jest.fn();
 
@@ -213,7 +215,7 @@ describe(`ScrollRestoration`, () => {
       ],
       { basename: "/base", window: testWindow },
     );
-    render(<RouterProvider router={router} />);
+    let { unmount } = render(<RouterProvider router={router} />);
 
     // While <ScrollRestoration> is mounted we own scroll restoration
     expect(window.history.scrollRestoration).toBe("manual");
@@ -223,13 +225,20 @@ describe(`ScrollRestoration`, () => {
     window.dispatchEvent(new Event("pagehide"));
     expect(window.history.scrollRestoration).toBe("auto");
 
+    // A discarded document goes through mount again, so we leave that case
+    // to the browser
+    window.dispatchEvent(pageShowEvent(false));
+    expect(window.history.scrollRestoration).toBe("auto");
+
     // A bfcache restore keeps this document (and this component) alive, so we
     // own scroll restoration again
-    let pageshow = new Event("pageshow");
-    Object.defineProperty(pageshow, "persisted", { value: true });
-    window.dispatchEvent(pageshow);
-
+    window.dispatchEvent(pageShowEvent(true));
     expect(window.history.scrollRestoration).toBe("manual");
+
+    // …until we're unmounted, after which the browser keeps control
+    unmount();
+    window.dispatchEvent(pageShowEvent(true));
+    expect(window.history.scrollRestoration).toBe("auto");
   });
 
   describe("SSR", () => {
@@ -416,6 +425,12 @@ describe(`ScrollRestoration`, () => {
     });
   });
 });
+
+function pageShowEvent(persisted: boolean) {
+  let event = new Event("pageshow");
+  Object.defineProperty(event, "persisted", { value: persisted });
+  return event;
+}
 
 const testPages = [
   {

--- a/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
+++ b/packages/react-router/__tests__/dom/scroll-restoration-test.tsx
@@ -192,6 +192,46 @@ describe(`ScrollRestoration`, () => {
     consoleWarnMock.mockRestore();
   });
 
+  it("re-enables manual scroll restoration when the page is restored from the bfcache", () => {
+    let testWindow = getWindow("/base");
+    window.scrollTo = jest.fn();
+
+    let router = createBrowserRouter(
+      [
+        {
+          path: "/",
+          Component() {
+            return (
+              <>
+                <Outlet />
+                <ScrollRestoration />
+              </>
+            );
+          },
+          children: testPages,
+        },
+      ],
+      { basename: "/base", window: testWindow },
+    );
+    render(<RouterProvider router={router} />);
+
+    // While <ScrollRestoration> is mounted we own scroll restoration
+    expect(window.history.scrollRestoration).toBe("manual");
+
+    // Hand it back to the browser when the page is hidden, so that a
+    // re-created document restores its own scroll position
+    window.dispatchEvent(new Event("pagehide"));
+    expect(window.history.scrollRestoration).toBe("auto");
+
+    // A bfcache restore keeps this document (and this component) alive, so we
+    // own scroll restoration again
+    let pageshow = new Event("pageshow");
+    Object.defineProperty(pageshow, "persisted", { value: true });
+    window.dispatchEvent(pageshow);
+
+    expect(window.history.scrollRestoration).toBe("manual");
+  });
+
   describe("SSR", () => {
     let scrollTo = window.scrollTo;
     beforeAll(() => {

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -3099,7 +3099,21 @@ export function useScrollRestoration({
   // Trigger manual scroll restoration while we're active
   React.useEffect(() => {
     window.history.scrollRestoration = "manual";
+
+    // The pagehide handler below hands scroll restoration back to the browser
+    // so that a re-created document restores its own scroll position. A
+    // bfcache restore keeps this document alive instead, so take it back over
+    // — otherwise the browser restores scroll on subsequent history
+    // traversals before we've rendered the destination route.
+    let handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        window.history.scrollRestoration = "manual";
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+
     return () => {
+      window.removeEventListener("pageshow", handlePageShow);
       window.history.scrollRestoration = "auto";
     };
   }, []);

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -3099,24 +3099,21 @@ export function useScrollRestoration({
   // Trigger manual scroll restoration while we're active
   React.useEffect(() => {
     window.history.scrollRestoration = "manual";
-
-    // The pagehide handler below hands scroll restoration back to the browser
-    // so that a re-created document restores its own scroll position. A
-    // bfcache restore keeps this document alive instead, so take it back over
-    // — otherwise the browser restores scroll on subsequent history
-    // traversals before we've rendered the destination route.
-    let handlePageShow = (event: PageTransitionEvent) => {
-      if (event.persisted) {
-        window.history.scrollRestoration = "manual";
-      }
-    };
-    window.addEventListener("pageshow", handlePageShow);
-
     return () => {
-      window.removeEventListener("pageshow", handlePageShow);
       window.history.scrollRestoration = "auto";
     };
   }, []);
+
+  // Take scroll restoration back over on a bfcache restore. The pagehide
+  // handler below hands it to the browser for documents that get discarded,
+  // but a restored document stays alive so the effect above never re-runs.
+  usePageShow(
+    React.useCallback((event: PageTransitionEvent) => {
+      if (event.persisted) {
+        window.history.scrollRestoration = "manual";
+      }
+    }, []),
+  );
 
   // Save positions on pagehide
   usePageHide(
@@ -3259,6 +3256,20 @@ function usePageHide(
     window.addEventListener("pagehide", callback, opts);
     return () => {
       window.removeEventListener("pagehide", callback, opts);
+    };
+  }, [callback, capture]);
+}
+
+function usePageShow(
+  callback: (event: PageTransitionEvent) => any,
+  options?: { capture?: boolean },
+): void {
+  let { capture } = options || {};
+  React.useEffect(() => {
+    let opts = capture != null ? { capture } : undefined;
+    window.addEventListener("pageshow", callback, opts);
+    return () => {
+      window.removeEventListener("pageshow", callback, opts);
     };
   }, [callback, capture]);
 }

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -3104,9 +3104,7 @@ export function useScrollRestoration({
     };
   }, []);
 
-  // Take scroll restoration back over on a bfcache restore. The pagehide
-  // handler below hands it to the browser for documents that get discarded,
-  // but a restored document stays alive so the effect above never re-runs.
+  // Re-enable manual scroll restoration on a bfcache restore
   usePageShow(
     React.useCallback((event: PageTransitionEvent) => {
       if (event.persisted) {
@@ -3260,6 +3258,10 @@ function usePageHide(
   }, [callback, capture]);
 }
 
+/*
+ * Setup a callback to be fired on the window's `pageshow` event. The event's
+ * `persisted` flag indicates the document was restored from the bfcache.
+ */
 function usePageShow(
   callback: (event: PageTransitionEvent) => any,
   options?: { capture?: boolean },


### PR DESCRIPTION
`<ScrollRestoration>` hands scroll restoration back to the browser on `pagehide` and never reclaims it. After a bfcache restore, the browser restores scroll on subsequent history traversals before the destination route has rendered.

## The bug

`useScrollRestoration` sets `history.scrollRestoration = "manual"` once on mount, and sets it back to `"auto"` in the `pagehide` handler:

```ts
// Trigger manual scroll restoration while we're active
React.useEffect(() => {
  window.history.scrollRestoration = "manual";
  return () => {
    window.history.scrollRestoration = "auto";
  };
}, []);

// Save positions on pagehide
usePageHide(
  React.useCallback(() => {
    // …save positions…
    window.history.scrollRestoration = "auto";
  }, [...]),
);
```

Handing it back on `pagehide` is the right move when the document is actually discarded: a re-created document restores its own scroll position before React has hydrated, and the effect above sets `"manual"` again on mount.

But a bfcache restore keeps the document alive, so the mount effect never re-runs and nothing sets it back to `"manual"`. The comment says *"while we're active"*. After a bfcache restore we're still active, yet the browser owns scroll restoration from then on.

This matters because `scrollRestoration` is a per-session-history-entry property, not a document-wide flag:

- the setter only changes the *active* entry ([`history.scrollRestoration`](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-scroll-restoration))
- entries created by `pushState` inherit the active entry's mode ([URL and history update steps](https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps))
- on traversal, restoration is decided by the *destination* entry's mode ([restore persisted state](https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state))

That means the entry that was active during `pagehide` stays `"auto"`, every entry pushed from it inherits `"auto"`, and traversing back to any of them lets the browser restore scroll synchronously, right after `popstate` and well before the router commits the destination route.

## What users see

A common trigger is a cross-document trip that comes back through the bfcache: an OAuth login, a payment redirect, an outbound link.

Once an entry is left in `"auto"`, pressing back does this: the browser restores the saved scroll position right away, while the document still shows the page you're leaving. If that page is shorter than the saved offset it gets clamped to its own maximum, so the outgoing page visibly jumps (often all the way to its bottom), and only then does the destination route render. Going back to a long list from a short detail page, it's hard to miss.

## The fix

Take control of scroll restoration again when the document is restored from the bfcache, and clean up the listener with the effect:

```ts
let handlePageShow = (event: PageTransitionEvent) => {
  if (event.persisted) {
    window.history.scrollRestoration = "manual";
  }
};
window.addEventListener("pageshow", handlePageShow);
```

The `persisted` guard keeps the existing behavior for discarded documents. Those mount again, which already sets `"manual"`. I checked that path in a browser as well: after a cross-document trip, a re-created document ends up back at `"manual"` through the existing mount effect, without needing this fix, so only the bfcache path needs handling.

This also preserves bfcache's own scroll handling. Per the spec, reactivating a document doesn't run "restore persisted state"; it simply keeps the frozen scroll position, and `pageshow` fires at the end of reactivation.

## Tests

I added a test to `packages/react-router/__tests__/dom/scroll-restoration-test.tsx`. It fails on `main` with `Expected: "manual" / Received: "auto"` and passes with the fix. It also covers the `persisted: false` case and cleanup on unmount, so the guard and the listener removal are both pinned.

`pnpm test packages/react-router/`:

```
Test Suites: 109 passed, 109 total
Tests:       15 skipped, 2212 passed, 2227 total
```

## Why no integration test

I couldn't turn this into an `integration/bug-report-test.ts` case. The bfcache is disabled in Playwright's Chromium, and I couldn't get it to engage in Playwright's Firefox either (the document was re-created every time), so the integration suite can't reach the browser-level symptom. The unit test instead pins the actual defect: the library leaves `scrollRestoration` at `"auto"` while still mounted.

Happy to reshape this as a `usePageShow` helper mirroring `usePageHide` if that fits better.
