### PR TITLE
fix: honor the relative option in useSubmit and fetcher.submit

### DIFF
--- a/packages/react-router/.changes/patch.submit-relative-option.md
+++ b/packages/react-router/.changes/patch.submit-relative-option.md
@@ -1,0 +1,1 @@
+Fix `useSubmit` and `fetcher.submit` ignoring the `relative` option when resolving the submission `action`

--- a/packages/react-router/.changes/patch.submit-relative-option.md
+++ b/packages/react-router/.changes/patch.submit-relative-option.md
@@ -1,1 +1,1 @@
-Fix `useSubmit` and `fetcher.submit` ignoring the `relative` option when resolving the submission `action`
+Properly respect the `relative` option in `useSubmit`/`fetcher.submit` when resolivng the `action` path

--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -4133,78 +4133,96 @@ function testDomRouter(
     });
 
     describe('submit() with relative="path"', () => {
-      function getRelativeSubmitRoutes(
-        actionPaths: string[],
-        Component: React.ComponentType,
-      ): RouteObject[] {
-        let action = ({ request }: { request: Request }) => {
-          actionPaths.push(new URL(request.url).pathname);
-          return null;
-        };
-        return [
-          {
-            path: "inbox",
-            action,
-            children: [
-              { path: "messages", action },
-              { path: "messages/:id", Component },
-            ],
-          },
-        ];
-      }
-
       it("submits relative to the URL for navigations", async () => {
-        let actionPaths: string[] = [];
         let router = createTestRouter(
-          getRelativeSubmitRoutes(actionPaths, function Component() {
-            let submit = useSubmit();
-            return (
-              <button
-                onClick={() =>
-                  submit(
-                    { a: "1" },
-                    { method: "post", action: "..", relative: "path" },
-                  )
-                }
-              >
-                Submit
-              </button>
-            );
-          }),
+          [
+            {
+              path: "inbox",
+              action: () => "INDEX",
+              children: [
+                {
+                  path: "messages",
+                  action: () => "MESSAGES",
+                  Component() {
+                    let actionData = useActionData();
+                    return <p>{actionData}</p>;
+                  },
+                },
+                {
+                  path: "messages/:id",
+                  Component() {
+                    let submit = useSubmit();
+                    return (
+                      <button
+                        onClick={() =>
+                          submit(
+                            { a: "1" },
+                            { method: "post", action: "..", relative: "path" },
+                          )
+                        }
+                      >
+                        Submit
+                      </button>
+                    );
+                  },
+                },
+              ],
+            },
+          ],
           { window: getWindow("/inbox/messages/1") },
         );
         render(<RouterProvider router={router} />);
 
         fireEvent.click(screen.getByText("Submit"));
-        await waitFor(() => expect(actionPaths.length).toBe(1));
-        expect(actionPaths[0]).toBe("/inbox/messages");
+        await waitFor(() => screen.getByText("MESSAGES"));
+        expect(router.state.location.pathname).toBe("/inbox/messages");
       });
 
       it("submits relative to the URL for fetchers", async () => {
-        let actionPaths: string[] = [];
         let router = createTestRouter(
-          getRelativeSubmitRoutes(actionPaths, function Component() {
-            let fetcher = useFetcher();
-            return (
-              <button
-                onClick={() =>
-                  fetcher.submit(
-                    { a: "1" },
-                    { method: "post", action: "..", relative: "path" },
-                  )
-                }
-              >
-                Submit
-              </button>
-            );
-          }),
+          [
+            {
+              path: "inbox",
+              action: () => "INDEX",
+              children: [
+                {
+                  path: "messages",
+                  action: () => "MESSAGES",
+                },
+                {
+                  path: "messages/:id",
+                  Component() {
+                    let fetcher = useFetcher();
+                    return (
+                      <>
+                        <button
+                          onClick={() =>
+                            fetcher.submit(
+                              { a: "1" },
+                              {
+                                method: "post",
+                                action: "..",
+                                relative: "path",
+                              },
+                            )
+                          }
+                        >
+                          Submit
+                        </button>
+                        {fetcher.data ? <p>{fetcher.data}</p> : null}
+                      </>
+                    );
+                  },
+                },
+              ],
+            },
+          ],
           { window: getWindow("/inbox/messages/1") },
         );
         render(<RouterProvider router={router} />);
 
         fireEvent.click(screen.getByText("Submit"));
-        await waitFor(() => expect(actionPaths.length).toBe(1));
-        expect(actionPaths[0]).toBe("/inbox/messages");
+        await waitFor(() => screen.getByText("MESSAGES"));
       });
     });
 

--- a/packages/react-router/__tests__/dom/data-browser-router-test.tsx
+++ b/packages/react-router/__tests__/dom/data-browser-router-test.tsx
@@ -4132,6 +4132,82 @@ function testDomRouter(
       });
     });
 
+    describe('submit() with relative="path"', () => {
+      function getRelativeSubmitRoutes(
+        actionPaths: string[],
+        Component: React.ComponentType,
+      ): RouteObject[] {
+        let action = ({ request }: { request: Request }) => {
+          actionPaths.push(new URL(request.url).pathname);
+          return null;
+        };
+        return [
+          {
+            path: "inbox",
+            action,
+            children: [
+              { path: "messages", action },
+              { path: "messages/:id", Component },
+            ],
+          },
+        ];
+      }
+
+      it("submits relative to the URL for navigations", async () => {
+        let actionPaths: string[] = [];
+        let router = createTestRouter(
+          getRelativeSubmitRoutes(actionPaths, function Component() {
+            let submit = useSubmit();
+            return (
+              <button
+                onClick={() =>
+                  submit(
+                    { a: "1" },
+                    { method: "post", action: "..", relative: "path" },
+                  )
+                }
+              >
+                Submit
+              </button>
+            );
+          }),
+          { window: getWindow("/inbox/messages/1") },
+        );
+        render(<RouterProvider router={router} />);
+
+        fireEvent.click(screen.getByText("Submit"));
+        await waitFor(() => expect(actionPaths.length).toBe(1));
+        expect(actionPaths[0]).toBe("/inbox/messages");
+      });
+
+      it("submits relative to the URL for fetchers", async () => {
+        let actionPaths: string[] = [];
+        let router = createTestRouter(
+          getRelativeSubmitRoutes(actionPaths, function Component() {
+            let fetcher = useFetcher();
+            return (
+              <button
+                onClick={() =>
+                  fetcher.submit(
+                    { a: "1" },
+                    { method: "post", action: "..", relative: "path" },
+                  )
+                }
+              >
+                Submit
+              </button>
+            );
+          }),
+          { window: getWindow("/inbox/messages/1") },
+        );
+        render(<RouterProvider router={router} />);
+
+        fireEvent.click(screen.getByText("Submit"));
+        await waitFor(() => expect(actionPaths.length).toBe(1));
+        expect(actionPaths[0]).toBe("/inbox/messages");
+      });
+    });
+
     describe("useSubmit/Form FormData", () => {
       it("gathers form data on <Form> submissions", async () => {
         let actionSpy = jest.fn();

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2603,6 +2603,7 @@ export function useSubmit(): SubmitFunction {
         await routerFetch(key, currentRouteId, options.action || action, {
           defaultShouldRevalidate: options.defaultShouldRevalidate,
           preventScrollReset: options.preventScrollReset,
+          relative: options.relative,
           formData,
           body,
           formMethod: options.method || (method as HTMLFormMethod),
@@ -2613,6 +2614,7 @@ export function useSubmit(): SubmitFunction {
         await routerNavigate(options.action || action, {
           defaultShouldRevalidate: options.defaultShouldRevalidate,
           preventScrollReset: options.preventScrollReset,
+          relative: options.relative,
           formData,
           body,
           formMethod: options.method || (method as HTMLFormMethod),


### PR DESCRIPTION
`useSubmit` accepts a `relative` option, documented on `SharedSubmitOptions` as "Determines whether the form action is relative to the route hierarchy or the pathname", and inherited by both `SubmitOptions` and `FetcherSubmitOptions`. It is never forwarded to the router. Neither branch of the submit callback includes it:

```tsx
if (options.navigate === false) {
  await routerFetch(key, currentRouteId, options.action || action, {
    defaultShouldRevalidate: options.defaultShouldRevalidate,
    preventScrollReset: options.preventScrollReset,
    // no `relative`
    formData,
    ...
  });
} else {
  await routerNavigate(options.action || action, {
    defaultShouldRevalidate: options.defaultShouldRevalidate,
    preventScrollReset: options.preventScrollReset,
    // no `relative`
    formData,
    ...
  });
}
```

`router.navigate` and `router.fetch` both accept `relative` and hand it to `normalizeTo`, which ends at `resolveTo(..., relative === "path")`. Dropped, it arrives as `undefined`, so an imperative submission always resolves its `action` route-relative regardless of what the caller asked for.

The effect is that the declarative and imperative APIs disagree on the same option. On `/inbox/messages/1`, matched by a `messages/:id` route nested under `inbox`:

```tsx
// action resolves to /inbox/messages
<Form action=".." relative="path" />

// both resolve to /inbox
submit(formData, { method: "post", action: "..", relative: "path" });
fetcher.submit(formData, { method: "post", action: "..", relative: "path" });
```

`<Form>` gets the right answer because it resolves its own `action` through `useFormAction(action, { relative })` and passes `submit` an already-absolute path. It also forwards `relative` to `submit`, where it is currently ignored.

## Fix

Pass `options.relative` through in both branches of `useSubmit`. Since `<Form>` resolves its action before calling `submit`, the value is a no-op on that path and existing `<Form relative="path">` behavior is unchanged.

## Tests

Two tests in `packages/react-router/__tests__/dom/data-browser-router-test.tsx`, one for the navigation branch and one for the fetcher branch, asserting the action runs at `/inbox/messages` instead of `/inbox`. Both fail before the change:

```
Expected: "/inbox/messages"
Received: "/inbox"
```

`pnpm test packages/react-router/__tests__/dom/data-browser-router-test.tsx` passes (311 tests), as do the existing `<Form action relative="path">` cases.

Also adds a patch change file.
