### PR TITLE
fix(react-router): configure crossOrigin for client asset prefetches

### DIFF
--- a/integration/cross-origin-test.ts
+++ b/integration/cross-origin-test.ts
@@ -1,0 +1,171 @@
+import { expect, type Page } from "@playwright/test";
+
+import {
+  createAppFixture,
+  createFixture,
+  css,
+  js,
+} from "./helpers/create-fixture.js";
+import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
+import {
+  createEditor,
+  type Files,
+  reactRouterConfig,
+  test,
+  viteConfig,
+} from "./helpers/vite.js";
+
+const appFiles = {
+  "react-router.config.ts": reactRouterConfig({
+    crossOrigin: "anonymous",
+    routeDiscovery: { mode: "initial" },
+  }),
+  "app/root.tsx": js`
+    import { Link, Links, Outlet, Scripts } from "react-router";
+    import rootStyles from "./root.css?url";
+
+    export function links() {
+      return [{ rel: "stylesheet", href: rootStyles }];
+    }
+
+    export default function Root() {
+      return (
+        <html>
+          <head><Links /></head>
+          <body>
+            <Link to="/about" prefetch="intent">About</Link>
+            <p data-hmr>HMR 0</p>
+            <Outlet />
+            <Scripts />
+          </body>
+        </html>
+      );
+    }
+  `,
+  "app/root.css": css`
+    body {
+      color: black;
+    }
+  `,
+  "app/routes/_index.tsx": js`
+    export default function Index() {
+      return <h1>Home</h1>;
+    }
+  `,
+  "app/routes/about.tsx": js`
+    import aboutStyles from "../about.css?url";
+
+    export function links() {
+      return [
+        { rel: "stylesheet", href: aboutStyles },
+        { rel: "stylesheet", href: "/hmr.css" },
+      ];
+    }
+
+    export async function clientLoader() {
+      return null;
+    }
+
+    export default function About() {
+      return <h1>About</h1>;
+    }
+  `,
+  "app/about.css": css`
+    h1 {
+      color: blue;
+    }
+  `,
+  "public/hmr.css": css`
+    h1 {
+      color: red;
+    }
+  `,
+};
+
+async function expectConfiguredCrossOrigin(
+  page: Page,
+  options: { hasModulePreloads: boolean },
+) {
+  await expect
+    .poll(() => page.evaluate(() => window.__reactRouterManifest?.crossOrigin))
+    .toBe("anonymous");
+
+  await expect(page.locator("link[rel='stylesheet']").first()).toHaveAttribute(
+    "crossorigin",
+    "anonymous",
+  );
+  await expect(page.locator("script[type='module']")).toHaveAttribute(
+    "crossorigin",
+    "anonymous",
+  );
+  if (options.hasModulePreloads) {
+    await expect(
+      page.locator("link[rel='modulepreload']").first(),
+    ).toHaveAttribute("crossorigin", "anonymous");
+  }
+
+  await page.getByRole("link", { name: "About" }).hover();
+  await expect(
+    page.locator("link[rel='prefetch'][as='style']").first(),
+  ).toHaveAttribute("crossorigin", "anonymous");
+}
+
+test.describe("crossOrigin config", () => {
+  test("flows through the production manifest and asset tags", async ({
+    page,
+  }) => {
+    let fixture = await createFixture({ files: appFiles });
+    let appFixture = await createAppFixture(fixture);
+
+    try {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      await expectConfiguredCrossOrigin(page, { hasModulePreloads: true });
+    } finally {
+      appFixture.close();
+    }
+  });
+
+  test("flows through the development manifest and asset tags", async ({
+    page,
+    dev,
+  }) => {
+    let files: Files = async ({ port }) => ({
+      ...appFiles,
+      "vite.config.ts": await viteConfig.basic({ port }),
+    });
+    let { cwd, port } = await dev(files);
+
+    let releaseCssRequest = () => {};
+    let cssRequestBlocked = new Promise<void>((resolve) => {
+      releaseCssRequest = resolve;
+    });
+    await page.route("**/hmr.css", async (route) => {
+      await cssRequestBlocked;
+      await route.fulfill({
+        contentType: "text/css",
+        body: "h1 { color: red; }",
+      });
+    });
+
+    await page.goto(`http://localhost:${port}/`);
+    try {
+      await expectConfiguredCrossOrigin(page, { hasModulePreloads: false });
+
+      let edit = createEditor(cwd);
+      await edit("app/root.tsx", (contents) =>
+        contents.replace("HMR 0", "HMR 1"),
+      );
+      await expect(page.locator("[data-hmr]")).toHaveText("HMR 1");
+
+      await page.getByRole("link", { name: "About" }).click();
+      await expect(
+        page.locator("link[rel='preload'][as='style'][href='/hmr.css']"),
+      ).toHaveAttribute("crossorigin", "anonymous");
+    } finally {
+      releaseCssRequest();
+    }
+
+    await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
+  });
+});

--- a/integration/vite-presets-test.ts
+++ b/integration/vite-presets-test.ts
@@ -29,6 +29,7 @@ const files = {
     export default {
       // Ensure user config takes precedence over preset config
       appDirectory: "app",
+      crossOrigin: "use-credentials",
 
       presets: [
         // Ensure user config is passed to reactRouterConfig hook
@@ -39,7 +40,10 @@ const files = {
               throw new Error("React Router user config doesn't have presets array.");
             }
 
-            let expected = JSON.stringify({ appDirectory: "app"});
+            let expected = JSON.stringify({
+              appDirectory: "app",
+              crossOrigin: "use-credentials",
+            });
             let actual = JSON.stringify(restUserConfig);
 
             if (actual !== expected) {
@@ -59,6 +63,7 @@ const files = {
           name: "test-preset",
           reactRouterConfig: async () => ({
             appDirectory: "INCORRECT_APP_DIR", // This is overridden by the user config further down this file
+            crossOrigin: "anonymous",
           }),
         },
         {
@@ -230,6 +235,7 @@ test.describe("Vite / presets", async () => {
         "basename",
         "buildDirectory",
         "buildEnd",
+        "crossOrigin",
         "future",
         "prerender",
         "routes",
@@ -243,6 +249,8 @@ test.describe("Vite / presets", async () => {
         "allowedActionOrigins",
         "unstable_routeConfig",
       ]);
+
+      expect(reactRouterConfig.crossOrigin).toBe("use-credentials");
 
       // Ensure future flags from presets are properly merged
       expect(buildEndArgsMeta.futureFlags).toEqual({

--- a/packages/react-router-dev/.changes/minor.cross-origin-config.md
+++ b/packages/react-router-dev/.changes/minor.cross-origin-config.md
@@ -1,0 +1,1 @@
+Add a top-level `crossOrigin` config option for Framework Mode asset links, scripts, and client-side CSS prefetches

--- a/packages/react-router-dev/config/config.ts
+++ b/packages/react-router-dev/config/config.ts
@@ -162,6 +162,14 @@ export type ReactRouterConfig = {
    */
   buildEnd?: BuildEndHook;
   /**
+   * The canonical app-wide CORS mode for initial generated asset links and
+   * scripts and imperative client prefetches. Component props override this
+   * value only for tags rendered by that component.
+   *
+   * This does not apply to RSC Framework Mode.
+   */
+  crossOrigin?: "anonymous" | "use-credentials";
+  /**
    * An array of URLs to prerender to HTML files at build time.  Can also be a
    * function returning an array to dynamically generate URLs.
    *
@@ -286,6 +294,10 @@ export type ResolvedReactRouterConfig = Readonly<{
    * A function that is called after the full React Router build is complete.
    */
   buildEnd?: BuildEndHook;
+  /**
+   * The CORS mode to use for generated asset links and scripts.
+   */
+  crossOrigin: ReactRouterConfig["crossOrigin"];
   /**
    * Enabled future flags
    */
@@ -751,6 +763,7 @@ async function resolveConfig({
   };
 
   let allowedActionOrigins = userAndPresetConfigs.allowedActionOrigins ?? false;
+  let crossOrigin = userAndPresetConfigs.crossOrigin;
   let splitRouteModules = userAndPresetConfigs.splitRouteModules ?? true;
   let subResourceIntegrity = userAndPresetConfigs.subResourceIntegrity ?? false;
 
@@ -759,6 +772,7 @@ async function resolveConfig({
     basename,
     buildDirectory,
     buildEnd,
+    crossOrigin,
     future,
     prerender,
     routes,

--- a/packages/react-router-dev/manifest.ts
+++ b/packages/react-router-dev/manifest.ts
@@ -22,6 +22,7 @@ export type ManifestRoute = {
 export type Manifest = {
   version: string;
   url?: string;
+  crossOrigin?: "anonymous" | "use-credentials";
   entry: {
     module: string;
     imports: string[];

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1026,7 +1026,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       }
     }
 
-    let fingerprintedValues = { entry, routes: browserRoutes };
+    let fingerprintedValues = {
+      crossOrigin: ctx.reactRouterConfig.crossOrigin,
+      entry,
+      routes: browserRoutes,
+    };
     let version = getHash(JSON.stringify(fingerprintedValues), 8);
     let manifestPath = path.posix.join(
       viteConfig.build.assetsDir,
@@ -1150,6 +1154,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     let reactRouterManifestForDev = {
       version: String(Math.random()),
       url: combineURLs(ctx.publicPath, virtual.browserManifest.url),
+      crossOrigin: ctx.reactRouterConfig.crossOrigin,
       hmr: {
         runtime: combineURLs(ctx.publicPath, virtualInjectHmrRuntime.url),
       },

--- a/packages/react-router/.changes/patch.prefetch-css-crossorigin.md
+++ b/packages/react-router/.changes/patch.prefetch-css-crossorigin.md
@@ -1,1 +1,1 @@
-Apply `crossOrigin` to client-side CSS prefetch links (`<Link prefetch>`) so assets prefetched from a cross-origin host use a CORS mode matching `<Links crossOrigin>` and are not fetched twice
+Apply a configured `crossOrigin` to initial Framework Mode asset tags and client-side CSS prefetch links (`<Link prefetch>`), while preserving explicit component and link descriptor overrides

--- a/packages/react-router/.changes/patch.prefetch-css-crossorigin.md
+++ b/packages/react-router/.changes/patch.prefetch-css-crossorigin.md
@@ -1,0 +1,1 @@
+Apply `crossOrigin` to client-side CSS prefetch links (`<Link prefetch>`) so assets prefetched from a cross-origin host use a CORS mode matching `<Links crossOrigin>` and are not fetched twice

--- a/packages/react-router/__tests__/dom/ssr/components-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/components-test.tsx
@@ -1,5 +1,5 @@
 import { createStaticHandler } from "react-router";
-import { act, fireEvent, render } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import * as React from "react";
 
 import {
@@ -8,6 +8,7 @@ import {
   Links,
   NavLink,
   Outlet,
+  PrefetchPageLinks,
   RouterProvider,
   Scripts,
 } from "../../../index";
@@ -154,6 +155,96 @@ describe("<Link />", () => {
 
 describe("<NavLink />", () => {
   itPrefetchesPageLinks(NavLink);
+});
+
+describe("<PrefetchPageLinks />", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function renderPrefetchLinks(
+    crossOrigin?: "anonymous" | "use-credentials",
+  ) {
+    let context = mockFrameworkContext({
+      routeModules: {
+        root: { default: () => null },
+        about: {
+          default: () => null,
+          links: () => [{ rel: "stylesheet", href: "/about.css" }],
+        },
+      },
+      manifest: {
+        ...mockFrameworkContext().manifest,
+        crossOrigin: "anonymous",
+        routes: {
+          root: {
+            id: "root",
+            path: "/",
+            module: "root.js",
+            hasLoader: false,
+            hasAction: false,
+            hasErrorBoundary: false,
+          },
+          about: {
+            id: "about",
+            path: "about",
+            module: "about.js",
+            hasLoader: false,
+            hasAction: false,
+            hasErrorBoundary: false,
+          },
+        },
+      },
+    });
+    let router;
+
+    act(() => {
+      router = createMemoryRouter([
+        {
+          id: "root",
+          path: "/",
+          element: (
+            <PrefetchPageLinks page="/about" crossOrigin={crossOrigin} />
+          ),
+        },
+        { id: "about", path: "/about", element: <h1>About</h1> },
+      ]);
+    });
+
+    let result = render(
+      <FrameworkContext.Provider value={context}>
+        <RouterProvider router={router} />
+      </FrameworkContext.Provider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        result.container.ownerDocument.querySelector(
+          "link[rel='prefetch'][as='style']",
+        ),
+      ).toBeTruthy(),
+    );
+
+    return result;
+  }
+
+  it("uses config crossOrigin as a fallback", async () => {
+    let { container, unmount } = await renderPrefetchLinks();
+
+    expect(
+      container.ownerDocument.querySelector("link[rel='prefetch'][as='style']"),
+    ).toHaveAttribute("crossorigin", "anonymous");
+    unmount();
+  });
+
+  it("prefers an explicit component crossOrigin over config", async () => {
+    let { container, unmount } = await renderPrefetchLinks("use-credentials");
+
+    expect(
+      container.ownerDocument.querySelector("link[rel='prefetch'][as='style']"),
+    ).toHaveAttribute("crossorigin", "use-credentials");
+    unmount();
+  });
 });
 
 describe("<ServerRouter>", () => {
@@ -479,10 +570,58 @@ describe("<Links />", () => {
     let link = container.querySelector("link[href='/style.css']");
     expect(link).toHaveAttribute("nonce", "server-nonce");
   });
+
+  it("uses manifest crossOrigin when one is not provided", () => {
+    let context = mockFrameworkContext({
+      manifest: {
+        ...mockFrameworkContext().manifest,
+        crossOrigin: "anonymous",
+      },
+      criticalCss: { rel: "stylesheet", href: "/critical.css" },
+    });
+
+    let { container } = render(
+      <DataRouterStateContext.Provider
+        value={{ matches: [], errors: null } as any}
+      >
+        <FrameworkContext.Provider value={context}>
+          <Links />
+        </FrameworkContext.Provider>
+      </DataRouterStateContext.Provider>,
+    );
+
+    expect(
+      container.querySelector("link[href='/critical.css']"),
+    ).toHaveAttribute("crossorigin", "anonymous");
+  });
+
+  it("prefers an explicit crossOrigin over manifest crossOrigin", () => {
+    let context = mockFrameworkContext({
+      manifest: {
+        ...mockFrameworkContext().manifest,
+        crossOrigin: "anonymous",
+      },
+      criticalCss: { rel: "stylesheet", href: "/critical.css" },
+    });
+
+    let { container } = render(
+      <DataRouterStateContext.Provider
+        value={{ matches: [], errors: null } as any}
+      >
+        <FrameworkContext.Provider value={context}>
+          <Links crossOrigin="use-credentials" />
+        </FrameworkContext.Provider>
+      </DataRouterStateContext.Provider>,
+    );
+
+    expect(
+      container.querySelector("link[href='/critical.css']"),
+    ).toHaveAttribute("crossorigin", "use-credentials");
+  });
 });
 
 describe("<Scripts />", () => {
-  it("propagates nonce to modulepreload links", async () => {
+  it("propagates nonce and resolves crossOrigin for asset tags", async () => {
     let staticHandlerContext = await createStaticHandler([{ path: "/" }]).query(
       new Request("http://localhost/"),
     );
@@ -510,6 +649,7 @@ describe("<Scripts />", () => {
         },
         url: "manifest.js",
         version: "",
+        crossOrigin: "anonymous",
       },
       routeDiscovery: { mode: "initial", manifestPath: "/__manifest" },
       routeModules: {
@@ -518,6 +658,7 @@ describe("<Scripts />", () => {
             <>
               <h1>Root</h1>
               <Scripts nonce="test-nonce" />
+              <Scripts nonce="test-nonce" crossOrigin="use-credentials" />
             </>
           ),
         },
@@ -556,6 +697,26 @@ describe("<Scripts />", () => {
         'link[rel="modulepreload"][href="preload-b.js"]',
       ),
     ).toHaveAttribute("nonce", "test-nonce");
+    expect(
+      container.ownerDocument.querySelector(
+        "script[type='module'][crossorigin='anonymous']",
+      ),
+    ).toBeTruthy();
+    expect(
+      container.ownerDocument.querySelector(
+        "script[type='module'][crossorigin='use-credentials']",
+      ),
+    ).toBeTruthy();
+    expect(
+      container.ownerDocument.querySelector(
+        "link[rel='modulepreload'][crossorigin='anonymous']",
+      ),
+    ).toBeTruthy();
+    expect(
+      container.ownerDocument.querySelector(
+        "link[rel='modulepreload'][crossorigin='use-credentials']",
+      ),
+    ).toBeTruthy();
   });
 
   it("propagates the ServerRouter nonce to default HydrateFallback scripts when a route has a clientLoader without a HydrateFallback", async () => {

--- a/packages/react-router/__tests__/dom/ssr/links-prefetch-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/links-prefetch-test.ts
@@ -5,8 +5,8 @@ import type { LinkDescriptor } from "../../../lib/router/links";
 import { getKeyedPrefetchLinks } from "../../../lib/dom/ssr/links";
 
 // Minimal fakes for the pure prefetch-link transform. `getKeyedPrefetchLinks`
-// only reads `match.route.id`, `manifest.routes[id]`, `manifest.crossOrigin`,
-// and the cached route module's `links()`, so we stub just those.
+// only reads `match.route.id`, `manifest.routes[id]`, and the cached route
+// module's `links()`, so we stub just those.
 function setup(
   links: LinkDescriptor[],
   crossOrigin?: AssetsManifest["crossOrigin"],
@@ -37,49 +37,31 @@ async function prefetchLinks(
 }
 
 describe("getKeyedPrefetchLinks crossOrigin", () => {
-  it("applies manifest.crossOrigin to prefetched stylesheet links", async () => {
-    let [link] = await prefetchLinks(
-      [{ rel: "stylesheet", href: "/assets/styles.css" }],
-      "anonymous",
-    );
+  it("preserves descriptor crossOrigin while transforming links", async () => {
+    let [link] = await prefetchLinks([
+      {
+        rel: "stylesheet",
+        href: "/assets/styles.css",
+        crossOrigin: "use-credentials",
+      },
+    ]);
     expect(link).toMatchObject({
       rel: "prefetch",
       as: "style",
       href: "/assets/styles.css",
-      crossOrigin: "anonymous",
-    });
-  });
-
-  it("applies manifest.crossOrigin to prefetched preload links", async () => {
-    let [link] = await prefetchLinks(
-      [{ rel: "preload", as: "font", href: "/assets/font.woff2" }],
-      "use-credentials",
-    );
-    expect(link).toMatchObject({
-      rel: "prefetch",
-      href: "/assets/font.woff2",
       crossOrigin: "use-credentials",
     });
   });
 
-  it("lets a per-descriptor crossOrigin win over manifest.crossOrigin", async () => {
+  it("leaves descriptor crossOrigin undefined when config provides one", async () => {
     let [link] = await prefetchLinks(
-      [
-        {
-          rel: "stylesheet",
-          href: "/assets/styles.css",
-          crossOrigin: "use-credentials",
-        },
-      ],
+      [{ rel: "preload", as: "font", href: "/assets/font.woff2" }],
       "anonymous",
     );
-    expect(link).toMatchObject({ crossOrigin: "use-credentials" });
-  });
-
-  it("leaves crossOrigin undefined when neither source provides one", async () => {
-    let [link] = await prefetchLinks([
-      { rel: "stylesheet", href: "/assets/styles.css" },
-    ]);
+    expect(link).toMatchObject({
+      rel: "prefetch",
+      href: "/assets/font.woff2",
+    });
     expect(link.crossOrigin).toBeUndefined();
   });
 });

--- a/packages/react-router/__tests__/dom/ssr/links-prefetch-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/links-prefetch-test.ts
@@ -1,0 +1,85 @@
+import type { DataRouteMatch } from "../../../lib/router/utils";
+import type { AssetsManifest } from "../../../lib/dom/ssr/entry";
+import type { RouteModules } from "../../../lib/dom/ssr/routeModules";
+import type { LinkDescriptor } from "../../../lib/router/links";
+import { getKeyedPrefetchLinks } from "../../../lib/dom/ssr/links";
+
+// Minimal fakes for the pure prefetch-link transform. `getKeyedPrefetchLinks`
+// only reads `match.route.id`, `manifest.routes[id]`, `manifest.crossOrigin`,
+// and the cached route module's `links()`, so we stub just those.
+function setup(
+  links: LinkDescriptor[],
+  crossOrigin?: AssetsManifest["crossOrigin"],
+) {
+  let routeId = "routes/thing";
+  let matches = [{ route: { id: routeId } }] as unknown as DataRouteMatch[];
+  let manifest = {
+    entry: { imports: [], module: "" },
+    routes: {
+      [routeId]: { id: routeId, module: `/assets/${routeId}.js` },
+    },
+    url: "/assets/manifest.js",
+    version: "1",
+    crossOrigin,
+  } as unknown as AssetsManifest;
+  // Pre-populate the cache so `loadRouteModule` resolves without importing.
+  let routeModules = { [routeId]: { links: () => links } } as RouteModules;
+  return { matches, manifest, routeModules };
+}
+
+async function prefetchLinks(
+  links: LinkDescriptor[],
+  crossOrigin?: AssetsManifest["crossOrigin"],
+) {
+  let { matches, manifest, routeModules } = setup(links, crossOrigin);
+  let keyed = await getKeyedPrefetchLinks(matches, manifest, routeModules);
+  return keyed.map((k) => k.link);
+}
+
+describe("getKeyedPrefetchLinks crossOrigin", () => {
+  it("applies manifest.crossOrigin to prefetched stylesheet links", async () => {
+    let [link] = await prefetchLinks(
+      [{ rel: "stylesheet", href: "/assets/styles.css" }],
+      "anonymous",
+    );
+    expect(link).toMatchObject({
+      rel: "prefetch",
+      as: "style",
+      href: "/assets/styles.css",
+      crossOrigin: "anonymous",
+    });
+  });
+
+  it("applies manifest.crossOrigin to prefetched preload links", async () => {
+    let [link] = await prefetchLinks(
+      [{ rel: "preload", as: "font", href: "/assets/font.woff2" }],
+      "use-credentials",
+    );
+    expect(link).toMatchObject({
+      rel: "prefetch",
+      href: "/assets/font.woff2",
+      crossOrigin: "use-credentials",
+    });
+  });
+
+  it("lets a per-descriptor crossOrigin win over manifest.crossOrigin", async () => {
+    let [link] = await prefetchLinks(
+      [
+        {
+          rel: "stylesheet",
+          href: "/assets/styles.css",
+          crossOrigin: "use-credentials",
+        },
+      ],
+      "anonymous",
+    );
+    expect(link).toMatchObject({ crossOrigin: "use-credentials" });
+  });
+
+  it("leaves crossOrigin undefined when neither source provides one", async () => {
+    let [link] = await prefetchLinks([
+      { rel: "stylesheet", href: "/assets/styles.css" },
+    ]);
+    expect(link.crossOrigin).toBeUndefined();
+  });
+});

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -210,10 +210,23 @@ function createHydratedRouter({
     router.initialize();
   }
 
+  let createRoutesForHMR = (
+    ...args: Parameters<typeof createClientRoutesWithHMRRevalidationOptOut>
+  ) =>
+    createClientRoutesWithHMRRevalidationOptOut(
+      args[0],
+      args[1],
+      args[2],
+      args[3],
+      args[4],
+      args[5],
+      localSsrInfo.manifest.crossOrigin,
+    );
+
   // @ts-ignore
   router.createRoutesForHMR =
     /* spacer so ts-ignore does not affect the right hand of the assignment */
-    createClientRoutesWithHMRRevalidationOptOut;
+    createRoutesForHMR;
   window.__reactRouterDataRouter = router;
 
   return router;

--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -126,6 +126,10 @@ function createHydratedRouter({
     ssrInfo.context.state,
     ssrInfo.context.ssr,
     ssrInfo.context.isSpaMode,
+    "",
+    undefined,
+    undefined,
+    ssrInfo.manifest.crossOrigin,
   );
 
   let hydrationData: HydrationState | undefined = undefined;

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -285,6 +285,9 @@ export function Links({ nonce, crossOrigin }: LinksProps): React.JSX.Element {
   if (nonce == null && contextNonce) {
     nonce = contextNonce;
   }
+  if (crossOrigin == null) {
+    crossOrigin = manifest.crossOrigin;
+  }
 
   return (
     <>
@@ -567,7 +570,9 @@ function PrefetchPageLinksImpl({
           key={key}
           nonce={linkProps.nonce}
           {...link}
-          crossOrigin={link.crossOrigin ?? linkProps.crossOrigin}
+          crossOrigin={
+            link.crossOrigin ?? linkProps.crossOrigin ?? manifest.crossOrigin
+          }
         />
       ))}
     </>
@@ -834,6 +839,9 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
   // internally without props (such as in the default `HydrateFallback`).
   if (scriptProps.nonce == null && contextNonce) {
     scriptProps = { ...scriptProps, nonce: contextNonce };
+  }
+  if (scriptProps.crossOrigin == null && manifest.crossOrigin) {
+    scriptProps = { ...scriptProps, crossOrigin: manifest.crossOrigin };
   }
 
   // Let <ServerRouter> know that we hydrated and we should render the single

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -66,9 +66,6 @@ export interface AssetsManifest {
     runtime: string;
   };
   sri?: Record<string, string> | true;
-  // The CORS mode to use when the client imperatively prefetches assets
-  // (e.g. `<Link prefetch>` CSS preloads). Mirrors the `<Links crossOrigin>` /
-  // `<Scripts crossOrigin>` render props so prefetched assets served from a
-  // cross-origin host fetch with a matching CORS mode and aren't double-fetched.
+  // App-wide CORS mode for generated tags and imperative client prefetches.
   crossOrigin?: "anonymous" | "use-credentials";
 }

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -66,4 +66,9 @@ export interface AssetsManifest {
     runtime: string;
   };
   sri?: Record<string, string> | true;
+  // The CORS mode to use when the client imperatively prefetches assets
+  // (e.g. `<Link prefetch>` CSS preloads). Mirrors the `<Links crossOrigin>` /
+  // `<Scripts crossOrigin>` render props so prefetched assets served from a
+  // cross-origin host fetch with a matching CORS mode and aren't double-fetched.
+  crossOrigin?: "anonymous" | "use-credentials";
 }

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -382,7 +382,17 @@ export async function fetchAndApplyManifestPatches(
   parentIds.forEach((parentId) =>
     patchRoutes(
       parentId || null,
-      createClientRoutes(patches, routeModules, null, ssr, isSpaMode, parentId),
+      createClientRoutes(
+        patches,
+        routeModules,
+        null,
+        ssr,
+        isSpaMode,
+        parentId,
+        undefined,
+        undefined,
+        manifest.crossOrigin,
+      ),
     ),
   );
 }

--- a/packages/react-router/lib/dom/ssr/links.ts
+++ b/packages/react-router/lib/dom/ssr/links.ts
@@ -37,26 +37,33 @@ export function getKeyedLinksForMatches(
   return dedupeLinkDescriptors(descriptors, preloads);
 }
 
-function getRouteCssDescriptors(route: EntryRoute): HtmlLinkDescriptor[] {
+function getRouteCssDescriptors(
+  route: EntryRoute,
+  crossOrigin?: "anonymous" | "use-credentials",
+): HtmlLinkDescriptor[] {
   if (!route.css) return [];
-  return route.css.map((href) => ({ rel: "stylesheet", href }));
+  return route.css.map((href) => ({ rel: "stylesheet", href, crossOrigin }));
 }
 
-export async function prefetchRouteCss(route: EntryRoute): Promise<void> {
+export async function prefetchRouteCss(
+  route: EntryRoute,
+  crossOrigin?: "anonymous" | "use-credentials",
+): Promise<void> {
   if (!route.css) return;
-  let descriptors = getRouteCssDescriptors(route);
+  let descriptors = getRouteCssDescriptors(route, crossOrigin);
   await Promise.all(descriptors.map(prefetchStyleLink));
 }
 
 export async function prefetchStyleLinks(
   route: EntryRoute,
   routeModule: RouteModule,
+  crossOrigin?: "anonymous" | "use-credentials",
 ): Promise<void> {
   if ((!route.css && !routeModule.links) || !isPreloadSupported()) return;
 
   let descriptors: LinkDescriptor[] = [];
   if (route.css) {
-    descriptors.push(...getRouteCssDescriptors(route));
+    descriptors.push(...getRouteCssDescriptors(route, crossOrigin));
   }
   if (routeModule.links) {
     descriptors.push(...routeModule.links());
@@ -70,6 +77,12 @@ export async function prefetchStyleLinks(
         ...descriptor,
         rel: "preload",
         as: "style",
+        // Preload must fetch with the same CORS mode as the eventual
+        // stylesheet load, otherwise the browser discards the preload and
+        // fetches the asset twice. A per-descriptor `crossOrigin` wins;
+        // otherwise fall back to the app-wide value (matching `<Links
+        // crossOrigin>` / the cross-origin asset host).
+        crossOrigin: descriptor.crossOrigin ?? crossOrigin,
       } as HtmlLinkDescriptor);
     }
   }
@@ -169,8 +182,17 @@ export async function getKeyedPrefetchLinks(
       .filter((link) => link.rel === "stylesheet" || link.rel === "preload")
       .map((link) =>
         link.rel === "stylesheet"
-          ? ({ ...link, rel: "prefetch", as: "style" } as HtmlLinkDescriptor)
-          : ({ ...link, rel: "prefetch" } as HtmlLinkDescriptor),
+          ? ({
+              ...link,
+              rel: "prefetch",
+              as: "style",
+              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
+            } as HtmlLinkDescriptor)
+          : ({
+              ...link,
+              rel: "prefetch",
+              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
+            } as HtmlLinkDescriptor),
       ),
   );
 }

--- a/packages/react-router/lib/dom/ssr/links.ts
+++ b/packages/react-router/lib/dom/ssr/links.ts
@@ -186,12 +186,10 @@ export async function getKeyedPrefetchLinks(
               ...link,
               rel: "prefetch",
               as: "style",
-              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
             } as HtmlLinkDescriptor)
           : ({
               ...link,
               rel: "prefetch",
-              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
             } as HtmlLinkDescriptor),
       ),
   );

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -181,6 +181,7 @@ export function createClientRoutesWithHMRRevalidationOptOut(
   initialState: HydrationState,
   ssr: boolean,
   isSpaMode: boolean,
+  crossOrigin?: "anonymous" | "use-credentials",
 ) {
   return createClientRoutes(
     manifest,
@@ -191,6 +192,7 @@ export function createClientRoutesWithHMRRevalidationOptOut(
     "",
     groupRoutesByParentId(manifest),
     needsRevalidation,
+    crossOrigin,
   );
 }
 
@@ -235,6 +237,7 @@ export function createClientRoutes(
     Omit<EntryRoute, "children">[]
   > = groupRoutesByParentId(manifest),
   needsRevalidation?: Set<string>,
+  crossOrigin?: "anonymous" | "use-credentials",
 ): DataRouteObject[] {
   return (routesByParentId[parentId] || []).map((route) => {
     let routeModule = routeModulesCache[route.id];
@@ -292,7 +295,7 @@ export function createClientRoutes(
       // prefetching style links via loadRouteModuleWithBlockingLinks.
       let cachedModule = routeModulesCache[route.id];
       let linkPrefetchPromise = cachedModule
-        ? prefetchStyleLinks(route, cachedModule)
+        ? prefetchStyleLinks(route, cachedModule, crossOrigin)
         : Promise.resolve();
       try {
         return handler();
@@ -463,6 +466,7 @@ export function createClientRoutes(
           let routeModulePromise = loadRouteModuleWithBlockingLinks(
             route,
             routeModulesCache,
+            crossOrigin,
           );
           prefetchRouteModuleChunks(route);
           return await routeModulePromise;
@@ -555,6 +559,7 @@ export function createClientRoutes(
       route.id,
       routesByParentId,
       needsRevalidation,
+      crossOrigin,
     );
     if (children.length > 0) dataRoute.children = children;
     return dataRoute;
@@ -631,16 +636,17 @@ function wrapShouldRevalidateForHdr(
 async function loadRouteModuleWithBlockingLinks(
   route: EntryRoute,
   routeModules: RouteModules,
+  crossOrigin?: "anonymous" | "use-credentials",
 ) {
   // Ensure the route module and its static CSS links are loaded in parallel as
   // soon as possible before blocking on the route module
   let routeModulePromise = loadRouteModule(route, routeModules);
-  let prefetchRouteCssPromise = prefetchRouteCss(route);
+  let prefetchRouteCssPromise = prefetchRouteCss(route, crossOrigin);
 
   let routeModule = await routeModulePromise;
   await Promise.all([
     prefetchRouteCssPromise,
-    prefetchStyleLinks(route, routeModule),
+    prefetchStyleLinks(route, routeModule, crossOrigin),
   ]);
 
   // Include all `browserSafeRouteExports` fields, except `HydrateFallback`


### PR DESCRIPTION
_This PR description was generated by Amp._

Fixes #15401 and completes the client-side half of #14678.

## Context

#14687 added `crossOrigin` to `<Links>`, but that render-time prop cannot reach the imperative CSS preload and prefetch paths used during client navigation.

## Problem

For assets hosted on another origin, client-generated CSS preloads used a different CORS mode than the eventual stylesheet request. Browsers could therefore discard the preload, fetch the stylesheet again, and briefly render the destination route without styles.

The initial implementation added runtime support for `manifest.crossOrigin`, but real development and production manifests had no producer for that field.

## Solution

- Add an optional top-level `crossOrigin` Framework Mode config as the canonical app-wide value.
- Emit it into development and production browser/server manifests and include it in the production manifest fingerprint.
- Use it as the default for `<Links>`, `<Scripts>`, route CSS preloads, and `<Link prefetch>` stylesheet links.
- Preserve descriptor → component prop → config precedence for rendered links.
- Carry the value through lazy route discovery and route recreation after HMR.

Using build config rather than new `ServerRouter`/`HydratedRouter` props gives both server and browser runtimes one source of truth without duplicating values across entry files. The option remains optional, so applications that do not configure it retain existing behavior. RSC Framework Mode is unchanged.

## Test steps

```sh
pnpm test packages/react-router/__tests__/dom/ssr/components-test.tsx packages/react-router/__tests__/dom/ssr/links-test.tsx packages/react-router/__tests__/dom/ssr/links-prefetch-test.ts --runInBand
pnpm test:integration:run integration/cross-origin-test.ts --project chromium
pnpm test:integration:run integration/vite-presets-test.ts --project chromium
pnpm run --filter react-router typecheck
pnpm run --filter @react-router/dev typecheck
```

## Videos and screenshots

Not applicable; this changes framework-generated asset attributes and prefetch behavior.

<details>
<summary>AI tool validation prompt</summary>

Copy and paste into your AI tool (Amp, Cursor, etc.):

```
Review remix-run/react-router PR #15402 on branch comp615/prefetch-css-crossorigin and verify:
1. Run the PR's focused unit and integration test commands.
2. Confirm react-router.config.ts crossOrigin reaches both development and production manifests.
3. Confirm initial Links/Scripts tags, Link-prefetched CSS, lazy route CSS, and post-HMR CSS preloads receive the configured value.
4. Confirm precedence is descriptor > component prop > config and omitted config preserves current behavior.
```

</details>

_This document was created by Amp and revised 1 time._
