### PR TITLE
fix(react-router): thread crossOrigin through prefetch helpers

### DIFF
--- a/packages/react-router/lib/dom-export/hydrated-router.tsx
+++ b/packages/react-router/lib/dom-export/hydrated-router.tsx
@@ -126,6 +126,10 @@ function createHydratedRouter({
     ssrInfo.context.state,
     ssrInfo.context.ssr,
     ssrInfo.context.isSpaMode,
+    "",
+    undefined,
+    undefined,
+    ssrInfo.manifest.crossOrigin,
   );
 
   let hydrationData: HydrationState | undefined = undefined;

--- a/packages/react-router/lib/dom/ssr/entry.ts
+++ b/packages/react-router/lib/dom/ssr/entry.ts
@@ -66,4 +66,9 @@ export interface AssetsManifest {
     runtime: string;
   };
   sri?: Record<string, string> | true;
+  // The CORS mode to use when the client imperatively prefetches assets
+  // (e.g. `<Link prefetch>` CSS preloads). Mirrors the `<Links crossOrigin>` /
+  // `<Scripts crossOrigin>` render props so prefetched assets served from a
+  // cross-origin host fetch with a matching CORS mode and aren't double-fetched.
+  crossOrigin?: "anonymous" | "use-credentials";
 }

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -382,7 +382,17 @@ export async function fetchAndApplyManifestPatches(
   parentIds.forEach((parentId) =>
     patchRoutes(
       parentId || null,
-      createClientRoutes(patches, routeModules, null, ssr, isSpaMode, parentId),
+      createClientRoutes(
+        patches,
+        routeModules,
+        null,
+        ssr,
+        isSpaMode,
+        parentId,
+        undefined,
+        undefined,
+        manifest.crossOrigin,
+      ),
     ),
   );
 }

--- a/packages/react-router/lib/dom/ssr/links.ts
+++ b/packages/react-router/lib/dom/ssr/links.ts
@@ -37,26 +37,33 @@ export function getKeyedLinksForMatches(
   return dedupeLinkDescriptors(descriptors, preloads);
 }
 
-function getRouteCssDescriptors(route: EntryRoute): HtmlLinkDescriptor[] {
+function getRouteCssDescriptors(
+  route: EntryRoute,
+  crossOrigin?: "anonymous" | "use-credentials",
+): HtmlLinkDescriptor[] {
   if (!route.css) return [];
-  return route.css.map((href) => ({ rel: "stylesheet", href }));
+  return route.css.map((href) => ({ rel: "stylesheet", href, crossOrigin }));
 }
 
-export async function prefetchRouteCss(route: EntryRoute): Promise<void> {
+export async function prefetchRouteCss(
+  route: EntryRoute,
+  crossOrigin?: "anonymous" | "use-credentials",
+): Promise<void> {
   if (!route.css) return;
-  let descriptors = getRouteCssDescriptors(route);
+  let descriptors = getRouteCssDescriptors(route, crossOrigin);
   await Promise.all(descriptors.map(prefetchStyleLink));
 }
 
 export async function prefetchStyleLinks(
   route: EntryRoute,
   routeModule: RouteModule,
+  crossOrigin?: "anonymous" | "use-credentials",
 ): Promise<void> {
   if ((!route.css && !routeModule.links) || !isPreloadSupported()) return;
 
   let descriptors: LinkDescriptor[] = [];
   if (route.css) {
-    descriptors.push(...getRouteCssDescriptors(route));
+    descriptors.push(...getRouteCssDescriptors(route, crossOrigin));
   }
   if (routeModule.links) {
     descriptors.push(...routeModule.links());
@@ -70,6 +77,12 @@ export async function prefetchStyleLinks(
         ...descriptor,
         rel: "preload",
         as: "style",
+        // Preload must fetch with the same CORS mode as the eventual
+        // stylesheet load, otherwise the browser discards the preload and
+        // fetches the asset twice. A per-descriptor `crossOrigin` wins;
+        // otherwise fall back to the app-wide value (matching `<Links
+        // crossOrigin>` / the cross-origin asset host).
+        crossOrigin: descriptor.crossOrigin ?? crossOrigin,
       } as HtmlLinkDescriptor);
     }
   }
@@ -169,8 +182,17 @@ export async function getKeyedPrefetchLinks(
       .filter((link) => link.rel === "stylesheet" || link.rel === "preload")
       .map((link) =>
         link.rel === "stylesheet"
-          ? ({ ...link, rel: "prefetch", as: "style" } as HtmlLinkDescriptor)
-          : ({ ...link, rel: "prefetch" } as HtmlLinkDescriptor),
+          ? ({
+              ...link,
+              rel: "prefetch",
+              as: "style",
+              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
+            } as HtmlLinkDescriptor)
+          : ({
+              ...link,
+              rel: "prefetch",
+              crossOrigin: link.crossOrigin ?? manifest.crossOrigin,
+            } as HtmlLinkDescriptor),
       ),
   );
 }

--- a/packages/react-router/lib/dom/ssr/routes.tsx
+++ b/packages/react-router/lib/dom/ssr/routes.tsx
@@ -181,6 +181,7 @@ export function createClientRoutesWithHMRRevalidationOptOut(
   initialState: HydrationState,
   ssr: boolean,
   isSpaMode: boolean,
+  crossOrigin?: "anonymous" | "use-credentials",
 ) {
   return createClientRoutes(
     manifest,
@@ -191,6 +192,7 @@ export function createClientRoutesWithHMRRevalidationOptOut(
     "",
     groupRoutesByParentId(manifest),
     needsRevalidation,
+    crossOrigin,
   );
 }
 
@@ -235,6 +237,7 @@ export function createClientRoutes(
     Omit<EntryRoute, "children">[]
   > = groupRoutesByParentId(manifest),
   needsRevalidation?: Set<string>,
+  crossOrigin?: "anonymous" | "use-credentials",
 ): DataRouteObject[] {
   return (routesByParentId[parentId] || []).map((route) => {
     let routeModule = routeModulesCache[route.id];
@@ -292,7 +295,7 @@ export function createClientRoutes(
       // prefetching style links via loadRouteModuleWithBlockingLinks.
       let cachedModule = routeModulesCache[route.id];
       let linkPrefetchPromise = cachedModule
-        ? prefetchStyleLinks(route, cachedModule)
+        ? prefetchStyleLinks(route, cachedModule, crossOrigin)
         : Promise.resolve();
       try {
         return handler();
@@ -463,6 +466,7 @@ export function createClientRoutes(
           let routeModulePromise = loadRouteModuleWithBlockingLinks(
             route,
             routeModulesCache,
+            crossOrigin,
           );
           prefetchRouteModuleChunks(route);
           return await routeModulePromise;
@@ -555,6 +559,7 @@ export function createClientRoutes(
       route.id,
       routesByParentId,
       needsRevalidation,
+      crossOrigin,
     );
     if (children.length > 0) dataRoute.children = children;
     return dataRoute;
@@ -631,16 +636,17 @@ function wrapShouldRevalidateForHdr(
 async function loadRouteModuleWithBlockingLinks(
   route: EntryRoute,
   routeModules: RouteModules,
+  crossOrigin?: "anonymous" | "use-credentials",
 ) {
   // Ensure the route module and its static CSS links are loaded in parallel as
   // soon as possible before blocking on the route module
   let routeModulePromise = loadRouteModule(route, routeModules);
-  let prefetchRouteCssPromise = prefetchRouteCss(route);
+  let prefetchRouteCssPromise = prefetchRouteCss(route, crossOrigin);
 
   let routeModule = await routeModulePromise;
   await Promise.all([
     prefetchRouteCssPromise,
-    prefetchStyleLinks(route, routeModule),
+    prefetchStyleLinks(route, routeModule, crossOrigin),
   ]);
 
   // Include all `browserSafeRouteExports` fields, except `HydrateFallback`


### PR DESCRIPTION
Fixes #15401. Threads crossOrigin through CSS prefetch helpers.