### PR TITLE
fix(dom): decode pathname in NavLink active comparison

### DIFF
--- a/packages/react-router/__tests__/dom/nav-link-active-test.tsx
+++ b/packages/react-router/__tests__/dom/nav-link-active-test.tsx
@@ -247,6 +247,38 @@ describe("NavLink", () => {
         "",
       ]);
     });
+
+    // Regression: https://github.com/remix-run/react-router/issues/10781
+    it("matches when the pipe character is used in the path", () => {
+      let renderer: TestRenderer.ReactTestRenderer;
+
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <BrowserRouter window={getWindow("/users/a|b")}>
+            <Routes>
+              <Route
+                path="/users/:name"
+                element={
+                  <>
+                    <NavLink to=".">user</NavLink>
+                    <NavLink to="/users/a|b">user (explicit)</NavLink>
+                    <NavLink to="/users/a/b">other</NavLink>
+                  </>
+                }
+              />
+            </Routes>
+          </BrowserRouter>,
+        );
+      });
+
+      let anchors = renderer.root.findAllByType("a");
+
+      expect(anchors.map((a) => a.props.className)).toEqual([
+        "active",
+        "active",
+        "",
+      ]);
+    });
   });
 
   describe("when it matches a partial URL segment", () => {

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -36,6 +36,7 @@ import type {
 } from "../router/utils";
 import {
   defaultMapRouteProperties,
+  decodePath,
   ErrorResponseImpl,
   SUPPORTED_ERROR_TYPES,
   joinPaths,
@@ -1650,6 +1651,17 @@ export const NavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>(
       routerState && routerState.navigation && routerState.navigation.location
         ? routerState.navigation.location.pathname
         : null;
+
+    // When generated, `toPathname` is URL-encoded (e.g. `%7C` for `|`), but
+    // `location.pathname` from the browser keeps these characters raw.
+    // Decode both sides so pathnames with special characters are compared
+    // consistently. `decodePath` is safe because it preserves already-encoded
+    // `%2F` sequences and leaves malformed encodings unchanged.
+    toPathname = decodePath(toPathname);
+    locationPathname = decodePath(locationPathname);
+    nextLocationPathname = nextLocationPathname
+      ? decodePath(nextLocationPathname)
+      : null;
 
     if (!caseSensitive) {
       locationPathname = locationPathname.toLowerCase();


### PR DESCRIPTION
Fixes #10781

`navigator.encodeLocation` percent-encodes special characters (e.g. `|` ? `%7C`) via `new URL()`, but `location.pathname` from the browser keeps them raw. This caused `NavLink` to never match when dynamic segments contained characters like `|`.

Decode both sides with the existing `decodePath` helper before comparing so the active-state check is encoding-consistent. Added a regression test for the pipe character.

Also related to #14619.