### PR TITLE
Time out stalled Lazy Route Discovery manifest requests instead of hanging forever

### DIFF
--- a/packages/react-router/.changes/patch.fog-of-war-discovery-timeout.md
+++ b/packages/react-router/.changes/patch.fog-of-war-discovery-timeout.md
@@ -1,0 +1,3 @@
+Time out stalled Lazy Route Discovery manifest requests instead of hanging the pending navigation or fetcher forever.
+
+`fetch()` has no default timeout, so a `/__manifest` request that never settled (proxy stall, exhausted HTTP/1.1 connection pool, dropped connection) previously pinned a fetcher in a permanent `"submitting"`/`"loading"` state with no error surfaced anywhere. The discovery request now aborts after 10 seconds and the resulting error settles the navigation/fetcher through the normal error-boundary path.

--- a/packages/react-router/__tests__/dom/ssr/fog-of-war-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/fog-of-war-test.ts
@@ -1,4 +1,9 @@
-import { getPathsWithAncestors } from "../../../lib/dom/ssr/fog-of-war";
+import {
+  FOG_OF_WAR_TIMEOUT_MS,
+  fetchAndApplyManifestPatches,
+  getPathsWithAncestors,
+} from "../../../lib/dom/ssr/fog-of-war";
+import type { AssetsManifest } from "../../../lib/dom/ssr/entry";
 
 describe("fog of war", () => {
   describe("getPathsWithAncestors", () => {
@@ -20,6 +25,103 @@ describe("fog of war", () => {
 
     test("normalizes paths without leading slashes", () => {
       expect(getPathsWithAncestors(["a/b"])).toEqual(["/a", "/a/b"]);
+    });
+  });
+
+  describe("fetchAndApplyManifestPatches discovery timeout", () => {
+    let originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.useRealTimers();
+    });
+
+    function manifest(): AssetsManifest {
+      return {
+        entry: { imports: [], module: "" },
+        routes: {},
+        url: "",
+        version: "test",
+      };
+    }
+
+    function callFetchAndApply(signal?: AbortSignal) {
+      return fetchAndApplyManifestPatches(
+        ["/a"],
+        null,
+        manifest(),
+        {},
+        true,
+        false,
+        undefined,
+        "/__manifest",
+        () => {},
+        signal,
+      );
+    }
+
+    test("a manifest request that never settles rejects after the timeout instead of hanging", async () => {
+      jest.useFakeTimers();
+      // A fetch that never resolves and never rejects on its own — but a real
+      // fetch aborts when its signal fires, and the timeout composition relies
+      // on that, so the stub honors the signal.
+      global.fetch = ((_url: any, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(
+              Object.assign(new Error("aborted"), { name: "AbortError" }),
+            ),
+          );
+        })) as typeof fetch;
+
+      let result = callFetchAndApply();
+      // Prevent an unhandled rejection between timer flush and assertion.
+      let outcome = result.then(
+        () => "resolved",
+        (e: unknown) => e,
+      );
+
+      await jest.advanceTimersByTimeAsync(FOG_OF_WAR_TIMEOUT_MS + 1);
+
+      let error = await outcome;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/timed out after/);
+    });
+
+    test("a caller abort still resolves silently (no error) before the timeout", async () => {
+      jest.useFakeTimers();
+      global.fetch = ((_url: any, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(
+              Object.assign(new Error("aborted"), { name: "AbortError" }),
+            ),
+          );
+        })) as typeof fetch;
+
+      let controller = new AbortController();
+      let result = callFetchAndApply(controller.signal);
+      controller.abort();
+
+      await expect(result).resolves.toBeUndefined();
+    });
+
+    test("a fast response is unaffected and the timeout timer is cleaned up", async () => {
+      jest.useFakeTimers();
+      // Minimal response stub: a real undici Response interacts badly with
+      // fake timers (unbounded microtask/timer churn), and only these fields
+      // are read by fetchAndApplyManifestPatches.
+      global.fetch = (() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: async () => ({}),
+        } as unknown as Response)) as typeof fetch;
+
+      await expect(callFetchAndApply()).resolves.toBeUndefined();
+      // Nothing pending: the timeout timer was cleared on success.
+      expect(jest.getTimerCount()).toBe(0);
     });
   });
 });

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -299,6 +299,48 @@ export async function handleClientVersionMismatch(
   return true;
 }
 
+// A stalled manifest request must eventually fail the discovery rather than
+// hang it: `fetch()` has no default timeout, so a request that never settles
+// (proxy stall, exhausted HTTP/1.1 connection pool, dropped connection)
+// previously pinned the pending navigation or fetcher in a permanent
+// "loading"/"submitting" state with no error surfaced anywhere. Timing out
+// makes the discovery throw, which the router already routes to the nearest
+// error boundary via `discoverRoutes`'s error result.
+export const FOG_OF_WAR_TIMEOUT_MS = 10_000;
+
+// `AbortSignal.any`/`AbortSignal.timeout` composition, written by hand so we
+// don't raise the browser support floor for this one call site.
+function signalWithTimeout(
+  signal: AbortSignal | undefined,
+  timeoutMs: number,
+): { signal: AbortSignal; cleanup: () => void } {
+  let controller = new AbortController();
+  let timeoutId = setTimeout(
+    () =>
+      controller.abort(
+        new Error(
+          `Route discovery manifest request timed out after ${timeoutMs}ms`,
+        ),
+      ),
+    timeoutMs,
+  );
+  let onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
 export async function fetchAndApplyManifestPatches(
   paths: string[],
   errorReloadPath: string | null,
@@ -335,8 +377,12 @@ export async function fetchAndApplyManifestPatches(
   }
 
   let serverPatches: AssetsManifest["routes"];
+  let { signal: fetchSignal, cleanup } = signalWithTimeout(
+    signal,
+    FOG_OF_WAR_TIMEOUT_MS,
+  );
   try {
-    let res = await fetch(url, { signal });
+    let res = await fetch(url, { signal: fetchSignal });
 
     if (!res.ok) {
       throw new Error(`${res.status} ${res.statusText}`);
@@ -354,8 +400,17 @@ export async function fetchAndApplyManifestPatches(
 
     serverPatches = (await res.json()) as AssetsManifest["routes"];
   } catch (e) {
+    // The caller (navigation/fetcher) aborting stays silent, as before. A
+    // timeout abort is NOT silent: the caller signal is still live, so the
+    // rejection propagates and settles the pending state with an error
+    // instead of hanging it forever.
     if (signal?.aborted) return;
+    if (fetchSignal.aborted && fetchSignal.reason instanceof Error) {
+      throw fetchSignal.reason;
+    }
     throw e;
+  } finally {
+    cleanup();
   }
 
   // Patch routes we don't know about yet into the manifest


### PR DESCRIPTION
Closes #15406

A `fetcher.submit()` (or navigation) to a route not yet in the client manifest awaits the `/__manifest` discovery fetch with only the caller's abort signal — and `fetch()` has no default timeout. If that request stalls (proxy stall, exhausted HTTP/1.1 connection pool, dropped connection), the fetcher is pinned in `"submitting"` **forever**, silently: no error state, no console output, no way for app code to detect or recover. Repro and full mechanism in #15406.

## Change

`fetchAndApplyManifestPatches` composes the caller's signal with a 10-second timeout (hand-rolled composition rather than `AbortSignal.any`/`AbortSignal.timeout`, to avoid raising the browser support floor). On timeout the discovery rejects with a descriptive error; `discoverRoutes`' existing `{ type: "error" }` handling then settles the pending navigation/fetcher through the normal error-boundary path (`setFetcherError` / navigation error). Caller aborts remain silent, exactly as before. Successful responses clear the timer.

Open questions I'd welcome guidance on:

- Whether the timeout should be configurable (e.g. via the `routeDiscovery` config) rather than a constant — I kept the minimal shape pending maintainer preference.
- Whether a dedicated error subclass would be preferable to a plain `Error` for boundary discrimination.

## Tests

Three added in `fog-of-war-test.ts` (fake timers, signal-honoring fetch stubs):

1. A never-settling manifest request rejects after the timeout with the timeout error (previously: hung forever).
2. A caller abort before the timeout still resolves silently (existing behavior preserved).
3. A fast response is unaffected and the timeout timer is cleaned up (no pending timers).

`packages/react-router` dom/ssr suite: 46 passed. Package typecheck clean. Change file included (`patch.fog-of-war-discovery-timeout.md`).