### PR TITLE
bump vite

### DIFF
--- a/playground/framework-spa/package.json
+++ b/playground/framework-spa/package.json
@@ -23,7 +23,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "typescript": "catalog:",
-    "vite": "^8.0.0"
+    "vite": "^8.2.1"
   },
   "engines": {
     "node": ">=22.22.0"

--- a/tutorials/address-book/package.json
+++ b/tutorials/address-book/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^19.2.3",
     "cross-env": "^7.0.3",
     "typescript": "^5.4.5",
-    "vite": "^5.4.11"
+    "vite": "^8.2.1"
   },
   "engines": {
     "node": ">=22.22.0"


### PR DESCRIPTION
# Review
object-path  <=0.11.7
Severity: high
Prototype Pollution in object-path - https://github.com/advisories/GHSA-v39p-96qg-c8rf
Prototype pollution in object-path - https://github.com/advisories/GHSA-cwx2-736x-mf6w
Prototype Pollution in object-path - https://github.com/advisories/GHSA-8v63-cqqc-6r2c
fix available via `npm audit fix --force`
Will install sort-by@0.0.2, which is a breaking change
node_modules/object-path
  sort-by  >=1.1.0
  Depends on vulnerable versions of object-path
  node_modules/sort-by

2 vulnerabilities (1 moderate, 1 high) << not doing, just leaving a note