### PR TITLE
Release 6.30.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   <summary>Table of Contents</summary>
 
 - [React Router Releases](#react-router-releases)
+  - [v6.30.5](#v6305)
+  - [v6.30.5](#v6305)
   - [v6.30.4](#v6304)
   - [v6.30.3](#v6303)
   - [v6.30.2](#v6302)
@@ -101,6 +103,19 @@ We manage release notes in this file instead of the paginated Github Releases Pa
   - [v6.0.0](#v600)
 
 </details>
+
+## v6.30.5
+
+Date: 2026-08-18
+
+### Patch Changes
+
+- `react-router` - Fix double slash normalization for `useNavigate` colon urls ([#15410](https://github.com/remix-run/react-router/pull/15410))
+
+  - As a reminder, `navigate()` is only intended for navigations within the React Router application and not for external navigations to other domains
+  - This change may be a breaking bug fix if you are using `navigate` for external navigations
+
+**Full Changelog**: [`v6.30.4...v6.30.5`](https://github.com/remix-run/react-router/compare/react-router@6.30.4...react-router@6.30.5)
 
 ## v6.30.5
 

--- a/packages/react-router-dom-v5-compat/CHANGELOG.md
+++ b/packages/react-router-dom-v5-compat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `react-router-dom-v5-compat`
 
+## v6.30.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)
+
 ## v6.30.4
 
 ### Patch Changes

--- a/packages/react-router-dom-v5-compat/package.json
+++ b/packages/react-router-dom-v5-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom-v5-compat",
-  "version": "6.30.4",
+  "version": "6.30.5",
   "description": "Migration path to React Router v6 from v4/5",
   "keywords": [
     "react",

--- a/packages/react-router-dom/CHANGELOG.md
+++ b/packages/react-router-dom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `react-router-dom`
 
+## v6.30.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)
+
 ## v6.30.4
 
 ### Patch Changes

--- a/packages/react-router-dom/package.json
+++ b/packages/react-router-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-dom",
-  "version": "6.30.4",
+  "version": "6.30.5",
   "description": "Declarative routing for React web applications",
   "keywords": [
     "react",

--- a/packages/react-router-native/CHANGELOG.md
+++ b/packages/react-router-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `react-router-native`
 
+## v6.30.5
+
+### Patch Changes
+
+- Updated dependencies:
+  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)
+
 ## v6.30.4
 
 ### Patch Changes

--- a/packages/react-router-native/package.json
+++ b/packages/react-router-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router-native",
-  "version": "6.30.4",
+  "version": "6.30.5",
   "description": "Declarative routing for React Native applications",
   "keywords": [
     "react",

--- a/packages/react-router/.changes/patch.fix-navigate-urls.md
+++ b/packages/react-router/.changes/patch.fix-navigate-urls.md
@@ -1,4 +1,0 @@
-Fix double slash normalization for `useNavigate` colon urls
-
-- As a reminder, `navigate()` is only intended for navigations within the React Router application and not for external navigations to other domains
-- This change may be a breaking bug fix if you are using `navigate` for external navigations

--- a/packages/react-router/CHANGELOG.md
+++ b/packages/react-router/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `react-router`
 
+## v6.30.5
+
+### Patch Changes
+
+- Fix double slash normalization for `useNavigate` colon urls ([#15410](https://github.com/remix-run/react-router/pull/15410))
+
+  - As a reminder, `navigate()` is only intended for navigations within the React Router application and not for external navigations to other domains
+  - This change may be a breaking bug fix if you are using `navigate` for external navigations
+
 ## v6.30.4
 
 ### Patch Changes

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-router",
-  "version": "6.30.4",
+  "version": "6.30.5",
   "description": "Declarative routing for React",
   "keywords": [
     "react",


### PR DESCRIPTION
This PR is managed by the [`release`](https://github.com/remix-run/react-router/blob/v6/.github/workflows/release.yml) workflow. Do not edit it manually.

# Releases

| Package | Version |
|---------|---------|
| react-router | `6.30.4` → `6.30.5` |
| react-router-dom | `6.30.4` → `6.30.5` |
| react-router-dom-v5-compat | `6.30.4` → `6.30.5` |
| react-router-native | `6.30.4` → `6.30.5` |

# Changelogs

## react-router v6.30.5

### Patch Changes

- Fix double slash normalization for `useNavigate` colon urls ([#15410](https://github.com/remix-run/react-router/pull/15410))

  - As a reminder, `navigate()` is only intended for navigations within the React Router application and not for external navigations to other domains
  - This change may be a breaking bug fix if you are using `navigate` for external navigations


## react-router-dom v6.30.5

### Patch Changes

- Updated dependencies:
  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)


## react-router-dom-v5-compat v6.30.5

### Patch Changes

- Updated dependencies:
  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)


## react-router-native v6.30.5

### Patch Changes

- Updated dependencies:
  - [`react-router@6.30.5`](https://github.com/remix-run/react-router/releases/tag/react-router@6.30.5)
