### PR TITLE
Harden GitHub Actions workflow inputs

### DIFF
--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -50,4 +50,8 @@ jobs:
       - name: Apply actions
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          WORKFLOW_RUN_HEAD_REPO_ID: ${{ github.event.workflow_run.head_repository.id }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: node scripts/pr.ts actions pr-checks-result.json

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -95,9 +95,12 @@ jobs:
       # pushes over remote branches in case of a branch name collision
       - name: Build/push branch (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INSTALLABLE_BRANCH: ${{ inputs.installableBranch }}
         run: |
-          node ./scripts/previews/branch.ts ${{ inputs.installableBranch }}
-          git push --set-upstream origin ${{ inputs.installableBranch }}
+          git check-ref-format --branch "$INSTALLABLE_BRANCH"
+          node ./scripts/previews/branch.ts "$INSTALLABLE_BRANCH"
+          git push --set-upstream origin "$INSTALLABLE_BRANCH"
           echo "💿 pushed installable branch: https://github.com/$GITHUB_REPOSITORY/commit/$(git rev-parse HEAD)"
 
       # Cleanup PR preview/pr-{number} branches when the PR is closed

--- a/.github/workflows/release-comments-manual.yml
+++ b/.github/workflows/release-comments-manual.yml
@@ -39,4 +39,5 @@ jobs:
       - name: Comment on released issues and pull requests
         env:
           GH_TOKEN: ${{ github.token }}
-        run: pnpm run release-comments --release=${{ github.event.inputs.release }}
+          RELEASE: ${{ inputs.release }}
+        run: pnpm run release-comments --release="$RELEASE"

--- a/scripts/pr.ts
+++ b/scripts/pr.ts
@@ -28,6 +28,10 @@
  *
  * Environment (actions):
  *   GITHUB_TOKEN  - Required (issues:write + pull-requests:write).
+ *   WORKFLOW_RUN_HEAD_OWNER   - Required. workflow_run.head_repository.owner.login
+ *   WORKFLOW_RUN_HEAD_REPO_ID - Required. workflow_run.head_repository.id
+ *   WORKFLOW_RUN_HEAD_BRANCH  - Required. workflow_run.head_branch
+ *   WORKFLOW_RUN_HEAD_SHA     - Required. workflow_run.head_sha
  */
 import * as fs from "node:fs";
 import * as util from "node:util";
@@ -39,6 +43,7 @@ import {
   createPrComment,
   getPrComments,
   getPrFiles,
+  getWorkflowRunPrNumber,
   removePrLabel,
   updatePrComment,
 } from "./utils/github.ts";
@@ -344,7 +349,9 @@ async function runActions() {
     return;
   }
 
-  let { prNumber, actions } = JSON.parse(fs.readFileSync(filename, "utf8")) as {
+  let { prNumber: artifactPrNumber, actions } = JSON.parse(
+    fs.readFileSync(filename, "utf8"),
+  ) as {
     prNumber: number;
     actions: Action[];
   };
@@ -352,6 +359,25 @@ async function runActions() {
   if (actions.length === 0) {
     console.log("No actions to apply");
     return;
+  }
+
+  let headRepositoryId = Number(requireEnv("WORKFLOW_RUN_HEAD_REPO_ID"));
+  if (!Number.isSafeInteger(headRepositoryId) || headRepositoryId <= 0) {
+    throw new Error("WORKFLOW_RUN_HEAD_REPO_ID must be a positive integer");
+  }
+
+  // The artifact is PR-controlled. Resolve its only permitted target from the
+  // trusted workflow_run event and reject stale or cross-PR instructions.
+  let prNumber = await getWorkflowRunPrNumber({
+    headOwner: requireEnv("WORKFLOW_RUN_HEAD_OWNER"),
+    headRepositoryId,
+    headBranch: requireEnv("WORKFLOW_RUN_HEAD_BRANCH"),
+    headSha: requireEnv("WORKFLOW_RUN_HEAD_SHA"),
+  });
+  if (artifactPrNumber !== prNumber) {
+    throw new Error(
+      `Artifact targets PR #${String(artifactPrNumber)}, but workflow run belongs to PR #${prNumber}`,
+    );
   }
 
   console.log(actions);

--- a/scripts/previews/branch.ts
+++ b/scripts/previews/branch.ts
@@ -55,7 +55,7 @@ async function main() {
   );
 
   // Switch to new branch and reset to current commit on base branch
-  logAndExec(`git checkout -B ${installableBranch}`);
+  logAndExec(["git", "checkout", "-B", installableBranch]);
 
   // Build dist/ folders
   logAndExec("pnpm build");

--- a/scripts/utils/github.ts
+++ b/scripts/utils/github.ts
@@ -5,6 +5,13 @@ import { getGitTag } from "./packages.ts";
 const OWNER = "remix-run";
 const REPO = "react-router";
 
+type WorkflowRunHead = {
+  headOwner: string;
+  headRepositoryId: number;
+  headBranch: string;
+  headSha: string;
+};
+
 function getToken(): string {
   let token = process.env.GITHUB_TOKEN;
   if (!token) {
@@ -117,6 +124,32 @@ export async function findOpenPr(head: string, base: string) {
   });
 
   return response.data.length > 0 ? response.data[0] : null;
+}
+
+/**
+ * Resolve the open PR whose current head produced a workflow_run event.
+ */
+export async function getWorkflowRunPrNumber(workflowRun: WorkflowRunHead) {
+  let response = await request("GET /repos/{owner}/{repo}/pulls", {
+    ...requestOptions(),
+    state: "open",
+    head: `${workflowRun.headOwner}:${workflowRun.headBranch}`,
+    per_page: 100,
+  });
+
+  let matches = response.data.filter(
+    (pr) =>
+      pr.head.repo?.id === workflowRun.headRepositoryId &&
+      pr.head.ref === workflowRun.headBranch &&
+      pr.head.sha === workflowRun.headSha,
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one open PR for workflow run, found ${matches.length}`,
+    );
+  }
+
+  return matches[0].number;
 }
 
 /**


### PR DESCRIPTION
Hardens GitHub Actions workflows that consume manual inputs or PR-produced artifacts.

- Passes workflow inputs through environment variables and validates installable branch names before use
- Invokes Git without interpolating branch names through a shell
- Binds privileged PR actions to the exact workflow-run repository, branch, and SHA before applying artifact instructions

This follows up on #15352 by addressing the same injection class in the remaining workflow inputs and preventing cross-PR artifact targeting.
