### PR TITLE
fix(react-router): encode splat param values in generatePath

### DIFF
--- a/packages/react-router/__tests__/generatePath-test.tsx
+++ b/packages/react-router/__tests__/generatePath-test.tsx
@@ -151,6 +151,19 @@ describe("generatePath", () => {
       );
     });
 
+    it("encodes splat (*) values per segment, preserving `/` separators", () => {
+      expect(
+        generatePath("/files/*", { "*": "my report/final draft.pdf" }),
+      ).toBe("/files/my%20report/final%20draft.pdf");
+      expect(generatePath("/files/*", { "*": "café/menu" })).toBe(
+        "/files/caf%C3%A9/menu",
+      );
+      // already-safe splat values are unchanged
+      expect(generatePath("/courses/*", { "*": "routing/grades" })).toBe(
+        "/courses/routing/grades",
+      );
+    });
+
     it("preserves characters RFC 3986 allows literally in a path segment", () => {
       // pchar sub-delims plus ":" and "@" — see RFC 3986 §3.3
       expect(generatePath("/courses/:id", { id: "$&+,;=:@" })).toBe(

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1582,8 +1582,11 @@ export function generatePath<Path extends string>(
 
       // only apply the splat if it's the last segment
       if (isLastSegment && segment === "*") {
-        // Apply the splat
-        return stringify(params["*" as keyof typeof params]);
+        // Apply the splat, encoding each segment while preserving separators
+        return stringify(params["*" as keyof typeof params])
+          .split("/")
+          .map(encodePathParam)
+          .join("/");
       }
 
       const keyMatch = segment.match(/^:([\w-]+)(\??)(.*)/);


### PR DESCRIPTION
## Summary

`generatePath` encodes named params (via `encodePathParam`) but returns splat (`*`) values verbatim, so a splat value containing characters that need escaping produces an invalid path:

```ts
generatePath("/files/*", { "*": "my report/final draft.pdf" })
// before: "/files/my report/final draft.pdf"   (unencoded spaces)
// after:  "/files/my%20report/final%20draft.pdf"
```

This also contradicts the function's own JSDoc, which states: *"Splat (`*`) values are encoded per segment, preserving `/` separators."*

## Fix

Encode each splat segment while preserving the `/` separators — mirroring the named-param branch (`encodePathParam(stringify(param))`) and the exact inverse of `decodePath` (which decodes per segment). Already-safe splat values (e.g. `routing/grades`) are unchanged.

## Test

Added a case to the existing `param encoding` block covering spaces, unicode (`café`), and an already-safe splat. It fails on `main` (values left raw) and passes with this change.
