### PR TITLE
fix: normalize RSC server redirects

### DIFF
--- a/packages/react-router/.changes/unstable.normalize-rsc-server-redirects.md
+++ b/packages/react-router/.changes/unstable.normalize-rsc-server-redirects.md
@@ -1,0 +1,1 @@
+Improve redirect handling during RSC server rendering

--- a/packages/react-router/__tests__/rsc/html-stream-test.ts
+++ b/packages/react-router/__tests__/rsc/html-stream-test.ts
@@ -191,6 +191,29 @@ describe("injectRSCPayload", () => {
 });
 
 describe("routeRSCServerRequest", () => {
+  it("normalizes RSC server redirect locations", async () => {
+    let response = await routeRSCServerRequest({
+      request: new Request("https://remix.run/"),
+      serverResponse: new Response(createRSCStream().stream, { status: 202 }),
+      createFromReadableStream: async (body) => {
+        await readStream(body);
+        return {
+          type: "redirect",
+          location: "//example/path?search=value#hash",
+          status: 302,
+        } as never;
+      },
+      async renderHTML() {
+        throw new Error("Unexpected HTML render");
+      },
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "/example/path?search=value#hash",
+    );
+  });
+
   it("passes a nonce to the HTML renderer and RSC payload scripts", async () => {
     let renderNonce: string | undefined;
     let response = await routeRSCServerRequest({

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -12,6 +12,7 @@ import {
   hasInvalidProtocol,
   isMutationMethod,
 } from "../router/router";
+import { normalizeRedirectLocation } from "./redirect";
 import type {
   RSCPayload,
   RSCRouteManifest,
@@ -22,13 +23,8 @@ import type {
   DataRouteObject,
   DataStrategyFunction,
   DataStrategyFunctionArgs,
-  RouterContextProvider,
 } from "../router/utils";
-import { ErrorResponseImpl, createContext, resolvePath } from "../router/utils";
-import {
-  normalizeRelativeUrl,
-  PROTOCOL_RELATIVE_URL_REGEX,
-} from "../router/url";
+import { ErrorResponseImpl, createContext } from "../router/utils";
 import type {
   DecodedSingleFetchResults,
   FetchAndDecodeFunction,
@@ -1131,17 +1127,6 @@ function debounce(callback: (...args: unknown[]) => unknown, wait: number) {
 function isExternalLocation(location: string) {
   const newLocation = new URL(location, window.location.href);
   return newLocation.origin !== window.location.origin;
-}
-
-function normalizeRedirectLocation(location: string): string {
-  location = normalizeRelativeUrl(location);
-
-  if (PROTOCOL_RELATIVE_URL_REGEX.test(location)) {
-    let path = resolvePath(location);
-    return path.pathname + path.search + path.hash;
-  }
-
-  return location;
 }
 
 function cloneRoutes(routes: DataRouteObject[] | undefined): DataRouteObject[] {

--- a/packages/react-router/lib/rsc/redirect.ts
+++ b/packages/react-router/lib/rsc/redirect.ts
@@ -1,0 +1,16 @@
+import { resolvePath } from "../router/utils";
+import {
+  normalizeRelativeUrl,
+  PROTOCOL_RELATIVE_URL_REGEX,
+} from "../router/url";
+
+export function normalizeRedirectLocation(location: string): string {
+  location = normalizeRelativeUrl(location);
+
+  if (PROTOCOL_RELATIVE_URL_REGEX.test(location)) {
+    let path = resolvePath(location);
+    return path.pathname + path.search + path.hash;
+  }
+
+  return location;
+}

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -16,6 +16,7 @@ import {
   decodeRouteErrorResponseDigest,
 } from "../errors";
 import { escapeHtml } from "../dom/ssr/markup";
+import { normalizeRedirectLocation } from "./redirect";
 
 const defaultManifestPath = "/__manifest";
 
@@ -200,7 +201,8 @@ export async function routeRSCServerRequest({
       serverResponse.status === SINGLE_FETCH_REDIRECT_STATUS &&
       payload.type === "redirect"
     ) {
-      if (hasInvalidProtocol(payload.location)) {
+      let location = normalizeRedirectLocation(payload.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
@@ -209,7 +211,7 @@ export async function routeRSCServerRequest({
       headers.delete("Content-Length");
       headers.delete("Content-Type");
       headers.delete("X-Remix-Response");
-      headers.set("Location", payload.location);
+      headers.set("Location", location);
 
       return new Response(serverResponseB?.body || "", {
         headers,
@@ -258,11 +260,12 @@ export async function routeRSCServerRequest({
     headers.set("Content-Type", "text/html; charset=utf-8");
 
     if (renderRedirect) {
-      if (hasInvalidProtocol(renderRedirect.location)) {
+      let location = normalizeRedirectLocation(renderRedirect.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
-      headers.set("Location", renderRedirect.location);
+      headers.set("Location", location);
       return new Response(html, {
         status: renderRedirect.status,
         headers,
@@ -272,13 +275,14 @@ export async function routeRSCServerRequest({
     const redirectTransform = new TransformStream({
       flush(controller) {
         if (renderRedirect) {
-          if (hasInvalidProtocol(renderRedirect.location)) {
+          let location = normalizeRedirectLocation(renderRedirect.location);
+          if (hasInvalidProtocol(location)) {
             return;
           }
 
           controller.enqueue(
             new TextEncoder().encode(
-              `<meta http-equiv="refresh" content="0;url=${escapeHtml(renderRedirect.location)}"/>`,
+              `<meta http-equiv="refresh" content="0;url=${escapeHtml(location)}"/>`,
             ),
           );
         }
@@ -311,14 +315,15 @@ export async function routeRSCServerRequest({
     }
 
     if (renderRedirect) {
-      if (hasInvalidProtocol(renderRedirect.location)) {
+      let location = normalizeRedirectLocation(renderRedirect.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
-      return new Response(`Redirect: ${renderRedirect.location}`, {
+      return new Response(`Redirect: ${location}`, {
         status: renderRedirect.status,
         headers: {
-          Location: renderRedirect.location,
+          Location: location,
         },
       });
     }
@@ -404,11 +409,12 @@ export async function routeRSCServerRequest({
       headers.set("Content-Type", "text/html; charset=utf-8");
 
       if (retryRedirect) {
-        if (hasInvalidProtocol(retryRedirect.location)) {
+        let location = normalizeRedirectLocation(retryRedirect.location);
+        if (hasInvalidProtocol(location)) {
           throw new Error("Invalid redirect location");
         }
 
-        headers.set("Location", retryRedirect.location);
+        headers.set("Location", location);
         return new Response(html, {
           status: retryRedirect.status,
           headers,
@@ -418,13 +424,14 @@ export async function routeRSCServerRequest({
       const retryRedirectTransform = new TransformStream({
         flush(controller) {
           if (retryRedirect) {
-            if (hasInvalidProtocol(retryRedirect.location)) {
+            let location = normalizeRedirectLocation(retryRedirect.location);
+            if (hasInvalidProtocol(location)) {
               return;
             }
 
             controller.enqueue(
               new TextEncoder().encode(
-                `<meta http-equiv="refresh" content="0;url=${escapeHtml(retryRedirect.location)}"/>`,
+                `<meta http-equiv="refresh" content="0;url=${escapeHtml(location)}"/>`,
               ),
             );
           }
@@ -527,14 +534,15 @@ export function RSCStaticRouter({ getPayload, nonce }: RSCStaticRouterProps) {
   const payload = React.use(decoded);
 
   if (payload.type === "redirect") {
-    if (hasInvalidProtocol(payload.location)) {
+    let location = normalizeRedirectLocation(payload.location);
+    if (hasInvalidProtocol(location)) {
       throw new Error("Invalid redirect location");
     }
 
     throw new Response(null, {
       status: payload.status,
       headers: {
-        Location: payload.location,
+        Location: location,
       },
     });
   }


### PR DESCRIPTION
## What does this change?

Improves redirect handling during RSC server rendering.

Redirect locations are normalized consistently across browser and server paths, including response headers and streamed document redirects.

## Testing

- RSC HTML stream tests
- `react-router` typecheck
