### PR TITLE
fix: normalize RSC server redirects

### DIFF
--- a/packages/react-router/.changes/unstable.normalize-rsc-server-redirects.md
+++ b/packages/react-router/.changes/unstable.normalize-rsc-server-redirects.md
@@ -1,0 +1,1 @@
+Improve redirect handling during RSC server rendering

--- a/packages/react-router/__tests__/rsc/server-test.ts
+++ b/packages/react-router/__tests__/rsc/server-test.ts
@@ -3,9 +3,29 @@ import {
   type RSCMatch,
   type RSCRouteConfigEntry,
 } from "../../lib/rsc/server.rsc";
+import { routeRSCServerRequest } from "../../lib/rsc/server.ssr";
 import { URL_LIMIT } from "../../lib/dom/ssr/fog-of-war";
 
 describe("RSC server", () => {
+  test("normalizes redirect locations", async () => {
+    let response = await routeRSCServerRequest({
+      request: new Request("https://remix.run/"),
+      serverResponse: new Response("RSC payload", { status: 202 }),
+      createFromReadableStream: async () => ({
+        type: "redirect",
+        location: "//example/path?search=value#hash",
+        status: 302,
+      }),
+      async renderHTML() {
+        throw new Error("Unexpected HTML render");
+      },
+    });
+
+    expect(response.headers.get("Location")).toBe(
+      "/example/path?search=value#hash",
+    );
+  });
+
   describe("manifest requests", () => {
     test("rejects manifest requests over the URL limit", async () => {
       let path = `/${"a".repeat(URL_LIMIT)}.manifest`;

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -24,8 +24,7 @@ import type {
   DataStrategyFunctionArgs,
   RouterContextProvider,
 } from "../router/utils";
-import { ErrorResponseImpl, createContext, resolvePath } from "../router/utils";
-import { PROTOCOL_RELATIVE_URL_REGEX } from "../router/url";
+import { ErrorResponseImpl, createContext } from "../router/utils";
 import type {
   DecodedSingleFetchResults,
   FetchAndDecodeFunction,
@@ -45,6 +44,7 @@ import { RSCRouterGlobalErrorBoundary } from "./errorBoundaries";
 import type { RouteModules } from "../dom/ssr/routeModules";
 import { populateRSCRouteModules } from "./route-modules";
 import { URL_LIMIT, getPathsWithAncestors } from "../dom/ssr/fog-of-war";
+import { normalizeRedirectLocation } from "./redirect";
 
 const defaultManifestPath = "/__manifest";
 
@@ -1109,15 +1109,6 @@ function debounce(callback: (...args: unknown[]) => unknown, wait: number) {
 function isExternalLocation(location: string) {
   const newLocation = new URL(location, window.location.href);
   return newLocation.origin !== window.location.origin;
-}
-
-function normalizeRedirectLocation(location: string): string {
-  if (PROTOCOL_RELATIVE_URL_REGEX.test(location)) {
-    let path = resolvePath(location);
-    return path.pathname + path.search + path.hash;
-  }
-
-  return location;
 }
 
 function cloneRoutes(routes: DataRouteObject[] | undefined): DataRouteObject[] {

--- a/packages/react-router/lib/rsc/redirect.ts
+++ b/packages/react-router/lib/rsc/redirect.ts
@@ -1,0 +1,11 @@
+import { resolvePath } from "../router/utils";
+import { PROTOCOL_RELATIVE_URL_REGEX } from "../router/url";
+
+export function normalizeRedirectLocation(location: string): string {
+  if (PROTOCOL_RELATIVE_URL_REGEX.test(location)) {
+    let path = resolvePath(location);
+    return path.pathname + path.search + path.hash;
+  }
+
+  return location;
+}

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -16,6 +16,7 @@ import {
   decodeRouteErrorResponseDigest,
 } from "../errors";
 import { escapeHtml } from "../dom/ssr/markup";
+import { normalizeRedirectLocation } from "./redirect";
 
 const defaultManifestPath = "/__manifest";
 
@@ -203,7 +204,8 @@ export async function routeRSCServerRequest({
       serverResponse.status === SINGLE_FETCH_REDIRECT_STATUS &&
       payload.type === "redirect"
     ) {
-      if (hasInvalidProtocol(payload.location)) {
+      let location = normalizeRedirectLocation(payload.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
@@ -212,7 +214,7 @@ export async function routeRSCServerRequest({
       headers.delete("Content-Length");
       headers.delete("Content-Type");
       headers.delete("X-Remix-Response");
-      headers.set("Location", payload.location);
+      headers.set("Location", location);
 
       return new Response(serverResponseB?.body || "", {
         headers,
@@ -260,11 +262,12 @@ export async function routeRSCServerRequest({
     headers.set("Content-Type", "text/html; charset=utf-8");
 
     if (renderRedirect) {
-      if (hasInvalidProtocol(renderRedirect.location)) {
+      let location = normalizeRedirectLocation(renderRedirect.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
-      headers.set("Location", renderRedirect.location);
+      headers.set("Location", location);
       return new Response(html, {
         status: renderRedirect.status,
         headers,
@@ -274,13 +277,14 @@ export async function routeRSCServerRequest({
     const redirectTransform = new TransformStream({
       flush(controller) {
         if (renderRedirect) {
-          if (hasInvalidProtocol(renderRedirect.location)) {
+          let location = normalizeRedirectLocation(renderRedirect.location);
+          if (hasInvalidProtocol(location)) {
             return;
           }
 
           controller.enqueue(
             new TextEncoder().encode(
-              `<meta http-equiv="refresh" content="0;url=${escapeHtml(renderRedirect.location)}"/>`,
+              `<meta http-equiv="refresh" content="0;url=${escapeHtml(location)}"/>`,
             ),
           );
         }
@@ -313,14 +317,15 @@ export async function routeRSCServerRequest({
     }
 
     if (renderRedirect) {
-      if (hasInvalidProtocol(renderRedirect.location)) {
+      let location = normalizeRedirectLocation(renderRedirect.location);
+      if (hasInvalidProtocol(location)) {
         throw new Error("Invalid redirect location");
       }
 
-      return new Response(`Redirect: ${renderRedirect.location}`, {
+      return new Response(`Redirect: ${location}`, {
         status: renderRedirect.status,
         headers: {
-          Location: renderRedirect.location,
+          Location: location,
         },
       });
     }
@@ -405,11 +410,12 @@ export async function routeRSCServerRequest({
       headers.set("Content-Type", "text/html; charset=utf-8");
 
       if (retryRedirect) {
-        if (hasInvalidProtocol(retryRedirect.location)) {
+        let location = normalizeRedirectLocation(retryRedirect.location);
+        if (hasInvalidProtocol(location)) {
           throw new Error("Invalid redirect location");
         }
 
-        headers.set("Location", retryRedirect.location);
+        headers.set("Location", location);
         return new Response(html, {
           status: retryRedirect.status,
           headers,
@@ -419,13 +425,14 @@ export async function routeRSCServerRequest({
       const retryRedirectTransform = new TransformStream({
         flush(controller) {
           if (retryRedirect) {
-            if (hasInvalidProtocol(retryRedirect.location)) {
+            let location = normalizeRedirectLocation(retryRedirect.location);
+            if (hasInvalidProtocol(location)) {
               return;
             }
 
             controller.enqueue(
               new TextEncoder().encode(
-                `<meta http-equiv="refresh" content="0;url=${escapeHtml(retryRedirect.location)}"/>`,
+                `<meta http-equiv="refresh" content="0;url=${escapeHtml(location)}"/>`,
               ),
             );
           }
@@ -520,14 +527,15 @@ export function RSCStaticRouter({ getPayload }: RSCStaticRouterProps) {
   const payload = useSafe(decoded);
 
   if (payload.type === "redirect") {
-    if (hasInvalidProtocol(payload.location)) {
+    let location = normalizeRedirectLocation(payload.location);
+    if (hasInvalidProtocol(location)) {
       throw new Error("Invalid redirect location");
     }
 
     throw new Response(null, {
       status: payload.status,
       headers: {
-        Location: payload.location,
+        Location: location,
       },
     });
   }


### PR DESCRIPTION
Backport of #15418 to `v7`.

## What does this change?

Improves redirect handling during RSC server rendering.

Redirect locations are normalized consistently across browser and server paths, including response headers and streamed document redirects.

## Testing

- RSC server tests
- `react-router` build and typecheck
