### PR TITLE
fix: improve matching perf

### DIFF
--- a/packages/react-router/.changes/patch.linear-route-matching.md
+++ b/packages/react-router/.changes/patch.linear-route-matching.md
@@ -1,0 +1,1 @@
+Improve route matching performance for long paths

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1584,7 +1584,7 @@ function matchPathImpl<Path extends string>(
   if (!match) return null;
 
   let matchedPathname = match[0];
-  let pathnameBase = matchedPathname.replace(/(.)\/+$/, "$1");
+  let pathnameBase = removeTrailingSlash(matchedPathname, 1);
   let captureGroups = match.slice(1);
   let params: Params = compiledParams.reduce<Mutable<Params>>(
     (memo, { paramName, isOptional }, index) => {
@@ -1592,9 +1592,10 @@ function matchPathImpl<Path extends string>(
       // instead of using params["*"] later because it will be decoded then
       if (paramName === "*") {
         let splatValue = captureGroups[index] || "";
-        pathnameBase = matchedPathname
-          .slice(0, matchedPathname.length - splatValue.length)
-          .replace(/(.)\/+$/, "$1");
+        pathnameBase = removeTrailingSlash(
+          matchedPathname.slice(0, matchedPathname.length - splatValue.length),
+          1,
+        );
       }
 
       const value = captureGroups[index];
@@ -1944,8 +1945,14 @@ export const removeDoubleSlashes = (path: string): string =>
 export const joinPaths = (paths: string[]): string =>
   removeDoubleSlashes(paths.join("/"));
 
-export const removeTrailingSlash = (path: string): string =>
-  path.replace(/\/+$/, "");
+// Scan from the end to avoid repeated RegExp work on long paths.
+export function removeTrailingSlash(path: string, minLength = 0): string {
+  let end = path.length;
+  while (end > minLength && path.charCodeAt(end - 1) === 47) {
+    end--;
+  }
+  return end === path.length ? path : path.slice(0, end);
+}
 
 export const normalizePathname = (pathname: string): string =>
   removeTrailingSlash(pathname).replace(/^\/*/, "/");


### PR DESCRIPTION
Backport of #15417 to `v7`.

## What does this change?

Improves route matching performance for long paths by using a linear trailing-slash cleanup.

This applies consistently to regular matches and splat route bases.

## Testing

- Existing `matchPath` tests
- Existing `matchRoutes` tests
- `react-router` build and typecheck
