### PR TITLE
fix: match optional static segments containing non-word characters

### DIFF
--- a/packages/react-router/.changes/patch.optional-static-segment-matching.md
+++ b/packages/react-router/.changes/patch.optional-static-segment-matching.md
@@ -1,0 +1,1 @@
+Fix `matchPath` not treating a static segment as optional when it contains characters outside `[\w-]`

--- a/packages/react-router/__tests__/matchPath-test.tsx
+++ b/packages/react-router/__tests__/matchPath-test.tsx
@@ -442,6 +442,18 @@ describe("matchPath optional static segments", () => {
     match = matchPath("/school?abc", "/abc");
     expect(match).toBe(null);
   });
+
+  it("should match an optional static segment containing non-word characters", () => {
+    expect(matchPath("/docs/v1.0?/intro", "/docs/v1.0/intro")).toMatchObject({
+      pathname: "/docs/v1.0/intro",
+    });
+    expect(matchPath("/docs/v1.0?/intro", "/docs/intro")).toMatchObject({
+      pathname: "/docs/intro",
+    });
+    // The `?` must not survive into the compiled RegExp as a quantifier on the
+    // preceding character
+    expect(matchPath("/docs/v1.0?/intro", "/docs/v1./intro")).toBe(null);
+  });
 });
 
 describe("matchPath *", () => {

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1770,7 +1770,7 @@ export function compilePath(
           return "/([^\\/]+)";
         },
       ) // Dynamic segment
-      .replace(/\/([\w-]+)\?(?=\/|$|\()/g, "(?:/$1)?"); // Optional static segment (non-capturing)
+      .replace(/\/((?:[^/?()[\]*^\\]|\\.)+)\?(?=\/|$|\()/g, "(?:/$1)?"); // Optional static segment (non-capturing)
 
   if (path.endsWith("*")) {
     params.push({ paramName: "*" });


### PR DESCRIPTION
`compilePath` only treats a static segment as optional when it matches `[\w-]+`. A segment containing anything else (a dot, a space, `%`, non-ASCII) is not recognised, and because `?` is deliberately left out of the regex-escape class one line above (it doubles as the optional marker), the unrecognised `?` reaches the compiled `RegExp` as a quantifier on the preceding character.

So `matchPath("/docs/v1.0?/intro", ...)` compiles to `^\/docs\/v1\.0?\/intro\/*$`, making the `0` optional rather than the segment. It is wrong in both directions: `/docs/intro` does not match when it should, and `/docs/v1/intro` matches when it should not.

This also puts `matchPath` at odds with the rest of the router. `explodeOptionalSegments`, used by `matchRoutes`, tests `first.endsWith("?")` with no character restriction; `generatePath` strips the marker unconditionally at `utils.ts:1599`; and `docs/start/data/routing.md:242` states the contract as "make a route segment optional by adding a `?` to the end of the segment". I verified the disagreement rather than inferring it: `matchRoutes` accepts the exact pattern `matchPath` rejects.

This extends the principle from #15200, which introduced this line: a leftover `?` reaching the compiled pattern as an unescaped quantifier is a bug. That fix covered word-character segments; this covers the rest.

**Fix:** widen the segment class at `utils.ts:1773`. It deliberately excludes the metacharacters injected by the dynamic-segment rule applied on the previous line (`( ) [ ] * ^ \`); a naive `[^/]+` matches across those and rewrites a generated `(?:/([^\/]*))?` fragment into `(?:/*))?`. The `\\.` branch admits escaped literals such as `v1\.0`. The two branches are disjoint, so this adds no backtracking ambiguity, which matters given the linear-matching work in #15417.

The regression test goes in `__tests__/matchPath-test.tsx` inside the existing `matchPath optional static segments` block, beside the pinned test that scopes out mid-segment question marks.

**Verification** (`--runInBand` for determinism, same command both times):

- Unpatched: 2 failed, 15 skipped, 2218 passed. New test fails with `Received has value: null` at `matchPath-test.tsx:450`.
- Patched: 0 failed, 15 skipped, 2220 passed. Snapshots 822 passed in both.
- The two suites failing in both runs fail to load at all (`Cannot find module 'react-router/dom'`, a missing local build artifact) and are unrelated.
- Prettier clean on all three files.

**Deliberately not bundled**, as a separate sub-case with its own pinned test: a mid-segment `?` such as `/school?abc` is still an unescaped quantifier.
