### PR TITLE
fix(dev): let SPA Vite builds exit after prerendering

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -310,6 +310,26 @@ export const build = ({
   });
 };
 
+export const viteBuild = ({
+  cwd,
+  timeout = 20_000,
+}: {
+  cwd: string;
+  timeout?: number;
+}) => {
+  let nodeBin = process.argv[0];
+  let viteBin = "node_modules/vite/bin/vite.js";
+
+  return spawnSync(nodeBin, [viteBin, "build"], {
+    cwd,
+    timeout,
+    env: {
+      ...process.env,
+      ...colorEnv,
+    },
+  });
+};
+
 export const reactRouterServe = async ({
   cwd,
   port,

--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -10,11 +10,39 @@ import {
 } from "./helpers/create-fixture.js";
 import type { Fixture, AppFixture } from "./helpers/create-fixture.js";
 import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
-import { createProject, build, reactRouterConfig } from "./helpers/vite.js";
+import {
+  createProject,
+  build,
+  reactRouterConfig,
+  viteBuild,
+} from "./helpers/vite.js";
 
 test.describe("SPA Mode", () => {
   let fixture: Fixture;
   let appFixture: AppFixture;
+
+  test("direct vite build exits after SPA prerendering", async () => {
+    let cwd = await createProject(
+      {
+        "react-router.config.ts": reactRouterConfig({ ssr: false }),
+      },
+      "vite-8-template",
+    );
+    let result = viteBuild({ cwd });
+    let output =
+      (result.stdout?.toString("utf8") ?? "") +
+      (result.stderr?.toString("utf8") ?? "");
+
+    if (
+      (result.error as NodeJS.ErrnoException | null | undefined)?.code ===
+      "ETIMEDOUT"
+    ) {
+      throw new Error(`VITE_BUILD_DID_NOT_EXIT\n${output}`);
+    }
+
+    expect(result.error, output).toBeFalsy();
+    expect(result.status, output).toBe(0);
+  });
 
   [true, false].forEach((splitRouteModules) => {
     test.describe(`splitRouteModules: ${splitRouteModules}`, () => {

--- a/packages/react-router-dev/.changes/patch.vite-spa-build-exit.md
+++ b/packages/react-router-dev/.changes/patch.vite-spa-build-exit.md
@@ -1,0 +1,1 @@
+fix: close React Router plugin resources with Vite preview servers

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1622,6 +1622,19 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         };
       },
       configurePreviewServer(previewServer) {
+        let originalClose = previewServer.close.bind(previewServer);
+        let closePromise: Promise<void> | undefined;
+        previewServer.close = () => {
+          closePromise ??= (async () => {
+            try {
+              await originalClose();
+            } finally {
+              await closePluginResources();
+            }
+          })();
+          return closePromise;
+        };
+
         let cachedHandler: RequestHandler | null = null;
 
         async function getHandler(): Promise<RequestHandler> {


### PR DESCRIPTION
## What changed

A direct `vite build` in SPA mode completed its output but kept running because the internal prerender preview closed its HTTP server without closing the React Router plugin resources created while resolving the preview config.

Wrap the preview server's idempotent `close()` method so callers also await cleanup of the plugin's child compiler, config loader, and typegen watcher. Normal watcher behavior while a preview server is running is unchanged.

## Tests

Added a focused SPA integration regression that invokes the Vite CLI directly and requires it to exit naturally after prerendering instead of using the React Router CLI's explicit process exit.

Fixes #15427