### PR TITLE
fix(dev/vite): remove stale server build when ssr:false

### DIFF
--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -1359,19 +1359,23 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           },
         };
       },
-      // buildApp: {
-      //   order: "post",
-      //   handler: async (builder) => {
-      //     let { reactRouterConfig } = ctx;
+      buildApp: {
+        order: "post",
+        handler: async (builder) => {
+          let { reactRouterConfig } = ctx;
 
-      //     let serverBuildDirectory =
-      //       builder.environments.ssr.config?.build?.outDir;
-      //     if (serverBuildDirectory && !reactRouterConfig.ssr) {
-      //       // For both SPA mode and prerendering, we can remove the server builds
-      //       rmSync(serverBuildDirectory, { force: true, recursive: true });
-      //     }
-      //   },
-      // },
+          let serverBuildDirectory =
+            builder.environments.ssr?.config?.build?.outDir ??
+            getServerBuildDirectory(reactRouterConfig);
+          if (serverBuildDirectory && !reactRouterConfig.ssr) {
+            // For both SPA mode and prerendering, we can remove the server builds
+            // since there is no runtime server. The cleaner version of this was
+            // commented out in 75de31f but the `build/server/index.js` artifact
+            // was left behind (see https://github.com/remix-run/react-router/issues/15305).
+            await rm(serverBuildDirectory, { force: true, recursive: true });
+          }
+        },
+      },
       configEnvironment(name, options) {
         if (isReactRouterServerEnvironment(ctx, name)) {
           const vite = getVite();


### PR DESCRIPTION
Fixes #15305

The `buildApp` post-handler that deletes `serverBuildDirectory` was commented out in 75de31f, leaving `build/server/index.js` behind after `ssr:false` builds.

Reactivate it with async `rm` and a fallback to `getServerBuildDirectory` for non-standard `outDir` layouts.