### PR TITLE
fix: pass --conditions as argv when relaunching the dev CLI

### DIFF
--- a/integration/cli-test.ts
+++ b/integration/cli-test.ts
@@ -43,9 +43,7 @@ function delay(ms: number) {
 }
 
 function restartCount(output: string) {
-  return (
-    output.match(/\[restart\] Relaunching with NODE_OPTIONS:/g)?.length ?? 0
-  );
+  return output.match(/\[restart\] Relaunching with /g)?.length ?? 0;
 }
 
 function getLogs(stdout: string, stderr: string) {

--- a/packages/react-router-dev/.changes/patch.pass-development-conditions-cli-flags-relaunching.md
+++ b/packages/react-router-dev/.changes/patch.pass-development-conditions-cli-flags-relaunching.md
@@ -1,0 +1,1 @@
+Pass development conditions as CLI flags when relaunching the dev process

--- a/packages/react-router-dev/__tests__/restart-with-conditions-test.ts
+++ b/packages/react-router-dev/__tests__/restart-with-conditions-test.ts
@@ -1,0 +1,60 @@
+import {
+  restartWithMergedOptions,
+  resolveRestartSpawn,
+} from "../restart-with-conditions";
+
+describe("resolveRestartSpawn", () => {
+  it("inserts extra flags into argv and leaves NODE_OPTIONS unchanged", () => {
+    let result = resolveRestartSpawn(
+      ["/usr/bin/node", "/app/cli.js", "dev"],
+      "--conditions=development",
+      { NODE_OPTIONS: "--max-old-space-size=2048", PATH: "/bin" },
+    );
+
+    expect(result.command).toBe("/usr/bin/node");
+    expect(result.args).toEqual([
+      "--conditions=development",
+      "/app/cli.js",
+      "dev",
+    ]);
+    expect(result.env.REACT_ROUTER_DEV_RESTARTED).toBe("true");
+    expect(result.env.NODE_OPTIONS).toBe("--max-old-space-size=2048");
+    expect(result.env.PATH).toBe("/bin");
+  });
+
+  it("still relaunches when NODE_OPTIONS is unset", () => {
+    let result = resolveRestartSpawn(
+      ["/usr/bin/bun", "/app/cli.js", "dev"],
+      "--conditions=development",
+      {},
+    );
+
+    expect(result.command).toBe("/usr/bin/bun");
+    expect(result.args[0]).toBe("--conditions=development");
+    expect(result.env.NODE_OPTIONS).toBeUndefined();
+  });
+});
+
+describe("restartWithMergedOptions", () => {
+  let originalRestarted: string | undefined;
+
+  beforeEach(() => {
+    originalRestarted = process.env.REACT_ROUTER_DEV_RESTARTED;
+    delete process.env.REACT_ROUTER_DEV_RESTARTED;
+  });
+
+  afterEach(() => {
+    if (originalRestarted === undefined) {
+      delete process.env.REACT_ROUTER_DEV_RESTARTED;
+    } else {
+      process.env.REACT_ROUTER_DEV_RESTARTED = originalRestarted;
+    }
+  });
+
+  it("throws if the process has already been restarted", () => {
+    process.env.REACT_ROUTER_DEV_RESTARTED = "true";
+    expect(() => restartWithMergedOptions("--conditions=development")).toThrow(
+      /already been restarted/,
+    );
+  });
+});

--- a/packages/react-router-dev/restart-with-conditions.ts
+++ b/packages/react-router-dev/restart-with-conditions.ts
@@ -2,8 +2,32 @@ import { spawn, type ChildProcess } from "node:child_process";
 import process from "node:process";
 
 /**
- * Restarts the current Node process, appending new flags to the
- * existing NODE_OPTIONS. SIGINT/SIGTERM are always forwarded to the child.
+ * Build the child process invocation used to relaunch the CLI with extra flags.
+ *
+ * Extra flags are placed on argv immediately after the runtime binary. Putting
+ * them in NODE_OPTIONS is not portable: Bun silently ignores `--conditions`
+ * there, so the child would restart again and hit the already-restarted guard.
+ */
+export function resolveRestartSpawn(
+  argv: readonly string[],
+  extraOptions: string,
+  env: NodeJS.ProcessEnv,
+): { command: string; args: string[]; env: NodeJS.ProcessEnv } {
+  const extraArgs = extraOptions.split(/\s+/).filter(Boolean);
+  const [command, ...args] = argv;
+  return {
+    command: command as string,
+    args: [...extraArgs, ...args],
+    env: {
+      ...env,
+      REACT_ROUTER_DEV_RESTARTED: "true",
+    },
+  };
+}
+
+/**
+ * Restarts the current process with extra CLI flags after argv[0].
+ * SIGINT/SIGTERM are always forwarded to the child.
  */
 export function restartWithMergedOptions(nodeOptions: string): void {
   if (process.env.REACT_ROUTER_DEV_RESTARTED === "true") {
@@ -11,21 +35,17 @@ export function restartWithMergedOptions(nodeOptions: string): void {
       "restartWithMergedOptions() was called, but the process has already been restarted. This is likely a bug in @react-router/dev.",
     );
   }
-  const mergedOptions = [process.env.NODE_OPTIONS, nodeOptions]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
 
-  console.log(`[restart] Relaunching with NODE_OPTIONS: ${mergedOptions}`);
+  const { command, args, env } = resolveRestartSpawn(
+    process.argv,
+    nodeOptions,
+    process.env,
+  );
 
-  const [cmd, ...args] = process.argv;
+  console.log(`[restart] Relaunching with ${nodeOptions}`);
 
-  const child: ChildProcess = spawn(cmd, args, {
-    env: {
-      ...process.env,
-      NODE_OPTIONS: mergedOptions,
-      REACT_ROUTER_DEV_RESTARTED: "true",
-    },
+  const child: ChildProcess = spawn(command, args, {
+    env,
     stdio: "inherit",
   });
 


### PR DESCRIPTION
Fixes #15433

## Changelog
`react-router dev` relaunches itself with `--conditions=development` so the package `imports` map resolves the development build. Since 8.3.0 that relaunch put the flag in `NODE_OPTIONS`. Node honors that. Bun does not: it keeps the env var but never applies `--conditions`, so `#development-condition-enabled` stays false, `dev()` restarts a second time, and the already-restarted guard throws.

## Description
Pass the extra flags on argv immediately after the runtime binary (`node --conditions=development …` / `bun --conditions=development …`) and stop writing them into `NODE_OPTIONS`. Existing `NODE_OPTIONS` from the user are still inherited. The already-restarted guard is unchanged.

## Test evidence
Fail-then-pass on `packages/react-router-dev/__tests__/restart-with-conditions-test.ts`:
- before: spawn args had no `--conditions` flag; it was merged into `NODE_OPTIONS`
- after: `--conditions=development` is `args[0]`; caller `NODE_OPTIONS` is left alone

`pnpm test packages/react-router-dev/`: 10 suites, 190 tests passed.

Local Bun check matching the issue: `NODE_OPTIONS=--conditions=development bun --bun` leaves the flag in the environment but not in `process.execArgv`. `bun --bun --conditions=development` puts it on `execArgv`.