### PR TITLE
Improved documentation about CSRF

### DIFF
--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -66,6 +66,18 @@ export function action(_: Route.ActionArgs) {
 }
 ```
 
+<docs-warning>Actions on resource routes are **not** covered by React Router's
+[origin check][security-csrf]. A direct `POST`/`PUT`/`PATCH`/`DELETE` to a
+resource route URL runs your `action` regardless of which origin sent it —
+that is deliberate, since resource routes exist to be called by other origins.
+Submissions from your own `<Form>` or `useFetcher` are checked, because they
+arrive as data requests.
+
+If a resource route changes state and relies on cookie authentication, add your
+own protection — a `SameSite` session cookie, a bearer token, a CSRF token, or
+an origin check in [middleware][middleware]. See
+[Security][security-csrf].</docs-warning>
+
 ## Return Types
 
 Resource Routes are flexible when it comes to the return type - you can return [`Response`][Response] instances or [`data()`][data] objects. A good general rule of thumb when deciding which type to use is:
@@ -124,3 +136,5 @@ export function action() {
 [form]: ../api/components/Form
 [await]: ../api/components/Await
 [error-boundary]: ../start/framework/route-module#errorboundary
+[security-csrf]: ./security#cross-site-request-forgery
+[middleware]: ./middleware

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -28,6 +28,45 @@ Add a nonce to these two spots in [`entry.server.tsx`][entryserver]:
 
 For RSC Framework and RSC Data Mode, generate the nonce in `entry.ssr.tsx` and pass it to `routeRSCServerRequest`, `RSCStaticRouter`, and the CSP response header. See the [RSC Content Security Policy nonce guide][rsc-csp]. The nonce is only needed while generating the HTML document; it should not be included in the RSC payload or passed to `matchRSCServerRequest`.
 
+## `Cross-Site Request Forgery`
+
+React Router validates the origin of action submissions. When a request includes an `Origin` header, React Router first compares it with the origin of the request URL. Same-origin requests are accepted only when the **scheme, host, and port** all match. Cross-origin requests are accepted only when their **host** matches one of the patterns in [`allowedActionOrigins`][allowedactionorigins]. Rejected requests receive a `400` response and your `action` does not run. This check is enabled by default.
+
+### Configuring allowed origins
+
+Same-origin submissions are always allowed when the scheme, host, and port match exactly. [`allowedActionOrigins`][allowedactionorigins] specifies *additional* origins that you want to accept; it does not replace the same-origin check. By default, the list is empty, which means that only same-origin submissions are accepted.
+
+Unlike the same-origin check, which compares the complete origin, entries in `allowedActionOrigins` are **host patterns**. They are matched only against the host of the `Origin` header; the scheme is not considered. Patterns use micromatch glob syntax: `*` matches one label and `**` matches multiple labels:
+
+```ts filename=react-router.config.ts id="4ohbqp"
+export default {
+  allowedActionOrigins: [
+    "example.com", // example.com
+    "*.example.com", // sub.example.com
+    "**.example.com", // sub.domain.example.com
+  ],
+} satisfies Config;
+```
+
+Because the port is part of the host, patterns are also matched against the port. For example, `example.com:8443` must be listed explicitly. The scheme is not part of the match, so listing `example.com` accepts submissions from both `http://example.com` and `https://example.com`.
+
+A value of `["**"]` matches every host and effectively disables the origin check. Use this only if you have another mechanism protecting your actions.
+
+The list can also be configured at runtime on the server build instead of in the config file.
+
+### Methods that are checked
+
+React Router checks `POST`, `PUT`, `PATCH`, and `DELETE` submissions. `GET` and `HEAD` requests are not checked.
+
+This means that loaders do not receive this protection. For operations that mutate state, use an `action` rather than a `loader`.
+
+### Cases that are not covered
+
+* **Requests without an `Origin` header.** React Router only performs the origin check when the request includes an `Origin` header. Non-browser clients such as webhook senders and server-to-server callers commonly do not send one, so they are not blocked by this check. If such an endpoint relies on cookies or other ambient credentials, use additional authentication or CSRF protection as appropriate.
+
+* **Direct requests to a resource route.** A [resource route][resource-routes] is a route module that exports a `loader` or `action` but does not have a default component or an `ErrorBoundary`. Resource routes are intended to expose endpoints that can be called by other origins, so direct requests to their actions are not subject to the origin check. Requests from your own application to a resource route through [`<Form>`][form] or [`useFetcher`][usefetcher] are still checked because they are handled as data requests. If a resource route changes state and authenticates its caller with a cookie, it needs its own CSRF protection.
+
+
 [csp]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP
 [entryserver]: ../api/framework-conventions/entry.server.tsx
 [nonce]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
@@ -37,3 +76,7 @@ For RSC Framework and RSC Data Mode, generate the nonce in `entry.ssr.tsx` and p
 [scrollrestoration]: ../api/components/ScrollRestoration
 [serverrouter]: ../api/framework-routers/ServerRouter
 [rsc-csp]: ./react-server-components#content-security-policy-nonces
+[allowedactionorigins]: ../api/framework-conventions/react-router.config.ts#allowedactionorigins
+[form]: ../api/components/Form
+[resource-routes]: ./resource-routes
+[usefetcher]: ../api/hooks/useFetcher


### PR DESCRIPTION
This commit introduces in the security documentation a chapter about CSRF protection mechanisms.

It also adds a warning to the resource routes documentation to highlight that actions on them are not covered by CSRF checks.