### PR TITLE
fix(react-router): make setSearchParams a stable reference across navigations

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -161,6 +161,7 @@
 - Geist5000
 - GeoffKarnov
 - gesposito
+- greedyivan
 - gianlucca
 - gijo-varghese
 - goldins

--- a/packages/react-router/.changes/patch.stable-set-search-params.md
+++ b/packages/react-router/.changes/patch.stable-set-search-params.md
@@ -1,0 +1,1 @@
+Fix `setSearchParams` from `useSearchParams` to hold a stable reference across navigations and re-renders, making it safe to use in `useEffect` dependencies; calls read the latest committed `searchParams`/`navigate` values, even through a reference captured before a navigation

--- a/packages/react-router/__tests__/dom/search-params-test.tsx
+++ b/packages/react-router/__tests__/dom/search-params-test.tsx
@@ -10,7 +10,9 @@ import {
   useBlocker,
   RouterProvider,
   useLocation,
+  useNavigate,
 } from "../../index";
+import type { SetURLSearchParams } from "../../index";
 
 describe("useSearchParams", () => {
   let node: HTMLDivElement;
@@ -293,5 +295,432 @@ describe("useSearchParams", () => {
         blocked=blocked
       </pre>
     `);
+  });
+
+  it("maintains a stable setSearchParams reference when the search changes", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams();
+      latestSetter = setSearchParams;
+      return (
+        <div>
+          <p id="output">a={searchParams.get("a")}</p>
+          <button id="update" onClick={() => setSearchParams({ a: "2" })}>
+            update
+          </button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search?a=1"]}>
+          <Routes>
+            <Route path="search" element={<SearchPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#update")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/a=2/);
+    expect(latestSetter).toBe(initialSetter);
+  });
+
+  it("maintains a stable setSearchParams reference when the pathname changes", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    function SearchPage() {
+      let location = useLocation();
+      let [, setSearchParams] = useSearchParams();
+      let navigate = useNavigate();
+      latestSetter = setSearchParams;
+      return (
+        <div>
+          <p id="output">pathname={location.pathname}</p>
+          <button id="navigate" onClick={() => navigate("/other")}>
+            navigate
+          </button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search"]}>
+          <Routes>
+            <Route path="/*" element={<SearchPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#navigate")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(
+      /pathname=\/other/,
+    );
+    expect(latestSetter).toBe(initialSetter);
+  });
+
+  it("reads the latest committed search params from a reference captured before a navigation", () => {
+    let firstSetter: SetURLSearchParams | undefined;
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams();
+      let navigate = useNavigate();
+      if (firstSetter === undefined) {
+        firstSetter = setSearchParams;
+      }
+      return (
+        <div>
+          <p id="output">{searchParams.toString()}</p>
+          <button id="to-a1" onClick={() => navigate("/search?a=1")}>
+            to a=1
+          </button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search"]}>
+          <Routes>
+            <Route path="search" element={<SearchPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      node
+        .querySelector("#to-a1")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/a=1/);
+
+    act(() => {
+      firstSetter!((prev) => {
+        let next = new URLSearchParams(prev);
+        next.set("b", prev.get("a") === "1" ? "fresh" : "stale");
+        return next;
+      });
+    });
+
+    expect(node.querySelector("#output")!.textContent).toMatch(/a=1&b=fresh/);
+  });
+
+  it("does not build functional updates on each other when called in the same tick", () => {
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams();
+      return (
+        <div>
+          <p id="output">{searchParams.toString()}</p>
+          <button
+            id="double"
+            onClick={() => {
+              setSearchParams((prev) => {
+                prev.set("foo", "one");
+                return prev;
+              });
+              setSearchParams((prev) => {
+                prev.set(
+                  "bar",
+                  prev.get("foo") === "one" ? "built" : "not-built",
+                );
+                return prev;
+              });
+            }}
+          >
+            double
+          </button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search"]}>
+          <Routes>
+            <Route path="search" element={<SearchPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      node
+        .querySelector("#double")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/bar=not-built/);
+    expect(node.querySelector("#output")!.innerHTML).not.toMatch(/foo/);
+  });
+
+  it("maintains a stable setSearchParams reference across unrelated re-renders", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    function SearchPage() {
+      let [, setSearchParams] = useSearchParams();
+      latestSetter = setSearchParams;
+      return null;
+    }
+    function Parent() {
+      let [count, setCount] = React.useState(0);
+      return (
+        <div>
+          <p id="output">count={count}</p>
+          <button id="bump" onClick={() => setCount(count + 1)}>
+            bump
+          </button>
+          <SearchPage />
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search"]}>
+          <Routes>
+            <Route path="search" element={<Parent />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#bump")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/count=1/);
+    expect(latestSetter).toBe(initialSetter);
+  });
+
+  it("maintains a stable setSearchParams reference and fresh reads in a data router", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    let firstSetter: SetURLSearchParams | undefined;
+    global.history.pushState({}, "", "/search");
+    let router = createBrowserRouter([
+      {
+        path: "/search",
+        Component() {
+          let [searchParams, setSearchParams] = useSearchParams();
+          if (firstSetter === undefined) {
+            firstSetter = setSearchParams;
+          }
+          latestSetter = setSearchParams;
+          return (
+            <div>
+              <p id="output">{searchParams.toString()}</p>
+              <button id="update" onClick={() => setSearchParams({ a: "2" })}>
+                update
+              </button>
+            </div>
+          );
+        },
+      },
+    ]);
+
+    act(() => {
+      ReactDOM.createRoot(node).render(<RouterProvider router={router} />);
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#update")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/a=2/);
+    expect(latestSetter).toBe(initialSetter);
+
+    act(() => {
+      firstSetter!((prev) => {
+        let next = new URLSearchParams(prev);
+        next.set("b", prev.get("a") === "2" ? "fresh" : "stale");
+        return next;
+      });
+    });
+
+    expect(node.querySelector("#output")!.textContent).toMatch(/a=2&b=fresh/);
+  });
+
+  it("maintains a stable setSearchParams reference when sibling data routes share an element", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    function SharedPage() {
+      let location = useLocation();
+      let [, setSearchParams] = useSearchParams();
+      let navigate = useNavigate();
+      latestSetter = setSearchParams;
+      return (
+        <div>
+          <p id="output">pathname={location.pathname}</p>
+          <button id="navigate" onClick={() => navigate("/b")}>
+            navigate
+          </button>
+        </div>
+      );
+    }
+    let sharedElement = <SharedPage />;
+    global.history.pushState({}, "", "/a");
+    let router = createBrowserRouter([
+      { path: "/a", element: sharedElement },
+      { path: "/b", element: sharedElement },
+    ]);
+
+    act(() => {
+      ReactDOM.createRoot(node).render(<RouterProvider router={router} />);
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#navigate")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(
+      /pathname=\/b/,
+    );
+    expect(latestSetter).toBe(initialSetter);
+  });
+
+  it("maintains a stable setSearchParams reference in StrictMode", () => {
+    let latestSetter: SetURLSearchParams | undefined;
+    function SearchPage() {
+      let [searchParams, setSearchParams] = useSearchParams();
+      latestSetter = setSearchParams;
+      return (
+        <div>
+          <p id="output">a={searchParams.get("a")}</p>
+          <button id="update" onClick={() => setSearchParams({ a: "2" })}>
+            update
+          </button>
+        </div>
+      );
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <React.StrictMode>
+          <MemoryRouter initialEntries={["/search?a=1"]}>
+            <Routes>
+              <Route path="search" element={<SearchPage />} />
+            </Routes>
+          </MemoryRouter>
+        </React.StrictMode>,
+      );
+    });
+
+    let initialSetter = latestSetter!;
+
+    act(() => {
+      node
+        .querySelector("#update")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.innerHTML).toMatch(/a=2/);
+    expect(latestSetter).toBe(initialSetter);
+  });
+
+  it("reads the previous committed search from another component's layout effect in the same commit, and fresh values from passive effects", () => {
+    let firstSetter: SetURLSearchParams | undefined;
+    let currentSetter: SetURLSearchParams | undefined;
+    function BoundaryParent() {
+      let [searchParams, setSearchParams] = useSearchParams();
+      let navigate = useNavigate();
+      if (firstSetter === undefined) {
+        firstSetter = setSearchParams;
+      }
+      currentSetter = setSearchParams;
+      return (
+        <div>
+          <p id="output">{searchParams.toString()}</p>
+          <button id="to-a1" onClick={() => navigate("/search?a=1")}>
+            to a=1
+          </button>
+          <BoundaryChild />
+        </div>
+      );
+    }
+    function BoundaryChild() {
+      let location = useLocation();
+      let layoutCalledRef = React.useRef(false);
+      let passiveCalledRef = React.useRef(false);
+
+      React.useLayoutEffect(() => {
+        if (!layoutCalledRef.current && location.search === "?a=1") {
+          layoutCalledRef.current = true;
+          firstSetter!((prev) => {
+            let next = new URLSearchParams(prev);
+            next.set(
+              "b",
+              prev.get("a") === "1" ? "layout-fresh" : "layout-stale",
+            );
+            return next;
+          });
+        }
+      });
+
+      React.useEffect(() => {
+        if (
+          !passiveCalledRef.current &&
+          location.search.includes("b=layout-stale")
+        ) {
+          passiveCalledRef.current = true;
+          currentSetter!((prev) => {
+            let next = new URLSearchParams(prev);
+            next.set(
+              "c",
+              prev.get("b") === "layout-stale" ? "passive-fresh" : "passive-stale",
+            );
+            return next;
+          });
+        }
+      });
+
+      return null;
+    }
+
+    act(() => {
+      ReactDOM.createRoot(node).render(
+        <MemoryRouter initialEntries={["/search"]}>
+          <Routes>
+            <Route path="search" element={<BoundaryParent />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    act(() => {
+      node
+        .querySelector("#to-a1")!
+        .dispatchEvent(new Event("click", { bubbles: true }));
+    });
+
+    expect(node.querySelector("#output")!.textContent).toMatch(
+      /b=layout-stale&c=passive-fresh/,
+    );
+    expect(node.querySelector("#output")!.textContent).not.toMatch(/a=1/);
   });
 });

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -2355,6 +2355,16 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
  * other state causes the component to re-render and URL will not reflect the
  * values.
  *
+ * `setSearchParams` is also a stable reference — it stays the same for the
+ * lifetime of the component — so it is also safe to use as a dependency in
+ * `useEffect` hooks. When called, it reads the `searchParams` and `navigate`
+ * values from the latest committed render, even when you call a reference
+ * captured before a navigation. Calls made from inside another component's
+ * `useLayoutEffect` that flushes earlier in the same commit may see the
+ * previous render's values; calls from event handlers and passive effects
+ * (`useEffect`) always see the latest committed values. See the queueing
+ * caveat above for functional updates.
+ *
  * @public
  * @category Hooks
  * @param defaultInit
@@ -2408,17 +2418,25 @@ export function useSearchParams(
   );
 
   let navigate = useNavigate();
+
+  let searchParamsRef = React.useRef(searchParams);
+  let navigateRef = React.useRef(navigate);
+  React.useLayoutEffect(() => {
+    searchParamsRef.current = searchParams;
+    navigateRef.current = navigate;
+  });
+
   let setSearchParams = React.useCallback<SetURLSearchParams>(
     (nextInit, navigateOptions) => {
       const newSearchParams = createSearchParams(
         typeof nextInit === "function"
-          ? nextInit(new URLSearchParams(searchParams))
+          ? nextInit(new URLSearchParams(searchParamsRef.current))
           : nextInit,
       );
       hasSetSearchParamsRef.current = true;
-      navigate("?" + newSearchParams, navigateOptions);
+      navigateRef.current("?" + newSearchParams, navigateOptions);
     },
-    [navigate, searchParams],
+    [],
   );
 
   return [searchParams, setSearchParams];


### PR DESCRIPTION
Fixes #9991

> This PR was prepared with AI assistance (analysis, fix, tests); the approach, the code and the tests were reviewed by a human, and this description was fact-checked against the React sources and docs before submission.

## What is broken

`setSearchParams` is rebuilt whenever the URL changes: the `useCallback` depends on `searchParams` — and, outside data routers, on a `navigate` that churns on pathname changes. The consequence is the one this issue is about: `useEffect(..., [setSearchParams])` refires on every navigation, memo boundaries break, and ref-based workarounds accumulate in userland for over three years.

## What the fix does

The returned function holds one identity for the lifetime of the hook. It does not capture changing values: it reads `searchParams` and `navigate` through refs that are switched during the commit phase, in a layout effect. A call — through any reference, captured before or after a navigation — reads the values of the latest committed render. Event handlers, timeouts, and passive effects always see the latest committed values.

That is the timing React's own effect-event mechanism uses: its internal reference is switched in the commit, before layout effects run. The public `useEffectEvent` API cannot carry this by its own contract — its identity "intentionally changes on every render", and it is specified as effect-local: "Do not call them during rendering or pass them to other components or Hooks" (react.dev). A public setter is both of those things. So this PR implements the platform's timing with the platform's documented primitives: `useRef` + `useLayoutEffect` + `useCallback`.

Nothing else about the hook changes: the type, the defaults merging, the blocked-navigation behavior and the queueing caveat are untouched. On the server the mirrors don't run — effects don't — and the setter is never called during render. `useLayoutEffect` is already used unconditionally in this file by `<Router>` and friends, the ancestors of every `useSearchParams` call, so no new SSR surface is introduced.

## Alternatives considered

- **`setSearchParams = useEffectEvent(...)`** (the literal shape of the redirect) — does not deliver a stable identity: the wrapper is a new function on every render by contract, so `useEffect` deps churn harder than today. Returning an effect event from a hook also steps outside what React documents for that API.
- **A passive `useEffect` mirror (#14785)** — works in the common case, but the switch happens after paint: in the window between commit and the passive flush, a captured reference reads the previous navigation. It also keeps `[navigate]` in the deps, which churns on pathname changes outside data routers.
- **Reading current state from the router at call time** (like `useNavigate` in data routers) — the strongest semantics, but a stable owner only exists in data mode; the declarative mode keeps location in component state. One guarantee across both modes is worth more than two different ones.

## Tests

Nine new cases in `search-params-test.tsx`, all against real React (no mocks): identity across search changes; identity across pathname changes in both router modes (the data-mode case covers `useNavigate` churning through route ids); freshness through a reference captured before a navigation; same-tick no-queueing (characterization of the documented caveat); parent re-render; StrictMode double-invoke; and the layout-effect boundary below. Six of them fail on current `main` and pass here. Full package suite: 127/127 suites, 2603 tests; typecheck, lint, build and change-file validation clean.

## Limitations (stated plainly)

- Calls made from another component's `useLayoutEffect` that flushes earlier in the same commit may see the previous render's values. The platform mechanism has the same boundary — its switch is also in the commit phase. The JSDoc states this.
- Two calls in the same tick still don't build on each other — the existing docs warning remains true; this is a URL setter, not React state.
