### PR TITLE
fix(dev): declare source maps from the route module transforms

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -52,6 +52,7 @@ type ViteConfigBuildArgs = {
   assetsInlineLimit?: number;
   assetsDir?: string;
   cssCodeSplit?: boolean;
+  sourcemap?: boolean | "inline" | "hidden";
 };
 
 type ViteConfigBaseArgs = {
@@ -87,6 +88,7 @@ export const viteConfig = {
     assetsInlineLimit,
     assetsDir,
     cssCodeSplit,
+    sourcemap,
   }: ViteConfigBuildArgs = {}) => {
     return dedent`
       build: {
@@ -95,6 +97,7 @@ export const viteConfig = {
         cssCodeSplit: ${
           cssCodeSplit !== undefined ? cssCodeSplit : "undefined"
         },
+        sourcemap: ${JSON.stringify(sourcemap)},
       },
     `;
   },

--- a/integration/split-route-modules-test.ts
+++ b/integration/split-route-modules-test.ts
@@ -1,4 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
+import { globSync, readFileSync } from "node:fs";
+import { SourceMap } from "node:module";
+import path from "node:path";
 import getPort from "get-port";
 import dedent from "dedent";
 
@@ -249,6 +252,63 @@ async function unblockClientLoader(page: Page) {
 }
 
 test.describe("Split route modules", async () => {
+  test("emits source maps for split route chunks", async () => {
+    let marker = "SPLIT_ROUTE_SOURCE_MAP_TEST";
+    let cwd = await createProject({
+      "react-router.config.ts": reactRouterConfig({
+        splitRouteModules: true,
+      }),
+      "vite.config.js": await viteConfig.basic({ sourcemap: true }),
+      "app/routes/_index.tsx": js`
+        export async function clientLoader() {
+          throw new Error("${marker}");
+        }
+
+        export default function Index() {
+          return <h1>Index</h1>;
+        }
+      `,
+    });
+
+    let { status, stderr } = build({ cwd });
+    expect(status).toBe(0);
+    expect(stderr.toString()).not.toContain("SOURCEMAP_BROKEN");
+
+    let chunkPath = globSync(path.join(cwd, "build/client/assets/*.js")).find(
+      (file) => readFileSync(file, "utf8").includes(marker),
+    );
+    expect(chunkPath).toBeDefined();
+
+    let chunk = readFileSync(chunkPath!, "utf8");
+    let markerOffset = chunk.indexOf(marker);
+    let generatedLines = chunk.slice(0, markerOffset).split("\n");
+    let generatedLine = generatedLines.length - 1;
+    let generatedColumn = generatedLines.at(-1)!.length;
+
+    let map = JSON.parse(readFileSync(`${chunkPath}.map`, "utf8"));
+    let entry = new SourceMap(map).findEntry(generatedLine, generatedColumn);
+    if (!("originalSource" in entry)) {
+      throw new Error("Expected to find a source map entry for the marker");
+    }
+    expect(entry.originalSource?.split("?")[0].replaceAll("\\", "/")).toMatch(
+      /app\/routes\/_index\.tsx$/,
+    );
+
+    let sourceIndex = map.sources.findIndex((source: string) =>
+      source
+        .split("?")[0]
+        .replaceAll("\\", "/")
+        .endsWith("app/routes/_index.tsx"),
+    );
+    expect(sourceIndex).not.toBe(-1);
+    let source = map.sourcesContent[sourceIndex];
+    expect(source).toContain(marker);
+    let originalMarkerOffset = source.indexOf(marker);
+    let originalLine =
+      source.slice(0, originalMarkerOffset).split("\n").length - 1;
+    expect(entry.originalLine).toBe(originalLine);
+  });
+
   test.describe("enabled", () => {
     let port: number;
     let cwd: string;

--- a/packages/react-router-dev/.changes/patch.route-transform-sourcemaps.md
+++ b/packages/react-router-dev/.changes/patch.route-transform-sourcemaps.md
@@ -1,0 +1,4 @@
+Declare source maps from the route module transforms so split route chunks map back to the original file
+
+- `react-router:split-route-modules` now generates a source map when it reprints a route through Babel, instead of returning `null`. Without it the reprinted chunk carried no mapping of its own, so a stack frame in a split route resolved against whatever mapping happened to survive - pointing at the wrong function in the route file.
+- `react-router:build-client-route` now returns an empty mappings string. The re-export barrel it emits is generated code with no original behind it, so this says "deliberately not mappable" rather than leaving it to be treated as if it still lined up with the route module.

--- a/packages/react-router-dev/.changes/patch.route-transform-sourcemaps.md
+++ b/packages/react-router-dev/.changes/patch.route-transform-sourcemaps.md
@@ -1,4 +1,1 @@
-Declare source maps from the route module transforms so split route chunks map back to the original file
-
-- `react-router:split-route-modules` now generates a source map when it reprints a route through Babel, instead of returning `null`. Without it the reprinted chunk carried no mapping of its own, so a stack frame in a split route resolved against whatever mapping happened to survive - pointing at the wrong function in the route file.
-- `react-router:build-client-route` now returns an empty mappings string. The re-export barrel it emits is generated code with no original behind it, so this says "deliberately not mappable" rather than leaving it to be treated as if it still lined up with the route module.
+Fix stack trace locations for split route modules when source maps are enabled in the `reactRouter` Vite plugin

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2000,7 +2000,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           })
           .join(", ");
 
-        return `export { ${reexports} } from "./${routeFileName}";`;
+        return {
+          code: `export { ${reexports} } from "./${routeFileName}";`,
+          // This barrel is generated, so there's no original code behind it to
+          // map back to. An empty mappings string says so explicitly, rather
+          // than leaving Rollup to assume the output still lines up with the
+          // route module it replaced.
+          map: { mappings: "" },
+        };
       },
     },
     {
@@ -3327,7 +3334,10 @@ async function getRouteChunkIfEnabled(
     normalizeRelativeFilePath(id, ctx.reactRouterConfig) +
     (typeof input === "string" ? "" : "?read");
 
-  return getRouteChunkCode(code, chunkName, cache, cacheKey);
+  return getRouteChunkCode(code, chunkName, cache, cacheKey, {
+    sourceMaps: true,
+    sourceFileName: path.basename(id.split("?")[0]),
+  });
 }
 
 function validateRouteChunks({

--- a/packages/react-router-dev/vite/route-chunks-test.ts
+++ b/packages/react-router-dev/vite/route-chunks-test.ts
@@ -4,6 +4,7 @@ import type { Cache } from "./cache";
 import {
   hasChunkableExport,
   getChunkedExport,
+  getRouteChunkCode,
   omitChunkedExports,
 } from "./route-chunks";
 
@@ -1630,6 +1631,56 @@ describe("route chunks", () => {
       expect(
         omitChunkedExports(code, ["chunk"], {}, ...cache)?.code,
       ).toMatchInlineSnapshot(`"export const main = "main";"`);
+    });
+  });
+  describe("source maps", () => {
+    const code = dedent`
+      import { thing } from "./thing";
+      export function meta() { return []; }
+      export function clientLoader() { return thing; }
+      export default function Route() { return null; }
+    `;
+
+    const generateOptions = { sourceMaps: true, sourceFileName: "home.tsx" };
+
+    test("chunked export maps back to its line in the route module", () => {
+      const chunk = getRouteChunkCode(
+        code,
+        "clientLoader",
+        ...cache,
+        generateOptions,
+      );
+
+      expect(chunk?.code).toMatchInlineSnapshot(`
+        "import { thing } from "./thing";
+        export function clientLoader() {
+          return thing;
+        }"
+      `);
+      expect(chunk?.map?.sources).toEqual(["home.tsx"]);
+      expect(chunk?.map?.mappings).not.toBe("");
+
+      // `clientLoader` is line 3 of the route module but line 2 of the chunk,
+      // so a stack frame in the chunk only resolves correctly if the mapping
+      // survived generation.
+      expect(
+        chunk?.rawMappings?.find((mapping) => mapping.name === "clientLoader")
+          ?.original,
+      ).toEqual({ line: 3, column: 16 });
+    });
+
+    test("main chunk maps back to the route module", () => {
+      const main = getRouteChunkCode(code, "main", ...cache, generateOptions);
+
+      expect(main?.map?.sources).toEqual(["home.tsx"]);
+      expect(
+        main?.rawMappings?.find((mapping) => mapping.name === "Route")
+          ?.original,
+      ).toEqual({ line: 4, column: 24 });
+    });
+
+    test("no map is generated unless it is asked for", () => {
+      expect(getRouteChunkCode(code, "clientLoader", ...cache)?.map).toBeNull();
     });
   });
 });

--- a/packages/react-router-dev/vite/route-chunks.ts
+++ b/packages/react-router-dev/vite/route-chunks.ts
@@ -956,12 +956,19 @@ export function getRouteChunkCode(
   chunkName: RouteChunkName,
   cache: Cache,
   cacheKey: string,
+  generateOptions: GeneratorOptions = {},
 ): GeneratorResult | undefined {
   if (chunkName === mainChunkName) {
-    return omitChunkedExports(code, routeChunkExportNames, {}, cache, cacheKey);
+    return omitChunkedExports(
+      code,
+      routeChunkExportNames,
+      generateOptions,
+      cache,
+      cacheKey,
+    );
   }
 
-  return getChunkedExport(code, chunkName, {}, cache, cacheKey);
+  return getChunkedExport(code, chunkName, generateOptions, cache, cacheKey);
 }
 
 const routeChunkQueryStringPrefix = "?route-chunk=";


### PR DESCRIPTION
Closes #15439.

Both route module transforms hand their output back without declaring a source map. The second one is the one with a real consequence, so I'll start there.

**`react-router:split-route-modules` loses the mapping.** It reprints a route through Babel via `getRouteChunkCode`, which calls `generate(ast, {})`. Without `sourceMaps: true`, `@babel/generator` returns `map: null`, so the reprinted chunk carries no mapping of its own and the frame resolves against whatever survives further down the chain. It doesn't degrade gracefully — it lands somewhere wrong.

I checked what that actually costs on `playground/framework-vite-7` with `build.sourcemap: true` and a `clientLoader` added to `_index.tsx` (line 7 of the file). Decoding the first segment of the emitted `_index-client-loader-*.js.map`:

```
before:  generated 1:0  ->  _index.tsx 12:9
after:   generated 1:0  ->  _index.tsx  7:0
```

Line 7 is `export async function clientLoader() {`, which is right. Line 12 is `return <h1>Hello, {loaderData.planet}!</h1>;` inside the default component — code that isn't even in that chunk. So a stack trace from a split route was pointing at an unrelated function.

The plumbing for this was already there: `getChunkedExport` and `omitChunkedExports` both take `GeneratorOptions` and return a `GeneratorResult`, and the plugin already returns that object straight to Vite. Only `getRouteChunkCode` hardcoded `{}`, so it just needed threading through, plus a `sourceFileName` so the map names the route file rather than babel's `"unknown"` default.

**`react-router:build-client-route` returns a bare string.** That one is generated code — a re-export barrel with no original behind it — so there's nothing to map. It now returns `map: { mappings: "" }`, which is the conventional way to say "deliberately not mappable" instead of leaving Rollup to assume the output still lines up with the route module it replaced.

One thing I should be straight about: I could not reproduce the `SOURCEMAP_BROKEN` warnings themselves in this repo. `playground/framework` is on Vite 8, where the bundler is rolldown and that warning doesn't exist, and the Vite 7 playground didn't emit them either even with sourcemaps on and splitting active. So I can't claim a warning count went from N to 0. What I can show is the mapping itself changing from wrong to correct, which is the part users feel.

Worth noting the Vite 8 build is byte-identical before and after — same chunk hashes, same maps — so this doesn't change output there.

## Testing

Three tests added to `route-chunks-test.ts`, asserting on `rawMappings` so the assertion is about a specific line rather than "a map exists":

```
✓ chunked export maps back to its line in the route module
✓ main chunk maps back to the route module
✓ no map is generated unless it is asked for
```

Reverting only `route-chunks.ts` and re-running fails the first two (`2 failed, 60 passed`), passing again with it restored.

Full package suite: `9 suites / 190 tests / 185 snapshots` green, `tsc` clean, eslint clean, prettier clean.
