### PR TITLE
Validate client-side navigation targets

### DIFF
--- a/packages/react-router/.changes/patch.validate-client-navigation-targets.md
+++ b/packages/react-router/.changes/patch.validate-client-navigation-targets.md
@@ -1,0 +1,1 @@
+Add additional URL validation on client side navigations/redirects

--- a/packages/react-router/__tests__/external-navigation-test.tsx
+++ b/packages/react-router/__tests__/external-navigation-test.tsx
@@ -1,0 +1,425 @@
+import * as React from "react";
+import * as TestRenderer from "react-test-renderer";
+
+import type { Navigator } from "../lib/context";
+import { setup } from "./router/utils/data-router-setup";
+import { createBrowserHistory } from "../lib/router/history";
+import {
+  getNavigatorCurrentUrl,
+  validateNavigationTarget,
+} from "../lib/router/navigation";
+import { createRouter } from "../lib/router/router";
+import { Navigate, Route, Router, Routes } from "../lib/components";
+import { useNavigate } from "../lib/hooks";
+import { redirect } from "../lib/router/utils";
+import getWindow from "./utils/getWindow";
+
+const EXPLICIT_EXTERNAL_URLS = [
+  "http://example.com/path",
+  "https://example.com/path",
+  "//example.com/path",
+  "mailto:test@example.com",
+  "tel:5551234567",
+];
+
+const IMPLICIT_EXTERNAL_URLS = [
+  "/\t/example.com/path",
+  "/\\example.com/path",
+  "\\/example.com/path",
+  "\\\\example.com/path",
+];
+
+const INVALID_PROTOCOL_URLS = [
+  // eslint-disable-next-line no-script-url
+  "javascript:console.log('hi')",
+  "data:foo",
+];
+
+const EXTERNAL_URLS = [
+  ...EXPLICIT_EXTERNAL_URLS,
+  ...IMPLICIT_EXTERNAL_URLS,
+  ...INVALID_PROTOCOL_URLS,
+];
+
+const VALID_INTERNAL_URLS = [
+  {
+    original: "\\example.com/path",
+    resolved: "/example.com/path",
+  },
+];
+
+describe("external navigation support", () => {
+  it.each(EXTERNAL_URLS)(
+    "router.navigate throws for external navigation to %s",
+    async (to) => {
+      let t = setup({
+        routes: [{ id: "index", index: true }],
+      });
+
+      await expect(t.router.navigate(to)).rejects.toThrow(
+        "External navigation is not allowed",
+      );
+      expect(t.router.state.location.pathname).toBe("/");
+    },
+  );
+
+  it.each(VALID_INTERNAL_URLS)(
+    "router.navigate does not throw for an internal navigation to %s",
+    async (to) => {
+      let t = setup({
+        routes: [{ id: "index", index: true }],
+      });
+
+      await t.router.navigate(to.original);
+      expect(t.router.state.location.pathname).toBe(to.resolved);
+      expect(t.history.push).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: to.resolved }),
+        null,
+      );
+    },
+  );
+
+  it.each(EXTERNAL_URLS)(
+    "router.navigate throws for an external navigation mask to %s",
+    async (to) => {
+      let t = setup({
+        routes: [
+          { id: "index", index: true },
+          { id: "internal", path: "/internal" },
+        ],
+      });
+
+      await expect(
+        t.router.navigate("/internal", { mask: to }),
+      ).rejects.toThrow("External navigation is not allowed");
+      expect(t.router.state.location.pathname).toBe("/");
+    },
+  );
+
+  it.each(VALID_INTERNAL_URLS)(
+    "router.navigate does not throw for an internal navigation mask to %s",
+    async (to) => {
+      let t = setup({
+        routes: [
+          { id: "index", index: true },
+          { id: "internal", path: "/internal" },
+        ],
+      });
+
+      await t.router.navigate("/internal", { mask: to.original });
+      expect(t.router.state.location.pathname).toBe("/internal");
+      expect(t.history.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: "/internal",
+          mask: expect.objectContaining({ pathname: to.resolved }),
+        }),
+        null,
+      );
+    },
+  );
+
+  it.each(EXTERNAL_URLS)(
+    "<Navigate> throws for external navigation to %s",
+    (to) => {
+      let testWindow = getWindow("/");
+      let history = createBrowserHistory({ window: testWindow });
+      let pushSpy = jest.spyOn(history, "push");
+
+      expect(() => {
+        TestRenderer.act(() => {
+          TestRenderer.create(
+            <Router
+              location={history.location}
+              navigationType={history.action}
+              navigator={history}
+            >
+              <Routes>
+                <Route index element={<Navigate to={to} />} />
+                <Route path="/example.com/path" element={<h1>Internal</h1>} />
+              </Routes>
+            </Router>,
+          );
+        });
+      }).toThrow("External navigation is not allowed");
+
+      expect(pushSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(VALID_INTERNAL_URLS)(
+    "<Navigate> does not throw for internal navigation to %s",
+    async (to) => {
+      let testWindow = getWindow("/");
+      let history = createBrowserHistory({ window: testWindow });
+      let pushSpy = jest.spyOn(history, "push");
+
+      let routes = (
+        <Routes>
+          <Route index element={<Navigate to={to.original} />} />
+          <Route path={to.resolved} element={<h1>Internal</h1>} />
+        </Routes>
+      );
+
+      TestRenderer.act(() => {
+        TestRenderer.create(
+          <Router
+            location={history.location}
+            navigationType={history.action}
+            navigator={history}
+          >
+            {routes}
+          </Router>,
+        );
+      });
+
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: to.resolved }),
+        undefined,
+        expect.any(Object),
+      );
+    },
+  );
+
+  it.each(EXTERNAL_URLS)(
+    "useNavigate throws for external navigation to %s",
+    (to) => {
+      function Home() {
+        let navigate = useNavigate();
+        return <button onClick={() => navigate(to)}>Navigate</button>;
+      }
+
+      let testWindow = getWindow("/");
+      let history = createBrowserHistory({ window: testWindow });
+      let pushSpy = jest.spyOn(history, "push");
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Router
+            location={history.location}
+            navigationType={history.action}
+            navigator={history}
+          >
+            <Routes>
+              <Route index element={<Home />} />
+            </Routes>
+          </Router>,
+        );
+      });
+
+      expect(() => renderer.root.findByType("button").props.onClick()).toThrow(
+        "External navigation is not allowed",
+      );
+      expect(pushSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(VALID_INTERNAL_URLS)(
+    "useNavigate does not throw for internal navigation to %s",
+    (to) => {
+      function Home() {
+        let navigate = useNavigate();
+        return <button onClick={() => navigate(to.original)}>Navigate</button>;
+      }
+
+      let testWindow = getWindow("/");
+      let history = createBrowserHistory({ window: testWindow });
+      let pushSpy = jest.spyOn(history, "push");
+
+      let renderer: TestRenderer.ReactTestRenderer;
+      TestRenderer.act(() => {
+        renderer = TestRenderer.create(
+          <Router
+            location={history.location}
+            navigationType={history.action}
+            navigator={history}
+          >
+            <Routes>
+              <Route index element={<Home />} />
+            </Routes>
+          </Router>,
+        );
+      });
+
+      TestRenderer.act(() =>
+        renderer.root.findByType("button").props.onClick(),
+      );
+      expect(pushSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: to.resolved }),
+        undefined,
+        expect.any(Object),
+      );
+    },
+  );
+
+  it.each(IMPLICIT_EXTERNAL_URLS)(
+    "client-side redirect rejects implicit external redirects to %s",
+    async (location) => {
+      let testWindow = getWindow("/");
+      testWindow = {
+        ...testWindow,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        location: {
+          ...testWindow.location,
+          assign: jest.fn(),
+          replace: jest.fn(),
+        },
+      } as unknown as Window;
+      let router = createRouter({
+        history: createBrowserHistory(),
+        routes: [
+          { path: "/" },
+          {
+            path: "/start",
+            loader: () => redirect(location),
+          },
+        ],
+        window: testWindow,
+      }).initialize();
+
+      await expect(router.navigate("/start")).rejects.toThrow(
+        "External navigation is not allowed",
+      );
+      expect(testWindow.location.assign).not.toHaveBeenCalled();
+      router.dispose();
+    },
+  );
+
+  it.each(INVALID_PROTOCOL_URLS)(
+    "client-side redirect rejects implicit external redirects to %s",
+    async (location) => {
+      let testWindow = getWindow("/");
+      testWindow = {
+        ...testWindow,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        location: {
+          ...testWindow.location,
+          assign: jest.fn(),
+          replace: jest.fn(),
+        },
+      } as unknown as Window;
+      let router = createRouter({
+        history: createBrowserHistory(),
+        routes: [
+          { path: "/" },
+          {
+            path: "/start",
+            loader: () => redirect(location),
+          },
+        ],
+        window: testWindow,
+      }).initialize();
+
+      await expect(router.navigate("/start")).rejects.toThrow(
+        "Invalid redirect location",
+      );
+      expect(testWindow.location.assign).not.toHaveBeenCalled();
+      router.dispose();
+    },
+  );
+
+  it.each(EXPLICIT_EXTERNAL_URLS)(
+    "client-side redirects permit explicit external redirects to %s",
+    async (location) => {
+      let testWindow = getWindow("/");
+      testWindow = {
+        ...testWindow,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        location: {
+          ...testWindow.location,
+          assign: jest.fn(),
+          replace: jest.fn(),
+        },
+      } as unknown as Window;
+      let router = createRouter({
+        history: createBrowserHistory(),
+        routes: [
+          { path: "/" },
+          {
+            path: "/start",
+            loader: () => redirect(location),
+          },
+        ],
+        window: testWindow,
+      }).initialize();
+
+      await router.navigate("/start");
+      expect(testWindow.location.assign).toHaveBeenCalledWith(location);
+      router.dispose();
+    },
+  );
+
+  it.each(VALID_INTERNAL_URLS)(
+    "client-side redirects permit valid internal redirects to %s",
+    async (to) => {
+      let testWindow = getWindow("/");
+      testWindow = {
+        ...testWindow,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        location: {
+          ...testWindow.location,
+          assign: jest.fn(),
+          replace: jest.fn(),
+        },
+      } as unknown as Window;
+      let history = createBrowserHistory();
+      jest.spyOn(history, "push");
+      let router = createRouter({
+        history,
+        routes: [
+          { path: "/" },
+          {
+            path: "/start",
+            loader: () => redirect(to.original),
+          },
+        ],
+        window: testWindow,
+      }).initialize();
+
+      await router.navigate("/start");
+      expect(history.push).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: to.resolved }),
+        expect.any(Object),
+      );
+      router.dispose();
+    },
+  );
+
+  it("uses an absolute createHref as a custom navigator base", () => {
+    let navigator = {
+      createHref: () => "https://custom.example/",
+    } as unknown as Navigator;
+
+    expect(getNavigatorCurrentUrl(navigator).origin).toBe(
+      "https://custom.example",
+    );
+  });
+
+  it("rejects an invalid resolved destination", () => {
+    expect(() =>
+      validateNavigationTarget(
+        "/internal",
+        "http://[",
+        new URL("https://app.example/"),
+        "reject",
+      ),
+    ).toThrow();
+  });
+
+  it("rejects an explicit destination whose origin changed", () => {
+    expect(() =>
+      validateNavigationTarget(
+        "https://first.example/path",
+        "https://second.example/path",
+        new URL("https://app.example/"),
+        "allow-explicit",
+      ),
+    ).toThrow("External navigation is not allowed");
+  });
+});

--- a/packages/react-router/__tests__/router/utils/data-router-setup.ts
+++ b/packages/react-router/__tests__/router/utils/data-router-setup.ts
@@ -25,6 +25,7 @@ import {
 } from "../../../lib/router/utils";
 
 import { isRedirect, tick } from "./utils";
+import getWindow from "../../utils/getWindow";
 
 // Routes passed into setup() should just have a boolean for loader/action
 // indicating they want a stub.  They get enhanced back to AgnosticRouteObjects
@@ -309,10 +310,13 @@ export function setup({
 
   // jsdom is making more and more properties non-configurable, so we inject
   // our own jest-friendly window.
-  let testWindow = {
-    ...window,
+  let testWindow = getWindow("/");
+  testWindow = {
+    ...testWindow,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
     location: {
-      ...window.location,
+      ...testWindow.location,
       assign: jest.fn(),
       replace: jest.fn(),
     },

--- a/packages/react-router/__tests__/useNavigate-test.tsx
+++ b/packages/react-router/__tests__/useNavigate-test.tsx
@@ -761,33 +761,6 @@ describe("useNavigate", () => {
           </h1>
         `);
       });
-
-      it("normalizes mixed leading separators", async () => {
-        for (let to of ["//foo", "\\\\foo", "/\\foo", "\\/foo"]) {
-          let renderer: TestRenderer.ReactTestRenderer;
-          TestRenderer.act(() => {
-            renderer = TestRenderer.create(
-              <MemoryRouter initialEntries={["/home"]}>
-                <Routes>
-                  <Route path="home" element={<UseNavigateButton to={to} />} />
-                  <Route path="foo" element={<p>foo</p>} />
-                </Routes>
-              </MemoryRouter>,
-            );
-          });
-
-          // @ts-expect-error
-          let button = renderer.root.findByType("button");
-          await TestRenderer.act(() => button.props.onClick());
-
-          // @ts-expect-error
-          expect(renderer.toJSON()).toMatchInlineSnapshot(`
-            <p>
-              foo
-            </p>
-          `);
-        }
-      });
     });
 
     describe("with a relative href (relative=route)", () => {

--- a/packages/react-router/lib/components.tsx
+++ b/packages/react-router/lib/components.tsx
@@ -8,6 +8,7 @@ import type {
 } from "./router/history";
 import {
   Action as NavigationType,
+  createPath,
   createMemoryHistory,
   invariant,
   parsePath,
@@ -74,6 +75,10 @@ import {
 import type { ViewTransition } from "./dom/global";
 import { warnOnce } from "./server-runtime/warnings";
 import type { ClientInstrumentation } from "./router/instrumentation";
+import {
+  getNavigatorCurrentUrl,
+  validateNavigationTarget,
+} from "./router/navigation";
 import { useOptimistic } from "react";
 
 export const hydrationRouteProperties: (keyof RouteObject)[] = [
@@ -618,6 +623,7 @@ export function RouterProvider({
   let navigator = React.useMemo((): Navigator => {
     return {
       createHref: router.createHref,
+      createURL: router.createURL,
       encodeLocation: router.encodeLocation,
       go: (n) => router.navigate(n),
       push: (to, state, opts) =>
@@ -893,7 +899,7 @@ export function Navigate({
     `<Navigate> may be used only in the context of a <Router> component.`,
   );
 
-  let { static: isStatic } = React.useContext(NavigationContext);
+  let { static: isStatic, navigator } = React.useContext(NavigationContext);
 
   warning(
     !isStatic,
@@ -913,6 +919,12 @@ export function Navigate({
     getResolveToMatches(matches),
     locationPathname,
     relative === "path",
+  );
+  validateNavigationTarget(
+    typeof to === "string" ? to : createPath(to),
+    navigator.createHref(path),
+    getNavigatorCurrentUrl(navigator),
+    "reject",
   );
   let jsonPath = JSON.stringify(path);
 

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -101,6 +101,8 @@ export interface NavigateOptions {
 export interface Navigator {
   createHref: History["createHref"];
   // Optional for backwards-compat with Router/HistoryRouter usage (edge case)
+  createURL?: History["createURL"];
+  // Optional for backwards-compat with Router/HistoryRouter usage (edge case)
   encodeLocation?: History["encodeLocation"];
   go: History["go"];
   push(to: To, state?: any, opts?: NavigateOptions): void;

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -13,6 +13,7 @@ import {
 import type { Location, Path, To } from "./router/history";
 import {
   Action as NavigationType,
+  createPath,
   invariant,
   parsePath,
   warning,
@@ -63,6 +64,10 @@ import {
   decodeRedirectErrorDigest,
   decodeRouteErrorResponseDigest,
 } from "./errors";
+import {
+  getNavigatorCurrentUrl,
+  validateNavigationTarget,
+} from "./router/navigation";
 
 /**
  * Resolves a URL against the current {@link Location}.
@@ -423,6 +428,13 @@ function useNavigateUnstable(): NavigateFunction {
             ? basename
             : joinPaths([basename, path.pathname]);
       }
+
+      validateNavigationTarget(
+        typeof to === "string" ? to : createPath(to),
+        navigator.createHref(path),
+        getNavigatorCurrentUrl(navigator),
+        "reject",
+      );
 
       (!!options.replace ? navigator.replace : navigator.push)(
         path,
@@ -1117,7 +1129,7 @@ function RSCErrorHandler({
   children: React.ReactNode;
   error: unknown;
 }) {
-  let { basename } = React.useContext(NavigationContext);
+  let { basename, navigator } = React.useContext(NavigationContext);
 
   if (
     typeof error === "object" &&
@@ -1132,6 +1144,12 @@ function RSCErrorHandler({
 
       let parsed = parseToInfo(redirect.location, basename);
       let target = parsed.absoluteURL || parsed.to;
+      validateNavigationTarget(
+        redirect.location,
+        target,
+        getNavigatorCurrentUrl(navigator),
+        "allow-explicit",
+      );
       if (hasInvalidProtocol(target)) {
         throw new Error("Invalid redirect location");
       }

--- a/packages/react-router/lib/router/navigation.ts
+++ b/packages/react-router/lib/router/navigation.ts
@@ -1,0 +1,69 @@
+import type { Navigator } from "../context";
+
+const DEFAULT_NAVIGATION_URL = new URL("http://localhost");
+
+export type ExternalNavigationPolicy = "allow-explicit" | "reject";
+
+export function getNavigatorCurrentUrl(navigator: Navigator): URL {
+  if (navigator.createURL) {
+    return navigator.createURL("/");
+  }
+
+  try {
+    return new URL(navigator.createHref("/"), DEFAULT_NAVIGATION_URL);
+  } catch {
+    return DEFAULT_NAVIGATION_URL;
+  }
+}
+
+function isSameOrigin(a: URL, b: URL): boolean {
+  return (
+    a.origin === b.origin &&
+    (a.origin !== "null" || (a.protocol === b.protocol && a.host === b.host))
+  );
+}
+
+function isExplicitUrl(destination: string, target: URL): boolean {
+  if (destination.startsWith("//")) {
+    return true;
+  }
+
+  let protocol = target.protocol.toLowerCase();
+  if (!destination.toLowerCase().startsWith(protocol)) {
+    return false;
+  }
+
+  return (
+    target.host === "" || destination.slice(protocol.length).startsWith("//")
+  );
+}
+
+export function validateNavigationTarget(
+  original: string | null,
+  resolved: string,
+  currentUrl: URL,
+  externalPolicy: ExternalNavigationPolicy,
+): void {
+  let originalUrl: URL | null = null;
+  try {
+    originalUrl = original == null ? null : new URL(original, currentUrl);
+  } catch {}
+  let resolvedUrl = new URL(resolved, currentUrl);
+  let originalIsExternal =
+    originalUrl != null && !isSameOrigin(originalUrl, currentUrl);
+  let resolvedIsExternal = !isSameOrigin(resolvedUrl, currentUrl);
+
+  if (externalPolicy === "reject") {
+    if (originalIsExternal || resolvedIsExternal) {
+      throw new Error("External navigation is not allowed");
+    }
+  } else if (resolvedIsExternal) {
+    if (
+      originalUrl == null ||
+      !isExplicitUrl(original!, originalUrl) ||
+      !isSameOrigin(originalUrl, resolvedUrl)
+    ) {
+      throw new Error("External navigation is not allowed");
+    }
+  }
+}

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -74,11 +74,13 @@ import {
   getRoutePattern,
   removeDoubleSlashes,
   flattenAndRankRoutes,
+  resolvePath,
 } from "./utils";
 import {
   normalizeProtocolRelativeUrl,
   PROTOCOL_RELATIVE_URL_REGEX,
 } from "./url";
+import { validateNavigationTarget } from "./navigation";
 
 ////////////////////////////////////////////////////////////////////////////////
 //#region Types and Constants
@@ -231,6 +233,15 @@ export interface Router {
    * @param location
    */
   createHref(location: Location | URL): string;
+
+  /**
+   * @private
+   * PRIVATE - DO NOT USE
+   *
+   * Utility function to create a URL for the given location
+   * @param location
+   */
+  createURL?(to: To): URL;
 
   /**
    * @private
@@ -1708,11 +1719,23 @@ export function createRouter(init: RouterInit): Router {
               ...opts.mask,
             };
       maskPath = {
-        pathname: "",
-        search: "",
-        hash: "",
-        ...partialPath,
+        pathname: partialPath.pathname ?? "",
+        search: partialPath.search ?? "",
+        hash: partialPath.hash ?? "",
       };
+
+      if (PROTOCOL_RELATIVE_URL_REGEX.test(maskPath.pathname)) {
+        throw new Error("External navigation is not allowed");
+      } else if (maskPath.pathname.startsWith("\\")) {
+        maskPath.pathname = maskPath.pathname.replace(/^\\+/, "/");
+      }
+
+      validateNavigationTarget(
+        typeof opts.mask === "string" ? opts.mask : createPath(opts.mask),
+        createPath(maskPath),
+        init.history.createURL("/"),
+        "reject",
+      );
     }
 
     let currentLocation = state.location;
@@ -1733,6 +1756,17 @@ export function createRouter(init: RouterInit): Router {
       ...nextLocation,
       ...init.history.encodeLocation(nextLocation),
     };
+
+    validateNavigationTarget(
+      to == null
+        ? init.history.createHref(state.location)
+        : typeof to === "string"
+          ? to
+          : createPath(to),
+      init.history.createHref(nextLocation.mask || nextLocation),
+      init.history.createURL("/"),
+      "reject",
+    );
 
     let userReplace = opts && opts.replace != null ? opts.replace : undefined;
 
@@ -3251,11 +3285,19 @@ export function createRouter(init: RouterInit): Router {
 
     let location = redirect.response.headers.get("Location");
     invariant(location, "Expected a Location header on the redirect Response");
+    let originalLocation = location;
+    let currentUrl = new URL(request.url);
     location = normalizeRedirectLocation(
       location,
-      new URL(request.url),
+      currentUrl,
       basename,
       init.history,
+    );
+    validateNavigationTarget(
+      originalLocation,
+      location,
+      currentUrl,
+      "allow-explicit",
     );
     let redirectLocation = createLocation(state.location, location, {
       _isRedirect: true,
@@ -4013,6 +4055,7 @@ export function createRouter(init: RouterInit): Router {
     // Passthrough to history-aware createHref used by useHref so we get proper
     // hash-aware URLs in DOM paths
     createHref: (to: To) => init.history.createHref(to),
+    createURL: (to: To) => init.history.createURL(to),
     encodeLocation: (to: To) => init.history.encodeLocation(to),
     getFetcher,
     resetFetcher,

--- a/packages/react-router/lib/router/utils.ts
+++ b/packages/react-router/lib/router/utils.ts
@@ -1875,7 +1875,7 @@ export function resolvePath(to: To, fromPathname = "/"): Path {
   let pathname: string;
   if (toPathname) {
     toPathname = removeDoubleSlashes(toPathname);
-    if (toPathname.startsWith("/")) {
+    if (toPathname.startsWith("/") || toPathname.startsWith("\\")) {
       pathname = resolvePathname(toPathname.substring(1), "/");
     } else {
       pathname = resolvePathname(toPathname, fromPathname);

--- a/packages/react-router/lib/rsc/browser.tsx
+++ b/packages/react-router/lib/rsc/browser.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../router/utils";
 import { ErrorResponseImpl, createContext, resolvePath } from "../router/utils";
 import { PROTOCOL_RELATIVE_URL_REGEX } from "../router/url";
+import { validateNavigationTarget } from "../router/navigation";
 import type {
   DecodedSingleFetchResults,
   FetchAndDecodeFunction,
@@ -151,6 +152,12 @@ export function createCallServer({
         .then(async (payload) => {
           if (payload.type === "redirect") {
             let location = normalizeRedirectLocation(payload.location);
+            validateNavigationTarget(
+              payload.location,
+              location,
+              new URL(window.location.href),
+              "allow-explicit",
+            );
             if (payload.reload || isExternalLocation(location)) {
               if (hasInvalidProtocol(location)) {
                 throw new Error("Invalid redirect location");
@@ -179,6 +186,12 @@ export function createCallServer({
           ) {
             if (rerender.type === "redirect") {
               let location = normalizeRedirectLocation(rerender.location);
+              validateNavigationTarget(
+                rerender.location,
+                location,
+                new URL(window.location.href),
+                "allow-explicit",
+              );
               if (rerender.reload || isExternalLocation(location)) {
                 if (hasInvalidProtocol(location)) {
                   throw new Error("Invalid redirect location");


### PR DESCRIPTION
This improves consistency when handling client-side navigation targets by validating both the supplied destination and its resolved URL.

- Programmatic navigations reject unsupported external destinations.
- Client-side redirects continue to support explicit external destinations.
- External links and server-side redirects remain supported.
