### PR TITLE
docs: explain shouldRevalidate and call-site revalidation opt-out

### DIFF
--- a/docs/how-to/fetchers.md
+++ b/docs/how-to/fetchers.md
@@ -305,3 +305,8 @@ Fetchers can be submitted programmatically with `fetcher.submit`:
 ```
 
 Note the input event's form is passed as the first argument to `fetcher.submit`. The fetcher will use that form to submit the request, reading its attributes and serializing the data from its elements.
+
+`fetcher.submit` accepts the same [`defaultShouldRevalidate`][fetcher-submit-options] option as [`<Form>`][form]. Pass `false` to skip loader revalidation for that submission. See [Revalidation Optimization](./optimize-revalidation) for how that interacts with route-level `shouldRevalidate`.
+
+[fetcher-submit-options]: https://api.reactrouter.com/v8/interfaces/react-router.FetcherSubmitOptions.html#defaultshouldrevalidate
+[form]: ../api/components/Form#defaultshouldrevalidate

--- a/docs/how-to/fetchers.md
+++ b/docs/how-to/fetchers.md
@@ -85,7 +85,7 @@ export default function Component() {
 
 ### 3. Submit the form
 
-If you submit the form now, the fetcher will call the action and revalidate the route data automatically.
+If you submit the form now, the fetcher will call the action and revalidate the route data automatically. See [Revalidation Optimization](./optimize-revalidation) to skip that reload for a route or a single submission.
 
 ### 4. Render pending state
 

--- a/docs/how-to/optimize-revalidation.md
+++ b/docs/how-to/optimize-revalidation.md
@@ -1,12 +1,185 @@
 ---
 title: Revalidation Optimization
-hidden: true
 ---
 
-[copy pasted]
+# Revalidation Optimization
 
-During client-side transitions, React Router will optimize reloading of routes that are already rendering, like not reloading layout routes that aren't changing. In other cases, like form submissions or search param changes, React Router doesn't know which routes need to be reloaded, so it reloads them all to be safe. This ensures your UI always stays in sync with the state on your server.
+[MODES: framework, data]
 
-This function lets apps further optimize by returning `false` when React Router is about to reload a route. If you define this function on a route module, React Router will defer to your function on every navigation and every revalidation after an action is called. Again, this makes it possible for your UI to get out of sync with your server if you do it wrong, so be careful.
+<br/>
+<br/>
 
-`fetcher.load` calls also revalidate, but because they load a specific URL, they don't have to worry about route param or URL search param revalidations. `fetcher.load`'s only revalidate by default after action submissions and explicit revalidation requests via [`useRevalidator`][use-revalidator].
+After a mutation or some navigations, React Router re-runs loaders so
+the UI stays in sync with the server. That default is the right
+starting point. When a loader is expensive, or a mutation cannot
+affect that route's data, you can skip the reload.
+
+<docs-warning>
+Skipping revalidation can leave the UI out of sync with the server.
+Prefer targeting a specific action or navigation, and fall back to
+`defaultShouldRevalidate` instead of always returning `false`.
+</docs-warning>
+
+## Default behavior
+
+**Framework Mode with SSR** revalidates every matched loader after
+navigations and after [`<Form>`][form], [`useSubmit`][use-submit],
+`<fetcher.Form>`, and `fetcher.submit`. That includes the root
+route. This is different from [Data Mode][data-mode].
+
+**Data Mode** already skips some loaders on navigations (for example
+a parent whose params did not change). It still revalidates after
+an action that returns a non-error status, when search params
+change, when the route's own params change, and when navigating to
+the same URL.
+
+Each matched route is decided independently. A child that skips
+revalidation does not skip its parent or `root`. After
+`fetcher.submit()`, a leaf `shouldRevalidate` that returns `false`
+still leaves the root loader free to run.
+
+[`fetcher.load`][use-fetcher] only revalidates by default after
+action submissions and explicit [`useRevalidator`][use-revalidator]
+calls, not on search-param or param-driven navigations.
+
+A plain `fetch()` to a [resource route][resource-routes] does not
+go through the router, so it does not revalidate loaders.
+
+## Skip a route with `shouldRevalidate`
+
+Export `shouldRevalidate` from the [route module][route-module]
+(Framework Mode) or set it on the [route object][data-mode]
+(Data Mode). Returning `false` skips **that route's** loader.
+
+```tsx filename=app/routes/dashboard.tsx
+export function shouldRevalidate() {
+  return false;
+}
+```
+
+```tsx
+createBrowserRouter([
+  {
+    path: "/dashboard",
+    loader: dashboardLoader,
+    shouldRevalidate: () => false,
+    Component: Dashboard,
+  },
+]);
+```
+
+Always returning `false` opts that route out of the default
+behavior completely, including cases you usually still want
+(param changes, explicit [`useRevalidator`][use-revalidator]).
+Prefer the conditional form below.
+
+## Opt out of specific requests
+
+Inspect
+[`ShouldRevalidateFunctionArgs`][should-revalidate-args]
+and return `defaultShouldRevalidate` for everything else.
+
+```tsx
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+
+export function shouldRevalidate({
+  formMethod,
+  formAction,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (
+    formMethod === "POST" &&
+    formAction?.endsWith("/analytics")
+  ) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
+}
+```
+
+Other useful fields:
+
+- `formData`, `json`, `text` — the submission body
+- `actionResult`, `actionStatus` — the action's return value
+- `currentUrl`, `nextUrl`, `currentParams`, `nextParams` —
+  the navigation
+
+You can ignore search-param-only updates while still
+revalidating when the pathname changes:
+
+```tsx
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (currentUrl.pathname === nextUrl.pathname) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
+}
+```
+
+## Skip revalidation for one event
+
+Pass `defaultShouldRevalidate={false}` at the call site so you
+do not have to change every route file. This works on
+[`<Form>`][form], [`<Link>`][link], `<fetcher.Form>`, and as an
+option to [`useSubmit`][use-submit], `fetcher.submit`,
+[`useNavigate`][use-navigate], and
+[`useSearchParams`][use-search-params].
+
+```tsx
+import { Form, Link } from "react-router";
+
+<Link
+  to="/search?q=shoes"
+  defaultShouldRevalidate={false}
+>
+  Search Shoes
+</Link>
+
+<Form
+  method="post"
+  action="/analytics"
+  defaultShouldRevalidate={false}
+>
+  <button>Track Click</button>
+</Form>
+```
+
+```tsx
+fetcher.submit(
+  { intent: "save-progress" },
+  {
+    method: "post",
+    action: "/save-progress",
+    defaultShouldRevalidate: false,
+  },
+);
+```
+
+If a matched route does **not** export `shouldRevalidate`, this
+value is used directly for that loader. If it **does** export
+`shouldRevalidate`, the value is passed in as
+`defaultShouldRevalidate` and the route still has the final say.
+
+That is why a child `shouldRevalidate` that always returns
+`false` cannot hide a root reload after `fetcher.submit`. Either
+also opt `root` out for that case, or pass
+`defaultShouldRevalidate: false` at the call site when `root`
+has no `shouldRevalidate` of its own.
+
+[data-mode]: ../start/data/route-object#shouldrevalidate
+[form]: ../api/components/Form
+[link]: ../api/components/Link
+[resource-routes]: ./resource-routes
+[route-module]: ../start/framework/route-module#shouldrevalidate
+[should-revalidate-args]: https://api.reactrouter.com/v8/interfaces/react-router.ShouldRevalidateFunctionArgs.html
+[use-fetcher]: ../api/hooks/useFetcher
+[use-navigate]: ../api/hooks/useNavigate
+[use-revalidator]: ../api/hooks/useRevalidator
+[use-search-params]: ../api/hooks/useSearchParams
+[use-submit]: ../api/hooks/useSubmit

--- a/docs/how-to/optimize-revalidation.md
+++ b/docs/how-to/optimize-revalidation.md
@@ -22,25 +22,23 @@ Prefer targeting a specific action or navigation, and fall back to
 
 ## Default behavior
 
-**Framework Mode with SSR** revalidates every matched loader after
-navigations and after [`<Form>`][form], [`useSubmit`][use-submit],
-`<fetcher.Form>`, and `fetcher.submit`. That includes the root
-route. This is different from [Data Mode][data-mode].
+The default behavior differs between Framework and Data Modes:
 
-**Data Mode** already skips some loaders on navigations (for example
-a parent whose params did not change). It still revalidates after
-an action that returns a non-error status, when search params
-change, when the route's own params change, and when navigating to
-the same URL.
+- **Framework Mode with SSR**
+  - Defaults to opt-out behavior - active loaders are revalidated on navigations and successful submissions ([`Link`][link], [`Form`][form], [`fetcher.submit`](fetcher-submit))
+  - Failed submissions returning a 4xx/5xx status do not trigger revalidations by default
+- **Framework "SPA Mode" and Data Mode**
+  - Defaults to opt-out behavior on successful submissions - active loaders are revalidated on successful submissions ([`Form`][form], [`fetcher.submit`])
+    - Failed submissions returning a 4xx/5xx status do not trigger revalidations by default
+  - Defaults to opt-in behavior for GET navigations ([`Link`][link]) - active loaders are only revalidated if their dynamic params changed, or if any search params changed
+    - A GET navigation to the _exact_ same URL is treated like a page refresh and all loaders are revalidated.
 
-Each matched route is decided independently. A child that skips
-revalidation does not skip its parent or `root`. After
-`fetcher.submit()`, a leaf `shouldRevalidate` that returns `false`
-still leaves the root loader free to run.
+Matched matched routes are handled independently - A child that skips
+revalidation does not skip any ancestor routes.
 
-[`fetcher.load`][use-fetcher] only revalidates by default after
-action submissions and explicit [`useRevalidator`][use-revalidator]
-calls, not on search-param or param-driven navigations.
+[`fetcher.load`][use-fetcher] only revalidates by default after action
+submissions and explicit [`useRevalidator`][use-revalidator] calls, not
+on search-param or param-driven navigations.
 
 A plain `fetch()` to a [resource route][resource-routes] does not
 go through the router, so it does not revalidate loaders.
@@ -52,12 +50,14 @@ Export `shouldRevalidate` from the [route module][route-module]
 (Data Mode). Returning `false` skips **that route's** loader.
 
 ```tsx filename=app/routes/dashboard.tsx
+// Framework Mode
 export function shouldRevalidate() {
   return false;
 }
 ```
 
-```tsx
+```tsx src/main.tsx
+// Data Mode
 createBrowserRouter([
   {
     path: "/dashboard",

--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -66,6 +66,8 @@ export function action(_: Route.ActionArgs) {
 }
 ```
 
+Calling this `action` through [`<Form>`][form] or [`useFetcher`][fetcher] still revalidates matched UI loaders. A plain `fetch()` to the resource URL does not. See [Revalidation Optimization][optimize-revalidation].
+
 ## Return Types
 
 Resource Routes are flexible when it comes to the return type - you can return [`Response`][Response] instances or [`data()`][data] objects. A good general rule of thumb when deciding which type to use is:
@@ -124,3 +126,4 @@ export function action() {
 [form]: ../api/components/Form
 [await]: ../api/components/Await
 [error-boundary]: ../start/framework/route-module#errorboundary
+[optimize-revalidation]: ./optimize-revalidation

--- a/docs/how-to/resource-routes.md
+++ b/docs/how-to/resource-routes.md
@@ -66,7 +66,7 @@ export function action(_: Route.ActionArgs) {
 }
 ```
 
-Calling this `action` through [`<Form>`][form] or [`useFetcher`][fetcher] still revalidates matched UI loaders. A plain `fetch()` to the resource URL does not. See [Revalidation Optimization][optimize-revalidation].
+Calling this `action` through [`<Form>`][form] or [`useFetcher`][fetcher] still revalidates matched UI loaders. A plain `fetch()` to the resource URL does not. See [Revalidation Optimization][optimize-revalidation] for more info.
 
 ## Return Types
 

--- a/docs/start/data/actions.md
+++ b/docs/start/data/actions.md
@@ -9,7 +9,7 @@ order: 5
 
 ## Defining Actions
 
-Data mutations are done through Route actions defined on the `action` property of a route object. When the action completes, all loader data on the page is revalidated to keep your UI in sync with the data without writing any code to do it.
+Data mutations are done through Route actions defined on the `action` property of a route object. When the action completes, all loader data on the page is revalidated to keep your UI in sync with the data without writing any code to do it. To skip some or all of those reloads, see [Revalidation Optimization][optimize-revalidation].
 
 ```tsx
 import { createBrowserRouter } from "react-router";
@@ -136,3 +136,4 @@ function Project() {
 Next: [Navigating](./navigating)
 
 [fetchers]: ../../how-to/fetchers
+[optimize-revalidation]: ../../how-to/optimize-revalidation

--- a/docs/start/data/route-object.md
+++ b/docs/start/data/route-object.md
@@ -188,7 +188,7 @@ export default function Items() {
 
 Loader data is automatically revalidated after certain events like navigations and form submissions.
 
-This hook enables you to opt in or out of the default revalidation behavior. The default behavior is nuanced to avoid calling loaders unnecessarily.
+This function lets you opt in or out of the default revalidation behavior **for this route's loader**. It does not skip parent or sibling loaders. The default behavior is nuanced to avoid calling loaders unnecessarily.
 
 A route loader is revalidated when:
 
@@ -201,20 +201,33 @@ By defining this function, you opt out of the default behavior completely and ca
 ```tsx
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 
-function shouldRevalidate(
-  arg: ShouldRevalidateFunctionArgs,
-) {
-  return true; // false
+function shouldRevalidate({
+  formMethod,
+  formAction,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (
+    formMethod === "POST" &&
+    formAction?.endsWith("/analytics")
+  ) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
 }
 
 createBrowserRouter([
   {
     path: "/",
-    shouldRevalidate: shouldRevalidate,
+    shouldRevalidate,
     Component: MyRoute,
   },
 ]);
 ```
+
+To skip revalidation for a single `<Form>`, `<Link>`, `useSubmit`, or `fetcher.submit`, pass [`defaultShouldRevalidate={false}`][form-default-should-revalidate] at the call site. Routes without `shouldRevalidate` use that value directly.
+
+See [Revalidation Optimization][optimize-revalidation] for call-site opt-out, parent/child behavior, and more examples.
 
 [`ShouldRevalidateFunctionArgs` Reference Documentation ↗](https://api.reactrouter.com/v8/interfaces/react-router.ShouldRevalidateFunctionArgs.html)
 
@@ -263,6 +276,8 @@ See also:
 
 Next: [Data Loading](./data-loading)
 
+[form-default-should-revalidate]: ../../api/components/Form#defaultshouldrevalidate
 [loader-params]: https://api.reactrouter.com/v8/interfaces/react-router.LoaderFunctionArgs
 [middleware]: ../../how-to/middleware
+[optimize-revalidation]: ../../how-to/optimize-revalidation
 [use-matches]: ../../api/hooks/useMatches

--- a/docs/start/framework/actions.md
+++ b/docs/start/framework/actions.md
@@ -9,7 +9,7 @@ order: 6
 
 ## Introduction
 
-Data mutations are done through Route actions. When the action completes, all loader data on the page is revalidated to keep your UI in sync with the data without writing any code to do it.
+Data mutations are done through Route actions. When the action completes, all loader data on the page is revalidated to keep your UI in sync with the data without writing any code to do it. To skip some or all of those reloads, see [Revalidation Optimization][optimize-revalidation].
 
 Route actions defined with `action` are only called on the server while actions defined with `clientAction` are run in the browser.
 
@@ -172,3 +172,4 @@ See the [Using Fetchers][fetchers] guide for more information.
 Next: [Navigating](./navigating)
 
 [fetchers]: ../../how-to/fetchers
+[optimize-revalidation]: ../../how-to/optimize-revalidation

--- a/docs/start/framework/actions.md
+++ b/docs/start/framework/actions.md
@@ -165,11 +165,12 @@ fetcher.submit(
 );
 ```
 
-See the [Using Fetchers][fetchers] guide for more information.
+`fetcher.submit` takes [`FetcherSubmitOptions`][fetcher-submit-options], including `defaultShouldRevalidate`. See the [Using Fetchers][fetchers] guide for more information.
 
 ---
 
 Next: [Navigating](./navigating)
 
 [fetchers]: ../../how-to/fetchers
+[fetcher-submit-options]: https://api.reactrouter.com/v8/interfaces/react-router.FetcherSubmitOptions.html#defaultshouldrevalidate
 [optimize-revalidation]: ../../how-to/optimize-revalidation

--- a/docs/start/framework/route-module.md
+++ b/docs/start/framework/route-module.md
@@ -486,17 +486,42 @@ The meta of the last matching route is used, allowing you to override parent rou
 
 In framework mode with SSR, route loaders are automatically revalidated after all navigations and form submissions (this is different from [Data Mode][data-mode-should-revalidate]). This enables middleware and loaders to share a request context and optimize in different ways than they would in Data Mode.
 
-Defining this function allows you to opt out of revalidation for a route loader for navigations and form submissions.
+Defining this function allows you to opt out of revalidation for **this route's** loader. It does not skip parent or sibling loaders. After `fetcher.submit()`, `root` still revalidates unless it also opts out.
+
+Returning `false` for every call turns revalidation off for this loader:
+
+```tsx
+export function shouldRevalidate() {
+  return false;
+}
+```
+
+<docs-warning>
+Always returning `false` can leave this route's UI out of sync with the server. Prefer inspecting the arguments and falling back to `defaultShouldRevalidate`.
+</docs-warning>
 
 ```tsx
 import type { ShouldRevalidateFunctionArgs } from "react-router";
 
-export function shouldRevalidate(
-  arg: ShouldRevalidateFunctionArgs,
-) {
-  return true;
+export function shouldRevalidate({
+  formMethod,
+  formAction,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (
+    formMethod === "POST" &&
+    formAction?.endsWith("/analytics")
+  ) {
+    return false;
+  }
+
+  return defaultShouldRevalidate;
 }
 ```
+
+To skip revalidation for a single `<Form>`, `<Link>`, `useSubmit`, or `fetcher.submit` without changing every route file, pass [`defaultShouldRevalidate={false}`][form-default-should-revalidate] at the call site. Routes without a `shouldRevalidate` export use that value directly; routes that export one receive it as `defaultShouldRevalidate` and still decide.
+
+See [Revalidation Optimization][optimize-revalidation] for Framework vs Data Mode defaults, parent/child behavior, and more examples.
 
 When using [SPA Mode][spa-mode], there are no server loaders to call on navigations, so `shouldRevalidate` behaves the same as it does in [Data Mode][data-mode-should-revalidate].
 
@@ -522,6 +547,8 @@ Next: [Rendering Strategies](./rendering)
 [meta-params]: https://api.reactrouter.com/v8/interfaces/react-router.MetaArgs
 [meta-function]: https://api.reactrouter.com/v8/types/react-router.MetaDescriptor.html
 [data-mode-should-revalidate]: ../data/route-object#shouldrevalidate
+[form-default-should-revalidate]: ../../api/components/Form#defaultshouldrevalidate
+[optimize-revalidation]: ../../how-to/optimize-revalidation
 [spa-mode]: ../../how-to/spa
 [client-data]: ../../how-to/client-data
 [styling]: ../../explanation/styling


### PR DESCRIPTION
## Summary

The Framework Mode [route module](https://reactrouter.com/start/framework/route-module#shouldrevalidate) page documents `shouldRevalidate` as `return true` and links out to the typedoc. That seems like a bit of a step down from the v6 [`shouldRevalidate`](https://reactrouter.com/6.30.6/route/should-revalidate) page, and it never mentions:

- returning `false` to skip **this route's** loader
- that a child cannot skip `root` / parent loaders (so `fetcher.submit()` still revalidates the rest of the tree)
- inspecting `formMethod` / `formAction` / `defaultShouldRevalidate`
- call-site `defaultShouldRevalidate={false}` on `Form`, `Link`, `useSubmit`, `fetcher.submit`, `navigate`, and `setSearchParams`

The call-site API is on the Form and Link reference pages, but it is easy to miss if you start from the route module guide. It was added as `unstable_defaultShouldRevalidate` in v7.11 and stabilized in v7.15.

## Changes

- Fill in `docs/how-to/optimize-revalidation.md` (it was a hidden stub; [#15431](https://github.com/remix-run/react-router/pull/15431) already links to it)
- Expand Framework and Data Mode `shouldRevalidate` sections with opt-out examples and links to that how-to
- Point Actions, Fetchers, and Resource Routes at the same guidance

## Test plan

- [ ] Confirm headings and internal links render on a docs preview
- [ ] Click through Form `#defaultshouldrevalidate` and the typedoc `ShouldRevalidateFunctionArgs` link