### PR TITLE
fix: preserve the cause of turbo-stream decode failures

### DIFF
--- a/integration/error-boundary-v2-test.ts
+++ b/integration/error-boundary-v2-test.ts
@@ -76,7 +76,10 @@ test.describe("ErrorBoundary", () => {
             let error = useRouteError();
             return isRouteErrorResponse(error) ?
               <p id="parent-error-response">{error.status + ' ' + error.data}</p> :
-              <p id="parent-error">{error.message}</p>;
+              <>
+                <p id="parent-error">{error.message}</p>
+                <p id="parent-error-cause">{error.cause?.name ?? "No cause"}</p>
+              </>;
           }
         `,
 
@@ -180,6 +183,24 @@ test.describe("ErrorBoundary", () => {
         "#parent-error-response",
         "500 CDN Error!",
       );
+    });
+
+    test("Turbo-stream decode errors preserve their cause", async ({
+      page,
+    }) => {
+      await page.route(/\/parent\/child-with-boundary\.data$/, (route) => {
+        route.fulfill({ status: 200, body: "Invalid turbo-stream response" });
+      });
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/parent");
+      await app.clickLink("/parent/child-with-boundary");
+      await waitForAndAssert(
+        page,
+        app,
+        "#parent-error",
+        "Unable to decode turbo-stream response",
+      );
+      await waitForAndAssert(page, app, "#parent-error-cause", "SyntaxError");
     });
   });
 

--- a/packages/react-router/.changes/patch.turbo-stream-decode-cause.md
+++ b/packages/react-router/.changes/patch.turbo-stream-decode-cause.md
@@ -1,0 +1,1 @@
+Preserve the underlying decode failure as the `cause` of the `Unable to decode turbo-stream response` error.

--- a/packages/react-router/lib/dom/ssr/single-fetch.tsx
+++ b/packages/react-router/lib/dom/ssr/single-fetch.tsx
@@ -654,14 +654,14 @@ async function fetchAndDecodeViaTurboStream(
       }
     }
     return { status: res.status, data };
-  } catch {
+  } catch (cause) {
     // Can't clone after consuming the body via turbo-stream so we can't
     // include the body here.  In an ideal world we'd look for a turbo-stream
     // content type here, or even X-Remix-Response but then folks can't
     // statically deploy their prerendered .data files to a CDN unless they can
     // tell that CDN to add special headers to those certain files - which is a
     // bit restrictive.
-    throw new Error("Unable to decode turbo-stream response");
+    throw new Error("Unable to decode turbo-stream response", { cause });
   }
 }
 


### PR DESCRIPTION
I, personally, am uncommonly catching these errors in Sentry. I would like to debug further, but I cannot, because the actual error is not surfaced.

This pull request attaches a `cause` to the error to help surface the issue.

This pattern is already used elsewhere in the codebase:

https://github.com/remix-run/react-router/blob/2e0bf721591e218611841242ad4077111663f7f5/packages/react-router/lib/rsc/browser.tsx#L644-L651