### PR TITLE
fix(dev): use SPA fallback as index.html when public/index.html exists

### DIFF
--- a/integration/vite-spa-mode-test.ts
+++ b/integration/vite-spa-mode-test.ts
@@ -1172,6 +1172,105 @@ test.describe("SPA Mode", () => {
     });
   });
 
+  test("uses the SPA fallback as index.html when a public/index.html exists", async ({
+    page,
+  }) => {
+    // A `public/index.html` gets copied into the client build directory by
+    // Vite, but the generated SPA shell must still be the main entry point
+    // served at `/` by static hosts
+    // https://github.com/remix-run/react-router/issues/15444
+    fixture = await createFixture({
+      spaMode: true,
+      files: {
+        "react-router.config.ts": reactRouterConfig({
+          ssr: false,
+        }),
+        "public/index.html": String.raw`
+          <link rel="icon" href="/favicon.png" type="image/png" />
+          <link rel="manifest" href="/manifest.webmanifest" />
+        `,
+        "app/root.tsx": js`
+          import { Links, Meta, Outlet, Scripts } from "react-router";
+
+          export function links() {
+            return [
+              { rel: "icon", href: "/favicon.png", type: "image/png" },
+              { rel: "manifest", href: "/manifest.webmanifest" },
+            ];
+          }
+
+          export default function Root() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <h1 data-root>Root</h1>
+                  <Outlet />
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+
+          export function HydrateFallback() {
+            return (
+              <html lang="en">
+                <head>
+                  <Meta />
+                  <Links />
+                </head>
+                <body>
+                  <h1 data-loading>Loading SPA...</h1>
+                  <Scripts />
+                </body>
+              </html>
+            );
+          }
+        `,
+        "app/routes/_index.tsx": js`
+          export default function Component() {
+            return <h2 data-route>Index</h2>;
+          }
+        `,
+      },
+    });
+
+    let clientDir = path.join(fixture.projectDir, "build", "client");
+
+    // The SPA fallback must not be left behind in \`__spa-fallback.html\`
+    expect(fs.existsSync(path.join(clientDir, "__spa-fallback.html"))).toBe(
+      false,
+    );
+
+    // \`index.html\` must be the full generated SPA shell, not the copied
+    // \`public/index.html\`
+    let html = await fs.promises.readFile(
+      path.join(clientDir, "index.html"),
+      "utf-8",
+    );
+    expect(html).toMatch(/^<!DOCTYPE html>/);
+    expect(html).toMatch("<html");
+    expect(html).toMatch("<body");
+    expect(html).toMatch('<h1 data-loading="true">Loading SPA...</h1>');
+    expect(html).toMatch('<link rel="icon" href="/favicon.png"');
+    expect(html).toMatch("window.__reactRouterContext =");
+    expect(html).toMatch("import(");
+
+    // The document served at \`/\` must hydrate into the running app
+    appFixture = await createAppFixture(fixture);
+    try {
+      let app = new PlaywrightFixture(appFixture, page);
+      await app.goto("/");
+      await page.waitForSelector("[data-root]");
+      expect(await page.locator("[data-route]").textContent()).toBe("Index");
+    } finally {
+      appFixture.close();
+    }
+  });
+
   test("only imports the root route in the server build when SSRing index.html", async ({
     page,
   }) => {

--- a/packages/react-router-dev/.changes/patch.fix-spa-index-html.md
+++ b/packages/react-router-dev/.changes/patch.fix-spa-index-html.md
@@ -1,0 +1,1 @@
+Fix SPA mode (`ssr: false`) generating a broken `index.html` when a `public/index.html` exists — the generated SPA shell is now correctly promoted to `build/client/index.html` instead of being left behind in `__spa-fallback.html`

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2691,9 +2691,16 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           let spaFallback = path.join(buildDirectory, "__spa-fallback.html");
           let index = path.join(buildDirectory, "index.html");
 
-          // If the user didn't prerendered `/`, uses the SPA fallback as the main entry point.
+          // If the user didn't prerender `/`, the SPA fallback becomes the main
+          // entry point. This overwrites any `index.html` copied into the client
+          // build directory from the `public` directory so the SPA shell is
+          // served at `/` on static hosts.
+          let prerenderedRoot = ctx.prerenderPaths?.has("/") ?? false;
           let finalSpaPath: string | undefined;
-          if (existsSync(spaFallback) && !existsSync(index)) {
+          if (
+            existsSync(spaFallback) &&
+            (!prerenderedRoot || !existsSync(index))
+          ) {
             await rename(spaFallback, index);
             finalSpaPath = index;
           } else if (existsSync(spaFallback)) {


### PR DESCRIPTION
## What?

In SPA mode (`ssr: false` without prerendering `/`), always promote the generated SPA fallback to `index.html`, even when Vite has already copied a `public/index.html` into the client build directory.

## Why?

Since the v8 Environment API migration, the SPA shell is first generated as `__spa-fallback.html` and later renamed to `index.html`.

When an application contains `public/index.html`, Vite copies that file into the output directory first. The existing finalize logic sees that `index.html` already exists and skips the rename, leaving the actual generated SPA shell in `__spa-fallback.html`.

Static hosts then serve the copied `public/index.html` instead of the React Router SPA shell.

This restores the previous SPA behavior while preserving the existing behavior when `/` itself is prerendered.

## Testing

- Added a regression test for `ssr: false` with `public/index.html`
- Verified the generated `index.html` contains the complete SPA document and hydrates correctly
- Verified the regression test fails without the production fix
- `vite-spa-mode`: 46/46 passed
- `vite-prerender`: 37/37 passed
- `vite-build`: 16/16 passed
- ESLint passed
- Prettier passed
- `@react-router/dev` typecheck passed
- integration TypeScript check passed
- change-file validation passed

Fixes #15444