### PR TITLE
fix(dev): respect forwarded proxy headers

### DIFF
--- a/packages/react-router-dev/.changes/patch.trust-dev-proxy-headers.md
+++ b/packages/react-router-dev/.changes/patch.trust-dev-proxy-headers.md
@@ -1,0 +1,1 @@
+Respect trusted reverse proxy host and protocol headers in the development server

--- a/packages/react-router-dev/vite/node-adapter-test.ts
+++ b/packages/react-router-dev/vite/node-adapter-test.ts
@@ -1,0 +1,47 @@
+import {
+  type AddressInfo,
+  createServer,
+  request as sendRequest,
+} from "node:http";
+import type * as Vite from "vite";
+import { fromNodeRequest } from "./node-adapter";
+
+describe("fromNodeRequest", () => {
+  it("uses forwarded host and protocol headers", async () => {
+    let requestUrl = await new Promise<string>((resolve, reject) => {
+      let server = createServer(async (nodeReq, nodeRes) => {
+        let viteRequest = Object.assign(nodeReq, {
+          originalUrl: nodeReq.url,
+        }) as Vite.Connect.IncomingMessage;
+
+        try {
+          let request = await fromNodeRequest(viteRequest, nodeRes);
+          resolve(request.url);
+          nodeRes.end();
+        } catch (error) {
+          reject(error);
+        } finally {
+          server.close();
+        }
+      });
+
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        let { port } = server.address() as AddressInfo;
+        let request = sendRequest({
+          host: "127.0.0.1",
+          port,
+          headers: {
+            host: "internal.example.com",
+            "x-forwarded-host": "public.example.com",
+            "x-forwarded-proto": "https",
+          },
+        });
+        request.on("error", reject);
+        request.end();
+      });
+    });
+
+    expect(requestUrl).toBe("https://public.example.com/");
+  });
+});

--- a/packages/react-router-dev/vite/node-adapter-test.ts
+++ b/packages/react-router-dev/vite/node-adapter-test.ts
@@ -7,7 +7,7 @@ import type * as Vite from "vite";
 import { fromNodeRequest } from "./node-adapter";
 
 describe("fromNodeRequest", () => {
-  it("uses forwarded host and protocol headers", async () => {
+  it("uses the forwarded protocol without trusting the forwarded host", async () => {
     let requestUrl = await new Promise<string>((resolve, reject) => {
       let server = createServer(async (nodeReq, nodeRes) => {
         let viteRequest = Object.assign(nodeReq, {
@@ -32,8 +32,8 @@ describe("fromNodeRequest", () => {
           host: "127.0.0.1",
           port,
           headers: {
-            host: "internal.example.com",
-            "x-forwarded-host": "public.example.com",
+            host: "public.example.com",
+            "x-forwarded-host": "evil.example.com",
             "x-forwarded-proto": "https",
           },
         });

--- a/packages/react-router-dev/vite/node-adapter.ts
+++ b/packages/react-router-dev/vite/node-adapter.ts
@@ -19,5 +19,5 @@ export async function fromNodeRequest(
   );
   nodeReq.url = nodeReq.originalUrl;
 
-  return createRequest(nodeReq, nodeRes);
+  return createRequest(nodeReq, nodeRes, { trustProxy: true });
 }

--- a/packages/react-router-dev/vite/node-adapter.ts
+++ b/packages/react-router-dev/vite/node-adapter.ts
@@ -19,5 +19,10 @@ export async function fromNodeRequest(
   );
   nodeReq.url = nodeReq.originalUrl;
 
-  return createRequest(nodeReq, nodeRes, { trustProxy: true });
+  return createRequest(nodeReq, nodeRes, {
+    // Vite validates the Host header against server.allowedHosts. Keep that
+    // validated host instead of trusting a client-controlled forwarded host.
+    host: nodeReq.headers.host ?? "localhost",
+    trustProxy: true,
+  });
 }


### PR DESCRIPTION
Use the forwarded protocol in the Vite development server's Node request adapter so action requests behind an HTTPS reverse proxy retain their public scheme.

Keep the original `Host` header, which Vite validates against `server.allowedHosts`, instead of trusting a client-controlled forwarded host. Adds an HTTP-level regression test covering a valid forwarded protocol alongside a spoofed `X-Forwarded-Host`.

Closes #15454