### PR TITLE
fix(dev): use X-Forwarded-Proto for the dev request URL

### DIFF
--- a/docs/api/other-api/dev.md
+++ b/docs/api/other-api/dev.md
@@ -4,6 +4,8 @@ title: "@react-router/dev (CLI)"
 
 # React Router CLI
 
+[MODES: framework]
+
 The React Router CLI comes from the `@react-router/dev` package. Make sure it is in your `package.json` `devDependencies` so it doesn't get deployed to your server.
 
 To get a full list of available commands and flags, run:
@@ -68,6 +70,16 @@ That way your app is _always_ up to date with the latest code changes, client-si
 | `--port`           | Specify port                                          | `number`                                            |         |
 | `--profile`        | Start built-in Node.js inspector                      |                                                     |         |
 | `--strictPort`     | Exit if specified port is already in use              | `boolean`                                           |         |
+
+### Reverse proxies
+
+The built-in `react-router dev` and `vite preview` servers provided by the `reactRouter()` Vite plugin automatically use `X-Forwarded-Proto` when constructing `request.url`. This preserves the browser-facing protocol when a reverse proxy terminates HTTPS and forwards requests over HTTP, allowing same-origin action submissions to pass origin validation. No React Router configuration is required.
+
+The first header value is used if it is `http` or `https` (case-insensitive, with surrounding whitespace and an optional trailing `:` ignored). Missing or invalid values fall back to the connection's protocol. The URL host and port still come from `Host`, not `X-Forwarded-Host` or the standard `Forwarded` header. Preserve the browser-facing host and port in `Host` and configure Vite's [`server.allowedHosts`](https://vite.dev/config/server-options#server-allowedhosts) or [`preview.allowedHosts`](https://vite.dev/config/preview-options#preview-allowedhosts) as needed.
+
+<docs-warning>
+Dev and preview servers are not production servers and should not be publicly accessible. Configure your reverse proxy to overwrite client-supplied `X-Forwarded-Proto` headers.
+</docs-warning>
 
 ## `react-router reveal`
 

--- a/integration/vite-forwarded-proto-test.ts
+++ b/integration/vite-forwarded-proto-test.ts
@@ -1,0 +1,89 @@
+import { expect } from "@playwright/test";
+import dedent from "dedent";
+
+import {
+  reactRouterConfig,
+  test,
+  viteConfig,
+  viteMajorTemplates,
+  type Files,
+} from "./helpers/vite.js";
+
+test.describe("Vite forwarded protocol", () => {
+  for (let { templateName } of viteMajorTemplates) {
+    for (let server of ["dev", "preview"] as const) {
+      test(`${templateName} ${server} honors X-Forwarded-Proto without configuration`, async ({
+        dev,
+        vitePreview,
+        request,
+      }) => {
+        let files: Files = async ({ port }) => ({
+          "react-router.config.ts": reactRouterConfig(),
+          "vite.config.ts": await viteConfig.basic({ port, templateName }),
+          "app/routes/proxy.tsx": dedent`
+              import { useActionData, useLoaderData } from "react-router";
+
+              export function loader({ request }) {
+                return request.url;
+              }
+
+              export function action({ request }) {
+                return request.url;
+              }
+
+              export default function ProxyRoute() {
+                let loaderUrl = useLoaderData();
+                let actionUrl = useActionData();
+                return <>
+                  <p id="loader-url">{loaderUrl}</p>
+                  <p id="action-url">{actionUrl}</p>
+                </>;
+              }
+            `,
+        });
+
+        let startServer = server === "dev" ? dev : vitePreview;
+        let { port } = await startServer(files, templateName);
+        let url = `http://localhost:${port}/proxy?query=value`;
+        let publicUrl = `https://localhost:${port}/proxy?query=value`;
+        let headers = {
+          // Simulate an HTTPS-terminating proxy forwarding over HTTP.
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Host": "untrusted.example.com",
+        };
+
+        let loaderResponse = await request.get(url, { headers });
+        expect(loaderResponse.status()).toBe(200);
+        expect(await loaderResponse.text()).toContain(
+          `<p id="loader-url">${publicUrl}</p>`,
+        );
+
+        let actionResponse = await request.post(url, {
+          headers: { ...headers, Origin: `https://localhost:${port}` },
+          form: { value: "test" },
+        });
+        expect(actionResponse.status()).toBe(200);
+        expect(await actionResponse.text()).toContain(
+          `<p id="action-url">${publicUrl}</p>`,
+        );
+
+        // Trusting the protocol must not allow an unrelated action origin.
+        let crossOriginResponse = await request.post(url, {
+          headers: { ...headers, Origin: "https://untrusted.example.com" },
+          form: { value: "test" },
+        });
+        expect(crossOriginResponse.status()).toBe(400);
+
+        // Requests without forwarded headers continue to use HTTP.
+        let directResponse = await request.post(url, {
+          headers: { Origin: `http://localhost:${port}` },
+          form: { value: "test" },
+        });
+        expect(directResponse.status()).toBe(200);
+        expect(await directResponse.text()).toContain(
+          `<p id="action-url">${url}</p>`,
+        );
+      });
+    }
+  }
+});

--- a/packages/react-router-dev/.changes/patch.dev-forwarded-proto-request-url.md
+++ b/packages/react-router-dev/.changes/patch.dev-forwarded-proto-request-url.md
@@ -1,0 +1,1 @@
+Fix `react-router dev` aborting actions behind an HTTPS reverse proxy by using `X-Forwarded-Proto` to construct the dev request URL, so `request.url` keeps the scheme the browser sees and passes action origin validation. `X-Forwarded-Host` is not trusted since Vite only validates the `Host` header against `server.allowedHosts`

--- a/packages/react-router-dev/.changes/patch.dev-forwarded-proto-request-url.md
+++ b/packages/react-router-dev/.changes/patch.dev-forwarded-proto-request-url.md
@@ -1,1 +1,3 @@
-Fix `react-router dev` aborting actions behind an HTTPS reverse proxy by using `X-Forwarded-Proto` to construct the dev request URL, so `request.url` keeps the scheme the browser sees and passes action origin validation. `X-Forwarded-Host` is not trusted since Vite only validates the `Host` header against `server.allowedHosts`
+Fix action submissions behind an HTTPS reverse proxy in `react-router dev` and `vite preview` by using `X-Forwarded-Proto` when constructing `request.url`.
+
+No React Router configuration is required. The URL host continues to come from `Host`, not `X-Forwarded-Host`. Configure reverse proxies to overwrite client-supplied `X-Forwarded-Proto` headers, and do not expose dev or preview servers publicly.

--- a/packages/react-router-dev/vite/node-adapter-test.ts
+++ b/packages/react-router-dev/vite/node-adapter-test.ts
@@ -1,0 +1,88 @@
+import { IncomingMessage, ServerResponse } from "node:http";
+import type { Socket } from "node:net";
+import { fromNodeRequest } from "./node-adapter";
+
+function createNodeReq({
+  method = "GET",
+  url = "/",
+  headers = {},
+  encrypted = false,
+}: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  encrypted?: boolean;
+} = {}): IncomingMessage {
+  let req = new IncomingMessage({ encrypted } as unknown as Socket);
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  // Vite's Connect server sets `req.originalUrl`
+  (req as IncomingMessage & { originalUrl: string }).originalUrl = url;
+  return req;
+}
+
+describe("fromNodeRequest", () => {
+  test("constructs an http:// URL for a plain HTTP connection", async () => {
+    let req = createNodeReq({
+      headers: { host: "localhost:3000" },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("http://localhost:3000/");
+  });
+
+  test("honors X-Forwarded-Proto from a reverse proxy", async () => {
+    let req = createNodeReq({
+      headers: {
+        host: "demo.example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("https://demo.example.com/");
+  });
+
+  test("uses the first value of a comma-separated X-Forwarded-Proto chain", async () => {
+    let req = createNodeReq({
+      headers: {
+        host: "demo.example.com",
+        "x-forwarded-proto": "https, http",
+      },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("https://demo.example.com/");
+  });
+
+  test("ignores invalid X-Forwarded-Proto values", async () => {
+    let req = createNodeReq({
+      headers: {
+        host: "localhost:3000",
+        "x-forwarded-proto": "ftp",
+      },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("http://localhost:3000/");
+  });
+
+  test("ignores X-Forwarded-Host so Vite's allowedHosts check stays authoritative", async () => {
+    let req = createNodeReq({
+      headers: {
+        host: "demo.example.com",
+        "x-forwarded-host": "evil.example.com",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("https://demo.example.com/");
+  });
+});

--- a/packages/react-router-dev/vite/node-adapter-test.ts
+++ b/packages/react-router-dev/vite/node-adapter-test.ts
@@ -10,7 +10,7 @@ function createNodeReq({
 }: {
   method?: string;
   url?: string;
-  headers?: Record<string, string>;
+  headers?: Record<string, string | string[]>;
   encrypted?: boolean;
 } = {}): IncomingMessage {
   let req = new IncomingMessage({ encrypted } as unknown as Socket);
@@ -33,44 +33,54 @@ describe("fromNodeRequest", () => {
     expect(request.url).toBe("http://localhost:3000/");
   });
 
-  test("honors X-Forwarded-Proto from a reverse proxy", async () => {
-    let req = createNodeReq({
-      headers: {
-        host: "demo.example.com",
-        "x-forwarded-proto": "https",
+  describe.each([false, true])("encrypted: %s", (encrypted) => {
+    let protocol = encrypted ? "https" : "http";
+
+    test.each([undefined, "", "ftp", "https-invalid", ", https"])(
+      "falls back to the connection protocol for X-Forwarded-Proto: %s",
+      async (forwardedProto) => {
+        let req = createNodeReq({
+          encrypted,
+          headers: {
+            host: "localhost:3000",
+            ...(forwardedProto === undefined
+              ? {}
+              : { "x-forwarded-proto": forwardedProto }),
+          },
+        });
+
+        let request = await fromNodeRequest(req, new ServerResponse(req));
+
+        expect(request.url).toBe(`${protocol}://localhost:3000/`);
       },
-    });
-
-    let request = await fromNodeRequest(req, new ServerResponse(req));
-
-    expect(request.url).toBe("https://demo.example.com/");
+    );
   });
 
-  test("uses the first value of a comma-separated X-Forwarded-Proto chain", async () => {
-    let req = createNodeReq({
-      headers: {
-        host: "demo.example.com",
-        "x-forwarded-proto": "https, http",
-      },
-    });
+  test.each([
+    { forwardedProto: "https", protocol: "https" },
+    { forwardedProto: "http", protocol: "http" },
+    { forwardedProto: " HTTPS: ", protocol: "https" },
+    { forwardedProto: "https, http", protocol: "https" },
+    { forwardedProto: ["https", "http"], protocol: "https" },
+  ])(
+    "honors X-Forwarded-Proto: $forwardedProto without configuration",
+    async ({ forwardedProto, protocol }) => {
+      let req = createNodeReq({
+        encrypted: protocol === "http",
+        url: "/path?query=value",
+        headers: {
+          host: "demo.example.com:3000",
+          "x-forwarded-proto": forwardedProto,
+        },
+      });
 
-    let request = await fromNodeRequest(req, new ServerResponse(req));
+      let request = await fromNodeRequest(req, new ServerResponse(req));
 
-    expect(request.url).toBe("https://demo.example.com/");
-  });
-
-  test("ignores invalid X-Forwarded-Proto values", async () => {
-    let req = createNodeReq({
-      headers: {
-        host: "localhost:3000",
-        "x-forwarded-proto": "ftp",
-      },
-    });
-
-    let request = await fromNodeRequest(req, new ServerResponse(req));
-
-    expect(request.url).toBe("http://localhost:3000/");
-  });
+      expect(request.url).toBe(
+        `${protocol}://demo.example.com:3000/path?query=value`,
+      );
+    },
+  );
 
   test("ignores X-Forwarded-Host so Vite's allowedHosts check stays authoritative", async () => {
     let req = createNodeReq({
@@ -78,11 +88,25 @@ describe("fromNodeRequest", () => {
         host: "demo.example.com",
         "x-forwarded-host": "evil.example.com",
         "x-forwarded-proto": "https",
+        forwarded: "host=evil.example.com;proto=http",
       },
     });
 
     let request = await fromNodeRequest(req, new ServerResponse(req));
 
     expect(request.url).toBe("https://demo.example.com/");
+  });
+
+  test("does not trust the Forwarded header", async () => {
+    let req = createNodeReq({
+      headers: {
+        host: "localhost:3000",
+        forwarded: "host=evil.example.com;proto=https",
+      },
+    });
+
+    let request = await fromNodeRequest(req, new ServerResponse(req));
+
+    expect(request.url).toBe("http://localhost:3000/");
   });
 });

--- a/packages/react-router-dev/vite/node-adapter.ts
+++ b/packages/react-router-dev/vite/node-adapter.ts
@@ -19,5 +19,28 @@ export async function fromNodeRequest(
   );
   nodeReq.url = nodeReq.originalUrl;
 
-  return createRequest(nodeReq, nodeRes);
+  return createRequest(nodeReq, nodeRes, {
+    // The dev server speaks HTTP itself, so `X-Forwarded-Proto` from a reverse
+    // proxy is honored to keep `request.url`'s origin in sync with the browser
+    // (e.g. for action origin validation). `X-Forwarded-Host` is deliberately
+    // ignored: Vite only validates the `Host` header against
+    // `server.allowedHosts`, so trusting it would bypass that check.
+    protocol: getForwardedProtocol(nodeReq),
+  });
+}
+
+function getForwardedProtocol(
+  nodeReq: Vite.Connect.IncomingMessage,
+): string | undefined {
+  let forwardedProto = nodeReq.headers["x-forwarded-proto"];
+  let proto = (
+    Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto
+  )
+    ?.split(",")[0]
+    .trim()
+    .toLowerCase();
+  if (proto?.endsWith(":")) {
+    proto = proto.slice(0, -1);
+  }
+  return proto === "http" || proto === "https" ? `${proto}:` : undefined;
 }

--- a/packages/react-router-dev/vite/node-adapter.ts
+++ b/packages/react-router-dev/vite/node-adapter.ts
@@ -20,11 +20,9 @@ export async function fromNodeRequest(
   nodeReq.url = nodeReq.originalUrl;
 
   return createRequest(nodeReq, nodeRes, {
-    // The dev server speaks HTTP itself, so `X-Forwarded-Proto` from a reverse
-    // proxy is honored to keep `request.url`'s origin in sync with the browser
-    // (e.g. for action origin validation). `X-Forwarded-Host` is deliberately
-    // ignored: Vite only validates the `Host` header against
-    // `server.allowedHosts`, so trusting it would bypass that check.
+    // Honor the browser-facing protocol behind an HTTPS-terminating proxy so
+    // action origin validation sees the correct origin. Keep using Host:
+    // Vite's allowedHosts checks do not validate X-Forwarded-Host.
     protocol: getForwardedProtocol(nodeReq),
   });
 }


### PR DESCRIPTION
## Root cause

`react-router dev` always constructs `request.url` with the `http` scheme because the Vite dev server itself speaks HTTP. Since #15419, action origin validation compares full origins (scheme + host), so actions behind an HTTPS reverse proxy abort with "The `request.url` origin does not match `origin` header" — the browser sends `Origin: https://demo.example.com` while `request.url` is `http://demo.example.com` (#15454).

## Change

`fromNodeRequest` now passes the protocol from `X-Forwarded-Proto` to `createRequest` (first comma-separated value, `http`/`https` only; anything else falls back to the connection protocol).

`X-Forwarded-Host` is deliberately **not** trusted: Vite's host check only validates the `Host` header against `server.allowedHosts`, so a spoofed forwarded host would bypass that protection and take over the origin used by action origin validation. This addresses the feedback on #15462, which was closed by its author.

## Validation

- New unit tests for `fromNodeRequest`: plain HTTP, `X-Forwarded-Proto` honored, comma-separated chain (first value wins), invalid proto ignored, spoofed `X-Forwarded-Host` ignored
- Full `@react-router/dev` suite: 192 tests / 184 snapshots passing
- Package typecheck introduces no new errors (pre-existing errors on `main` are from unbuilt workspace deps)

Closes #15454