### PR TITLE
fix: avoid page reloads for zero-delta blocker events

### DIFF
--- a/packages/react-router/.changes/patch.zero-delta-navigation-blocker.md
+++ b/packages/react-router/.changes/patch.zero-delta-navigation-blocker.md
@@ -1,0 +1,1 @@
+Avoid reloading the page when a navigation blocker encounters a synthetic `popstate` event with no change to the history index, such as those emitted by single-spa.

--- a/packages/react-router/__tests__/router/navigation-blocking-test.ts
+++ b/packages/react-router/__tests__/router/navigation-blocking-test.ts
@@ -1,4 +1,7 @@
-import { createMemoryHistory } from "../../lib/router/history";
+import {
+  createBrowserHistory,
+  createMemoryHistory,
+} from "../../lib/router/history";
 import type { Router } from "../../lib/router/router";
 import { createRouter } from "../../lib/router/router";
 
@@ -499,6 +502,52 @@ describe("navigation blocking", () => {
         expect(router.state.location.pathname).toBe(pathnameBeforeNavigation);
       });
     });
+  });
+
+  describe("synthetic popstate events", () => {
+    beforeEach(() => {
+      window.history.replaceState(null, "", "/");
+    });
+
+    afterEach(() => {
+      router.dispose();
+      jest.restoreAllMocks();
+      window.history.replaceState(null, "", "/");
+    });
+
+    it.each(["push", "replace"] as const)(
+      "does not reload for a zero-delta popstate after %s",
+      (method) => {
+        let history = createBrowserHistory({ window });
+        router = createRouter({ history, routes }).initialize();
+        let go = jest.spyOn(window.history, "go").mockImplementation(() => {});
+        let fn = () => true;
+        router.getBlocker("KEY", fn);
+
+        // Integrations such as single-spa emit popstate after pushState and
+        // replaceState even though the history index has not moved again.
+        history[method]("/contact");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+
+        expect(go).not.toHaveBeenCalled();
+        expect(router.state.location.pathname).toBe("/contact");
+        expect(router.getBlocker("KEY", fn).state).toBe("unblocked");
+
+        // A subsequent back navigation must still reach the blocker instead
+        // of being mistaken for the completion of a history restoration.
+        window.history.replaceState(
+          { ...window.history.state, idx: window.history.state.idx - 1 },
+          "",
+          "/",
+        );
+        window.dispatchEvent(new PopStateEvent("popstate"));
+
+        expect(go).toHaveBeenCalledTimes(1);
+        expect(go).toHaveBeenCalledWith(1);
+        expect(router.state.location.pathname).toBe("/contact");
+        expect(router.getBlocker("KEY", fn).state).toBe("blocked");
+      },
+    );
   });
 });
 

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1328,7 +1328,9 @@ export function createRouter(init: RouterInit): Router {
           historyAction,
         });
 
-        if (blockerKey && delta != null) {
+        // Synthetic popstate events can have a zero delta. There is no history
+        // traversal to undo in that case, and history.go(0) would reload the page.
+        if (blockerKey && delta != null && delta !== 0) {
           // Restore the URL to match the current UI, but don't update router state
           let nextHistoryUpdatePromise = new Promise<void>((resolve) => {
             unblockBlockerHistoryUpdate = resolve;


### PR DESCRIPTION
Fixes #11621.

When an integration such as single-spa emits a synthetic `popstate` after `pushState` or `replaceState`, the browser history adapter reports a delta of zero. An active navigation blocker currently tries to undo that event with `history.go(-0)`, which reloads the page. It also leaves a pending history-restoration callback that can swallow the next POP event.

Skip history restoration for zero-delta events and allow the router to synchronize with the current location. Real back/forward traversals continue through the existing blocker path. This affects the shared data router used in Data and Framework modes.

The regression tests cover synthetic events after both push and replace, verify that no reload is requested, and confirm that a subsequent back navigation is still blocked. Both new cases failed against the original implementation with a recorded `history.go(-0)` call.

Validation:
- Router unit tests and React `useBlocker` tests: 32 suites, 962 tests and 37 snapshots passed.
- `react-router` TypeScript check passed.
- Changed files pass Prettier and ESLint with no errors; the two router.ts warnings are also present on the base revision.
- Includes a package change file.

Dependencies were installed from the unchanged lockfile using pnpm 11.9.0 (the locally available version) and Node 22.22.0. Browser E2E and the full monorepo suite were not run.

AI assistance: Codex prepared and tested this contribution on behalf of @hamedrabah.
