### PR TITLE
Fix crash when prefetching page links for an unloaded route module

### DIFF
--- a/packages/react-router/.changes/patch.null-check-prefetch-links.md
+++ b/packages/react-router/.changes/patch.null-check-prefetch-links.md
@@ -1,0 +1,1 @@
+Fix a crash when `<Link prefetch>` runs against a route whose module is not yet loaded (`Cannot read properties of undefined (reading 'links')`)

--- a/packages/react-router/__tests__/dom/ssr/links-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/links-test.tsx
@@ -2,6 +2,10 @@ import { render } from "@testing-library/react";
 import * as React from "react";
 
 import { Links, Outlet, createRoutesStub } from "../../../index";
+import { getKeyedPrefetchLinks } from "../../../lib/dom/ssr/links";
+import type { AssetsManifest } from "../../../lib/dom/ssr/entry";
+import type { RouteModules } from "../../../lib/dom/ssr/routeModules";
+import type { DataRouteMatch } from "../../../lib/router/utils";
 
 describe("<Links>", () => {
   describe("crossOrigin", () => {
@@ -169,5 +173,74 @@ describe("<Links>", () => {
       expect(stylesheetLink).toBeTruthy();
       expect(stylesheetLink?.getAttribute("crossorigin")).toBe("anonymous");
     });
+  });
+});
+
+describe("getKeyedPrefetchLinks", () => {
+  let matches: DataRouteMatch[];
+  let manifest: AssetsManifest;
+
+  beforeEach(() => {
+    matches = [
+      {
+        params: {},
+        pathname: "/idk",
+        pathnameBase: "/idk",
+        route: { id: "idk", path: "idk" },
+      },
+    ];
+    manifest = {
+      routes: {
+        idk: {
+          id: "idk",
+          module: "idk.js",
+          hasAction: false,
+          hasLoader: false,
+          hasClientAction: false,
+          hasClientLoader: false,
+          hasClientMiddleware: false,
+          hasErrorBoundary: false,
+          clientActionModule: undefined,
+          clientLoaderModule: undefined,
+          clientMiddlewareModule: undefined,
+          hydrateFallbackModule: undefined,
+        },
+      },
+      entry: { imports: [], module: "" },
+      url: "",
+      version: "",
+    };
+  });
+
+  it("does not throw when the route module cache has an empty slot", async () => {
+    // `idk in routeModules` is true, but the value is undefined — the same
+    // shape loadRouteModule returns without falling through to import().
+    let routeModules: RouteModules = { idk: undefined };
+
+    await expect(
+      getKeyedPrefetchLinks(matches, manifest, routeModules),
+    ).resolves.toEqual([]);
+  });
+
+  it("returns stylesheet links as prefetch descriptors when the module is loaded", async () => {
+    let routeModules: RouteModules = {
+      idk: {
+        default: () => null,
+        links: () => [{ rel: "stylesheet", href: "/foo.css" }],
+      },
+    };
+
+    await expect(
+      getKeyedPrefetchLinks(matches, manifest, routeModules),
+    ).resolves.toEqual([
+      {
+        key: JSON.stringify({
+          as: "style",
+          href: "/foo.css",
+          rel: "prefetch",
+        }),
+        link: { rel: "prefetch", as: "style", href: "/foo.css" },
+      },
+    ]);
   });
 });

--- a/packages/react-router/lib/dom/ssr/links.ts
+++ b/packages/react-router/lib/dom/ssr/links.ts
@@ -156,7 +156,10 @@ export async function getKeyedPrefetchLinks(
       let route = manifest.routes[match.route.id];
       if (route) {
         let mod = await loadRouteModule(route, routeModules);
-        return mod.links ? mod.links() : [];
+        // loadRouteModule can return undefined when the routeModules cache
+        // already has the route id keyed to an empty slot. Sibling
+        // getKeyedLinksForMatches already uses module?.links?.().
+        return mod?.links ? mod.links() : [];
       }
       return [];
     }),


### PR DESCRIPTION
## Context

`getKeyedPrefetchLinks` (used by `<Link prefetch>` / `PrefetchPageLinks`) does:

```ts
let mod = await loadRouteModule(route, routeModules);
return mod.links ? mod.links() : [];
```

`loadRouteModule` can return \`undefined\` when \`route.id in routeModulesCache\` is true but the value is an empty slot (`RouteModules` is `{ [id: string]: RouteModule | undefined }`). That throws:

`TypeError: Cannot read properties of undefined (reading 'links')`

as an `unhandledrejection` — `useKeyedPrefetchLinks` has no `.catch()`.

The sibling `getKeyedLinksForMatches` already uses `module?.links?.()`.

Seen in production on React Router 8.3.1 (framework mode, `prefetch="intent"` on list rows that remount on search/sort). The page does not break; only stylesheet prefetch fails.

## Fix

Null-check the module, same as the sibling:

```ts
return mod?.links ? mod.links() : [];
```

## Tests

- empty cache slot → resolves to `[]` (does not throw)
- loaded module with `links()` → still returns prefetch descriptors

- [x] CHANGELOG.md / `.changes` entry (`patch.null-check-prefetch-links.md`)
- [ ] Docs — n/a (bugfix, no API change)