### PR TITLE
Fix integration test environment cleanup

### DIFF
--- a/integration/error-sanitization-test.ts
+++ b/integration/error-sanitization-test.ts
@@ -325,7 +325,11 @@ test.describe("Error Sanitization", () => {
       process.env.NODE_ENV = "development";
     });
     test.afterEach(() => {
-      process.env.NODE_ENV = ogEnv;
+      if (ogEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = ogEnv;
+      }
     });
 
     test("renders document without errors", async () => {

--- a/integration/rsc/utils.ts
+++ b/integration/rsc/utils.ts
@@ -24,7 +24,14 @@ export const implementations: Implementation[] = [
   {
     name: "vite",
     template: "rsc-vite",
-    build: ({ cwd }: { cwd: string }) => spawnSync("pnpm", ["build"], { cwd }),
+    build: ({ cwd }: { cwd: string }) =>
+      spawnSync("pnpm", ["build"], {
+        cwd,
+        env: {
+          ...process.env,
+          NODE_ENV: "production",
+        },
+      }),
     run: ({ cwd, port }) =>
       createDev(["server.js", "-p", String(port)])({
         cwd,


### PR DESCRIPTION
Ran into some unrelated integration test issues while working on https://github.com/remix-run/react-router/pull/15467

Basically:

- Error-sanitization tests were restoring `NODE_ENV` as the literal string "undefined" instead of removing it.
- RSC builds inherited whatever `NODE_ENV` previous tests left behind, causing production bundles to be built with development JSX (`jsxDEV`) and fail at runtime.

I'm not 100% sure why the api-only PR caused these issue to crop up and not on `main`, probably a hidden race condition that's wasn't hit until I added an additional integration suite.