### PR TITLE
Fix address-book tutorial by upgrading Vite to v8

### DIFF
--- a/tutorials/address-book/package.json
+++ b/tutorials/address-book/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^19.2.3",
     "cross-env": "^7.0.3",
     "typescript": "^5.4.5",
-    "vite": "^5.4.11"
+    "vite": "^8.0.3"
   },
   "engines": {
     "node": ">=22.22.0"


### PR DESCRIPTION
## Summary

The Address Book tutorial template still pins Vite 5, which is incompatible with React Router 8.

`tutorials/address-book/package.json` currently has `"vite": "^5.4.11"`, but `@react-router/dev` now requires Vite 7 or 8 (`peer vite@"^7.0.0 || ^8.0.0"`). That breaks the first two tutorial steps after scaffolding with:

```sh
npx create-react-router@latest --template remix-run/react-router/tutorials/address-book