### PR TITLE
perf(vite): compile route modules once per build, filter the hooks that ran on every module and skip Babel scope tracking in the route transform

### DIFF
--- a/integration/vite-build-test.ts
+++ b/integration/vite-build-test.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
-import { globSync } from "node:fs";
+import { globSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
 
@@ -379,6 +380,93 @@ test.describe("Build", () => {
 
         expect(pageErrors).toEqual([]);
       });
+    });
+  });
+});
+
+test.describe("Route compilation", () => {
+  viteMajorTemplates.forEach(({ templateName, templateDisplayName }) => {
+    test(`${templateDisplayName} / reuses transformed routes and generated route chunks within each build`, async () => {
+      let route = (value: string) => js`
+        export const handle = "${value}";
+        export default function Route() {
+          return <h1>Transformed route</h1>;
+        }
+      `;
+      let cwd = await createProject(
+        {
+          "react-router.config.ts": reactRouterConfig({
+            splitRouteModules: true,
+          }),
+          "vite.config.ts": js`
+            import { resolve } from "node:path";
+            import { reactRouter } from "@react-router/dev/vite";
+
+            let command;
+            export default {
+              plugins: [
+                {
+                  name: "add-route-export",
+                  enforce: "pre",
+                  configEnvironment(name, options, { command }) {
+                    if (command === "build" && name === "client") {
+                      options.build.rollupOptions.input.push(
+                        resolve("app/routes/_index.tsx") + "?route-chunk=clientLoader",
+                      );
+                    }
+                  },
+                  configResolved(config) {
+                    command = config.command;
+                  },
+                  transform(code, id) {
+                    if (!id.split("?")[0].endsWith("/app/routes/_index.tsx")) return;
+                    if (command === "serve") console.log("CHILD_ROUTE_COMPILATION");
+                    return {
+                      code: code.replace(
+                        /export const handle = ("[^"]+");/,
+                        "export async function clientLoader() { return $1; }",
+                      ),
+                      map: null,
+                    };
+                  },
+                },
+                reactRouter(),
+              ],
+            };
+          `,
+          "app/routes/_index.tsx": route("FIRST_BUILD"),
+        },
+        templateName,
+      );
+
+      for (let value of ["FIRST_BUILD", "SECOND_BUILD"]) {
+        writeFileSync(path.join(cwd, "app/routes/_index.tsx"), route(value));
+        let { status, stdout, stderr } = build({ cwd });
+        expect(status, stderr.toString()).toBe(0);
+        expect(
+          stdout.toString().match(/CHILD_ROUTE_COMPILATION/g),
+        ).toHaveLength(1);
+
+        let manifestFiles = globSync("build/client/assets/manifest-*.js", {
+          cwd,
+        });
+        expect(manifestFiles).toHaveLength(1);
+        let manifest = JSON.parse(
+          readFileSync(path.join(cwd, manifestFiles[0]), "utf8").slice(
+            "window.__reactRouterManifest=".length,
+            -1,
+          ),
+        );
+        let routeManifest = manifest.routes["routes/_index"];
+        expect(routeManifest.hasClientLoader).toBe(true);
+        expect(routeManifest.clientLoaderModule).toEqual(expect.any(String));
+        let { clientLoader } = await import(
+          pathToFileURL(
+            path.join(cwd, "build/client", routeManifest.clientLoaderModule),
+          ).href
+        );
+        expect(await clientLoader()).toBe(value);
+      }
     });
   });
 });

--- a/integration/vite-dot-server-test.ts
+++ b/integration/vite-dot-server-test.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { readFileSync } from "node:fs";
 import { expect } from "@playwright/test";
 import stripAnsi from "strip-ansi";
 import dedent from "dedent";
@@ -10,6 +11,7 @@ import {
   grep,
   build,
   viteConfig,
+  viteMajorTemplates,
 } from "./helpers/vite.js";
 
 let serverOnlyModule = `
@@ -266,5 +268,97 @@ test.describe("Vite / server-only escape hatch", async () => {
     });
     await expect(page.locator("[data-title]")).toHaveText("This should work");
     expect(page.errors).toEqual([]);
+  });
+});
+
+test.describe("Vite / client module resolution", () => {
+  viteMajorTemplates.forEach(({ templateName, templateDisplayName }) => {
+    test(`${templateDisplayName} / preserves plugin resolution results without resolving twice`, async () => {
+      let cwd = await createProject(
+        {
+          "vite.config.ts": `
+            import { writeFileSync } from "node:fs";
+            import { reactRouter } from "@react-router/dev/vite";
+
+            let resolutions = { "test:internal": 0, "test:external": 0 };
+            export default {
+              plugins: [
+                reactRouter(),
+                {
+                  name: "custom-resolution",
+                  enforce: "pre",
+                  resolveId(id, importer, options) {
+                    if (!(id in resolutions)) return;
+                    if (!options.ssr) resolutions[id]++;
+                    return {
+                      id: id === "test:internal"
+                        ? "\\0test:internal"
+                        : "https://example.com/external.js",
+                      external: id === "test:external",
+                      moduleSideEffects: true,
+                      meta: { customResolution: id },
+                    };
+                  },
+                  load(id) {
+                    if (id === "\\0test:internal") return 'export const message = "resolved";';
+                  },
+                  generateBundle(options, bundle) {
+                    if (this.environment.name !== "client") return;
+                    let internal = this.getModuleInfo("\\0test:internal");
+                    let external = this.getModuleInfo("https://example.com/external.js");
+                    writeFileSync("resolution-result.json", JSON.stringify({
+                      resolutions,
+                      internal: {
+                        meta: internal.meta,
+                        moduleSideEffects: internal.moduleSideEffects,
+                      },
+                      external: {
+                        meta: external.meta,
+                        imports: Object.values(bundle).flatMap((output) =>
+                          output.type === "chunk" ? output.imports : [],
+                        ).filter((id) => id === "https://example.com/external.js"),
+                      },
+                    }));
+                  },
+                },
+              ],
+            };
+          `,
+          "app/client.ts": `
+            import { suffix } from "test:external";
+            import { message } from "test:internal";
+            export const content = message + suffix;
+          `,
+          "app/routes/_index.tsx": `
+            import { content } from "../client";
+            export default () => <h1>{content}</h1>;
+          `,
+        },
+        templateName,
+      );
+      let { status, stderr } = build({ cwd });
+      expect(status, stderr.toString()).toBe(0);
+      expect(
+        JSON.parse(
+          readFileSync(path.join(cwd, "resolution-result.json"), "utf8"),
+        ),
+      ).toMatchObject({
+        resolutions: { "test:internal": 1, "test:external": 1 },
+        internal: {
+          meta: { customResolution: "test:internal" },
+          moduleSideEffects: true,
+        },
+        external: {
+          meta: { customResolution: "test:external" },
+          imports: ["https://example.com/external.js"],
+        },
+      });
+      expect(
+        grep(
+          path.join(cwd, "build/client"),
+          /https:\/\/example\.com\/external\.js/,
+        ),
+      ).toHaveLength(1);
+    });
   });
 });

--- a/packages/react-router-dev/.changes/patch.vite-plugin-build-performance.md
+++ b/packages/react-router-dev/.changes/patch.vite-plugin-build-performance.md
@@ -1,0 +1,1 @@
+Reduce redundant route lookups, plugin hooks, module resolution, and route compilation in the Vite plugin.

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -52,6 +52,7 @@ import { generate, parse } from "./babel";
 import type { NodeRequestHandler } from "./node-adapter";
 import { fromNodeRequest } from "./node-adapter";
 import {
+  cssModulesRegExp,
   getCssStringFromViteDevModuleCode,
   getStylesForPathname,
   isCssModulesFile,
@@ -67,6 +68,7 @@ import {
   type RouteChunkExportName,
   routeChunkNames,
   routeChunkExportNames,
+  routeChunkModuleIdRegExp,
   detectRouteChunks,
   getRouteChunkCode,
   isRouteChunkModuleId,
@@ -160,6 +162,21 @@ from the client build output. This is important in cases where custom route
 exports are only ever used on the server. Without this optimization, we can't
 tree-shake any unused custom exports because routes are entry points. */
 const BUILD_CLIENT_ROUTE_QUERY_STRING = "?__react-router-build-client-route";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exactIdRegExp(...ids: string[]): RegExp {
+  return new RegExp(`^(?:${ids.map(escapeRegExp).join("|")})$`);
+}
+
+const buildClientRouteIdRegExp = new RegExp(
+  `${escapeRegExp(BUILD_CLIENT_ROUTE_QUERY_STRING)}$`,
+);
+
+const clientFileRegExp = /\.client(\.[cm]?[jt]sx?)?$/;
+const clientDirRegExp = /\/\.client\//;
 
 export type EnvironmentName = "client" | SsrEnvironmentName;
 
@@ -260,6 +277,13 @@ let virtual = {
   serverManifest: VirtualModule.create("server-manifest"),
   browserManifest: VirtualModule.create("browser-manifest"),
 };
+
+const virtualModuleIdRegExp = exactIdRegExp(
+  ...Object.values(virtual).map((vmod) => vmod.id),
+);
+const virtualModuleResolvedIdRegExp = exactIdRegExp(
+  ...Object.values(virtual).map((vmod) => vmod.resolvedId),
+);
 
 let invalidateVirtualModules = (viteDevServer: Vite.ViteDevServer) => {
   Object.values(virtual).forEach((vmod) => {
@@ -1516,10 +1540,11 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         });
         await viteChildCompiler.pluginContainer.buildStart({});
       },
-      async transform(code, id) {
-        if (isCssModulesFile(id)) {
+      transform: {
+        filter: { id: cssModulesRegExp },
+        handler(code, id) {
           cssModulesManifest[id] = code;
-        }
+        },
       },
       async configureServer(viteDevServer) {
         setDevServerHooks({
@@ -1935,15 +1960,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       // all reference the same underlying file. This plugin addresses this by
       // ensuring that any explicit imports of a route module resolve to a
       // module that simply re-exports from its underlying chunks, if present.
-      async transform(code, id, options) {
-        // Routes are only chunked in build mode
-        if (viteCommand !== "build") return;
-
-        // Routes aren't chunked on the server
-        if (options?.ssr) {
-          return;
-        }
-
+      async transform(code, id) {
         // Ensure we're only operating on routes
         if (!isRoute(ctx.reactRouterConfig, id)) {
           return;
@@ -1998,9 +2015,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     {
       name: "react-router:build-client-route",
       transform: {
-        filter: { id: /\?__react-router-build-client-route$/ },
+        filter: { id: buildClientRouteIdRegExp },
         async handler(code, id, options) {
-          if (!id.endsWith(BUILD_CLIENT_ROUTE_QUERY_STRING)) return;
           let routeModuleId = id.replace(BUILD_CLIENT_ROUTE_QUERY_STRING, "");
 
           let routeFileName = path.basename(routeModuleId);
@@ -2040,16 +2056,8 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         return environment.config.consumer === "client";
       },
       transform: {
-        filter: {
-          id: new RegExp(`\\?route-chunk=(${routeChunkNames.join("|")})$`),
-        },
-        async handler(code, id, options) {
-          // Routes aren't chunked on the server
-          if (options?.ssr) return;
-
-          // Ignore anything not marked as a route chunk
-          if (!isRouteChunkModuleId(id)) return;
-
+        filter: { id: routeChunkModuleIdRegExp },
+        async handler(code, id) {
           invariant(
             viteCommand === "build",
             "Route modules are only split in build mode",
@@ -2109,18 +2117,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       name: "react-router:virtual-modules",
       enforce: "pre",
       resolveId: {
-        filter: {
-          id: /^virtual:react-router\/(server-build|server-manifest|browser-manifest)$/,
-        },
+        filter: { id: virtualModuleIdRegExp },
         handler(id) {
           const vmod = Object.values(virtual).find((vmod) => vmod.id === id);
           if (vmod) return vmod.resolvedId;
         },
       },
       load: {
-        filter: {
-          id: /^\0virtual:react-router\/(server-build|server-manifest|browser-manifest)$/,
-        },
+        filter: { id: virtualModuleResolvedIdRegExp },
         async handler(id) {
           switch (id) {
             case virtual.serverBuild.resolvedId: {
@@ -2194,7 +2198,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           viteCommand === "serve" &&
           (options as { scan?: boolean })?.scan === true;
 
-        if (isOptimizeDeps || options?.ssr) return;
+        if (isOptimizeDeps) return;
 
         let isResolving = options?.custom?.["react-router:dot-server"] ?? false;
         if (isResolving) return;
@@ -2259,24 +2263,19 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         return environment.config.consumer === "server";
       },
       transform: {
-        filter: { id: [/\.client(\.[cm]?[jt]sx?)?$/, /\/\.client\//] },
-        async handler(code, id, options) {
-          if (!options?.ssr) return;
-          let clientFileRE = /\.client(\.[cm]?[jt]sx?)?$/;
-          let clientDirRE = /\/\.client\//;
-          if (clientFileRE.test(id) || clientDirRE.test(id)) {
-            let exports = getExportNames(code);
-            return {
-              code: exports
-                .map((name) =>
-                  name === "default"
-                    ? "export default undefined;"
-                    : `export const ${name} = undefined;`,
-                )
-                .join("\n"),
-              map: null,
-            };
-          }
+        filter: { id: [clientFileRegExp, clientDirRegExp] },
+        handler(code) {
+          let exports = getExportNames(code);
+          return {
+            code: exports
+              .map((name) =>
+                name === "default"
+                  ? "export default undefined;"
+                  : `export const ${name} = undefined;`,
+              )
+              .join("\n"),
+            map: null,
+          };
         },
       },
     },
@@ -2343,18 +2342,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       name: "react-router:inject-hmr-runtime",
       enforce: "pre",
       resolveId: {
-        filter: { id: /^virtual:react-router\/inject-hmr-runtime$/ },
-        handler(id) {
-          if (id === virtualInjectHmrRuntime.id) {
-            return virtualInjectHmrRuntime.resolvedId;
-          }
+        filter: { id: exactIdRegExp(virtualInjectHmrRuntime.id) },
+        handler() {
+          return virtualInjectHmrRuntime.resolvedId;
         },
       },
       load: {
-        filter: { id: /^\0virtual:react-router\/inject-hmr-runtime$/ },
-        async handler(id) {
-          if (id !== virtualInjectHmrRuntime.resolvedId) return;
-
+        filter: { id: exactIdRegExp(virtualInjectHmrRuntime.resolvedId) },
+        handler() {
           return [
             `import RefreshRuntime from "${virtualHmrRuntime.id}"`,
             "RefreshRuntime.injectIntoGlobalHook(window)",
@@ -2369,16 +2364,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
       name: "react-router:hmr-runtime",
       enforce: "pre",
       resolveId: {
-        filter: { id: /^virtual:react-router\/hmr-runtime$/ },
-        handler(id) {
-          if (id === virtualHmrRuntime.id) return virtualHmrRuntime.resolvedId;
+        filter: { id: exactIdRegExp(virtualHmrRuntime.id) },
+        handler() {
+          return virtualHmrRuntime.resolvedId;
         },
       },
       load: {
-        filter: { id: /^\0virtual:react-router\/hmr-runtime$/ },
-        async handler(id) {
-          if (id !== virtualHmrRuntime.resolvedId) return;
-
+        filter: { id: exactIdRegExp(virtualHmrRuntime.resolvedId) },
+        async handler() {
           let reactRefreshDir = path.dirname(
             nodeRequire.resolve("react-refresh/package.json"),
           );
@@ -2412,18 +2405,12 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
             exclude: /\/node_modules\//,
           },
         },
-        async handler(code, id, options) {
-          if (viteCommand !== "serve") return;
-          if (id.includes("/node_modules/")) return;
-
+        async handler(code, id) {
           let [filepath] = id.split("?");
-          let extensionsRE = /\.(jsx?|tsx?|mdx?)$/;
-          if (!extensionsRE.test(filepath)) return;
 
           let devRuntime = "react/jsx-dev-runtime";
-          let ssr = options?.ssr === true;
           let isJSX = filepath.endsWith("x");
-          let useFastRefresh = !ssr && (isJSX || code.includes(devRuntime));
+          let useFastRefresh = isJSX || code.includes(devRuntime);
           if (!useFastRefresh) return;
 
           if (isRouteVirtualModule(id)) {

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -238,6 +238,7 @@ type ReactRouterPluginContext = {
   viteManifestEnabled: boolean;
   reactRouterManifest: ReactRouterManifest | null;
   prerenderPaths: Set<string> | null;
+  compiledRouteFiles?: Map<string, Promise<string>>;
 };
 
 let virtualHmrRuntime = VirtualModule.create("hmr-runtime");
@@ -535,23 +536,36 @@ const compileRouteFile = async (
   let { pluginContainer, moduleGraph } = viteChildCompiler;
 
   let routePath = path.resolve(ctx.reactRouterConfig.appDirectory, routeFile);
-  let url = resolveFileUrl(ctx, routePath);
+  let compiledRouteFiles = readRouteFile ? undefined : ctx.compiledRouteFiles;
+  let cached = compiledRouteFiles?.get(routePath);
+  if (cached) return cached;
 
-  let resolveId = async () => {
-    let result = await pluginContainer.resolveId(url, undefined, { ssr });
-    if (!result) throw new Error(`Could not resolve module ID for ${url}`);
-    return result.id;
+  let compile = async () => {
+    let url = resolveFileUrl(ctx, routePath);
+
+    let resolveId = async () => {
+      let result = await pluginContainer.resolveId(url, undefined, { ssr });
+      if (!result) throw new Error(`Could not resolve module ID for ${url}`);
+      return result.id;
+    };
+
+    let [id, code] = await Promise.all([
+      resolveId(),
+      readRouteFile?.() ?? readFile(routePath, "utf-8"),
+      // pluginContainer.transform(...) fails if we don't do this first:
+      moduleGraph.ensureEntryFromUrl(url, ssr),
+    ]);
+
+    let transformed = await pluginContainer.transform(code, id, { ssr });
+    return transformed.code;
   };
 
-  let [id, code] = await Promise.all([
-    resolveId(),
-    readRouteFile?.() ?? readFile(routePath, "utf-8"),
-    // pluginContainer.transform(...) fails if we don't do this first:
-    moduleGraph.ensureEntryFromUrl(url, ssr),
-  ]);
-
-  let transformed = await pluginContainer.transform(code, id, { ssr });
-  return transformed.code;
+  let promise = compile().catch((error) => {
+    compiledRouteFiles?.delete(routePath);
+    throw error;
+  });
+  compiledRouteFiles?.set(routePath, promise);
+  return promise;
 };
 
 const getRouteModuleExports = async (
@@ -947,7 +961,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         cache,
         ctx,
         routeFile,
-        { routeFile, viteChildCompiler },
+        { routeFile, viteChildCompiler, sourceExports },
       );
 
       if (enforceSplitRouteModules) {
@@ -1102,7 +1116,7 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
           cache,
           ctx,
           routeFile,
-          { routeFile, viteChildCompiler },
+          { routeFile, viteChildCompiler, sourceExports },
         );
 
         validateRouteChunks({
@@ -1416,6 +1430,16 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
 
         viteConfig = resolvedViteConfig;
         invariant(viteConfig);
+
+        if (
+          viteConfig.command === "build" &&
+          !viteConfig.build.watch &&
+          Object.values(viteConfig.environments).every(
+            (environment) => !environment.build.watch,
+          )
+        ) {
+          ctx.compiledRouteFiles = new Map();
+        }
 
         // We load the same Vite config file again for the child compiler so
         // that both parent and child compiler's plugins have independent state.
@@ -1896,6 +1920,10 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     },
     {
       name: "react-router:route-chunks-index",
+      apply: "build",
+      applyToEnvironment(environment) {
+        return environment.config.consumer === "client";
+      },
       // This plugin provides the route module "index" since route modules can
       // be chunked and may be made up of multiple smaller modules. This plugin
       // primarily ensures code is never duplicated across a route module and
@@ -1969,168 +1997,196 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     },
     {
       name: "react-router:build-client-route",
-      async transform(code, id, options) {
-        if (!id.endsWith(BUILD_CLIENT_ROUTE_QUERY_STRING)) return;
-        let routeModuleId = id.replace(BUILD_CLIENT_ROUTE_QUERY_STRING, "");
+      transform: {
+        filter: { id: /\?__react-router-build-client-route$/ },
+        async handler(code, id, options) {
+          if (!id.endsWith(BUILD_CLIENT_ROUTE_QUERY_STRING)) return;
+          let routeModuleId = id.replace(BUILD_CLIENT_ROUTE_QUERY_STRING, "");
 
-        let routeFileName = path.basename(routeModuleId);
+          let routeFileName = path.basename(routeModuleId);
 
-        let sourceExports = await getRouteModuleExports(
-          viteChildCompiler,
-          ctx,
-          routeModuleId,
-        );
+          let sourceExports = await getRouteModuleExports(
+            viteChildCompiler,
+            ctx,
+            routeModuleId,
+          );
 
-        let { chunkedExports = [] } = options?.ssr
-          ? {}
-          : await detectRouteChunksIfEnabled(cache, ctx, id, code);
+          let { chunkedExports = [] } = options?.ssr
+            ? {}
+            : await detectRouteChunksIfEnabled(cache, ctx, id, code);
 
-        let reexports = sourceExports
-          .filter((exportName) => {
-            let isRouteEntryExport =
-              (options?.ssr &&
-                SERVER_ONLY_ROUTE_EXPORTS.includes(exportName)) ||
-              CLIENT_ROUTE_EXPORTS.includes(exportName);
+          let reexports = sourceExports
+            .filter((exportName) => {
+              let isRouteEntryExport =
+                (options?.ssr &&
+                  SERVER_ONLY_ROUTE_EXPORTS.includes(exportName)) ||
+                CLIENT_ROUTE_EXPORTS.includes(exportName);
 
-            let isChunkedExport = chunkedExports.includes(
-              exportName as string & RouteChunkExportName,
-            );
+              let isChunkedExport = chunkedExports.includes(
+                exportName as string & RouteChunkExportName,
+              );
 
-            return isRouteEntryExport && !isChunkedExport;
-          })
-          .join(", ");
+              return isRouteEntryExport && !isChunkedExport;
+            })
+            .join(", ");
 
-        return `export { ${reexports} } from "./${routeFileName}";`;
+          return `export { ${reexports} } from "./${routeFileName}";`;
+        },
       },
     },
     {
       name: "react-router:split-route-modules",
-      async transform(code, id, options) {
-        // Routes aren't chunked on the server
-        if (options?.ssr) return;
+      applyToEnvironment(environment) {
+        return environment.config.consumer === "client";
+      },
+      transform: {
+        filter: {
+          id: new RegExp(`\\?route-chunk=(${routeChunkNames.join("|")})$`),
+        },
+        async handler(code, id, options) {
+          // Routes aren't chunked on the server
+          if (options?.ssr) return;
 
-        // Ignore anything not marked as a route chunk
-        if (!isRouteChunkModuleId(id)) return;
+          // Ignore anything not marked as a route chunk
+          if (!isRouteChunkModuleId(id)) return;
 
-        invariant(
-          viteCommand === "build",
-          "Route modules are only split in build mode",
-        );
+          invariant(
+            viteCommand === "build",
+            "Route modules are only split in build mode",
+          );
 
-        let chunkName = getRouteChunkNameFromModuleId(id);
+          let chunkName = getRouteChunkNameFromModuleId(id);
 
-        if (!chunkName) {
-          throw new Error(`Invalid route chunk name "${chunkName}" in "${id}"`);
-        }
+          if (!chunkName) {
+            throw new Error(
+              `Invalid route chunk name "${chunkName}" in "${id}"`,
+            );
+          }
 
-        let chunk = await getRouteChunkIfEnabled(
-          cache,
-          ctx,
-          id,
-          chunkName,
-          code,
-        );
-
-        let preventEmptyChunkSnippet = ({ reason }: { reason: string }) =>
-          `Math.random()<0&&console.log(${JSON.stringify(reason)});`;
-
-        if (chunk === null) {
-          return preventEmptyChunkSnippet({
-            reason: "Split round modules disabled",
-          });
-        }
-
-        let enforceSplitRouteModules =
-          ctx.reactRouterConfig.splitRouteModules === "enforce";
-
-        if (enforceSplitRouteModules && chunkName === "main" && chunk) {
-          let exportNames = getExportNames(chunk.code);
-
-          validateRouteChunks({
+          let chunk = await getRouteChunkIfEnabled(
+            cache,
             ctx,
             id,
-            valid: {
-              clientAction: !exportNames.includes("clientAction"),
-              clientLoader: !exportNames.includes("clientLoader"),
-              clientMiddleware: !exportNames.includes("clientMiddleware"),
-              HydrateFallback: !exportNames.includes("HydrateFallback"),
-            },
-          });
-        }
+            chunkName,
+            code,
+          );
 
-        return (
-          chunk ?? preventEmptyChunkSnippet({ reason: `No ${chunkName} chunk` })
-        );
+          let preventEmptyChunkSnippet = ({ reason }: { reason: string }) =>
+            `Math.random()<0&&console.log(${JSON.stringify(reason)});`;
+
+          if (chunk === null) {
+            return preventEmptyChunkSnippet({
+              reason: "Split round modules disabled",
+            });
+          }
+
+          let enforceSplitRouteModules =
+            ctx.reactRouterConfig.splitRouteModules === "enforce";
+
+          if (enforceSplitRouteModules && chunkName === "main" && chunk) {
+            let exportNames = getExportNames(chunk.code);
+
+            validateRouteChunks({
+              ctx,
+              id,
+              valid: {
+                clientAction: !exportNames.includes("clientAction"),
+                clientLoader: !exportNames.includes("clientLoader"),
+                clientMiddleware: !exportNames.includes("clientMiddleware"),
+                HydrateFallback: !exportNames.includes("HydrateFallback"),
+              },
+            });
+          }
+
+          return (
+            chunk ??
+            preventEmptyChunkSnippet({ reason: `No ${chunkName} chunk` })
+          );
+        },
       },
     },
     {
       name: "react-router:virtual-modules",
       enforce: "pre",
-      resolveId(id) {
-        const vmod = Object.values(virtual).find((vmod) => vmod.id === id);
-        if (vmod) return vmod.resolvedId;
+      resolveId: {
+        filter: {
+          id: /^virtual:react-router\/(server-build|server-manifest|browser-manifest)$/,
+        },
+        handler(id) {
+          const vmod = Object.values(virtual).find((vmod) => vmod.id === id);
+          if (vmod) return vmod.resolvedId;
+        },
       },
-      async load(id) {
-        switch (id) {
-          case virtual.serverBuild.resolvedId: {
-            let routeIds = getServerBundleRouteIds(this, ctx);
-            return await getServerEntry({ routeIds });
-          }
-          case virtual.serverManifest.resolvedId: {
-            let routeIds = getServerBundleRouteIds(this, ctx);
-            invariant(viteConfig);
-            let reactRouterServerManifest: ReactRouterManifest;
+      load: {
+        filter: {
+          id: /^\0virtual:react-router\/(server-build|server-manifest|browser-manifest)$/,
+        },
+        async handler(id) {
+          switch (id) {
+            case virtual.serverBuild.resolvedId: {
+              let routeIds = getServerBundleRouteIds(this, ctx);
+              return await getServerEntry({ routeIds });
+            }
+            case virtual.serverManifest.resolvedId: {
+              let routeIds = getServerBundleRouteIds(this, ctx);
+              invariant(viteConfig);
+              let reactRouterServerManifest: ReactRouterManifest;
 
-            if (viteCommand === "build") {
-              let {
-                reactRouterBrowserManifest,
-                reactRouterServerManifest: serverManifest,
-              } = await generateReactRouterManifestsForBuild({
-                viteConfig,
-                routeIds,
+              if (viteCommand === "build") {
+                let {
+                  reactRouterBrowserManifest,
+                  reactRouterServerManifest: serverManifest,
+                } = await generateReactRouterManifestsForBuild({
+                  viteConfig,
+                  routeIds,
+                });
+
+                reactRouterServerManifest = serverManifest;
+                // Cache the full browser manifest on context for prerendering later.
+                // Server bundle manifests only contain the routes for a single bundle.
+                ctx.reactRouterManifest = reactRouterBrowserManifest;
+              } else {
+                reactRouterServerManifest =
+                  await getReactRouterManifestForDev();
+                ctx.reactRouterManifest = reactRouterServerManifest;
+              }
+
+              // Check for invalid APIs when SSR is disabled
+              if (!ctx.reactRouterConfig.ssr) {
+                invariant(viteConfig);
+                validateSsrFalsePrerenderExports(
+                  viteConfig,
+                  ctx,
+                  reactRouterServerManifest,
+                  viteChildCompiler,
+                );
+              }
+
+              return `export default ${jsesc(reactRouterServerManifest, {
+                es6: true,
+              })};`;
+            }
+            case virtual.browserManifest.resolvedId: {
+              if (viteCommand === "build") {
+                throw new Error("This module only exists in development");
+              }
+
+              let reactRouterManifest = await getReactRouterManifestForDev();
+              let reactRouterManifestString = jsesc(reactRouterManifest, {
+                es6: true,
               });
 
-              reactRouterServerManifest = serverManifest;
-              // Cache the full browser manifest on context for prerendering later.
-              // Server bundle manifests only contain the routes for a single bundle.
-              ctx.reactRouterManifest = reactRouterBrowserManifest;
-            } else {
-              reactRouterServerManifest = await getReactRouterManifestForDev();
-              ctx.reactRouterManifest = reactRouterServerManifest;
+              return `window.__reactRouterManifest=${reactRouterManifestString};`;
             }
-
-            // Check for invalid APIs when SSR is disabled
-            if (!ctx.reactRouterConfig.ssr) {
-              invariant(viteConfig);
-              validateSsrFalsePrerenderExports(
-                viteConfig,
-                ctx,
-                reactRouterServerManifest,
-                viteChildCompiler,
-              );
-            }
-
-            return `export default ${jsesc(reactRouterServerManifest, {
-              es6: true,
-            })};`;
           }
-          case virtual.browserManifest.resolvedId: {
-            if (viteCommand === "build") {
-              throw new Error("This module only exists in development");
-            }
-
-            let reactRouterManifest = await getReactRouterManifestForDev();
-            let reactRouterManifestString = jsesc(reactRouterManifest, {
-              es6: true,
-            });
-
-            return `window.__reactRouterManifest=${reactRouterManifestString};`;
-          }
-        }
+        },
       },
     },
     {
       name: "react-router:dot-server",
+      applyToEnvironment(environment) {
+        return environment.config.consumer === "client";
+      },
       enforce: "pre",
       async resolveId(id, importer, options) {
         // https://vitejs.dev/config/dep-optimization-options
@@ -2150,14 +2206,14 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
         let serverDirRE = /\/\.server\//;
         let isDotServer =
           serverFileRE.test(resolved!.id) || serverDirRE.test(resolved!.id);
-        if (!isDotServer) return;
+        if (!isDotServer) return resolved;
 
-        if (!importer) return;
+        if (!importer) return resolved;
         if (viteCommand !== "build" && importer.endsWith(".html")) {
           // Vite has a special `index.html` importer for `resolveId` within `transformRequest`
           // https://github.com/vitejs/vite/blob/5684fcd8d27110d098b3e1c19d851f44251588f1/packages/vite/src/node/server/transformRequest.ts#L158
           // https://github.com/vitejs/vite/blob/5684fcd8d27110d098b3e1c19d851f44251588f1/packages/vite/src/node/server/pluginContainer.ts#L668
-          return;
+          return resolved;
         }
 
         let vite = getVite();
@@ -2199,23 +2255,29 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     },
     {
       name: "react-router:dot-client",
-      async transform(code, id, options) {
-        if (!options?.ssr) return;
-        let clientFileRE = /\.client(\.[cm]?[jt]sx?)?$/;
-        let clientDirRE = /\/\.client\//;
-        if (clientFileRE.test(id) || clientDirRE.test(id)) {
-          let exports = getExportNames(code);
-          return {
-            code: exports
-              .map((name) =>
-                name === "default"
-                  ? "export default undefined;"
-                  : `export const ${name} = undefined;`,
-              )
-              .join("\n"),
-            map: null,
-          };
-        }
+      applyToEnvironment(environment) {
+        return environment.config.consumer === "server";
+      },
+      transform: {
+        filter: { id: [/\.client(\.[cm]?[jt]sx?)?$/, /\/\.client\//] },
+        async handler(code, id, options) {
+          if (!options?.ssr) return;
+          let clientFileRE = /\.client(\.[cm]?[jt]sx?)?$/;
+          let clientDirRE = /\/\.client\//;
+          if (clientFileRE.test(id) || clientDirRE.test(id)) {
+            let exports = getExportNames(code);
+            return {
+              code: exports
+                .map((name) =>
+                  name === "default"
+                    ? "export default undefined;"
+                    : `export const ${name} = undefined;`,
+                )
+                .join("\n"),
+              map: null,
+            };
+          }
+        },
       },
     },
     {
@@ -2280,96 +2342,120 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     {
       name: "react-router:inject-hmr-runtime",
       enforce: "pre",
-      resolveId(id) {
-        if (id === virtualInjectHmrRuntime.id) {
-          return virtualInjectHmrRuntime.resolvedId;
-        }
+      resolveId: {
+        filter: { id: /^virtual:react-router\/inject-hmr-runtime$/ },
+        handler(id) {
+          if (id === virtualInjectHmrRuntime.id) {
+            return virtualInjectHmrRuntime.resolvedId;
+          }
+        },
       },
-      async load(id) {
-        if (id !== virtualInjectHmrRuntime.resolvedId) return;
+      load: {
+        filter: { id: /^\0virtual:react-router\/inject-hmr-runtime$/ },
+        async handler(id) {
+          if (id !== virtualInjectHmrRuntime.resolvedId) return;
 
-        return [
-          `import RefreshRuntime from "${virtualHmrRuntime.id}"`,
-          "RefreshRuntime.injectIntoGlobalHook(window)",
-          "window.$RefreshReg$ = () => {}",
-          "window.$RefreshSig$ = () => (type) => type",
-          "window.__vite_plugin_react_preamble_installed__ = true",
-        ].join("\n");
+          return [
+            `import RefreshRuntime from "${virtualHmrRuntime.id}"`,
+            "RefreshRuntime.injectIntoGlobalHook(window)",
+            "window.$RefreshReg$ = () => {}",
+            "window.$RefreshSig$ = () => (type) => type",
+            "window.__vite_plugin_react_preamble_installed__ = true",
+          ].join("\n");
+        },
       },
     },
     {
       name: "react-router:hmr-runtime",
       enforce: "pre",
-      resolveId(id) {
-        if (id === virtualHmrRuntime.id) return virtualHmrRuntime.resolvedId;
+      resolveId: {
+        filter: { id: /^virtual:react-router\/hmr-runtime$/ },
+        handler(id) {
+          if (id === virtualHmrRuntime.id) return virtualHmrRuntime.resolvedId;
+        },
       },
-      async load(id) {
-        if (id !== virtualHmrRuntime.resolvedId) return;
+      load: {
+        filter: { id: /^\0virtual:react-router\/hmr-runtime$/ },
+        async handler(id) {
+          if (id !== virtualHmrRuntime.resolvedId) return;
 
-        let reactRefreshDir = path.dirname(
-          nodeRequire.resolve("react-refresh/package.json"),
-        );
-        let reactRefreshRuntimePath = path.join(
-          reactRefreshDir,
-          "cjs/react-refresh-runtime.development.js",
-        );
+          let reactRefreshDir = path.dirname(
+            nodeRequire.resolve("react-refresh/package.json"),
+          );
+          let reactRefreshRuntimePath = path.join(
+            reactRefreshDir,
+            "cjs/react-refresh-runtime.development.js",
+          );
 
-        return [
-          "const exports = {}",
-          await readFile(reactRefreshRuntimePath, "utf8"),
-          await readFile(
-            nodeRequire.resolve("./static/refresh-utils.mjs"),
-            "utf8",
-          ),
-          "export default exports",
-        ].join("\n");
+          return [
+            "const exports = {}",
+            await readFile(reactRefreshRuntimePath, "utf8"),
+            await readFile(
+              nodeRequire.resolve("./static/refresh-utils.mjs"),
+              "utf8",
+            ),
+            "export default exports",
+          ].join("\n");
+        },
       },
     },
     {
       name: "react-router:react-refresh-babel",
-      async transform(code, id, options) {
-        if (viteCommand !== "serve") return;
-        if (id.includes("/node_modules/")) return;
-
-        let [filepath] = id.split("?");
-        let extensionsRE = /\.(jsx?|tsx?|mdx?)$/;
-        if (!extensionsRE.test(filepath)) return;
-
-        let devRuntime = "react/jsx-dev-runtime";
-        let ssr = options?.ssr === true;
-        let isJSX = filepath.endsWith("x");
-        let useFastRefresh = !ssr && (isJSX || code.includes(devRuntime));
-        if (!useFastRefresh) return;
-
-        if (isRouteVirtualModule(id)) {
-          return { code: addRefreshWrapper(ctx.reactRouterConfig, code, id) };
-        }
-
-        let result = await babel.transformAsync(code, {
-          babelrc: false,
-          configFile: false,
-          filename: id,
-          sourceFileName: filepath,
-          parserOpts: {
-            sourceType: "module",
-            allowAwaitOutsideFunction: true,
+      apply: "serve",
+      applyToEnvironment(environment) {
+        return environment.config.consumer === "client";
+      },
+      transform: {
+        filter: {
+          id: {
+            include: /\.(jsx?|tsx?|mdx?)(\?.*)?$/,
+            exclude: /\/node_modules\//,
           },
-          plugins: [
-            [
-              nodeRequire.resolve("react-refresh/babel"),
-              { skipEnvCheck: true },
-            ],
-          ],
-          sourceMaps: true,
-        });
-        if (result === null) return;
+        },
+        async handler(code, id, options) {
+          if (viteCommand !== "serve") return;
+          if (id.includes("/node_modules/")) return;
 
-        code = result.code!;
-        let refreshContentRE = /\$Refresh(?:Reg|Sig)\$\(/;
-        if (refreshContentRE.test(code)) {
-          code = addRefreshWrapper(ctx.reactRouterConfig, code, id);
-        }
-        return { code, map: result.map };
+          let [filepath] = id.split("?");
+          let extensionsRE = /\.(jsx?|tsx?|mdx?)$/;
+          if (!extensionsRE.test(filepath)) return;
+
+          let devRuntime = "react/jsx-dev-runtime";
+          let ssr = options?.ssr === true;
+          let isJSX = filepath.endsWith("x");
+          let useFastRefresh = !ssr && (isJSX || code.includes(devRuntime));
+          if (!useFastRefresh) return;
+
+          if (isRouteVirtualModule(id)) {
+            return { code: addRefreshWrapper(ctx.reactRouterConfig, code, id) };
+          }
+
+          let result = await babel.transformAsync(code, {
+            babelrc: false,
+            configFile: false,
+            filename: id,
+            sourceFileName: filepath,
+            parserOpts: {
+              sourceType: "module",
+              allowAwaitOutsideFunction: true,
+            },
+            plugins: [
+              [
+                nodeRequire.resolve("react-refresh/babel"),
+                { skipEnvCheck: true },
+              ],
+            ],
+            sourceMaps: true,
+          });
+          if (result === null) return;
+
+          code = result.code!;
+          let refreshContentRE = /\$Refresh(?:Reg|Sig)\$\(/;
+          if (refreshContentRE.test(code)) {
+            code = addRefreshWrapper(ctx.reactRouterConfig, code, id);
+          }
+          return { code, map: result.map };
+        },
       },
     },
     {
@@ -2827,6 +2913,11 @@ if (import.meta.hot && !inWebWorker) {
   });
 }`;
 
+const routesByFile = new WeakMap<
+  ResolvedReactRouterConfig,
+  Map<string, RouteManifestEntry>
+>();
+
 function getRoute(
   pluginConfig: ResolvedReactRouterConfig,
   file: string,
@@ -2835,10 +2926,16 @@ function getRoute(
   let routePath = vite.normalizePath(
     path.relative(pluginConfig.appDirectory, file),
   );
-  let route = Object.values(pluginConfig.routes).find(
-    (r) => vite.normalizePath(r.file) === routePath,
-  );
-  return route;
+  let routes = routesByFile.get(pluginConfig);
+  if (!routes) {
+    routes = new Map();
+    for (let route of Object.values(pluginConfig.routes)) {
+      let file = vite.normalizePath(route.file);
+      if (!routes.has(file)) routes.set(file, route);
+    }
+    routesByFile.set(pluginConfig, routes);
+  }
+  return routes.get(routePath);
 }
 
 function isRoute(
@@ -2867,7 +2964,7 @@ async function getRouteMetadata(
     cache,
     ctx,
     routeFile,
-    { routeFile, readRouteFile, viteChildCompiler },
+    { routeFile, readRouteFile, viteChildCompiler, sourceExports },
   );
 
   let moduleUrl = combineURLs(
@@ -3245,6 +3342,7 @@ type ResolveRouteFileCodeInput =
       routeFile: string;
       readRouteFile?: () => string | Promise<string>;
       viteChildCompiler: Vite.ViteDevServer | null;
+      sourceExports?: string[];
     };
 const resolveRouteFileCode = async (
   ctx: ReactRouterPluginContext,
@@ -3295,6 +3393,16 @@ async function detectRouteChunksIfEnabled(
   // the initial page load. Instead of firing off multiple requests to resolve
   // the root route code, we want it to be downloaded in a single request.
   if (isRootRouteModuleId(ctx, id)) {
+    return noRouteChunks();
+  }
+
+  if (
+    typeof input !== "string" &&
+    input.sourceExports &&
+    !routeChunkExportNames.some((exportName) =>
+      input.sourceExports!.includes(exportName),
+    )
+  ) {
     return noRouteChunks();
   }
 

--- a/packages/react-router-dev/vite/route-chunks.ts
+++ b/packages/react-router-dev/vite/route-chunks.ts
@@ -983,10 +983,12 @@ export function getRouteChunkModuleId(
   return `${filePath}${routeChunkQueryStrings[chunkName]}`;
 }
 
+export const routeChunkModuleIdRegExp = new RegExp(
+  `\\${routeChunkQueryStringPrefix}(?:${routeChunkNames.join("|")})$`,
+);
+
 export function isRouteChunkModuleId(id: string): boolean {
-  return Object.values(routeChunkQueryStrings).some((queryString) =>
-    id.endsWith(queryString),
-  );
+  return routeChunkModuleIdRegExp.test(id);
 }
 
 function isRouteChunkName(name: string): name is RouteChunkName {

--- a/packages/react-router-dev/vite/styles.ts
+++ b/packages/react-router-dev/vite/styles.ts
@@ -15,7 +15,7 @@ import * as babel from "./babel";
 const cssFileRegExp =
   /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;
 // https://github.com/vitejs/vite/blob/d6bde8b03d433778aaed62afc2be0630c8131908/packages/vite/src/node/plugins/css.ts#L160
-const cssModulesRegExp = new RegExp(`\\.module${cssFileRegExp.source}`);
+export const cssModulesRegExp = new RegExp(`\\.module${cssFileRegExp.source}`);
 
 const isCssFile = (file: string) => cssFileRegExp.test(file);
 export const isCssModulesFile = (file: string) => cssModulesRegExp.test(file);


### PR DESCRIPTION
Hi, and thanks for all the work on React Router. We've been running framework mode in production for a while and wanted to give a bit back after digging into our build times.

This caches the child compiler's output per build so each route module is compiled once instead of three times, makes `getRoute()` a map lookup instead of a scan over the route manifest, gives the hooks that only care about specific ids or one side of the build proper filters and `applyToEnvironment`, has the `.server` guard return what it resolved instead of letting Vite resolve the same import again, and drops Babel's scope tracking from the route module transform. For our ~210-route SSR app that takes route compilations from 623 down to 208 (a 67% drop) and `react-router build` from 13–17s to 8–9s on the same machine, with identical output.

Some background on how we got here. `react-router build` was spending most of its time inside the React Router Vite plugin rather than in the bundler, and profiling turned up a few things that scale with the number of routes and modules:

- `getRoute()` did a linear scan over the route manifest, and it's called from the `route-exports` and `route-chunks-index` transforms for every module. That was ~170µs per non-route module for us, ~14k calls per build. It now uses a map keyed by the normalized route file, built once per resolved config.
- Every route module was compiled by the child compiler three times per build (client route entry, server manifest exports, and `splitRouteModules` detection, which also ran serially). The compiled result is now shared within a build (never in dev or watch mode), and chunk detection looks at the exports we already have before compiling again, so exports added by other plugins still work.
- A handful of hooks ran for every module or environment even though they only care about specific ids or one side of the build (`build-client-route`, `split-route-modules`, `route-chunks-index`, `dot-client`, the virtual module and HMR runtime plugins, the CSS modules manifest transform, `react-refresh-babel`). They now use hook filters, `apply` and `applyToEnvironment`. The regexes come from the existing id constants.
- `react-router:dot-server` resolved every client import through `this.resolve()` and then returned `undefined`, so Vite resolved the same import again. It now returns what it resolved, including `meta`, `external` and `moduleSideEffects` from custom resolvers.
- `route-exports` built a full Babel scope for every route module on both sides of the build, but the only thing the server side used it for was picking an unused name for the `UNSAFE_with*Props` import. It now traverses without scope tracking and checks the source text for the candidate name instead, and it only asks `@babel/generator` for a source map in dev or when the environment's `build.sourcemap` is on. That is about 0.4s of main-thread time on our build, with the same identifiers in the output.

On the output: I diffed the server bundle after normalizing the build id and compared the client asset names including hashes, and nothing changed. rolldown's `PLUGIN_TIMINGS` also no longer lists the `route-chunks-index` transform or the `virtual-modules` load after this.

There are two new integration tests: one checks that a route is compiled once per build and still recompiled on the next build (including exports generated by another plugin), the other checks that the `.server` guard preserves resolution results without resolving twice. Both fail on `main` and pass here, on the Vite 7 and Vite 8 templates. Build, typecheck, lint, format, `changes:validate`, the jest `dev` project and the Vite build / dot-server / dot-client / split-route-modules / HMR / prerender / CSS / SPA mode / dev / basename integration suites are green on Chromium.

Happy to split this up if it's easier to review in pieces.


