### PR TITLE
fix: preserve source maps in RSC route transforms

### DIFF
--- a/integration/helpers/vite.ts
+++ b/integration/helpers/vite.ts
@@ -52,6 +52,7 @@ type ViteConfigBuildArgs = {
   assetsInlineLimit?: number;
   assetsDir?: string;
   cssCodeSplit?: boolean;
+  sourcemap?: boolean | "inline" | "hidden";
 };
 
 type ViteConfigBaseArgs = {
@@ -87,6 +88,7 @@ export const viteConfig = {
     assetsInlineLimit,
     assetsDir,
     cssCodeSplit,
+    sourcemap,
   }: ViteConfigBuildArgs = {}) => {
     return dedent`
       build: {
@@ -95,6 +97,7 @@ export const viteConfig = {
         cssCodeSplit: ${
           cssCodeSplit !== undefined ? cssCodeSplit : "undefined"
         },
+        sourcemap: ${JSON.stringify(sourcemap)},
       },
     `;
   },

--- a/integration/rsc-route-source-maps-test.ts
+++ b/integration/rsc-route-source-maps-test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+import { globSync, readFileSync } from "node:fs";
+import { SourceMap } from "node:module";
+import path from "node:path";
+
+import { build, createProject, viteConfig } from "./helpers/vite.js";
+
+const routeSource = `export function meta() {
+  return [{ title: "RSC_SHARED_ROUTE_SOURCE_MAP_TEST" }];
+}
+
+export async function clientLoader() {
+  throw new Error("RSC_ROUTE_SOURCE_MAP_TEST");
+}
+
+export async function clientAction() {
+  throw new Error("RSC_CLIENT_ACTION_SOURCE_MAP_TEST");
+}
+
+export async function loader() {
+  throw new Error("RSC_SERVER_ROUTE_SOURCE_MAP_TEST");
+}
+
+export default function Index() {
+  return <h1>Index</h1>;
+}
+`;
+
+function findMarkerMappings(
+  cwd: string,
+  output: "client" | "server",
+  marker: string,
+) {
+  return globSync(path.join(cwd, `build/${output}/**/*.js`)).flatMap(
+    (chunkPath) => {
+      let chunk = readFileSync(chunkPath, "utf8");
+      let markerOffset = chunk.indexOf(marker);
+      if (markerOffset === -1) {
+        return [];
+      }
+
+      let generatedLines = chunk.slice(0, markerOffset).split("\n");
+      let map = JSON.parse(readFileSync(`${chunkPath}.map`, "utf8"));
+      let entry = new SourceMap(map).findEntry(
+        generatedLines.length - 1,
+        generatedLines.at(-1)!.length,
+      );
+      if (!("originalSource" in entry)) {
+        throw new Error(`Expected a source map entry for ${marker}`);
+      }
+
+      return [{ chunkPath, entry }];
+    },
+  );
+}
+
+test("RSC Framework route modules preserve source maps", async () => {
+  let cwd = await createProject(
+    {
+      "vite.config.ts": await viteConfig.basic({
+        templateName: "rsc-vite-framework",
+        sourcemap: true,
+      }),
+      "app/routes/_index.tsx": routeSource,
+    },
+    "rsc-vite-framework",
+  );
+
+  let { status } = build({ cwd });
+  expect(status).toBe(0);
+
+  let expectations = [
+    ["client", "RSC_ROUTE_SOURCE_MAP_TEST", 5, 18],
+    ["server", "RSC_ROUTE_SOURCE_MAP_TEST", 5, 18],
+    ["client", "RSC_CLIENT_ACTION_SOURCE_MAP_TEST", 9, 18],
+    ["server", "RSC_CLIENT_ACTION_SOURCE_MAP_TEST", 9, 18],
+    ["client", "RSC_SHARED_ROUTE_SOURCE_MAP_TEST", 1, 19],
+    ["server", "RSC_SHARED_ROUTE_SOURCE_MAP_TEST", 1, 19],
+    ["server", "RSC_SERVER_ROUTE_SOURCE_MAP_TEST", 13, 18],
+  ] as const;
+
+  for (let [output, marker, originalLine, originalColumn] of expectations) {
+    let mappings = findMarkerMappings(cwd, output, marker);
+    expect(mappings, `${marker} in the ${output} output`).not.toHaveLength(0);
+
+    for (let { chunkPath, entry } of mappings) {
+      expect(
+        path.resolve(
+          path.dirname(chunkPath),
+          entry.originalSource!.split("?")[0],
+        ),
+      ).toBe(path.join(cwd, "app/routes/_index.tsx"));
+      expect(entry.originalLine).toBe(originalLine);
+      expect(entry.originalColumn).toBe(originalColumn);
+    }
+  }
+});

--- a/packages/react-router-dev/.changes/unstable.rsc-route-source-maps.md
+++ b/packages/react-router-dev/.changes/unstable.rsc-route-source-maps.md
@@ -1,0 +1,1 @@
+Fix source maps for route modules in unstable RSC Framework Mode

--- a/packages/react-router-dev/__tests__/rsc-virtual-route-modules-test.ts
+++ b/packages/react-router-dev/__tests__/rsc-virtual-route-modules-test.ts
@@ -1,4 +1,5 @@
 import * as assert from "node:assert";
+import { SourceMap } from "node:module";
 import ts from "typescript";
 
 import {
@@ -15,11 +16,14 @@ const plugin = virtualRouteModulesPlugin({
     return false;
   },
   async transformToJs(code: string, filename: string) {
-    return await ts.transpile(code, {
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.ESNext,
-      jsx: ts.JsxEmit.ReactJSX,
-    });
+    return {
+      code: await ts.transpile(code, {
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+        jsx: ts.JsxEmit.ReactJSX,
+      }),
+      map: null,
+    };
   },
 });
 
@@ -364,6 +368,42 @@ describe("server-route-module", () => {
 });
 
 describe("client-route-module=shared", () => {
+  it("leaves generated prefixes and HMR code unmapped", async () => {
+    const devTransform = plugin.transform.bind({
+      environment: { name: "client", mode: "dev" },
+    } as any);
+    const transformed = await devTransform(
+      fullClientModule,
+      "/test.js?client-route-module=shared",
+    );
+    assert.ok(transformed?.map && "version" in transformed.map);
+
+    let sourceMap = new SourceMap({
+      file: "",
+      sourceRoot: "",
+      sourcesContent: [],
+      ...transformed.map,
+    });
+    let generatedPrefix = sourceMap.findEntry(0, 0);
+    expect(
+      "originalSource" in generatedPrefix
+        ? generatedPrefix.originalSource
+        : undefined,
+    ).toBeUndefined();
+
+    let hmrOffset = transformed.code.indexOf("ReactRouterHMRMeta___");
+    let hmrLines = transformed.code.slice(0, hmrOffset).split("\n");
+    let generatedHmr = sourceMap.findEntry(
+      hmrLines.length - 1,
+      hmrLines.at(-1)!.length,
+    );
+    expect(
+      "originalSource" in generatedHmr
+        ? generatedHmr.originalSource
+        : undefined,
+    ).toBeUndefined();
+  });
+
   it("transforms full client modules", async () => {
     const transformed = await transform(
       fullClientModule,

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -107,32 +107,28 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
     }
   }
 
-  async function transformToJs(
-    code: string,
-    filename: string,
-  ): Promise<string> {
+  async function transformToJs(code: string, filename: string) {
     await preloadVite();
     let vite = getVite();
     let lang = getTransformLanguage(filename);
 
-    return (
-      "transformWithOxc" in vite && typeof vite.transformWithOxc === "function"
-        ? await vite.transformWithOxc(code, filename, {
-            lang,
-            jsx: {
-              runtime: "automatic",
-              development: viteCommand !== "build",
-              target: "esnext",
-            },
-          })
-        : await vite.transformWithEsbuild(code, filename, {
-            loader: lang,
+    return "transformWithOxc" in vite &&
+      typeof vite.transformWithOxc === "function"
+      ? await vite.transformWithOxc(code, filename, {
+          lang,
+          jsx: {
+            runtime: "automatic",
+            development: viteCommand !== "build",
             target: "esnext",
-            format: "esm",
-            jsx: "automatic",
-            jsxDev: viteCommand !== "build",
-          })
-    ).code;
+          },
+        })
+      : await vite.transformWithEsbuild(code, filename, {
+          loader: lang,
+          target: "esnext",
+          format: "esm",
+          jsx: "automatic",
+          jsxDev: viteCommand !== "build",
+        });
   }
 
   async function getClientVersion(source: string) {
@@ -917,7 +913,10 @@ function createRSCOptimizeDepsRouteModulesPlugin({
   transformToJs,
 }: {
   routeFiles: Set<string>;
-  transformToJs: (code: string, filename: string) => Promise<string>;
+  transformToJs: (
+    code: string,
+    filename: string,
+  ) => Promise<{ code: string; map: object | string | null }>;
 }): RSCOptimizeDepsRouteModulesPlugin {
   return {
     name: "react-router:rsc-optimize-deps-route-modules",
@@ -931,8 +930,10 @@ function createRSCOptimizeDepsRouteModulesPlugin({
           return;
         }
 
-        let js = await transformToJs(code, filename);
-        let generated = createClientRouteModuleForOptimizeDepsScan(js);
+        let transformed = await transformToJs(code, filename);
+        let generated = createClientRouteModuleForOptimizeDepsScan(
+          transformed.code,
+        );
 
         return {
           code: generated.code,

--- a/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
+++ b/packages/react-router-dev/vite/rsc/virtual-route-modules.ts
@@ -18,6 +18,71 @@ import * as ___EnsureClientRouteModuleForHMR_REACT___ from "react";
 export function EnsureClientRouteModuleForHMR___() { return ___EnsureClientRouteModuleForHMR_REACT___.createElement(___EnsureClientRouteModuleForHMR_REACT___.Fragment, null) }
 `;
 
+type TransformToJsResult = {
+  code: string;
+  map: object | string | null;
+};
+
+function createEmptySourceMap() {
+  // Route entries are generated, so there's no original code behind them to
+  // map back to. An empty mappings string says so explicitly, rather than
+  // leaving the bundler to assume the output still lines up with the route
+  // module it replaced.
+  return { version: 3, names: [], sources: [], mappings: "" };
+}
+
+function generateRouteModule(
+  code: string,
+  map: object | string | null,
+  filename: string,
+) {
+  const ast = babel.parse(code, {
+    sourceType: "module",
+  });
+  const generatorOptions: Parameters<typeof babel.generate>[1] & {
+    inputSourceMap: object | string | null;
+  } = {
+    sourceMaps: true,
+    sourceFileName: filename,
+    inputSourceMap: map,
+  };
+
+  return {
+    ast,
+    generate: () => babel.generate(ast, generatorOptions),
+  };
+}
+
+function prependUnmappedCode(
+  prefix: string,
+  generated: ReturnType<typeof babel.generate>,
+) {
+  if (generated.map) {
+    generated.map.mappings =
+      ";".repeat(prefix.match(/\n/g)?.length ?? 0) + generated.map.mappings;
+  }
+
+  return {
+    code: prefix + generated.code,
+    map: generated.map,
+  };
+}
+
+function appendUnmappedCode(
+  generated: ReturnType<typeof prependUnmappedCode>,
+  code: string,
+) {
+  if (!generated.code.endsWith("\n") && !code.startsWith("\n")) {
+    code = "\n" + code;
+  }
+
+  if (generated.map) {
+    generated.map.mappings += ";A".repeat(code.match(/\n/g)?.length ?? 0);
+  }
+
+  generated.code += code;
+}
+
 export function virtualRouteModulesPlugin({
   enforceSplitRouteModules,
   environments: { client = ["client", "ssr"], server = ["rsc"] } = {},
@@ -35,7 +100,10 @@ export function virtualRouteModulesPlugin({
   isRootRouteModule(filename: string): boolean;
   order?: "pre" | "post";
   shouldTransform?(filename: string): boolean;
-  transformToJs: (code: string, filename: string) => Promise<string>;
+  transformToJs: (
+    code: string,
+    filename: string,
+  ) => Promise<TransformToJsResult>;
 }) {
   let clientEnvironments = new Set(client);
   let serverEnvironments = new Set(server);
@@ -119,6 +187,7 @@ export function virtualRouteModulesPlugin({
 
     return {
       code: '"use client";\n' + result,
+      map: createEmptySourceMap(),
     };
   }
 
@@ -201,15 +270,18 @@ ${result}`;
 
     return {
       code: result,
+      map: createEmptySourceMap(),
     };
   }
 
-  function createServerRouteModule(code: string) {
-    const ast = babel.parse(code, {
-      sourceType: "module",
-    });
+  function createServerRouteModule(
+    code: string,
+    map: object | string | null,
+    filename: string,
+  ) {
+    const { ast, generate } = generateRouteModule(code, map, filename);
     removeExports(ast, CLIENT_ROUTE_EXPORTS);
-    return babel.generate(ast);
+    return generate();
   }
 
   async function createClientRouteModuleChunk(
@@ -219,12 +291,12 @@ ${result}`;
     routeId: string,
     isRootRouteModule: boolean,
     isDevMode: boolean,
+    map: object | string | null,
+    filename: string,
   ) {
     let routeChunks = detectRouteChunks(cache, id, code, isRootRouteModule);
 
-    const ast = babel.parse(code, {
-      sourceType: "module",
-    });
+    const { ast, generate } = generateRouteModule(code, map, filename);
     const { staticExports } = await parseRouteExports(code);
 
     if (chunk === "shared") {
@@ -238,9 +310,8 @@ ${result}`;
       removeExports(ast, Array.from(toRemove));
     }
 
-    const generated = babel.generate(ast);
-
-    let result = '"use client";\n' + generated.code;
+    const generated = generate();
+    let result = prependUnmappedCode('"use client";\n', generated);
 
     if (chunk === "shared") {
       if (
@@ -251,14 +322,17 @@ ${result}`;
         const hasRootLayout =
           staticExports.includes("Layout") ||
           staticExports.includes("ServerLayout");
-        result += `\nimport { createElement as __rr_createElement } from "react";\n`;
-        result += `import { UNSAFE_RSCDefaultRootErrorBoundary } from "react-router";\n`;
-        result += `export function ErrorBoundary() {\n`;
-        result += `  return __rr_createElement(UNSAFE_RSCDefaultRootErrorBoundary, { hasRootLayout: ${hasRootLayout} });\n`;
-        result += `}\n`;
+        appendUnmappedCode(
+          result,
+          `\nimport { createElement as __rr_createElement } from "react";\n` +
+            `import { UNSAFE_RSCDefaultRootErrorBoundary } from "react-router";\n` +
+            `export function ErrorBoundary() {\n` +
+            `  return __rr_createElement(UNSAFE_RSCDefaultRootErrorBoundary, { hasRootLayout: ${hasRootLayout} });\n` +
+            `}\n`,
+        );
       }
 
-      result += ENSURE_CLIENT_ROUTE_MODULE_CHUNK_FOR_HMR;
+      appendUnmappedCode(result, ENSURE_CLIENT_ROUTE_MODULE_CHUNK_FOR_HMR);
     }
 
     let hasAction = staticExports.includes("action");
@@ -271,16 +345,18 @@ ${result}`;
       staticExports.includes("ServerErrorBoundary");
 
     if (isDevMode) {
-      result += `export function ReactRouterHMRMeta___() {return null;};\n`;
-      result += `Object.assign(ReactRouterHMRMeta___, {
+      appendUnmappedCode(
+        result,
+        `export function ReactRouterHMRMeta___() {return null;};\n` +
+          `Object.assign(ReactRouterHMRMeta___, {
         hasAction: ${JSON.stringify(hasAction)},
         hasComponent: ${JSON.stringify(hasComponent)},
         hasErrorBoundary: ${JSON.stringify(hasErrorBoundary)},
         hasLoader: ${JSON.stringify(hasLoader)},
         hasClientLoader: ${JSON.stringify(staticExports.includes("clientLoader"))},
-      });\n`;
-      result += `\nif (import.meta.hot) {\n`;
-      result += `  import.meta.hot.accept((mod) => {
+      });\n` +
+          `\nif (import.meta.hot) {\n` +
+          `  import.meta.hot.accept((mod) => {
           if (typeof __reactRouterDataRouter === "object") {
             __reactRouterDataRouter._updateRoutesForHMR(new Map([[${JSON.stringify(routeId)}, {
               routeModule: mod,
@@ -294,13 +370,12 @@ ${result}`;
             }
           }
         });
-      `;
-      result += `}\n`;
+      ` +
+          `}\n`,
+      );
     }
 
-    return {
-      code: result,
-    };
+    return result;
   }
 
   return {
@@ -323,7 +398,8 @@ ${result}`;
       }
 
       // this.
-      let code = await transformToJs(_code, filename);
+      let transformed = await transformToJs(_code, filename);
+      let code = transformed.code;
 
       let searchParams =
         rest.length > 0 ? new URLSearchParams(rest.join("?")) : null;
@@ -339,11 +415,13 @@ ${result}`;
           routeId,
           isRootRouteModule(filename),
           this.environment.mode === "dev",
+          transformed.map,
+          filename,
         );
       }
 
       if (isServerRouteModule) {
-        return createServerRouteModule(code);
+        return createServerRouteModule(code, transformed.map, filename);
       }
 
       if (isClientEnvironment) {


### PR DESCRIPTION
This is a follow-up to #15440, which fixes route source maps in standard Framework Mode. RSC Framework uses a separate virtual route-module pipeline and remained affected, but I decided to treat it as a separate fix rather than adding it on to another PR.

This preserves source maps through the TSX and Babel transforms while leaving generated wrapper and HMR code explicitly unmapped.