### PR TITLE
Run prerendering in post buildApp hooks

### DIFF
--- a/integration/vite-plugin-cloudflare-test.ts
+++ b/integration/vite-plugin-cloudflare-test.ts
@@ -14,8 +14,12 @@ const tsx = dedent;
 const css = dedent;
 
 function defineFiles({
+  auxiliaryWorker = false,
   reversePlugins = false,
-}: { reversePlugins?: boolean } = {}): Files {
+}: {
+  auxiliaryWorker?: boolean;
+  reversePlugins?: boolean;
+} = {}): Files {
   const files: Files = async ({ port }) => {
     const inspectorPort = await getPort();
 
@@ -29,7 +33,13 @@ function defineFiles({
       ${await viteConfig.server({ port })}
       plugins: [
         cloudflare({
+          ${
+            auxiliaryWorker
+              ? 'auxiliaryWorkers: [{ configPath: "./wrangler.auxiliary.toml" }],'
+              : ""
+          }
           inspectorPort: ${inspectorPort},
+          ${auxiliaryWorker ? "persistState: false," : ""}
           viteEnvironment: { name: "ssr" },
         }),
         reactRouter(),
@@ -58,6 +68,29 @@ function defineFiles({
           padding: 20px;
         }
       `,
+      ...(auxiliaryWorker
+        ? {
+            "react-router.config.ts": tsx`
+              import type { Config } from "@react-router/dev/config";
+
+              export default {
+                prerender: ["/"],
+              } satisfies Config;
+            `,
+            "workers/auxiliary.ts": tsx`
+              export default {
+                fetch() {
+                  return new Response("Hello from auxiliary Worker");
+                },
+              } satisfies ExportedHandler;
+            `,
+            "wrangler.auxiliary.toml": `
+              name = "auxiliary-worker"
+              compatibility_date = "2025-03-17"
+              main = "./workers/auxiliary.ts"
+            `,
+          }
+        : {}),
     };
   };
   return files;
@@ -184,8 +217,8 @@ test.describe("vite-plugin-cloudflare", () => {
     );
   });
 
-  test("builds project with default server entry", async () => {
-    const files = defineFiles();
+  test("prerenders with an auxiliary Worker", async () => {
+    const files = defineFiles({ auxiliaryWorker: true, reversePlugins: true });
     const cwd = await createProject(
       await files({ port: 0 }),
       "vite-plugin-cloudflare-template",

--- a/packages/react-router-dev/.changes/patch.run-prerender-post-build.md
+++ b/packages/react-router-dev/.changes/patch.run-prerender-post-build.md
@@ -1,0 +1,1 @@
+Run prerendering after other Vite plugins finish their application build hooks

--- a/packages/react-router-dev/vite/plugin.ts
+++ b/packages/react-router-dev/vite/plugin.ts
@@ -2725,31 +2725,24 @@ export const reactRouterVitePlugin: ReactRouterVitePlugin = () => {
     }),
     {
       name: "react-router-build-end",
+      enforce: "post",
       sharedDuringBuild: true,
-      config: {
+      buildApp: {
         order: "post",
-        handler({ builder: { buildApp } = {} }) {
-          return {
-            builder: {
-              async buildApp(builder) {
-                try {
-                  await buildApp?.(builder);
+        async handler() {
+          try {
+            invariant(viteConfig);
+            let { buildManifest, reactRouterConfig } = ctx;
+            invariant(buildManifest, "Expected build manifest");
 
-                  invariant(viteConfig);
-                  let { buildManifest, reactRouterConfig } = ctx;
-                  invariant(buildManifest, "Expected build manifest");
-
-                  await reactRouterConfig.buildEnd?.({
-                    buildManifest,
-                    reactRouterConfig,
-                    viteConfig,
-                  });
-                } finally {
-                  await closePluginResources();
-                }
-              },
-            },
-          };
+            await reactRouterConfig.buildEnd?.({
+              buildManifest,
+              reactRouterConfig,
+              viteConfig,
+            });
+          } finally {
+            await closePluginResources();
+          }
         },
       },
     },

--- a/packages/react-router-dev/vite/plugins/prerender.ts
+++ b/packages/react-router-dev/vite/plugins/prerender.ts
@@ -215,197 +215,177 @@ export function prerender<Metadata extends Record<string, unknown>>(
 
   return {
     name: "prerender",
+    enforce: "post",
     sharedDuringBuild: true,
-    config: {
+    buildApp: {
       order: "post",
-      handler({ builder: { buildApp } = {} }) {
-        return {
-          builder: {
-            async buildApp(builder) {
-              await buildApp?.(builder);
+      async handler() {
+        const rawRequests =
+          typeof requests === "function" ? await requests() : requests;
 
-              const rawRequests =
-                typeof requests === "function" ? await requests() : requests;
+        const prerenderRequests = rawRequests.map(normalizePrerenderRequest);
 
-              const prerenderRequests = rawRequests.map(
-                normalizePrerenderRequest,
-              );
+        if (prerenderRequests.length === 0) {
+          return;
+        }
 
-              if (prerenderRequests.length === 0) {
-                return;
+        const prerenderConfig =
+          typeof config === "function" ? await config() : config;
+        const {
+          buildDirectory = viteConfig.environments.client.build.outDir,
+          concurrency = 1,
+          retryCount = 0,
+          retryDelay = 500,
+          maxRedirects = 0,
+          timeout = 10000,
+        } = prerenderConfig ?? {};
+
+        let ogIsBuildRequest = process.env.IS_RR_BUILD_REQUEST;
+        process.env.IS_RR_BUILD_REQUEST = "yes";
+        try {
+          const previewServer = await startPreviewServer(viteConfig);
+
+          try {
+            const baseUrl = getResolvedUrl(previewServer);
+
+            async function prerenderRequest(
+              input: string | Request,
+              metadata: Metadata | undefined,
+            ): Promise<PostProcessResult<Metadata>> {
+              let attemptCount = 0;
+              let redirectCount = 0;
+
+              const request = new Request(input);
+              const url = new URL(request.url);
+
+              if (url.origin !== baseUrl.origin) {
+                url.hostname = baseUrl.hostname;
+                url.protocol = baseUrl.protocol;
+                url.port = baseUrl.port;
               }
 
-              const prerenderConfig =
-                typeof config === "function" ? await config() : config;
-              const {
-                buildDirectory = viteConfig.environments.client.build.outDir,
-                concurrency = 1,
-                retryCount = 0,
-                retryDelay = 500,
-                maxRedirects = 0,
-                timeout = 10000,
-              } = prerenderConfig ?? {};
-
-              let ogIsBuildRequest = process.env.IS_RR_BUILD_REQUEST;
-              process.env.IS_RR_BUILD_REQUEST = "yes";
-              try {
-                const previewServer = await startPreviewServer(viteConfig);
-
+              async function attempt(
+                url: URL,
+              ): Promise<PostProcessResult<Metadata>> {
                 try {
-                  const baseUrl = getResolvedUrl(previewServer);
+                  const signal = AbortSignal.timeout(timeout);
+                  const prerenderReq = new Request(url, request);
+                  const response = await nodeHttpFetch(prerenderReq, {
+                    signal,
+                  });
 
-                  async function prerenderRequest(
-                    input: string | Request,
-                    metadata: Metadata | undefined,
-                  ): Promise<PostProcessResult<Metadata>> {
-                    let attemptCount = 0;
-                    let redirectCount = 0;
+                  if (
+                    response.status >= 300 &&
+                    response.status < 400 &&
+                    response.headers.has("location") &&
+                    ++redirectCount <= maxRedirects
+                  ) {
+                    const location = response.headers.get("location")!;
+                    const responseURL = new URL(response.url);
+                    const locationUrl = new URL(location, response.url);
 
-                    const request = new Request(input);
-                    const url = new URL(request.url);
-
-                    if (url.origin !== baseUrl.origin) {
-                      url.hostname = baseUrl.hostname;
-                      url.protocol = baseUrl.protocol;
-                      url.port = baseUrl.port;
+                    // External redirect: pass to postProcess
+                    if (responseURL.origin !== locationUrl.origin) {
+                      return await postProcess(request, response, metadata);
                     }
 
-                    async function attempt(
-                      url: URL,
-                    ): Promise<PostProcessResult<Metadata>> {
-                      try {
-                        const signal = AbortSignal.timeout(timeout);
-                        const prerenderReq = new Request(url, request);
-                        const response = await nodeHttpFetch(prerenderReq, {
-                          signal,
-                        });
+                    // Internal redirect within limit: follow it
+                    const redirectUrl = new URL(location, url);
+                    return await attempt(redirectUrl);
+                  }
 
-                        if (
-                          response.status >= 300 &&
-                          response.status < 400 &&
-                          response.headers.has("location") &&
-                          ++redirectCount <= maxRedirects
-                        ) {
-                          const location = response.headers.get("location")!;
-                          const responseURL = new URL(response.url);
-                          const locationUrl = new URL(location, response.url);
-
-                          // External redirect: pass to postProcess
-                          if (responseURL.origin !== locationUrl.origin) {
-                            return await postProcess(
-                              request,
-                              response,
-                              metadata,
-                            );
-                          }
-
-                          // Internal redirect within limit: follow it
-                          const redirectUrl = new URL(location, url);
-                          return await attempt(redirectUrl);
-                        }
-
-                        if (
-                          response.status >= 500 &&
-                          ++attemptCount <= retryCount
-                        ) {
-                          await new Promise((resolve) =>
-                            setTimeout(resolve, retryDelay),
-                          );
-                          return attempt(url);
-                        }
-
-                        return await postProcess(request, response, metadata);
-                      } catch (error) {
-                        if (++attemptCount <= retryCount) {
-                          await new Promise((resolve) =>
-                            setTimeout(resolve, retryDelay),
-                          );
-                          return attempt(url);
-                        }
-
-                        // If handleError does not throw, return empty array and continue
-                        handleError(
-                          request,
-                          error instanceof Error
-                            ? error
-                            : new Error(error?.toString() ?? "Unknown error"),
-                          metadata,
-                        );
-
-                        return [];
-                      }
-                    }
-
+                  if (response.status >= 500 && ++attemptCount <= retryCount) {
+                    await new Promise((resolve) =>
+                      setTimeout(resolve, retryDelay),
+                    );
                     return attempt(url);
                   }
 
-                  async function prerender(
-                    input: string | Request,
-                    metadata: Metadata | undefined,
-                  ): Promise<void> {
-                    const result = await prerenderRequest(input, metadata);
-                    const { files, requests } =
-                      normalizePostProcessResult(result);
-
-                    for (const file of files) {
-                      await writePrerenderFile(file, metadata);
-                    }
-
-                    for (const followUp of requests) {
-                      const normalized = normalizePrerenderRequest(followUp);
-                      await prerender(normalized.request, normalized.metadata);
-                    }
+                  return await postProcess(request, response, metadata);
+                } catch (error) {
+                  if (++attemptCount <= retryCount) {
+                    await new Promise((resolve) =>
+                      setTimeout(resolve, retryDelay),
+                    );
+                    return attempt(url);
                   }
 
-                  async function writePrerenderFile(
-                    file: PrerenderFile,
-                    metadata: Metadata | undefined,
-                  ) {
-                    // Removes leading slash if present (e.g. pathname "/about" -> "about")
-                    const normalizedPath = file.path.startsWith("/")
-                      ? file.path.slice(1)
-                      : file.path;
-                    const outputPath = path.join(
-                      buildDirectory,
-                      ...normalizedPath.split("/"),
-                    );
-
-                    await mkdir(path.dirname(outputPath), { recursive: true });
-                    await writeFile(outputPath, file.contents);
-
-                    const relativePath = path.relative(
-                      viteConfig.root,
-                      outputPath,
-                    );
-
-                    if (logFile) {
-                      logFile(relativePath, metadata);
-                    }
-
-                    return relativePath;
-                  }
-
-                  const pMap = await import("p-map");
-                  await pMap.default(
-                    prerenderRequests,
-                    async ({ request, metadata }) => {
-                      await prerender(request, metadata);
-                    },
-                    { concurrency },
+                  // If handleError does not throw, return empty array and continue
+                  handleError(
+                    request,
+                    error instanceof Error
+                      ? error
+                      : new Error(error?.toString() ?? "Unknown error"),
+                    metadata,
                   );
 
-                  if (finalize) {
-                    await finalize(buildDirectory);
-                  }
-                } finally {
-                  await previewServer.close();
+                  return [];
                 }
-              } finally {
-                process.env.IS_RR_BUILD_REQUEST = ogIsBuildRequest;
               }
-            },
-          },
-        };
+
+              return attempt(url);
+            }
+
+            async function prerender(
+              input: string | Request,
+              metadata: Metadata | undefined,
+            ): Promise<void> {
+              const result = await prerenderRequest(input, metadata);
+              const { files, requests } = normalizePostProcessResult(result);
+
+              for (const file of files) {
+                await writePrerenderFile(file, metadata);
+              }
+
+              for (const followUp of requests) {
+                const normalized = normalizePrerenderRequest(followUp);
+                await prerender(normalized.request, normalized.metadata);
+              }
+            }
+
+            async function writePrerenderFile(
+              file: PrerenderFile,
+              metadata: Metadata | undefined,
+            ) {
+              // Removes leading slash if present (e.g. pathname "/about" -> "about")
+              const normalizedPath = file.path.startsWith("/")
+                ? file.path.slice(1)
+                : file.path;
+              const outputPath = path.join(
+                buildDirectory,
+                ...normalizedPath.split("/"),
+              );
+
+              await mkdir(path.dirname(outputPath), { recursive: true });
+              await writeFile(outputPath, file.contents);
+
+              const relativePath = path.relative(viteConfig.root, outputPath);
+
+              if (logFile) {
+                logFile(relativePath, metadata);
+              }
+
+              return relativePath;
+            }
+
+            const pMap = await import("p-map");
+            await pMap.default(
+              prerenderRequests,
+              async ({ request, metadata }) => {
+                await prerender(request, metadata);
+              },
+              { concurrency },
+            );
+
+            if (finalize) {
+              await finalize(buildDirectory);
+            }
+          } finally {
+            await previewServer.close();
+          }
+        } finally {
+          process.env.IS_RR_BUILD_REQUEST = ogIsBuildRequest;
+        }
       },
     },
     configResolved(resolvedConfig) {

--- a/packages/react-router-dev/vite/rsc/plugin.ts
+++ b/packages/react-router-dev/vite/rsc/plugin.ts
@@ -471,12 +471,6 @@ export function reactRouterRSCVitePlugin(): Vite.PluginOption[] {
           };
         }
       },
-      buildApp: {
-        order: "post",
-        async handler() {
-          await configLoader.close();
-        },
-      },
     },
     (() => {
       let logged = false;
@@ -871,6 +865,17 @@ export default assetsManifest.clientVersion;
         return files;
       },
     }),
+    {
+      name: "react-router/rsc/build-end",
+      enforce: "post",
+      sharedDuringBuild: true,
+      buildApp: {
+        order: "post",
+        async handler() {
+          await configLoader.close();
+        },
+      },
+    },
   ];
 }
 


### PR DESCRIPTION
> The diff is much smaller if you enable "Hide Whitespace" on the diff view

React Router currently prerenders by wrapping the `buildApp` config. Once the delegated build completes, it starts prerendering immediately, which could fail if not every Vite environment has been built yet.

For example, Cloudflare Vite plugin uses a post `buildApp` hook to build auxiliary Workers, so React Router may start its preview server before their output exists.

Ideally, we want:

1. React Router builds the configured environments.
2. Cloudflare or other plugins build the remaining environments in their post `buildApp` hooks.
3. React Router starts the preview server and prerenders routes in a post `buildApp` hook with `enforce: "post"`, similar to [TanStack Start](https://github.com/TanStack/router/blob/539e5985cf2889e5238b854b88ff0c2917bbd3d0/packages/start-plugin-core/src/vite/plugins.ts#L76-L94).

I have updated the Cloudflare fixture to add an auxiliary Worker covering this flow. This will also prepare React Router for the upcoming Cloudflare Vite plugin v2 and its new Build Output design.