### PR TITLE
Skip view transitions on revalidation and initial hydration

### DIFF
--- a/packages/react-router/.changes/patch.skip-view-transitions-on-revalidation-and-hydration.md
+++ b/packages/react-router/.changes/patch.skip-view-transitions-on-revalidation-and-hydration.md
@@ -1,0 +1,3 @@
+Do not run a view transition for `router.revalidate()` or for the initial hydration.
+
+Both complete with a `POP` history action, so when the current path had previously been the source of a view-transitioned navigation they replayed a transition even though the location did not change. In apps this showed up as a full-document cross-fade on every revalidation after a reload or back/forward navigation, during which open overlays rendered incorrectly.

--- a/packages/react-router/.changes/patch.skip-view-transitions-on-revalidation-and-hydration.md
+++ b/packages/react-router/.changes/patch.skip-view-transitions-on-revalidation-and-hydration.md
@@ -1,3 +1,5 @@
 Do not run a view transition for `router.revalidate()` or for the initial hydration.
 
 Both complete with a `POP` history action, so when the current path had previously been the source of a view-transitioned navigation they replayed a transition even though the location did not change. In apps this showed up as a full-document cross-fade on every revalidation after a reload or back/forward navigation, during which open overlays rendered incorrectly.
+
+Preserve view transitions for back/forward navigations that interrupt hydration, including navigations between history entries with the same URL.

--- a/packages/react-router/__tests__/router/view-transition-test.ts
+++ b/packages/react-router/__tests__/router/view-transition-test.ts
@@ -144,6 +144,75 @@ describe("view transitions", () => {
     t.router.dispose();
   });
 
+  it.each([
+    { name: "back", delta: -1, routeId: "root", pathname: "/" },
+    { name: "forward", delta: 1, routeId: "a", pathname: "/a" },
+  ])(
+    "preserves a pending $name view transition through router.revalidate()",
+    async ({ delta, routeId, pathname }) => {
+      let t = setup({
+        routes: [
+          { id: "root", path: "/", loader: true },
+          { id: "a", path: "/a", loader: true },
+        ],
+        hydrationData: { loaderData: { root: "ROOT" } },
+      });
+      let spy = jest.fn();
+      let unsubscribe = t.router.subscribe(spy);
+
+      // Record the transition to replay on the pending POP.
+      let A = await t.navigate("/a", { viewTransition: true });
+      await A.loaders.a.resolve("A");
+      if (delta > 0) {
+        let B = await t.navigate(-1);
+        await B.loaders.root.resolve("ROOT");
+      }
+      spy.mockClear();
+
+      let pop = await t.navigate(delta);
+      expect(pop.loaders[routeId].stub).toHaveBeenCalledTimes(1);
+      expect(t.router.state.navigation).toMatchObject({
+        state: "loading",
+        historyAction: "POP",
+        location: { pathname },
+      });
+
+      let revalidation = await t.revalidate();
+      expect(revalidation.loaders[routeId].stub).toHaveBeenCalledTimes(1);
+      await pop.loaders[routeId].resolve("STALE DATA");
+      expect(t.router.state).toMatchObject({
+        navigation: { state: "loading", location: { pathname } },
+        revalidation: "loading",
+      });
+      expect(spy.mock.calls.every(([, opts]) => !opts.viewTransitionOpts)).toBe(
+        true,
+      );
+
+      await revalidation.loaders[routeId].resolve("REVALIDATED DATA");
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          historyAction: "POP",
+          navigation: IDLE_NAVIGATION,
+          revalidation: "idle",
+          location: expect.objectContaining({ pathname }),
+          loaderData: { [routeId]: "REVALIDATED DATA" },
+        }),
+        expect.objectContaining({
+          viewTransitionOpts: {
+            currentLocation: expect.objectContaining({ pathname: "/" }),
+            nextLocation: expect.objectContaining({ pathname: "/a" }),
+          },
+        }),
+      );
+      expect(
+        spy.mock.calls.filter(([, opts]) => opts.viewTransitionOpts),
+      ).toHaveLength(1);
+
+      unsubscribe();
+      t.router.dispose();
+    },
+  );
+
   it("preserves pending view transitions through redirects", async () => {
     let t = setup({
       routes: [
@@ -278,13 +347,18 @@ describe("view transitions", () => {
     router.dispose();
   });
 
-  it.each([
-    { name: "back", from: "/b", to: "/a", delta: -1 },
-    { name: "forward", from: "/a", to: "/b", delta: 1 },
-    { name: "back to the same URL", from: "/b", to: "/b", delta: -1 },
-  ])(
-    "enables view transitions when $name interrupts hydration",
-    async ({ from, to, delta }) => {
+  it.each(
+    [
+      { name: "back", from: "/b", to: "/a", delta: -1 },
+      { name: "forward", from: "/a", to: "/b", delta: 1 },
+      { name: "back to the same URL", from: "/b", to: "/b", delta: -1 },
+    ].flatMap((scenario) => [
+      { ...scenario, hydration: "pending" },
+      { ...scenario, hydration: "complete" },
+    ]),
+  )(
+    "enables view transitions for $name with hydration $hydration",
+    async ({ from, to, delta, hydration }) => {
       let initialEntries = delta < 0 ? [to, from] : [from, to];
       let window = getWindow(from);
       window.sessionStorage.setItem(
@@ -318,6 +392,21 @@ describe("view transitions", () => {
         renderFallback: false,
         loaderData: { page: "SSR DATA" },
       });
+
+      if (hydration === "complete") {
+        await dfd.resolve("HYDRATED DATA");
+        await tick();
+      }
+      expect(router.state).toMatchObject({
+        initialized: hydration === "complete",
+        loaderData: {
+          page: hydration === "complete" ? "HYDRATED DATA" : "SSR DATA",
+        },
+      });
+      expect(spy.mock.calls.every(([, opts]) => !opts.viewTransitionOpts)).toBe(
+        true,
+      );
+      spy.mockClear();
       let initialLocation = router.state.location;
 
       await router.navigate(delta);
@@ -341,7 +430,7 @@ describe("view transitions", () => {
         }),
       );
 
-      // The interrupted hydration must not commit or animate when it settles.
+      // Settling hydration after the POP must not commit or animate again.
       let calls = spy.mock.calls.length;
       await dfd.resolve("HYDRATED DATA");
       await tick();

--- a/packages/react-router/__tests__/router/view-transition-test.ts
+++ b/packages/react-router/__tests__/router/view-transition-test.ts
@@ -1,6 +1,8 @@
-import { IDLE_NAVIGATION } from "../../lib/router/router";
+import { createBrowserHistory } from "../../lib/router/history";
+import { IDLE_NAVIGATION, createRouter } from "../../lib/router/router";
+import getWindow from "../utils/getWindow";
 import { cleanup, setup } from "./utils/data-router-setup";
-import { createFormData } from "./utils/utils";
+import { createDeferred, createFormData, tick } from "./utils/utils";
 
 describe("view transitions", () => {
   // Detect any failures inside the router navigate code
@@ -171,5 +173,104 @@ describe("view transitions", () => {
 
     unsubscribe();
     t.router.dispose();
+  });
+
+  it("does not enable view transitions for a revalidation after a POP navigation", async () => {
+    let t = setup({
+      routes: [
+        { id: "root", path: "/", loader: true },
+        { id: "a", path: "/a", loader: true },
+      ],
+      hydrationData: { loaderData: { root: "ROOT" } },
+    });
+    let spy = jest.fn();
+    let unsubscribe = t.router.subscribe(spy);
+
+    // PUSH / -> /a - w/ transition
+    let A = await t.navigate("/a", { viewTransition: true });
+    await A.loaders.a.resolve("A");
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        navigation: IDLE_NAVIGATION,
+        location: expect.objectContaining({ pathname: "/a" }),
+      }),
+      expect.objectContaining({
+        viewTransitionOpts: {
+          currentLocation: expect.objectContaining({ pathname: "/" }),
+          nextLocation: expect.objectContaining({ pathname: "/a" }),
+        },
+      }),
+    );
+
+    // POP /a -> / - w/ transition (cached from above)
+    let B = await t.navigate(-1);
+    await B.loaders.root.resolve("ROOT*");
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        navigation: IDLE_NAVIGATION,
+        location: expect.objectContaining({ pathname: "/" }),
+      }),
+      expect.objectContaining({
+        viewTransitionOpts: {
+          currentLocation: expect.objectContaining({ pathname: "/" }),
+          nextLocation: expect.objectContaining({ pathname: "/a" }),
+        },
+      }),
+    );
+
+    // Revalidate at / - the router is still in a POP historyAction but a
+    // revalidation does not change location, so no transition
+    let R = await t.revalidate();
+    await R.loaders.root.resolve("ROOT**");
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        navigation: IDLE_NAVIGATION,
+        revalidation: "idle",
+        location: expect.objectContaining({ pathname: "/" }),
+        loaderData: { root: "ROOT**" },
+      }),
+      expect.objectContaining({ viewTransitionOpts: undefined }),
+    );
+
+    unsubscribe();
+    t.router.dispose();
+  });
+
+  it("does not enable view transitions for the initial hydration", async () => {
+    // A prior session recorded a transition away from /a, so /a is a known
+    // transition source when the page is reloaded
+    let window = getWindow("/a");
+    window.sessionStorage.setItem(
+      "remix-router-transitions",
+      JSON.stringify({ "/a": ["/b"] }),
+    );
+    let dfd = createDeferred();
+    let router = createRouter({
+      history: createBrowserHistory({ window }),
+      routes: [
+        { id: "a", path: "/a", loader: () => dfd.promise },
+        { path: "/b" },
+      ],
+      window,
+    });
+    let spy = jest.fn();
+    let unsubscribe = router.subscribe(spy);
+    router.initialize();
+    expect(router.state.initialized).toBe(false);
+
+    await dfd.resolve("A");
+    await tick();
+    expect(router.state.initialized).toBe(true);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialized: true,
+        navigation: IDLE_NAVIGATION,
+        location: expect.objectContaining({ pathname: "/a" }),
+      }),
+      expect.objectContaining({ viewTransitionOpts: undefined }),
+    );
+
+    unsubscribe();
+    router.dispose();
   });
 });

--- a/packages/react-router/__tests__/router/view-transition-test.ts
+++ b/packages/react-router/__tests__/router/view-transition-test.ts
@@ -1,5 +1,9 @@
-import { createBrowserHistory } from "../../lib/router/history";
+import {
+  createBrowserHistory,
+  createMemoryHistory,
+} from "../../lib/router/history";
 import { IDLE_NAVIGATION, createRouter } from "../../lib/router/router";
+import type { LoaderFunction } from "../../lib/router/utils";
 import getWindow from "../utils/getWindow";
 import { cleanup, setup } from "./utils/data-router-setup";
 import { createDeferred, createFormData, tick } from "./utils/utils";
@@ -273,4 +277,78 @@ describe("view transitions", () => {
     unsubscribe();
     router.dispose();
   });
+
+  it.each([
+    { name: "back", from: "/b", to: "/a", delta: -1 },
+    { name: "forward", from: "/a", to: "/b", delta: 1 },
+    { name: "back to the same URL", from: "/b", to: "/b", delta: -1 },
+  ])(
+    "enables view transitions when $name interrupts hydration",
+    async ({ from, to, delta }) => {
+      let initialEntries = delta < 0 ? [to, from] : [from, to];
+      let window = getWindow(from);
+      window.sessionStorage.setItem(
+        "remix-router-transitions",
+        JSON.stringify({ [initialEntries[0]]: [initialEntries[1]] }),
+      );
+      let dfd = createDeferred();
+      let loader: LoaderFunction = jest
+        .fn()
+        .mockReturnValueOnce(dfd.promise)
+        .mockReturnValue("POP DATA");
+      loader.hydrate = true;
+      let router = createRouter({
+        history: createMemoryHistory({
+          initialEntries,
+          initialIndex: delta < 0 ? 1 : 0,
+        }),
+        routes: [{ id: "page", path: "/:page", loader }],
+        hydrationData: { loaderData: { page: "SSR DATA" } },
+        window,
+      });
+      let spy = jest.fn();
+      let unsubscribe = router.subscribe(spy);
+      router.initialize();
+      await tick();
+
+      // SSR content is visible while the hydration loader is still pending.
+      expect(loader).toHaveBeenCalledTimes(1);
+      expect(router.state).toMatchObject({
+        initialized: false,
+        renderFallback: false,
+        loaderData: { page: "SSR DATA" },
+      });
+      let initialLocation = router.state.location;
+
+      await router.navigate(delta);
+      expect(router.state.location.key).not.toBe(initialLocation.key);
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          initialized: true,
+          navigation: IDLE_NAVIGATION,
+          location: expect.objectContaining({ pathname: to }),
+          loaderData: { page: "POP DATA" },
+        }),
+        expect.objectContaining({
+          viewTransitionOpts: {
+            currentLocation: expect.objectContaining({
+              pathname: initialEntries[0],
+            }),
+            nextLocation: expect.objectContaining({
+              pathname: initialEntries[1],
+            }),
+          },
+        }),
+      );
+
+      // The interrupted hydration must not commit or animate when it settles.
+      let calls = spy.mock.calls.length;
+      await dfd.resolve("HYDRATED DATA");
+      await tick();
+      expect(spy).toHaveBeenCalledTimes(calls);
+
+      unsubscribe();
+      router.dispose();
+    },
+  );
 });

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1593,8 +1593,14 @@ export function createRouter(init: RouterInit): Router {
 
     let viewTransitionOpts: ViewTransitionOpts | undefined;
 
-    // On POP, enable transitions if they were enabled on the original navigation
-    if (pendingAction === NavigationType.Pop) {
+    // On POP, enable transitions if they were enabled on the original navigation.
+    // Revalidations and the initial hydration also arrive here with a POP
+    // action, but they don't change location so there is nothing to animate.
+    if (
+      pendingAction === NavigationType.Pop &&
+      !isUninterruptedRevalidation &&
+      state.initialized
+    ) {
       // Forward takes precedence so they behave like the original navigation
       let priorPaths = appliedViewTransitions.get(state.location.pathname);
       if (priorPaths && priorPaths.has(location.pathname)) {

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -1594,12 +1594,12 @@ export function createRouter(init: RouterInit): Router {
     let viewTransitionOpts: ViewTransitionOpts | undefined;
 
     // On POP, enable transitions if they were enabled on the original navigation.
-    // Revalidations and the initial hydration also arrive here with a POP
-    // action, but they don't change location so there is nothing to animate.
+    // Initial hydration reuses the current location. Compare locations instead
+    // of state.initialized because a real POP can interrupt pending hydration.
     if (
       pendingAction === NavigationType.Pop &&
       !isUninterruptedRevalidation &&
-      state.initialized
+      location !== state.location
     ) {
       // Forward takes precedence so they behave like the original navigation
       let priorPaths = appliedViewTransitions.get(state.location.pathname);


### PR DESCRIPTION
Fixes #15483

`router.revalidate()` and the initial hydration both reach the `POP` view-transition replay in `completeNavigation`: `revalidate()` reuses `state.historyAction` (which is `POP` after back/forward or a reload) and `initialize()` runs the hydration as `startNavigation(NavigationType.Pop, …)`. Because `location === state.location` in both cases, the `appliedViewTransitions.has(location.pathname)` fallback matches whenever the current path was ever a transition source in the tab, and a full view transition runs for a data refresh or a first render.

The same function already excludes uninterrupted revalidations from history handling a few lines above; this applies the same exclusion to the view-transition branch, plus `state.initialized` for hydration. `PUSH`/`REPLACE` and real back/forward replays are unchanged.

```ts
if (
  pendingAction === NavigationType.Pop &&
  !isUninterruptedRevalidation &&
  state.initialized
) {
```

### Tests

Two cases added to `view-transition-test.ts`, both fail on `main` and pass with the change:

- `does not enable view transitions for a revalidation after a POP navigation` — PUSH `/ → /a` with transition, POP back (replays, as before), then `revalidate()` → `viewTransitionOpts: undefined`.
- `does not enable view transitions for the initial hydration` — `sessionStorage` seeded with `/a` as a transition source, router created at `/a` with a pending loader; hydration completes with `viewTransitionOpts: undefined`.

Runnable reproduction against `7.18.3`: https://github.com/jbalsas/react-router-pop-revalidation-view-transition (StackBlitz: https://stackblitz.com/github/jbalsas/react-router-pop-revalidation-view-transition).

A `v7` backport is in a separate PR.
