### PR TITLE
fix(react-router): avoid TextEncoderStream in SSR scripts

### DIFF
--- a/packages/react-router/.changes/patch.avoid-textencoderstream-in-scripts.md
+++ b/packages/react-router/.changes/patch.avoid-textencoderstream-in-scripts.md
@@ -1,0 +1,1 @@
+Avoid `TextEncoderStream` and `pipeThrough` in `<Scripts />` SSR inline script to prevent recursion crashes on iOS WKWebView hosts.

--- a/packages/react-router/__tests__/dom/ssr/scripts-stream-test.tsx
+++ b/packages/react-router/__tests__/dom/ssr/scripts-stream-test.tsx
@@ -1,0 +1,100 @@
+import assert from "node:assert";
+import * as React from "react";
+import { render } from "@testing-library/react";
+import { createStaticHandler } from "react-router";
+
+import { Scripts } from "../../../index";
+import { ServerRouter } from "../../../lib/dom/ssr/server";
+import invariant from "../../../lib/dom/ssr/invariant";
+import { mockEntryContext } from "../../utils/framework";
+
+describe("<Scripts /> streamScript", () => {
+  it("does not use pipeThrough or TextEncoderStream in streamScript to avoid WKWebView recursion crash", async () => {
+    let staticHandlerContext = await createStaticHandler([
+      { id: "root", path: "/" },
+    ]).query(new Request("http://localhost/"));
+
+    invariant(
+      !(staticHandlerContext instanceof Response),
+      "Expected a context",
+    );
+
+    let context = mockEntryContext({
+      staticHandlerContext,
+      serverHandoffString: "{}",
+      manifest: {
+        routes: {
+          root: {
+            hasLoader: true,
+            hasClientLoader: false,
+            hasAction: false,
+            hasErrorBoundary: false,
+            id: "root",
+            module: "root.js",
+            path: "/",
+          },
+        },
+        entry: {
+          imports: [],
+          module: "entry.js",
+        },
+        url: "manifest.js",
+        version: "",
+      },
+      routeModules: {
+        root: {
+          default: () => (
+            <div>
+              <h1>Root</h1>
+              <Scripts />
+            </div>
+          ),
+        },
+      },
+    });
+
+    let { container } = render(
+      <ServerRouter context={context} url="http://localhost/" />,
+    );
+
+    let inlineScripts = Array.from(
+      container.ownerDocument.querySelectorAll("script"),
+    ).map((s) => s.textContent || "");
+
+    let streamInlineScript = inlineScripts.find((s) =>
+      s.includes("__reactRouterContext.stream"),
+    );
+
+    expect(streamInlineScript).toBeDefined();
+    // Regression check for #15486: must not use pipeThrough or TextEncoderStream
+    assert(!streamInlineScript!.includes("pipeThrough"), "AssertionError: streamScript contains pipeThrough");
+    assert(!streamInlineScript!.includes("TextEncoderStream"), "AssertionError: streamScript contains TextEncoderStream");
+    expect(streamInlineScript).not.toContain("pipeThrough");
+    expect(streamInlineScript).not.toContain("TextEncoderStream");
+
+    delete (window as any).__reactRouterContext;
+    expect(() => {
+      // eslint-disable-next-line no-eval
+      eval(streamInlineScript!);
+    }).not.toThrow();
+
+    let stream = (window as any).__reactRouterContext?.stream;
+    let streamController = (window as any).__reactRouterContext?.streamController;
+
+    expect(stream).toBeDefined();
+    expect(streamController).toBeDefined();
+
+    let reader = stream.getReader();
+    streamController.enqueue("test chunk");
+    streamController.close();
+
+    let { value, done } = await reader.read();
+    expect(value.constructor.name).toBe("Uint8Array");
+    expect(new TextDecoder().decode(value)).toBe("test chunk");
+
+    let end = await reader.read();
+    expect(end.done).toBe(true);
+
+    delete (window as any).__reactRouterContext;
+  });
+});

--- a/packages/react-router/lib/dom/ssr/components.tsx
+++ b/packages/react-router/lib/dom/ssr/components.tsx
@@ -843,9 +843,14 @@ export function Scripts(scriptProps: ScriptsProps): React.JSX.Element | null {
     let streamScript =
       "window.__reactRouterContext.stream = new ReadableStream({" +
       "start(controller){" +
-      "window.__reactRouterContext.streamController = controller;" +
+      "var enc = new TextEncoder();" +
+      "window.__reactRouterContext.streamController = {" +
+      "enqueue: function(s){ controller.enqueue(enc.encode(s)); }," +
+      "close: function(){ controller.close(); }," +
+      "error: function(e){ controller.error(e); }" +
+      "};" +
       "}" +
-      "}).pipeThrough(new TextEncoderStream());";
+      "});";
 
     let contextScript = staticContext
       ? `window.__reactRouterContext = ${serverHandoffString};${streamScript}`


### PR DESCRIPTION
Closes #15486.

## Problem

In `packages/react-router/lib/dom/ssr/components.tsx`, the `<Scripts />` component unconditionally emits an inline script initializing `window.__reactRouterContext.stream`:

```js
window.__reactRouterContext.stream = new ReadableStream({
  start(controller) {
    window.__reactRouterContext.streamController = controller;
  }
}).pipeThrough(new TextEncoderStream());
```

On Chrome Mobile iOS, Google Search app, and other iOS WKWebView hosts, injected `WKUserScript` instances hook/wrap `pipeThrough` and/or `TextEncoderStream`, triggering mutual recursion that crashes with:
`RangeError: Maximum call stack size exceeded`.

Because this inline script runs first on SSR page load, the crash leaves `window.__reactRouterContext.streamController` undefined, causing subsequent stream transfer scripts to throw TypeErrors and completely breaking client hydration.

## Solution

Replace `pipeThrough(new TextEncoderStream())` with a manual `TextEncoder` wrapper inside the `ReadableStream` start handler:

```js
window.__reactRouterContext.stream = new ReadableStream({
  start(controller) {
    var enc = new TextEncoder();
    window.__reactRouterContext.streamController = {
      enqueue: function(s) { controller.enqueue(enc.encode(s)); },
      close:   function()  { controller.close(); },
      error:   function(e) { controller.error(e); }
    };
  }
});
```

- Completely removes `pipeThrough` and `TextEncoderStream` from the client inline script, avoiding the WKWebView recursion crash.
- Retains identical external contract (`ReadableStream<Uint8Array>` with `enqueue(string)`, `close()`, `error(e)`).
- Avoids extra transform stream allocation.
- Includes change file `patch.avoid-textencoderstream-in-scripts.md`.

*Note: AI-assisted implementation and automated review.*

## Testing

Added regression test `packages/react-router/__tests__/dom/ssr/scripts-stream-test.tsx`:
- Asserts emitted inline `<script>` does not contain `pipeThrough` or `TextEncoderStream`.
- Evals the emitted script, streams a test chunk through `streamController`, and verifies the reader receives decoded `Uint8Array` matching the input.
- Fails on unchanged source (`AssertionError: streamScript contains pipeThrough`), passes with the fix.

Verification:
- SSR component suite: 5 passed (44 tests, 10 snapshots)
- Package typecheck: `tsc -p packages/react-router/tsconfig.json --noEmit` passes clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
