### PR TITLE
fix: prevent stale discovery after manifest mismatch

### DIFF
--- a/integration/fog-of-war-test.ts
+++ b/integration/fog-of-war-test.ts
@@ -1461,6 +1461,105 @@ test.describe("Fog of War", () => {
     expect(wrongManifestRequests).toEqual([]);
   });
 
+  for (let operation of ["navigation", "fetcher"] as const) {
+    test(`manifest version mismatch fails ${operation} instead of loading a stale splat after a previous reload`, async ({
+      page,
+    }) => {
+      let fixture = await createFixture({
+        files: {
+          "app/root.tsx": js`
+            import { Link, Outlet, Scripts, useFetcher, useNavigation, useRouteError } from "react-router";
+
+            export function Layout({ children }) {
+              let navigation = useNavigation();
+              return (
+                <html lang="en">
+                  <body>
+                    <p data-navigation-state>{navigation.state}</p>
+                    {children}
+                    <Scripts />
+                  </body>
+                </html>
+              );
+            }
+
+            export default function Root() {
+              let fetcher = useFetcher();
+              return (
+                <>
+                  <Link to="/other" discover="none">Navigate</Link>
+                  <button onClick={() => fetcher.load("/other")}>Fetch</button>
+                  <Outlet />
+                </>
+              );
+            }
+
+            export function ErrorBoundary() {
+              let error = useRouteError();
+              return <p data-error>{error.message}</p>;
+            }
+          `,
+          "app/routes/$.tsx": js`
+            export function loader() { return "SPLAT"; }
+            export default function Splat() { return <h1>Splat</h1>; }
+          `,
+          "app/routes/other.tsx": js`
+            export function loader() { return "OTHER"; }
+            export default function Other() { return <h1>Other</h1>; }
+          `,
+        },
+      });
+      let appFixture = await createAppFixture(fixture);
+      let app = new PlaywrightFixture(appFixture, page);
+      try {
+        let documents: string[] = [];
+        let dataRequests: string[] = [];
+        page.on("request", (request) => {
+          if (request.resourceType() === "document") {
+            documents.push(request.url());
+          }
+          if (new URL(request.url()).pathname.endsWith(".data")) {
+            dataRequests.push(request.url());
+          }
+        });
+        await page.route(/\/__manifest\?/, (route) =>
+          route.fulfill({
+            status: 204,
+            headers: { "X-Remix-Reload-Document": "true" },
+          }),
+        );
+
+        // Start on the splat so it is present in the partial client manifest.
+        await app.goto("/unknown");
+        await expect(
+          page.getByRole("heading", { name: "Splat" }),
+        ).toBeVisible();
+        await page.evaluate(() => {
+          sessionStorage.setItem(
+            "react-router-manifest-version",
+            (window as any).__reactRouterManifest.version,
+          );
+        });
+        if (operation === "navigation") {
+          await page.getByRole("link", { name: "Navigate" }).click();
+        } else {
+          await page.getByRole("button", { name: "Fetch" }).click();
+        }
+
+        await expect(page.locator("[data-error]")).toHaveText(
+          "Unable to discover routes due to manifest version mismatch.",
+        );
+        await expect(page.locator("[data-navigation-state]")).toHaveText(
+          "idle",
+        );
+        expect(documents).toHaveLength(1);
+        expect(dataRequests).toEqual([]);
+      } finally {
+        await appFixture.close();
+      }
+    });
+  }
+
   test("manifest version mismatch reload should preserve query parameters and hash", async ({
     page,
   }) => {

--- a/integration/manifest-reload-recovery-test.ts
+++ b/integration/manifest-reload-recovery-test.ts
@@ -1,0 +1,221 @@
+import { chromium, expect, type Page, type Route } from "@playwright/test";
+
+import { test, type Files } from "./helpers/vite.js";
+
+const js = String.raw;
+const manifestRequest = /\/__manifest\?|\.manifest(?:\?|$)/;
+
+function getFiles(rsc: boolean) {
+  return {
+    "app/root.tsx": js`
+      import { useCallback } from "react";
+      import {
+        Link, Outlet, Scripts, useBeforeUnload, useFetcher,
+        useNavigation, useRouteError,
+      } from "react-router";
+
+      export function Layout({ children }) {
+        let navigation = useNavigation();
+        let fetcher = useFetcher();
+        useBeforeUnload(useCallback((event) => {
+          if (window.blockUnload) {
+            event.preventDefault();
+            event.returnValue = "Unsaved changes";
+          }
+        }, []));
+        return (
+          <html lang="en">
+            <body>
+              <p data-navigation-state>{navigation.state}</p>
+              <p data-fetcher-state>{fetcher.state}</p>
+              <button onClick={() => fetcher.load("/fetch")}>Fetch</button>
+              <Link to="/other" discover="none">Navigate</Link>
+              <Link to="/recovered" discover="none">Recover</Link>
+              {children}
+              ${rsc ? "" : "<Scripts />"}
+            </body>
+          </html>
+        );
+      }
+
+      export default function Root() {
+        return <Outlet />;
+      }
+
+      export function ErrorBoundary() {
+        let error = useRouteError();
+        return <p data-error>{error.message}</p>;
+      }
+    `,
+    "app/routes/$.tsx": js`
+      export function loader() { return "STALE SPLAT"; }
+      export default function Splat() { return <h1>Splat</h1>; }
+    `,
+    "app/routes/fetch.tsx": js`
+      export function loader() { return "FETCH"; }
+      export default function Fetch() { return <h1>Fetch</h1>; }
+    `,
+    "app/routes/other.tsx": js`
+      export function loader() { return "OTHER"; }
+      export default function Other() { return <h1>Other</h1>; }
+    `,
+    "app/routes/recovered.tsx": js`
+      import { useLoaderData } from "react-router";
+      export function loader() { return "Recovered"; }
+      export default function Recovered() {
+        return <h1>{useLoaderData()}</h1>;
+      }
+    `,
+    "app/routes/away.tsx": js`
+      export default function Away() { return <h1>Away</h1>; }
+    `,
+  };
+}
+
+async function cancelConcurrentReload(page: Page, baseUrl: string) {
+  let documents: string[] = [];
+  let dataRequests: string[] = [];
+  let manifestRoutes: Route[] = [];
+  let dialogs = 0;
+  page.on("request", (request) => {
+    if (request.resourceType() === "document") {
+      documents.push(request.url());
+    }
+    if (/\.(?:data|rsc)$/.test(new URL(request.url()).pathname)) {
+      dataRequests.push(request.url());
+    }
+  });
+  page.on("dialog", async (dialog) => {
+    expect(dialog.type()).toBe("beforeunload");
+    dialogs++;
+    await dialog.dismiss();
+  });
+  await page.route(manifestRequest, (route) => {
+    manifestRoutes.push(route);
+  });
+  await page.addInitScript(() => {
+    (window as any).blockUnload = true;
+    (window as any).restoredFromBFCache = false;
+    window.addEventListener("pageshow", (event) => {
+      (window as any).restoredFromBFCache = event.persisted;
+    });
+  });
+
+  // The splat is already in the stale client tree, but neither destination is.
+  await page.goto(`${baseUrl}/unknown`);
+  await expect(page.getByRole("heading", { name: "Splat" })).toBeVisible();
+  await page.getByRole("button", { name: "Fetch", exact: true }).click();
+  await page.getByRole("link", { name: "Navigate", exact: true }).click();
+  await expect.poll(() => manifestRoutes.length).toBe(2);
+  await expect(page.locator("[data-fetcher-state]")).toHaveText("loading");
+  await expect(page.locator("[data-navigation-state]")).toHaveText("loading");
+
+  await Promise.all(
+    manifestRoutes.map((route) =>
+      route.fulfill({
+        status: 204,
+        headers: { "X-Remix-Reload-Document": "true" },
+      }),
+    ),
+  );
+  await expect.poll(() => dialogs).toBe(1);
+  // Successful discovery must be available after the cancelled attempt settles.
+  await page.unroute(manifestRequest);
+  expect(dataRequests).toEqual([]);
+  expect(documents).toHaveLength(1);
+  return { documents, dataRequests, getDialogs: () => dialogs };
+}
+
+async function expectSettledAndRecover(page: Page, timeout = 10_000) {
+  await expect(page.locator("[data-error]")).toHaveText(
+    "Unable to discover routes due to manifest version mismatch.",
+    { timeout },
+  );
+  await expect(page.locator("[data-navigation-state]")).toHaveText("idle");
+  await expect(page.locator("[data-fetcher-state]")).toHaveText("idle");
+  await page.getByRole("link", { name: "Recover", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Recovered" })).toBeVisible();
+  await expect(page.locator("[data-error]")).toHaveCount(0);
+}
+
+for (let rsc of [false, true]) {
+  test.describe(rsc ? "RSC Framework" : "Framework", () => {
+    test("settles concurrent discovery when the user cancels the document reload", async ({
+      page,
+      reactRouterServe,
+      vitePreview,
+    }) => {
+      let files: Files = async () => getFiles(rsc);
+      let { port } = rsc
+        ? await vitePreview(files, "rsc-vite-framework")
+        : await reactRouterServe(files);
+      let { documents, dataRequests, getDialogs } =
+        await cancelConcurrentReload(page, `http://localhost:${port}`);
+
+      await expectSettledAndRecover(page);
+      expect(getDialogs()).toBe(1);
+      expect(documents).toHaveLength(1);
+      expect(dataRequests.every((url) => url.includes("/recovered."))).toBe(
+        true,
+      );
+    });
+
+    test.describe("BFCache", () => {
+      // Playwright disables BFCache by default. Use full Chromium with the cache
+      // enabled for a real history restoration, including its frozen JS state.
+      test("settles parked discovery after restoring the document", async ({
+        browserName,
+        reactRouterServe,
+        vitePreview,
+      }) => {
+        test.skip(browserName !== "chromium", "Requires Chromium BFCache");
+        let files: Files = async () => getFiles(rsc);
+        let { port } = rsc
+          ? await vitePreview(files, "rsc-vite-framework")
+          : await reactRouterServe(files);
+        let baseUrl = `http://localhost:${port}`;
+        let browser = await chromium.launch({
+          channel: "chromium",
+          ignoreDefaultArgs: ["--disable-back-forward-cache"],
+        });
+        let page = await browser.newPage();
+        try {
+          // Keep the grace-period timer frozen so only pageshow can settle the
+          // requests, even when the history traversal is slow on CI.
+          let time = new Date("2026-01-01T00:00:00Z");
+          await page.clock.install({ time });
+          await page.clock.pauseAt(time);
+          await cancelConcurrentReload(page, baseUrl);
+          await page.evaluate(() => {
+            (window as any).blockUnload = false;
+          });
+
+          await expect(page.locator("[data-navigation-state]")).toHaveText(
+            "loading",
+          );
+          await expect(page.locator("[data-fetcher-state]")).toHaveText(
+            "loading",
+          );
+          await page.goto(`${baseUrl}/away`, { timeout: 5_000 });
+          await expect(
+            page.getByRole("heading", { name: "Away" }),
+          ).toBeVisible();
+          await page.evaluate(() => {
+            (window as any).blockUnload = false;
+          });
+          // BFCache restoration does not emit a new load event.
+          await page.goBack({ waitUntil: "commit", timeout: 5_000 });
+          // A new document or a synthetic pageshow cannot satisfy this assertion.
+          await expect
+            .poll(() =>
+              page.evaluate(() => (window as any).restoredFromBFCache),
+            )
+            .toBe(true);
+          await expectSettledAndRecover(page, 1_000);
+        } finally {
+          await browser.close();
+        }
+      });
+    });
+  });
+}

--- a/integration/rsc-client-version-test.ts
+++ b/integration/rsc-client-version-test.ts
@@ -15,18 +15,38 @@ const templateName = "rsc-vite-framework" as const satisfies TemplateName;
 function getFiles() {
   return {
     "app/root.tsx": js`
-      import { Link, Outlet } from "react-router";
+      import { Link, Outlet, useNavigation, useRouteError } from "react-router";
 
-      export default function Root() {
+      export function Layout({ children }) {
+        let navigation = useNavigation();
         return (
           <html lang="en">
             <body>
-              <Link to="/other?token=abc123&ref=campaign#section1">
-                Go to Other
-              </Link>
-              <Outlet />
+              <p data-navigation-state>{navigation.state}</p>
+              {children}
             </body>
           </html>
+        );
+      }
+
+      export default function Root() {
+        return (
+          <>
+            <Link to="/other?token=abc123&ref=campaign#section1">
+              Go to Other
+            </Link>
+            <Outlet />
+          </>
+        );
+      }
+
+      export function ErrorBoundary() {
+        let error = useRouteError();
+        return (
+          <>
+            <p data-error>{error.message}</p>
+            <p data-error-cause>{error.cause?.message}</p>
+          </>
         );
       }
     `,
@@ -225,7 +245,7 @@ test.describe("RSC client versions", () => {
     expect(documentRequests[1]).toBe(`${baseUrl}/other`);
   });
 
-  test("does not reload repeatedly for the same stale client version", async ({
+  test("renders an error when manifest discovery already reloaded for the same client version", async ({
     page,
     vitePreview,
   }) => {
@@ -234,10 +254,6 @@ test.describe("RSC client versions", () => {
     let baseUrl = `http://localhost:${port}`;
     let documentRequests = trackDocumentRequests(page);
     let manifestRequests = await interceptWithStaleClientVersion(page);
-    let consoleErrors: string[] = [];
-    page.on("console", (message) => {
-      if (message.type() === "error") consoleErrors.push(message.text());
-    });
     let eagerMismatch = page.waitForResponse(
       (response) =>
         response.url().includes(".manifest") && response.status() === 204,
@@ -256,10 +272,61 @@ test.describe("RSC client versions", () => {
 
     await page.getByRole("link", { name: "Go to Other" }).click();
     await expect.poll(() => manifestRequests.length).toBeGreaterThan(1);
-    await expect
-      .poll(() => consoleErrors)
-      .toContain("Unable to discover routes due to manifest version mismatch.");
+    await expect(page.locator("[data-error]")).toHaveText(
+      "Unable to discover routes due to manifest version mismatch.",
+    );
+    await expect(page.locator("[data-navigation-state]")).toHaveText("idle");
+    await expect(page.locator("[data-location]")).toHaveCount(0);
+    expect(documentRequests).toHaveLength(1);
+  });
 
+  test("renders an error when an RSC payload mismatch already reloaded for the same client version", async ({
+    page,
+    vitePreview,
+  }) => {
+    let files: Files = async () => ({
+      ...getFiles(),
+      "react-router.config.ts": reactRouterConfig({
+        ssr: false,
+        prerender: ["/", "/other"],
+      }),
+    });
+    let { cwd, port } = await vitePreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+    let { default: assetsManifest } = await import(
+      pathToFileURL(
+        path.join(cwd, "build/server/__vite_rsc_assets_manifest.js"),
+      ).href
+    );
+    let clientVersion = assetsManifest.clientVersion as string;
+    let newVersion = clientVersion === "deadbeef" ? "feedface" : "deadbeef";
+
+    await page.route(/\/other\.rsc(?:\?|$)/, async (route) => {
+      let response = await route.fetch();
+      let source = await response.text();
+      expect(source).toContain(clientVersion);
+      await route.fulfill({
+        response,
+        body: source.replaceAll(clientVersion, newVersion),
+      });
+    });
+
+    await page.goto(`${baseUrl}/`);
+    await page.evaluate((version) => {
+      sessionStorage.setItem("react-router-manifest-version", version);
+    }, clientVersion);
+
+    await page.getByRole("link", { name: "Go to Other" }).click();
+
+    await expect(page.locator("[data-error]")).toHaveText(
+      "Unable to decode RSC response",
+    );
+    await expect(page.locator("[data-error-cause]")).toHaveText(
+      "Unable to discover routes due to manifest version mismatch.",
+    );
+    await expect(page.locator("[data-navigation-state]")).toHaveText("idle");
+    await expect(page.locator("[data-location]")).toHaveCount(0);
     expect(documentRequests).toHaveLength(1);
   });
 });

--- a/packages/react-router/.changes/patch.manifest-version-reload.md
+++ b/packages/react-router/.changes/patch.manifest-version-reload.md
@@ -2,4 +2,4 @@ Prevent stale route discovery during manifest version-mismatch recovery
 
 - Keep concurrent manifest responses pending while a document reload is in progress.
 - Report a discovery error when a previous reload failed to resolve a version mismatch instead of loading a stale route or reloading repeatedly.
-- Resume version checks when a document is restored from the back-forward cache.
+- Fail pending requests if a document reload does not complete within five seconds or the document is restored from the back-forward cache, allowing subsequent requests to recover.

--- a/packages/react-router/.changes/patch.manifest-version-reload.md
+++ b/packages/react-router/.changes/patch.manifest-version-reload.md
@@ -1,0 +1,5 @@
+Prevent stale route discovery during manifest version-mismatch recovery
+
+- Keep concurrent manifest responses pending while a document reload is in progress.
+- Report a discovery error when a previous reload failed to resolve a version mismatch instead of loading a stale route or reloading repeatedly.
+- Resume version checks when a document is restored from the back-forward cache.

--- a/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
@@ -1,7 +1,5 @@
 /** @jest-environment node */
 
-import { createMemoryHistory } from "../../../lib/router/history";
-import { createRouter, type Router } from "../../../lib/router/router";
 import { tick } from "../../router/utils/utils";
 
 type FogOfWar = typeof import("../../../lib/dom/ssr/fog-of-war");
@@ -203,75 +201,6 @@ describe("client version mismatch", () => {
 
       expect(reload.mock.calls).toEqual([["/target"]]);
       expect(settled).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(["pending reload", "previous reload"])(
-    "does not load a fallback splat during discovery with a %s",
-    async (scenario) => {
-      jest.spyOn(globalThis, "fetch").mockImplementation(
-        async () =>
-          new Response(null, {
-            status: 204,
-            headers: { "X-Remix-Reload-Document": "true" },
-          }),
-      );
-      let splatLoader = jest.fn(() => "SPLAT");
-      let router: Router;
-      router = createRouter({
-        history: createMemoryHistory(),
-        routes: [
-          { id: "root", path: "/" },
-          { id: "splat", path: "*", loader: splatLoader },
-        ],
-        patchRoutesOnNavigation: fogOfWar.getPatchRoutesOnNavigationFunction(
-          () => router,
-          {
-            version: "v1",
-            routes: {},
-            entry: { imports: [], module: "" },
-            url: "",
-          },
-          {},
-          true,
-          { mode: "lazy", manifestPath: "/__manifest" },
-          false,
-          undefined,
-        ),
-      }).initialize();
-
-      try {
-        if (scenario === "pending reload") {
-          router.fetch("first", "root", "/first");
-          await tick();
-        } else {
-          stored.set(storageKey, "v1");
-        }
-        expect(reload.mock.calls).toEqual(
-          scenario === "pending reload" ? [["http://localhost/"]] : [],
-        );
-
-        router.fetch("second", "root", "/second");
-        await tick();
-        expect(splatLoader).not.toHaveBeenCalled();
-
-        expect(router.getFetcher("first").state).toBe(
-          scenario === "pending reload" ? "loading" : "idle",
-        );
-        expect(router.getFetcher("second").state).toBe(
-          scenario === "pending reload" ? "loading" : "idle",
-        );
-        expect(router.state.errors).toEqual(
-          scenario === "pending reload"
-            ? null
-            : { root: new Error(mismatchMessage) },
-        );
-        expect(reload.mock.calls).toEqual(
-          scenario === "pending reload" ? [["http://localhost/"]] : [],
-        );
-      } finally {
-        router.dispose();
-      }
     },
   );
 });

--- a/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
@@ -1,0 +1,277 @@
+/** @jest-environment node */
+
+import { createMemoryHistory } from "../../../lib/router/history";
+import { createRouter, type Router } from "../../../lib/router/router";
+import { tick } from "../../router/utils/utils";
+
+type FogOfWar = typeof import("../../../lib/dom/ssr/fog-of-war");
+
+const storageKey = "react-router-manifest-version";
+const mismatchMessage =
+  "Unable to discover routes due to manifest version mismatch.";
+
+describe("client version mismatch", () => {
+  let fogOfWar: FogOfWar;
+  let stored: Map<string, string>;
+  let reload: jest.Mock;
+  let windowEvents: EventTarget;
+  let originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  let originalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "sessionStorage",
+  );
+
+  beforeEach(async () => {
+    // A new module instance models a new document, without exposing a reset API.
+    await jest.isolateModulesAsync(async () => {
+      fogOfWar = await import("../../../lib/dom/ssr/fog-of-war");
+    });
+    stored = new Map();
+    reload = jest.fn();
+    windowEvents = new EventTarget();
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        addEventListener: windowEvents.addEventListener.bind(windowEvents),
+        removeEventListener:
+          windowEvents.removeEventListener.bind(windowEvents),
+        location: {
+          origin: "http://localhost",
+          get href() {
+            return "http://localhost/";
+          },
+          set href(path: string) {
+            reload(path);
+          },
+        },
+      },
+    });
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => stored.get(key) ?? null,
+        setItem: (key: string, value: string) => stored.set(key, value),
+        removeItem: (key: string) => stored.delete(key),
+      },
+    });
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    for (let [key, descriptor] of [
+      ["window", originalWindow],
+      ["sessionStorage", originalStorage],
+    ] as const) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, key, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, key);
+      }
+    }
+  });
+
+  it("holds concurrent mismatches behind the pending document reload", async () => {
+    let settled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/first?query=1#hash")
+      .then(settled, settled);
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/second")
+      .then(settled, settled);
+    await tick();
+
+    expect(reload.mock.calls).toEqual([["/first?query=1#hash"]]);
+    expect(stored.get(storageKey)).toBe("v1");
+    expect(settled).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("rejects discovery when a previous document already tried this version", async () => {
+    stored.set(storageKey, "v1");
+    await expect(
+      fogOfWar.handleClientVersionMismatch(true, "v1", "/target"),
+    ).rejects.toThrow(mismatchMessage);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("defers eager mismatches until a navigation needs discovery", async () => {
+    await expect(
+      fogOfWar.handleClientVersionMismatch(true, "v1", null),
+    ).resolves.toBe(true);
+    expect(stored.size).toBe(0);
+    expect(reload).not.toHaveBeenCalled();
+
+    let settled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/target")
+      .then(settled, settled);
+    await tick();
+    expect(reload.mock.calls).toEqual([["/target"]]);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("clears loop detection on success when no reload is pending", async () => {
+    stored.set(storageKey, "v1");
+    await expect(
+      fogOfWar.handleClientVersionMismatch(false, "v1", "/target"),
+    ).resolves.toBe(false);
+    expect(stored.has(storageKey)).toBe(false);
+
+    fogOfWar.handleClientVersionMismatch(true, "v1", "/target");
+    expect(reload.mock.calls).toEqual([["/target"]]);
+  });
+
+  it("does not let a late successful response clear a pending reload", async () => {
+    fogOfWar.handleClientVersionMismatch(true, "v1", "/target");
+    let settled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(false, "v1", "/other")
+      .then(settled, settled);
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", null)
+      .then(settled, settled);
+    await tick();
+
+    expect(stored.get(storageKey)).toBe("v1");
+    expect(reload.mock.calls).toEqual([["/target"]]);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("allows recovery for a different client version", async () => {
+    stored.set(storageKey, "v1");
+    let settled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v2", "/target")
+      .then(settled, settled);
+    await tick();
+
+    expect(stored.get(storageKey)).toBe("v2");
+    expect(reload.mock.calls).toEqual([["/target"]]);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("resumes mismatch handling when the document is restored from BFCache", async () => {
+    fogOfWar.handleClientVersionMismatch(true, "v1", "/target");
+
+    // The initial pageshow must not clear an in-flight reload.
+    windowEvents.dispatchEvent(
+      Object.assign(new Event("pageshow"), { persisted: false }),
+    );
+    let beforeRestore = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/other")
+      .then(beforeRestore, beforeRestore);
+    await tick();
+    expect(beforeRestore).not.toHaveBeenCalled();
+
+    windowEvents.dispatchEvent(
+      Object.assign(new Event("pageshow"), { persisted: true }),
+    );
+    let afterRestore = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/other")
+      .then(afterRestore, afterRestore);
+    await tick();
+
+    expect(afterRestore).toHaveBeenCalledWith(new Error(mismatchMessage));
+    expect(reload.mock.calls).toEqual([["/target"]]);
+    await expect(
+      fogOfWar.handleClientVersionMismatch(false, "v1", "/other"),
+    ).resolves.toBe(false);
+  });
+
+  it.each(["getItem", "setItem", "removeItem"] as const)(
+    "tolerates unavailable sessionStorage.%s",
+    async (method) => {
+      jest.spyOn(sessionStorage, method).mockImplementation(() => {
+        throw new Error("Storage unavailable");
+      });
+      await expect(
+        fogOfWar.handleClientVersionMismatch(false, "v1", "/target"),
+      ).resolves.toBe(false);
+
+      let settled = jest.fn();
+      fogOfWar
+        .handleClientVersionMismatch(true, "v1", "/target")
+        .then(settled, settled);
+      fogOfWar
+        .handleClientVersionMismatch(true, "v1", "/other")
+        .then(settled, settled);
+      await tick();
+
+      expect(reload.mock.calls).toEqual([["/target"]]);
+      expect(settled).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["pending reload", "previous reload"])(
+    "does not load a fallback splat during discovery with a %s",
+    async (scenario) => {
+      jest.spyOn(globalThis, "fetch").mockImplementation(
+        async () =>
+          new Response(null, {
+            status: 204,
+            headers: { "X-Remix-Reload-Document": "true" },
+          }),
+      );
+      let splatLoader = jest.fn(() => "SPLAT");
+      let router: Router;
+      router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          { id: "root", path: "/" },
+          { id: "splat", path: "*", loader: splatLoader },
+        ],
+        patchRoutesOnNavigation: fogOfWar.getPatchRoutesOnNavigationFunction(
+          () => router,
+          {
+            version: "v1",
+            routes: {},
+            entry: { imports: [], module: "" },
+            url: "",
+          },
+          {},
+          true,
+          { mode: "lazy", manifestPath: "/__manifest" },
+          false,
+          undefined,
+        ),
+      }).initialize();
+
+      try {
+        if (scenario === "pending reload") {
+          router.fetch("first", "root", "/first");
+          await tick();
+        } else {
+          stored.set(storageKey, "v1");
+        }
+        expect(reload.mock.calls).toEqual(
+          scenario === "pending reload" ? [["http://localhost/"]] : [],
+        );
+
+        router.fetch("second", "root", "/second");
+        await tick();
+        expect(splatLoader).not.toHaveBeenCalled();
+
+        expect(router.getFetcher("first").state).toBe(
+          scenario === "pending reload" ? "loading" : "idle",
+        );
+        expect(router.getFetcher("second").state).toBe(
+          scenario === "pending reload" ? "loading" : "idle",
+        );
+        expect(router.state.errors).toEqual(
+          scenario === "pending reload"
+            ? null
+            : { root: new Error(mismatchMessage) },
+        );
+        expect(reload.mock.calls).toEqual(
+          scenario === "pending reload" ? [["http://localhost/"]] : [],
+        );
+      } finally {
+        router.dispose();
+      }
+    },
+  );
+});

--- a/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
+++ b/packages/react-router/__tests__/dom/ssr/client-version-mismatch-test.ts
@@ -1,7 +1,5 @@
 /** @jest-environment node */
 
-import { tick } from "../../router/utils/utils";
-
 type FogOfWar = typeof import("../../../lib/dom/ssr/fog-of-war");
 
 const storageKey = "react-router-manifest-version";
@@ -24,6 +22,7 @@ describe("client version mismatch", () => {
     await jest.isolateModulesAsync(async () => {
       fogOfWar = await import("../../../lib/dom/ssr/fog-of-war");
     });
+    jest.useFakeTimers();
     stored = new Map();
     reload = jest.fn();
     windowEvents = new EventTarget();
@@ -57,6 +56,8 @@ describe("client version mismatch", () => {
   });
 
   afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
     jest.restoreAllMocks();
     for (let [key, descriptor] of [
       ["window", originalWindow],
@@ -78,7 +79,7 @@ describe("client version mismatch", () => {
     fogOfWar
       .handleClientVersionMismatch(true, "v1", "/second")
       .then(settled, settled);
-    await tick();
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(reload.mock.calls).toEqual([["/first?query=1#hash"]]);
     expect(stored.get(storageKey)).toBe("v1");
@@ -105,7 +106,7 @@ describe("client version mismatch", () => {
     fogOfWar
       .handleClientVersionMismatch(true, "v1", "/target")
       .then(settled, settled);
-    await tick();
+    await jest.advanceTimersByTimeAsync(0);
     expect(reload.mock.calls).toEqual([["/target"]]);
     expect(settled).not.toHaveBeenCalled();
   });
@@ -130,7 +131,7 @@ describe("client version mismatch", () => {
     fogOfWar
       .handleClientVersionMismatch(true, "v1", null)
       .then(settled, settled);
-    await tick();
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(stored.get(storageKey)).toBe("v1");
     expect(reload.mock.calls).toEqual([["/target"]]);
@@ -143,41 +144,115 @@ describe("client version mismatch", () => {
     fogOfWar
       .handleClientVersionMismatch(true, "v2", "/target")
       .then(settled, settled);
-    await tick();
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(stored.get(storageKey)).toBe("v2");
     expect(reload.mock.calls).toEqual([["/target"]]);
     expect(settled).not.toHaveBeenCalled();
   });
 
-  it("resumes mismatch handling when the document is restored from BFCache", async () => {
-    fogOfWar.handleClientVersionMismatch(true, "v1", "/target");
+  it("rejects all waiting responses when a document reload does not complete", async () => {
+    let settled = jest.fn();
+    for (let [needsReload, path] of [
+      [true, "/target"],
+      [true, "/sibling"],
+      [false, "/successful-sibling"],
+      [true, null],
+    ] as const) {
+      fogOfWar
+        .handleClientVersionMismatch(needsReload, "v1", path)
+        .then(settled, settled);
+    }
+
+    await jest.advanceTimersByTimeAsync(4999);
+    expect(settled).not.toHaveBeenCalled();
+    expect(reload.mock.calls).toEqual([["/target"]]);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(settled.mock.calls).toEqual([
+      [new Error(mismatchMessage)],
+      [new Error(mismatchMessage)],
+      [new Error(mismatchMessage)],
+      [new Error(mismatchMessage)],
+    ]);
+    expect(stored.get(storageKey)).toBe("v1");
+
+    // A cancelled reload must not keep subsequent discoveries pending or loop.
+    await expect(
+      fogOfWar.handleClientVersionMismatch(true, "v1", "/retry"),
+    ).rejects.toThrow(mismatchMessage);
+    expect(reload.mock.calls).toEqual([["/target"]]);
+
+    await expect(
+      fogOfWar.handleClientVersionMismatch(false, "v1", "/retry"),
+    ).resolves.toBe(false);
+    expect(stored.has(storageKey)).toBe(false);
+  });
+
+  it("clears the pending reload when assigning the document location throws", async () => {
+    reload.mockImplementation(() => {
+      throw new Error("Navigation failed");
+    });
+    await expect(
+      fogOfWar.handleClientVersionMismatch(true, "v1", "/target"),
+    ).rejects.toThrow(mismatchMessage);
+    expect(stored.get(storageKey)).toBe("v1");
+
+    await expect(
+      fogOfWar.handleClientVersionMismatch(false, "v1", "/other"),
+    ).resolves.toBe(false);
+    expect(stored.has(storageKey)).toBe(false);
+    // Cleanup must also prevent an unhandled rejection from the reload timer.
+    await jest.advanceTimersByTimeAsync(5000);
+  });
+
+  it("rejects waiting responses when the document is restored from BFCache", async () => {
+    let settled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/target")
+      .then(settled, settled);
+    fogOfWar
+      .handleClientVersionMismatch(true, "v1", "/other")
+      .then(settled, settled);
 
     // The initial pageshow must not clear an in-flight reload.
     windowEvents.dispatchEvent(
       Object.assign(new Event("pageshow"), { persisted: false }),
     );
-    let beforeRestore = jest.fn();
-    fogOfWar
-      .handleClientVersionMismatch(true, "v1", "/other")
-      .then(beforeRestore, beforeRestore);
-    await tick();
-    expect(beforeRestore).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(settled).not.toHaveBeenCalled();
 
     windowEvents.dispatchEvent(
       Object.assign(new Event("pageshow"), { persisted: true }),
     );
-    let afterRestore = jest.fn();
-    fogOfWar
-      .handleClientVersionMismatch(true, "v1", "/other")
-      .then(afterRestore, afterRestore);
-    await tick();
+    await jest.advanceTimersByTimeAsync(0);
+    expect(settled.mock.calls).toEqual([
+      [new Error(mismatchMessage)],
+      [new Error(mismatchMessage)],
+    ]);
+    expect(stored.get(storageKey)).toBe("v1");
+    await expect(
+      fogOfWar.handleClientVersionMismatch(true, "v1", "/other"),
+    ).rejects.toThrow(mismatchMessage);
 
-    expect(afterRestore).toHaveBeenCalledWith(new Error(mismatchMessage));
-    expect(reload.mock.calls).toEqual([["/target"]]);
     await expect(
       fogOfWar.handleClientVersionMismatch(false, "v1", "/other"),
     ).resolves.toBe(false);
+
+    // The old timeout must not clear a newer reload after restoration.
+    let nextSettled = jest.fn();
+    fogOfWar
+      .handleClientVersionMismatch(true, "v2", "/next")
+      .then(nextSettled, nextSettled);
+    await jest.advanceTimersByTimeAsync(4000);
+    expect(nextSettled).not.toHaveBeenCalled();
+    fogOfWar
+      .handleClientVersionMismatch(false, "v2", "/next-sibling")
+      .then(nextSettled, nextSettled);
+    await jest.advanceTimersByTimeAsync(0);
+    expect(nextSettled).not.toHaveBeenCalled();
+    expect(stored.get(storageKey)).toBe("v2");
+    expect(reload.mock.calls).toEqual([["/target"], ["/next"]]);
   });
 
   it.each(["getItem", "setItem", "removeItem"] as const)(
@@ -197,7 +272,7 @@ describe("client version mismatch", () => {
       fogOfWar
         .handleClientVersionMismatch(true, "v1", "/other")
         .then(settled, settled);
-      await tick();
+      await jest.advanceTimersByTimeAsync(0);
 
       expect(reload.mock.calls).toEqual([["/target"]]);
       expect(settled).not.toHaveBeenCalled();

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -233,6 +233,7 @@ export function getManifestPath(
 }
 
 const MANIFEST_VERSION_STORAGE_KEY = "react-router-manifest-version";
+const MANIFEST_RELOAD_TIMEOUT = 5000;
 let pendingManifestReload: Promise<never> | undefined;
 
 export async function handleClientVersionMismatch(
@@ -292,23 +293,41 @@ export async function handleClientVersionMismatch(
 
   // Share the pending promise before starting navigation so concurrent requests
   // wait for the new document rather than triggering an ErrorBoundary flash.
-  pendingManifestReload = new Promise<never>(() => {
-    // check out of this hook cause the DJs never gonna re[s]olve this
+  let rejectReload: (error: Error) => void;
+  let reloadPromise = new Promise<never>((_, reject) => {
+    rejectReload = reject;
   });
-  // BFCache can restore this document and its module state after navigation.
-  // New requests must be able to retry version checks when the user comes back.
+  pendingManifestReload = reloadPromise;
+
+  let failReload = () => {
+    clearTimeout(timeout);
+    window.removeEventListener("pageshow", onPageShow);
+    pendingManifestReload = undefined;
+    // Preserve the stored version to prevent another reload loop. Reject rather
+    // than resume discovery against the stale route tree.
+    rejectReload(
+      new Error("Unable to discover routes due to manifest version mismatch."),
+    );
+  };
+  // A beforeunload prompt can cancel this navigation without notifying us. Give
+  // the reload time to finish, then fail any requests left in this document.
+  let timeout = setTimeout(failReload, MANIFEST_RELOAD_TIMEOUT);
   let onPageShow = (event: PageTransitionEvent) => {
     if (event.persisted) {
-      pendingManifestReload = undefined;
-      window.removeEventListener("pageshow", onPageShow);
+      // BFCache restores pending requests as well as module state.
+      failReload();
     }
   };
   window.addEventListener("pageshow", onPageShow);
 
   // Reload the destination on navigations, or the current page on fetcher calls.
-  window.location.href = errorReloadPath;
-  console.warn("Detected manifest version mismatch, reloading...");
-  return pendingManifestReload;
+  try {
+    window.location.href = errorReloadPath;
+    console.warn("Detected manifest version mismatch, reloading...");
+  } catch {
+    failReload();
+  }
+  return reloadPromise;
 }
 
 export async function fetchAndApplyManifestPatches(

--- a/packages/react-router/lib/dom/ssr/fog-of-war.ts
+++ b/packages/react-router/lib/dom/ssr/fog-of-war.ts
@@ -233,12 +233,19 @@ export function getManifestPath(
 }
 
 const MANIFEST_VERSION_STORAGE_KEY = "react-router-manifest-version";
+let pendingManifestReload: Promise<never> | undefined;
 
 export async function handleClientVersionMismatch(
   needsReload: boolean,
   version: string,
   errorReloadPath: string | null,
 ): Promise<boolean> {
+  // A sibling request already started a document navigation. Keep this request
+  // pending too, without clearing the loop guard or continuing on the stale tree.
+  if (pendingManifestReload) {
+    return pendingManifestReload;
+  }
+
   if (!needsReload) {
     // Reset loop-detection on a successful response
     try {
@@ -264,32 +271,44 @@ export async function handleClientVersionMismatch(
     return true;
   }
 
+  let alreadyReloaded = false;
   try {
-    // This will hard reload the destination path on navigations, or the
-    // current path on fetcher calls
-    if (sessionStorage.getItem(MANIFEST_VERSION_STORAGE_KEY) === version) {
-      // We've already tried fixing for this version, don't try again to
-      // avoid loops - just let this navigation/fetch 404
-      console.error(
-        "Unable to discover routes due to manifest version mismatch.",
-      );
-      return true;
+    alreadyReloaded =
+      sessionStorage.getItem(MANIFEST_VERSION_STORAGE_KEY) === version;
+    if (!alreadyReloaded) {
+      sessionStorage.setItem(MANIFEST_VERSION_STORAGE_KEY, version);
     }
-
-    sessionStorage.setItem(MANIFEST_VERSION_STORAGE_KEY, version);
   } catch {
     // Session storage unavailable
   }
 
-  window.location.href = errorReloadPath;
-  console.warn("Detected manifest version mismatch, reloading...");
+  // A previous document already attempted recovery for this version. Fail
+  // discovery instead of matching a fallback route in the unchanged route tree.
+  if (alreadyReloaded) {
+    throw new Error(
+      "Unable to discover routes due to manifest version mismatch.",
+    );
+  }
 
-  // Stall here and let the browser reload and avoid triggering a flash of
-  // an ErrorBoundary if we threw (same thing we do in `loadRouteModule()`)
-  await new Promise(() => {
+  // Share the pending promise before starting navigation so concurrent requests
+  // wait for the new document rather than triggering an ErrorBoundary flash.
+  pendingManifestReload = new Promise<never>(() => {
     // check out of this hook cause the DJs never gonna re[s]olve this
   });
-  return true;
+  // BFCache can restore this document and its module state after navigation.
+  // New requests must be able to retry version checks when the user comes back.
+  let onPageShow = (event: PageTransitionEvent) => {
+    if (event.persisted) {
+      pendingManifestReload = undefined;
+      window.removeEventListener("pageshow", onPageShow);
+    }
+  };
+  window.addEventListener("pageshow", onPageShow);
+
+  // Reload the destination on navigations, or the current page on fetcher calls.
+  window.location.href = errorReloadPath;
+  console.warn("Detected manifest version mismatch, reloading...");
+  return pendingManifestReload;
 }
 
 export async function fetchAndApplyManifestPatches(


### PR DESCRIPTION
This prevents concurrent manifest version-mismatch responses from resuming route discovery against a client route tree that is known to be stale.

It shares a pending document-reload promise across sibling discoveries, reports an explicit discovery error when the same client version already attempted a reload, and resets the page-lifetime guard when a document is restored from the back-forward cache. Regression coverage includes navigation, fetcher, and RSC manifest and payload mismatch paths.

Closes #15488
