### PR TITLE
Document RSC Server Function access control

### DIFF
--- a/docs/how-to/middleware.md
+++ b/docs/how-to/middleware.md
@@ -358,7 +358,9 @@ In theory, we could have leveraged [`AsyncLocalStorage`][asynclocalstorage] dire
 
 That said, this API still works great with React Router middleware and can be used in place of, or alongside of the `context` API:
 
-<docs-info>[`AsyncLocalStorage`][asynclocalstorage] is _especially_ powerful when using [React Server Components](../how-to/react-server-components) because it allows you to provide information from `middleware` to your Server Components and Server Actions because they run in the same server execution context 🤯</docs-info>
+<docs-info>[`AsyncLocalStorage`][asynclocalstorage] is _especially_ powerful when using [React Server Components](../how-to/react-server-components) because it allows you to provide information from `middleware` to your Server Components and route actions because they run in the same server execution context 🤯</docs-info>
+
+<docs-warning>Do not rely on route middleware to provide access control for React Server Functions. Server Functions are not inherently associated with a route, and a client can call the same Server Function through a URL with different middleware. Server Functions must perform all of their own access control checks. Use a route `action` instead when you want middleware-driven access control.</docs-warning>
 
 ```tsx filename=app/user-context.ts
 import { AsyncLocalStorage } from "node:async_hooks";

--- a/docs/how-to/react-server-components.md
+++ b/docs/how-to/react-server-components.md
@@ -498,16 +498,39 @@ Using Server Components in loaders can be helpful for incremental adoption of RS
 
 [Server Functions][react-server-functions-doc] are a React feature that allow you to call async functions executed on the server. They're defined with the [`"use server"`][use-server-docs] directive.
 
+<docs-warning>
+
+Treat every Server Function as a public endpoint. The client controls both the
+Server Function identifier and request URL, so do not rely on route middleware
+for authentication or authorization. Server Functions must perform their own
+access control and input validation; use a route `action` when access control
+should be middleware-driven.
+
+</docs-warning>
+
 ```tsx
 "use server";
 
+import { unstable_getRequest as getRequest } from "react-router";
+import { requireUser } from "./auth.ts";
+
 export async function updateFavorite(formData: FormData) {
-  let movieId = formData.get("id");
+  let user = await requireUser(getRequest());
+  let movieId = Number(formData.get("id"));
   let intent = formData.get("intent");
+
+  if (
+    !Number.isSafeInteger(movieId) ||
+    movieId <= 0 ||
+    (intent !== "add" && intent !== "remove")
+  ) {
+    throw new Error("Invalid form submission");
+  }
+
   if (intent === "add") {
-    await addFavorite(Number(movieId));
+    await addFavorite(user.id, movieId);
   } else {
-    await removeFavorite(Number(movieId));
+    await removeFavorite(user.id, movieId);
   }
 }
 ```

--- a/packages/react-router/.changes/unstable.rsc-server-function-middleware.md
+++ b/packages/react-router/.changes/unstable.rsc-server-function-middleware.md
@@ -1,0 +1,4 @@
+Document access control requirements for RSC Server Functions
+
+- Treat every Server Function as a public endpoint that must perform all of its own access control checks
+- Recommend route actions when access control should be provided by route middleware

--- a/packages/react-router/lib/rsc/server.rsc.ts
+++ b/packages/react-router/lib/rsc/server.rsc.ts
@@ -322,6 +322,13 @@ export type RouteDiscovery =
  * encoding an {@link unstable_RSCPayload} for consumption by an [RSC](https://react.dev/reference/rsc/server-components)
  * enabled client router.
  *
+ * Treat every React Server Function as a public endpoint. Server Functions are
+ * not inherently associated with a route. Any route middleware that runs is
+ * selected from the URL used to call a Server Function, but the client controls
+ * both the Server Function identifier and the URL. Perform all access control
+ * checks within each Server Function, or use a route action for
+ * middleware-driven access control.
+ *
  * @example
  * import {
  *   createTemporaryReferenceSet,


### PR DESCRIPTION
Clarifies the RSC Server Function security model: route middleware may run based on the request URL, but clients control both the URL and Server Function identifier, so middleware cannot be treated as an authorization boundary.

- Treat Server Functions as public endpoints that perform their own access control and input validation
- Show request-based authentication and validation in the Server Function example
- Recommend route actions when access control should be middleware-driven

