### PR TITLE
[v7] Fix HTML attribute escaping for RSC redirects

### DIFF
--- a/packages/react-router/.changes/patch.rsc-meta-redirect-escaping.md
+++ b/packages/react-router/.changes/patch.rsc-meta-redirect-escaping.md
@@ -1,0 +1,1 @@
+Correctly escape streamed RSC redirect locations in meta tag attributes

--- a/packages/react-router/lib/dom/ssr/markup.ts
+++ b/packages/react-router/lib/dom/ssr/markup.ts
@@ -17,3 +17,11 @@ const ESCAPE_REGEX = /[&><\u2028\u2029]/g;
 export function escapeHtml(html: string) {
   return html.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match]);
 }
+
+export function escapeAttribute(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/packages/react-router/lib/rsc/server.ssr.tsx
+++ b/packages/react-router/lib/rsc/server.ssr.tsx
@@ -15,7 +15,7 @@ import {
   decodeRedirectErrorDigest,
   decodeRouteErrorResponseDigest,
 } from "../errors";
-import { escapeHtml } from "../dom/ssr/markup";
+import { escapeAttribute } from "../dom/ssr/markup";
 
 const defaultManifestPath = "/__manifest";
 
@@ -280,7 +280,7 @@ export async function routeRSCServerRequest({
 
           controller.enqueue(
             new TextEncoder().encode(
-              `<meta http-equiv="refresh" content="0;url=${escapeHtml(renderRedirect.location)}"/>`,
+              `<meta http-equiv="refresh" content="0;url=${escapeAttribute(renderRedirect.location)}"/>`,
             ),
           );
         }
@@ -425,7 +425,7 @@ export async function routeRSCServerRequest({
 
             controller.enqueue(
               new TextEncoder().encode(
-                `<meta http-equiv="refresh" content="0;url=${escapeHtml(retryRedirect.location)}"/>`,
+                `<meta http-equiv="refresh" content="0;url=${escapeAttribute(retryRedirect.location)}"/>`,
               ),
             );
           }


### PR DESCRIPTION
Backport #15491 to `v7`.

Use HTML attribute escaping for redirect URLs rendered into RSC meta refresh tags
