### PR TITLE
Deprecate router view transitions in favor of React ViewTransition

### DIFF
--- a/docs/api/components/Form.md
+++ b/docs/api/components/Form.md
@@ -134,6 +134,9 @@ stack entry for this navigation
 
 ### viewTransition
 
+**Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+component instead. See the [migration guide](../../how-to/view-transitions).
+
 Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
 for this navigation. To apply specific styles during the transition, see
 [`useViewTransitionState`](../hooks/useViewTransitionState).

--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -203,6 +203,9 @@ Can be a string or a partial [`Path`](https://api.reactrouter.com/v8/interfaces/
 
 [modes: framework, data]
 
+**Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+component instead. See the [migration guide](../../how-to/view-transitions).
+
 Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
 for this navigation.
 

--- a/docs/api/components/NavLink.md
+++ b/docs/api/components/NavLink.md
@@ -89,9 +89,6 @@ a.active {
 a.pending {
   color: blue;
 }
-a.transitioning {
-  view-transition-name: my-transition;
-}
 ```
 
 Or you can specify a function that receives [`NavLinkRenderProps`](https://api.reactrouter.com/v8/types/react-router.NavLinkRenderProps.html) and
@@ -104,6 +101,10 @@ returns the `className`:
   ""
 )} />
 ```
+
+The `transitioning` class is deprecated and only tracks React Router's
+legacy view transitions. Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+component instead. See the [migration guide](../../how-to/view-transitions).
 
 ### discover
 
@@ -301,6 +302,9 @@ Can be a string or a partial [`Path`](https://api.reactrouter.com/v8/interfaces/
 ### viewTransition
 
 [modes: framework, data]
+
+**Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+component instead. See the [migration guide](../../how-to/view-transitions).
 
 Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
 for this navigation.

--- a/docs/api/hooks/useLinkClickHandler.md
+++ b/docs/api/hooks/useLinkClickHandler.md
@@ -48,10 +48,9 @@ function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    viewTransition?: boolean;
     defaultShouldRevalidate?: boolean;
     useTransitions?: boolean;
-  } = {},
+  } & Pick<NavigateOptions, "viewTransition"> = {},
 ): (event: React.MouseEvent<E, MouseEvent>) => void
 ```
 
@@ -84,8 +83,8 @@ The target attribute for the link. Defaults to `undefined`.
 
 ### options.viewTransition
 
-Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) for this navigation. To apply specific styles during the transition, see
-[`useViewTransitionState`](../hooks/useViewTransitionState). Defaults to `false`.
+**Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component
+instead. See the [migration guide](../../how-to/view-transitions).
 
 ### options.defaultShouldRevalidate
 

--- a/docs/api/hooks/useNavigate.md
+++ b/docs/api/hooks/useNavigate.md
@@ -39,7 +39,7 @@ The returned function signature is `navigate(to, options?)`/`navigate(delta)` wh
   * These options only work in Framework and Data modes:
     * `flushSync`: Wrap the DOM updates in [`ReactDom.flushSync`](https://react.dev/reference/react-dom/flushSync)
     * `preventScrollReset`: Do not scroll back to the top of the page after navigation
-    * `viewTransition`: Enable [`document.startViewTransition`](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition) for this navigation
+    * `viewTransition`: **Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component instead. See the [migration guide](../../how-to/view-transitions).
 
 ```tsx
 import { useNavigate } from "react-router";

--- a/docs/api/hooks/useSubmit.md
+++ b/docs/api/hooks/useSubmit.md
@@ -25,6 +25,10 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 The imperative version of [`<Form>`](../components/Form) that lets you submit a form
 from code instead of a user interaction.
 
+The `viewTransition` submission option is deprecated. Use React's
+[`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component
+instead. See the [migration guide](../../how-to/view-transitions).
+
 ```tsx
 import { useSubmit } from "react-router";
 

--- a/docs/api/hooks/useViewTransitionState.md
+++ b/docs/api/hooks/useViewTransitionState.md
@@ -22,6 +22,11 @@ https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/do
 
 [Reference Documentation ↗](https://api.reactrouter.com/v8/functions/react-router.useViewTransitionState.html)
 
+**Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+component to style transitions instead. This hook only tracks React Router's
+legacy view transitions, not transitions started by React. See the
+[migration guide](../../how-to/view-transitions).
+
 This hook returns `true` when there is an active [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
 and the specified location matches either side of the navigation (the URL you are
 navigating **to** or the URL you are navigating **from**). This can be used to apply finer-grained styles to

--- a/docs/how-to/view-transitions.md
+++ b/docs/how-to/view-transitions.md
@@ -4,16 +4,78 @@ title: View Transitions
 
 # View Transitions
 
-[MODES: framework, data]
+[MODES: framework, data, declarative]
 
 <br/>
 <br/>
 
-Enable smooth animations between page transitions in your React Router applications using the [View Transitions API][view-transitions-api]. This feature allows you to create seamless visual transitions during client-side navigation.
+Use React's [`<ViewTransition>`][react-view-transition] component to animate client-side navigations. This requires React and React DOM 19.3 or later.
 
-## Basic View Transition
+<docs-warning>
 
-### 1. Enable view transitions on navigation
+React Router's `viewTransition` props/options, `useViewTransitionState` hook, and `NavLink`'s `isTransitioning` render prop and `transitioning` class are deprecated in favor of React's `<ViewTransition>` component. The existing APIs continue to work, including with older React versions.
+
+</docs-warning>
+
+## Navigation View Transitions with React
+
+Wrap the outlet in a persistent `<ViewTransition>` boundary in a shared layout route. In Framework Mode, this can be your root route's default export; in Data and Declarative modes, use it as the component for a parent route with children:
+
+```tsx
+import { ViewTransition } from "react";
+import { Link, Outlet } from "react-router";
+
+export default function PageLayout() {
+  return (
+    <>
+      <nav>
+        <Link to="/">Home</Link>
+        <Link to="/about">About</Link>
+      </nav>
+      <ViewTransition>
+        <main>
+          <Outlet />
+        </main>
+      </ViewTransition>
+    </>
+  );
+}
+```
+
+Navigations that update the outlet cross-fade its contents. Keep the boundary mounted across navigations; you don't need to key it by location or remount the route tree. The navigation stays outside the animated region. Other updates inside the boundary can also animate when they run in a React Transition.
+
+React Router wraps router state updates in [`React.startTransition`][start-transition] by default, which lets React activate `<ViewTransition>` without additional configuration. React Transitions must remain enabled for navigation view transitions to work: do not set `useTransitions={false}` on your router.
+
+This applies to navigations from `<Link>`, `<NavLink>`, and `<Form>`, as well as programmatic navigation with `useNavigate` and `useSubmit`. No additional `startTransition` wrapper is needed.
+
+### Migrating from React Router's view transitions
+
+- Remove `viewTransition` from `<Link>`, `<NavLink>`, and `<Form>`, and remove `viewTransition: true` from navigation/submission options. React coordinates `document.startViewTransition()` itself; enabling both implementations can interrupt animations.
+- Replace `useViewTransitionState`, `isTransitioning`, and `.transitioning` styles with React's [View Transition classes][react-view-transition-classes]. Those router APIs only track the legacy transitions.
+- For shared elements such as an image moving from a list to a detail route, wrap each side in `<ViewTransition name="...">` with the same unique name. See React's [shared element example][react-shared-elements].
+- Keep React Transitions enabled. `useTransitions={false}` and synchronous updates such as `flushSync` can prevent React's animations.
+
+React's component is not a drop-in replacement for every legacy animation. In particular, React [skips view transitions for synchronous updates from `popstate`][react-router-transitions], so browser Back/Forward navigations may not animate. Browsers without View Transitions support still navigate normally.
+
+Respect reduced-motion preferences when adding animations:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}
+```
+
+## Legacy View Transitions (Deprecated)
+
+The following examples document the deprecated APIs for existing applications. These APIs are available in Framework and Data modes.
+
+### Basic View Transition
+
+#### 1. Enable view transitions on navigation
 
 The simplest way to enable view transitions is by adding the `viewTransition` prop to your `Link`, `NavLink`, or `Form` components. This automatically wraps the navigation update in `document.startViewTransition()`.
 
@@ -25,7 +87,7 @@ The simplest way to enable view transitions is by adding the `viewTransition` pr
 
 Without any additional CSS, this provides a basic cross-fade animation between pages.
 
-### 2. Enable view transitions with programmatic navigation
+#### 2. Enable view transitions with programmatic navigation
 
 When using programmatic navigation with the `useNavigate` hook, you can enable view transitions by passing the `viewTransition: true` option:
 
@@ -51,11 +113,11 @@ This provides the same cross-fade animation as using the `viewTransition` prop o
 
 For more information on using the View Transitions API, please refer to the ["Smooth transitions with the View Transition API" guide][view-transitions-guide] from the Google Chrome team.
 
-## Image Gallery Example
+### Image Gallery Example
 
 Let's build an image gallery that demonstrates how to trigger and use view transitions. We'll create a list of images that expand into a detail view with smooth animations.
 
-### 1. Create the image gallery route
+#### 1. Create the image gallery route
 
 ```tsx filename=routes/image-gallery.tsx
 import { NavLink } from "react-router";
@@ -91,7 +153,7 @@ export default function ImageGalleryRoute() {
 }
 ```
 
-### 2. Add transition styles
+#### 2. Add transition styles
 
 Define view transition names and animations for elements that should transition smoothly between routes.
 
@@ -127,7 +189,7 @@ Define view transition names and animations for elements that should transition 
 }
 ```
 
-### 3. Create the image detail route
+#### 3. Create the image detail route
 
 The detail view needs to use the same view transition names to create a seamless animation.
 
@@ -151,7 +213,7 @@ export default function ImageDetailsRoute({
 }
 ```
 
-### 4. Add matching transition styles for the detail view
+#### 4. Add matching transition styles for the detail view
 
 ```css filename=app.css
 /* Match transition names from the list view */
@@ -169,11 +231,11 @@ export default function ImageDetailsRoute({
 }
 ```
 
-## Advanced Usage
+### Advanced Usage
 
 You can control view transitions more precisely using either render props or the `useViewTransitionState` hook.
 
-### 1. Using render props
+#### 1. Using render props
 
 ```tsx filename=routes/image-gallery.tsx
 <NavLink to={`/image/${idx}`} viewTransition>
@@ -201,7 +263,7 @@ You can control view transitions more precisely using either render props or the
 </NavLink>
 ```
 
-### 2. Using the `useViewTransitionState` hook
+#### 2. Using the `useViewTransitionState` hook
 
 ```tsx filename=routes/image-gallery.tsx
 function NavImage(props: { src: string; idx: number }) {
@@ -234,4 +296,9 @@ function NavImage(props: { src: string; idx: number }) {
 ```
 
 [view-transitions-api]: https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition
+[react-view-transition]: https://react.dev/reference/react/ViewTransition
+[start-transition]: https://react.dev/reference/react/startTransition
+[react-view-transition-classes]: https://react.dev/reference/react/ViewTransition#view-transition-class
+[react-shared-elements]: https://react.dev/reference/react/ViewTransition#animating-a-shared-element
+[react-router-transitions]: https://react.dev/reference/react/ViewTransition#building-view-transition-enabled-routers
 [view-transitions-guide]: https://developer.chrome.com/docs/web-platform/view-transitions

--- a/docs/start/framework/navigating.md
+++ b/docs/start/framework/navigating.md
@@ -44,10 +44,6 @@ a.active {
 a.pending {
   animate: pulse 1s infinite;
 }
-
-a.transitioning {
-  /* css transition is running */
-}
 ```
 
 It also has callback props on `className`, `style`, and `children` with the states for inline styling or conditional rendering:
@@ -56,11 +52,10 @@ It also has callback props on `className`, `style`, and `children` with the stat
 // className
 <NavLink
   to="/messages"
-  className={({ isActive, isPending, isTransitioning }) =>
+  className={({ isActive, isPending }) =>
     [
       isPending ? "pending" : "",
       isActive ? "active" : "",
-      isTransitioning ? "transitioning" : "",
     ].join(" ")
   }
 >
@@ -72,11 +67,10 @@ It also has callback props on `className`, `style`, and `children` with the stat
 // style
 <NavLink
   to="/messages"
-  style={({ isActive, isPending, isTransitioning }) => {
+  style={({ isActive, isPending }) => {
     return {
       fontWeight: isActive ? "bold" : "",
       color: isPending ? "red" : "black",
-      viewTransitionName: isTransitioning ? "slide" : "",
     };
   }}
 >
@@ -87,11 +81,13 @@ It also has callback props on `className`, `style`, and `children` with the stat
 ```tsx
 // children
 <NavLink to="/tasks">
-  {({ isActive, isPending, isTransitioning }) => (
+  {({ isActive }) => (
     <span className={isActive ? "active" : ""}>Tasks</span>
   )}
 </NavLink>
 ```
+
+For animated navigations, see [View Transitions](../../how-to/view-transitions). The legacy `isTransitioning` render prop and `transitioning` class are deprecated in favor of React's `<ViewTransition>` component.
 
 ## Link
 

--- a/packages/react-router/.changes/minor.deprecate-view-transitions.md
+++ b/packages/react-router/.changes/minor.deprecate-view-transitions.md
@@ -1,0 +1,3 @@
+Deprecate React Router's view transition APIs in favor of React's `<ViewTransition>` component, available in React 19.3 and later
+
+This includes the `viewTransition` props/options, `useViewTransitionState`, and `NavLink`'s `isTransitioning` render prop and `transitioning` class. Existing behavior is unchanged. See the [migration guide](https://reactrouter.com/how-to/view-transitions) for a navigation example and compatibility considerations.

--- a/packages/react-router/lib/context.ts
+++ b/packages/react-router/lib/context.ts
@@ -109,7 +109,12 @@ export interface NavigateOptions {
   relative?: RelativeRoutingType;
   /** Wraps the initial state update for this navigation in a {@link https://react.dev/reference/react-dom/flushSync ReactDOM.flushSync} call instead of the default {@link https://react.dev/reference/react/startTransition React.startTransition} */
   flushSync?: boolean;
-  /** Enables a {@link https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API View Transition} for this navigation by wrapping the final state update in `document.startViewTransition()`. If you need to apply specific styles for this view transition, you will also need to leverage the {@link useViewTransitionState `useViewTransitionState()`} hook.  */
+  /**
+   * Enables a view transition for this navigation.
+   *
+   * @deprecated Use React's `<ViewTransition>` component instead. See the
+   * [migration guide](https://reactrouter.com/how-to/view-transitions).
+   */
   viewTransition?: boolean;
   /** Specifies the default revalidation behavior after this submission */
   defaultShouldRevalidate?: boolean;

--- a/packages/react-router/lib/dom/dom.ts
+++ b/packages/react-router/lib/dom/dom.ts
@@ -240,6 +240,9 @@ export interface SubmitOptions extends FetcherSubmitOptions {
 
   /**
    * Enable view transitions on this submission navigation
+   *
+   * @deprecated Use React's `<ViewTransition>` component instead. See the
+   * [migration guide](https://reactrouter.com/how-to/view-transitions).
    */
   viewTransition?: boolean;
 }

--- a/packages/react-router/lib/dom/lib.tsx
+++ b/packages/react-router/lib/dom/lib.tsx
@@ -1202,6 +1202,9 @@ export interface LinkProps extends Omit<
   to: To;
 
   /**
+   * **Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+   * component instead. See the [migration guide](../../how-to/view-transitions).
+   *
    * Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
    * for this navigation.
    *
@@ -1212,6 +1215,8 @@ export interface LinkProps extends Omit<
    * ```
    *
    * To apply specific styles for the transition, see {@link useViewTransitionState}
+   *
+   * @deprecated Use React's `<ViewTransition>` component instead.
    */
   viewTransition?: boolean;
 
@@ -1475,6 +1480,10 @@ export type NavLinkRenderProps = {
   /**
    * Indicates if a view transition to the link's URL is in progress.
    * See {@link useViewTransitionState}
+   *
+   * @deprecated Only tracks React Router's deprecated view transitions. Use
+   * React's `<ViewTransition>` component to style transitions instead. See the
+   * [migration guide](https://reactrouter.com/how-to/view-transitions).
    */
   isTransitioning: boolean;
 };
@@ -1520,9 +1529,6 @@ export interface NavLinkProps extends Omit<
    * a.pending {
    *   color: blue;
    * }
-   * a.transitioning {
-   *   view-transition-name: my-transition;
-   * }
    * ```
    *
    * Or you can specify a function that receives {@link NavLinkRenderProps} and
@@ -1535,6 +1541,10 @@ export interface NavLinkProps extends Omit<
    *   ""
    * )} />
    * ```
+   *
+   * The `transitioning` class is deprecated and only tracks React Router's
+   * legacy view transitions. Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+   * component instead. See the [migration guide](../../how-to/view-transitions).
    */
   className?: string | ((props: NavLinkRenderProps) => string | undefined);
 
@@ -1854,9 +1864,14 @@ export interface FormProps extends SharedFormProps {
   state?: any;
 
   /**
+   * **Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+   * component instead. See the [migration guide](../../how-to/view-transitions).
+   *
    * Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
    * for this navigation. To apply specific styles during the transition, see
    * {@link useViewTransitionState}.
+   *
+   * @deprecated Use React's `<ViewTransition>` component instead.
    */
   viewTransition?: boolean;
 }
@@ -2161,9 +2176,9 @@ ScrollRestoration.displayName = "ScrollRestoration";
  * @param options.state The state to add to the [`History`](https://developer.mozilla.org/en-US/docs/Web/API/History)
  * entry for this navigation. Defaults to `undefined`.
  * @param options.target The target attribute for the link. Defaults to `undefined`.
- * @param options.viewTransition Enables a [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
- * for this navigation. To apply specific styles during the transition, see
- * {@link useViewTransitionState}. Defaults to `false`.
+ * @param options.viewTransition **Deprecated.** Use React's
+ * [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component
+ * instead. See the [migration guide](../../how-to/view-transitions).
  * @param options.defaultShouldRevalidate Specify the default revalidation
  * behavior for the navigation. When not specified, loaders revalidate
  * according to the router's standard revalidation behavior.
@@ -2193,10 +2208,9 @@ export function useLinkClickHandler<E extends Element = HTMLAnchorElement>(
     state?: any;
     preventScrollReset?: boolean;
     relative?: RelativeRoutingType;
-    viewTransition?: boolean;
     defaultShouldRevalidate?: boolean;
     useTransitions?: boolean;
-  } = {},
+  } & Pick<NavigateOptions, "viewTransition"> = {},
 ): (event: React.MouseEvent<E, MouseEvent>) => void {
   let navigate = useNavigate();
   let location = useLocation();
@@ -2532,6 +2546,10 @@ let getUniqueFetcherId = () => `__${String(++fetcherId)}__`;
 /**
  * The imperative version of {@link Form | `<Form>`} that lets you submit a form
  * from code instead of a user interaction.
+ *
+ * The `viewTransition` submission option is deprecated. Use React's
+ * [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component
+ * instead. See the [migration guide](../../how-to/view-transitions).
  *
  * @example
  * import { useSubmit } from "react-router";
@@ -3314,6 +3332,11 @@ export function usePrompt({
 }
 
 /**
+ * **Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition)
+ * component to style transitions instead. This hook only tracks React Router's
+ * legacy view transitions, not transitions started by React. See the
+ * [migration guide](../../how-to/view-transitions).
+ *
  * This hook returns `true` when there is an active [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
  * and the specified location matches either side of the navigation (the URL you are
  * navigating **to** or the URL you are navigating **from**). This can be used to apply finer-grained styles to
@@ -3333,6 +3356,8 @@ export function usePrompt({
  * more details.
  * @returns `true` if there is an active [View Transition](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API)
  * and the resolved path matches the transition's destination or source pathname, otherwise `false`.
+ *
+ * @deprecated Use React's `<ViewTransition>` component instead.
  */
 export function useViewTransitionState(
   to: To,

--- a/packages/react-router/lib/hooks.tsx
+++ b/packages/react-router/lib/hooks.tsx
@@ -242,7 +242,7 @@ const navigateEffectWarning =
  *   * These options only work in Framework and Data modes:
  *     * `flushSync`: Wrap the DOM updates in [`ReactDom.flushSync`](https://react.dev/reference/react-dom/flushSync)
  *     * `preventScrollReset`: Do not scroll back to the top of the page after navigation
- *     * `viewTransition`: Enable [`document.startViewTransition`](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition) for this navigation
+ *     * `viewTransition`: **Deprecated.** Use React's [`<ViewTransition>`](https://react.dev/reference/react/ViewTransition) component instead. See the [migration guide](../../how-to/view-transitions).
  *
  * @example
  * import { useNavigate } from "react-router";

--- a/packages/react-router/lib/router/router.ts
+++ b/packages/react-router/lib/router/router.ts
@@ -622,6 +622,10 @@ type BaseNavigateOptions = BaseNavigateOrFetchOptions & {
   replace?: boolean;
   state?: any;
   fromRouteId?: string;
+  /**
+   * @deprecated Use React's `<ViewTransition>` component instead. See the
+   * [migration guide](https://reactrouter.com/how-to/view-transitions).
+   */
   viewTransition?: boolean;
   mask?: To;
 };


### PR DESCRIPTION
Deprecate React Router's `viewTransition` props/options, `useViewTransitionState`, and `NavLink`'s `isTransitioning` render prop and `transitioning` class in favor of React 19.3's `<ViewTransition>`. Runtime behavior remains unchanged, including support for older React versions.

Add a shared `PageLayout` example that wraps `<Outlet>` in a persistent React `<ViewTransition>`, using React Router's default React transitions. Update the API docs and migration guide, retain the legacy examples, and document the Back/Forward animation limitation.

This is intentionally a draft; we expect to wait a release or two before merging.

**Testing**

- Checked the documented layout with React and React DOM 19.3 in Chromium for Data and Declarative modes, including delayed loaders, programmatic navigation, form navigation, and route-state preservation.
- Confirmed the changed source files emit identical JavaScript and that `useLinkClickHandler` inherits the `viewTransition` deprecation annotation.
