### PR TITLE
Fix empty terminating splats with route-pattern matching

### DIFF
--- a/packages/react-router/.changes/unstable.route-pattern-matching.md
+++ b/packages/react-router/.changes/unstable.route-pattern-matching.md
@@ -1,6 +1,7 @@
 Add a new Data Mode-only `future.unstable_routePatternMatching` flag to opt into more efficient route matching based on the pathname matcher from `@remix-run/route-pattern`
 
 - Vendor the pathname-matching implementation while the flag remains unstable
+- Synthetic Chromium benchmarks reduced navigation and fetcher completion times by ~19–38% with 100 routes and ~71–88% with 1,000 routes, excluding network latency and React rendering
 - No route definition changes are required - syntax remains the same for public route definitions and route match fields
 - Once opting into this flag, you should no longer use legacy matching APIs (`matchRoutes`/`matchPath`/`useMatch`) as they are hardcoded to the previous regex-based matcher
   - A new `router.match()` API exists for those use cases but it's marked private and considered unstable along with the flag

--- a/packages/react-router/__tests__/router/route-pattern-matching-test.ts
+++ b/packages/react-router/__tests__/router/route-pattern-matching-test.ts
@@ -229,6 +229,168 @@ describe("unstable route-pattern matching", () => {
     expect(router.state.matches[1].route.path).toBe("files/*");
   });
 
+  describe.each([false, true])(
+    "splat matching (unstable_routePatternMatching: %s)",
+    (unstable_routePatternMatching) => {
+      it.each([
+        { path: "*", pathname: "/", params: { "*": "" } },
+        { path: "files/*", pathname: "/files", params: { "*": "" } },
+        {
+          path: "files/:folder/*",
+          pathname: "/files/docs",
+          params: { folder: "docs", "*": "" },
+        },
+        { path: "files/:folder?/*", pathname: "/files", params: { "*": "" } },
+      ])(
+        "matches an empty splat in $path at $pathname",
+        ({ path, pathname, params }) => {
+          let router = createMemoryRouter([{ path, id: "splat" }], {
+            future: { unstable_routePatternMatching },
+            initialEntries: [pathname],
+          });
+          try {
+            expect(router.state.errors).toBeNull();
+            expect(router.match(pathname)?.[0]).toMatchObject({
+              route: { id: "splat" },
+              pathname,
+              pathnameBase: pathname,
+              params,
+            });
+          } finally {
+            router.dispose();
+          }
+        },
+      );
+
+      it.each(["/projects/files", "/projects/files/", "/projects/files/a/b"])(
+        "prefers the static splat over a dynamic index at %s",
+        async (pathname) => {
+          let router = createMemoryRouter(
+            [
+              {
+                path: "/",
+                id: "root",
+                children: [
+                  {
+                    path: "projects",
+                    id: "projects",
+                    children: [
+                      {
+                        path: ":itemId",
+                        id: "item",
+                        children: [
+                          { index: true, id: "detail", loader: () => "detail" },
+                        ],
+                      },
+                      {
+                        path: "files/*",
+                        id: "files",
+                        loader: ({ params }) => params["*"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            { future: { unstable_routePatternMatching } },
+          );
+          let fetcherData: unknown;
+          let unsubscribe = router.subscribe((state) => {
+            let fetcher = state.fetchers.get("files");
+            if (fetcher?.state === "idle") fetcherData = fetcher.data;
+          });
+          router.getFetcher("files");
+
+          try {
+            let splat = pathname.endsWith("a/b") ? "a/b" : "";
+            // Fetch from the root first so a wrong target cannot be hidden by
+            // previously loaded navigation data.
+            await router.fetch("files", "root", pathname);
+            expect(router.state.errors).toBeNull();
+            expect(fetcherData).toBe(splat);
+
+            await router.navigate(pathname);
+            expect(router.state.errors).toBeNull();
+            expect(router.state.matches.map((m) => m.route.id)).toEqual([
+              "root",
+              "projects",
+              "files",
+            ]);
+            expect(router.state.matches.at(-1)).toMatchObject({
+              params: { "*": splat },
+              pathname,
+              pathnameBase: "/projects/files",
+            });
+            expect(router.state.loaderData).toEqual({ files: splat });
+          } finally {
+            unsubscribe();
+            router.dispose();
+          }
+        },
+      );
+
+      it.each([
+        { pathname: "/files", ids: ["files"], params: {} },
+        { pathname: "/files/", ids: ["files"], params: {} },
+        {
+          pathname: "/files/a/b",
+          ids: ["files", "splat"],
+          params: { "*": "a/b" },
+        },
+      ])(
+        "selects the parent or child splat at $pathname",
+        async ({ pathname, ids, params }) => {
+          let router = createMemoryRouter(
+            [
+              {
+                path: "/files",
+                id: "files",
+                children: [{ path: "*", id: "splat" }],
+              },
+            ],
+            {
+              future: { unstable_routePatternMatching },
+              initialEntries: ["/files"],
+            },
+          );
+          try {
+            let matches = router.match(pathname);
+            expect(matches?.map((m) => m.route.id)).toEqual(ids);
+            expect(matches?.at(-1)?.params).toEqual(params);
+
+            await router.navigate(pathname);
+            expect(router.state.errors).toBeNull();
+            expect(router.state.matches.map((m) => m.route.id)).toEqual(ids);
+            expect(router.state.matches.at(-1)?.params).toEqual(params);
+          } finally {
+            router.dispose();
+          }
+        },
+      );
+
+      it("prefers exact static routes over empty splats regardless of route order", () => {
+        for (let reverse of [false, true]) {
+          let routes = [
+            { path: "files/*", id: "splat" },
+            { path: "files", id: "exact" },
+          ];
+          let router = createMemoryRouter(reverse ? routes.reverse() : routes, {
+            future: { unstable_routePatternMatching },
+          });
+          try {
+            for (let pathname of ["/files", "/files/"]) {
+              expect(router.match(pathname)?.map((m) => m.route.id)).toEqual([
+                "exact",
+              ]);
+            }
+          } finally {
+            router.dispose();
+          }
+        }
+      });
+    },
+  );
+
   it("matches nested optional route paths", () => {
     let router = createMemoryRouter(
       [

--- a/packages/react-router/lib/router/matcher-route-pattern.ts
+++ b/packages/react-router/lib/router/matcher-route-pattern.ts
@@ -91,7 +91,10 @@ export class RoutePatternDataRouteMatcher implements DataRouteMatcher {
 
     let decoded = decodePath(pathname);
     let url = new URL("http://reactrouter.local");
-    url.pathname = pathname;
+    // Every route pattern accepts a trailing slash. Include one for trie lookup
+    // so a terminal splat can match an empty segment (e.g. /files for files/*).
+    // Reconstruct matches below using the original pathname and params.
+    url.pathname = pathname.endsWith("/") ? pathname : `${pathname}/`;
     invariant(
       this.#state,
       "Route pattern routes must be initialized before matching.",


### PR DESCRIPTION
Fix empty terminating splats when `future.unstable_routePatternMatching` is enabled. A route such as `files/*` now matches `/files`, instead of returning a 404 or falling through to a dynamic sibling.

Normalize the pathname with a trailing slash for trie lookup while reconstructing matches from the original pathname. Regression coverage checks both flag settings, navigation and fetcher results, and parent/exact-route precedence over empty child splats.

Also record the measured navigation and fetcher completion improvements in the unstable flag's change file.

**Testing**

- Synthetic Chromium benchmarks with 100 and 1,000 routes passed all 115 and 1,165 URL comparisons, respectively, after the fix. Measurements exclude network latency and React rendering.
